### PR TITLE
feat: approve and decline mutations for source request

### DIFF
--- a/__tests__/__snapshots__/SourceRequestResolver.ts.snap
+++ b/__tests__/__snapshots__/SourceRequestResolver.ts.snap
@@ -31,12 +31,48 @@ Array [
 ]
 `;
 
+exports[`compatibility routes POST /publications/requests/:id/approve should approve a source request 1`] = `
+SourceRequest {
+  "approved": true,
+  "closed": false,
+  "reason": null,
+}
+`;
+
+exports[`compatibility routes POST /publications/requests/:id/decline should decline a source request 1`] = `
+SourceRequest {
+  "approved": false,
+  "closed": true,
+  "reason": "not-active",
+}
+`;
+
 exports[`compatibility routes PUT /publications/requests/:id should update an existing source request 1`] = `
 SourceRequest {
   "sourceImage": "http://image.com",
   "sourceName": "A",
   "sourceTwitter": "a",
   "sourceUrl": "http://source.com",
+}
+`;
+
+exports[`mutation approveSourceRequest should approve a source request 1`] = `
+Object {
+  "approveSourceRequest": Object {
+    "approved": true,
+    "closed": false,
+    "reason": null,
+  },
+}
+`;
+
+exports[`mutation declineSourceRequest should decline a source request 1`] = `
+Object {
+  "declineSourceRequest": Object {
+    "approved": false,
+    "closed": true,
+    "reason": "not-active",
+  },
 }
 `;
 
@@ -49,26 +85,6 @@ Object {
     "userName": "Ido",
   },
 }
-`;
-
-exports[`mutation requestSource should not authorize when not logged in 1`] = `
-Array [
-  Object {
-    "extensions": Object {
-      "code": "UNAUTHORIZED_ERROR",
-    },
-    "locations": Array [
-      Object {
-        "column": 3,
-        "line": 3,
-      },
-    ],
-    "message": "Access denied! You need to be authorized to perform this action!",
-    "path": Array [
-      "requestSource",
-    ],
-  },
-]
 `;
 
 exports[`mutation requestSource should return bad request when url is not valid 1`] = `
@@ -106,29 +122,9 @@ Array [
 ]
 `;
 
-exports[`mutation updateRequestSource should not authorize when not moderator 1`] = `
-Array [
-  Object {
-    "extensions": Object {
-      "code": "UNAUTHORIZED_ERROR",
-    },
-    "locations": Array [
-      Object {
-        "column": 3,
-        "line": 3,
-      },
-    ],
-    "message": "Access denied! You don't have permission for this action!",
-    "path": Array [
-      "updateRequestSource",
-    ],
-  },
-]
-`;
-
-exports[`mutation updateRequestSource should partially update existing request 1`] = `
+exports[`mutation updateSourceRequest should partially update existing request 1`] = `
 Object {
-  "updateRequestSource": Object {
+  "updateSourceRequest": Object {
     "sourceFeed": "http://a.com/feed",
     "sourceId": "a",
     "sourceImage": "http://image.com",
@@ -137,26 +133,6 @@ Object {
     "sourceUrl": "http://source.com",
   },
 }
-`;
-
-exports[`query pendingSourceRequests should not authorize when not moderator 1`] = `
-Array [
-  Object {
-    "extensions": Object {
-      "code": "UNAUTHORIZED_ERROR",
-    },
-    "locations": Array [
-      Object {
-        "column": 3,
-        "line": 2,
-      },
-    ],
-    "message": "Access denied! You don't have permission for this action!",
-    "path": Array [
-      "pendingSourceRequests",
-    ],
-  },
-]
 `;
 
 exports[`query pendingSourceRequests should return pending source requests 1`] = `

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -1,5 +1,6 @@
 import { PubSub } from '@google-cloud/pubsub';
 import { SourceRequest } from '../entity';
+import { toLegacySourceRequest } from '../compatibility/entity';
 
 const pubsub = new PubSub();
 const sourceRequestTopic = pubsub.topic('pub-request');
@@ -13,12 +14,7 @@ export const notifySourceRequest = async (
   if (process.env.NODE_ENV === 'production') {
     await sourceRequestTopic.publishJSON({
       type: reason,
-      pubRequest: {
-        url: sourceReq.sourceUrl,
-        userId: sourceReq.userId,
-        userName: sourceReq.userName,
-        userEmail: sourceReq.userEmail,
-      },
+      pubRequest: toLegacySourceRequest(sourceReq),
     });
   }
 };

--- a/src/compatibility/entity.ts
+++ b/src/compatibility/entity.ts
@@ -1,0 +1,35 @@
+import { SourceRequest } from '../entity';
+
+export interface LegacySourceRequest {
+  id: string;
+  url: string;
+  userId: string;
+  userName?: string;
+  userEmail?: string;
+  approved?: boolean;
+  closed?: boolean;
+  pubId?: string;
+  pubName?: string;
+  pubImage?: string;
+  pubTwitter?: string;
+  pubRss?: string;
+  createdAt: Date;
+}
+
+export const toLegacySourceRequest = (
+  req: SourceRequest,
+): LegacySourceRequest => ({
+  id: req.id,
+  url: req.sourceUrl,
+  userId: req.userId,
+  userName: req.userName,
+  userEmail: req.userEmail,
+  approved: req.approved,
+  closed: req.closed,
+  pubId: req.sourceId,
+  pubName: req.sourceName,
+  pubImage: req.sourceImage,
+  pubTwitter: req.sourceTwitter,
+  pubRss: req.sourceFeed,
+  createdAt: req.createdAt,
+});


### PR DESCRIPTION
Two new mutations `approveSourceRequest` and `declineSourceRequest` to approve or decline a source request, respectively. Compatibility routes also included.