### PR TITLE
feat: trace graphql resolvers

### DIFF
--- a/__tests__/NotificationResolver.ts
+++ b/__tests__/NotificationResolver.ts
@@ -70,9 +70,6 @@ describe('compatibility route /notifications', () => {
       .slice(0, 5)
       .map((n) => ({ html: n.html, timestamp: n.timestamp.toISOString() }));
 
-    request(app.server)
-      .get('/v1/notifications')
-      .expect('content-type', 'application/health+json')
-      .expect(200, expected);
+    return request(app.server).get('/v1/notifications').expect(200, expected);
   });
 });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,7 +1,10 @@
 import { mock, MockProxy } from 'jest-mock-extended';
 import { FastifyRequest } from 'fastify';
 import { Connection } from 'typeorm';
-import { RootSpan, Span } from '@google-cloud/trace-agent/build/src/plugin-types';
+import {
+  RootSpan,
+  Span,
+} from '@google-cloud/trace-agent/build/src/plugin-types';
 import { Context } from '../src/Context';
 
 export class MockContext extends Context {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,10 +1,19 @@
-import { mock } from 'jest-mock-extended';
+import { mock, MockProxy } from 'jest-mock-extended';
 import { FastifyRequest } from 'fastify';
 import { Connection } from 'typeorm';
+import { RootSpan, Span } from '@google-cloud/trace-agent/build/src/plugin-types';
 import { Context } from '../src/Context';
 
 export class MockContext extends Context {
+  mockSpan: MockProxy<RootSpan> & RootSpan;
+
   constructor(con: Connection) {
     super(mock<FastifyRequest>(), con);
+    this.mockSpan = mock<RootSpan>();
+    this.mockSpan.createChildSpan.mockImplementation(() => mock<Span>());
+  }
+
+  get span(): RootSpan {
+    return this.mockSpan;
   }
 }

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,6 +1,7 @@
 import { Connection, EntitySchema, ObjectType, Repository } from 'typeorm';
 import { FastifyRequest, Logger } from 'fastify';
 import { GraphQLDatabaseLoader } from '@mando75/typeorm-graphql-loader';
+import { RootSpan } from '@google-cloud/trace-agent/build/src/plugin-types';
 
 export class Context {
   req: FastifyRequest;
@@ -19,6 +20,10 @@ export class Context {
 
   get log(): Logger {
     return this.req.log;
+  }
+
+  get span(): RootSpan {
+    return this.req.span;
   }
 
   getRepository<Entity>(

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -1,17 +1,13 @@
 import { ApolloServer, Config } from 'apollo-server-fastify';
 import { buildSchema } from 'type-graphql';
 import { NotificationResolver } from './resolver';
-
-// import { Context } from './Context';
-
-// const authChecker: AuthChecker<Context> = ({ context }) => {
-//   return !!context.userId;
-// };
+import { ResolverTracing } from './middleware';
 
 export default async function (config: Config): Promise<ApolloServer> {
   const schema = await buildSchema({
     resolvers: [NotificationResolver],
     emitSchemaFile: !process.env.NODE_ENV,
+    globalMiddlewares: [ResolverTracing],
   });
   return new ApolloServer({
     schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import * as fastify from 'fastify';
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyRequest } from 'fastify';
 import * as helmet from 'fastify-helmet';
 import * as fastJson from 'fast-json-stringify';
 import { createConnection, getConnection, getConnectionManager } from 'typeorm';
@@ -45,7 +45,7 @@ export default async function app(): Promise<FastifyInstance> {
   });
 
   const server = await createApolloServer({
-    context: (ctx): Context => new Context(ctx.req, connection),
+    context: (req: FastifyRequest): Context => new Context(req, connection),
     playground: isProd
       ? false
       : { settings: { 'request.credentials': 'include' } },

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './trace';

--- a/src/middleware/trace.ts
+++ b/src/middleware/trace.ts
@@ -1,0 +1,21 @@
+import { MiddlewareFn } from 'type-graphql';
+import { Context } from '../Context';
+
+export const ResolverTracing: MiddlewareFn<Context> = async (
+  { context, info },
+  next,
+) => {
+  const name = `${info.parentType.name}.${info.fieldName}`;
+  const childSpan = context.span.createChildSpan({ name });
+  childSpan.addLabel('/graphql/parent', info.parentType.name);
+  childSpan.addLabel('/graphql/field', info.fieldName);
+  childSpan.addLabel('/graphql/operation/name', info.operation.name);
+  childSpan.addLabel('/graphql/operation/type', info.operation.operation);
+  try {
+    await next();
+    childSpan.endSpan();
+  } catch (err) {
+    childSpan.endSpan();
+    throw err;
+  }
+};


### PR DESCRIPTION
A global middleware is attached to the apollo server to trace every resolver call.