### PR TITLE
feat: add tags and source fields to post type

### DIFF
--- a/__tests__/__snapshots__/bookmarks.ts.snap
+++ b/__tests__/__snapshots__/bookmarks.ts.snap
@@ -57,11 +57,28 @@ Object {
       Object {
         "node": Object {
           "id": "p3",
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
         },
       },
       Object {
         "node": Object {
           "id": "p1",
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
         },
       },
     ],

--- a/__tests__/bookmarks.ts
+++ b/__tests__/bookmarks.ts
@@ -17,9 +17,10 @@ import {
   testQueryErrorCode,
 } from './helpers';
 import appFunc from '../src';
-import { Bookmark, Post, Source } from '../src/entity';
+import { Bookmark, Post, PostTag, Source, SourceDisplay } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
-import { postsFixture } from './fixture/post';
+import { postsFixture, postTagsFixture } from './fixture/post';
+import { sourceDisplaysFixture } from './fixture/sourceDisplay';
 
 let app: FastifyInstance;
 let con: Connection;
@@ -70,7 +71,9 @@ beforeEach(async () => {
   loggedUser = null;
 
   await saveFixtures(Source, sourcesFixture);
+  await saveFixtures(SourceDisplay, sourceDisplaysFixture);
   await saveFixtures(Post, postsFixture);
+  await saveFixtures(PostTag, postTagsFixture);
 });
 
 afterAll(() => app.close());
@@ -180,6 +183,13 @@ describe('query bookmarks', () => {
     edges {
       node {
         id
+        source {
+          id
+          name
+          image
+          public
+        }
+        tags
       }
     }
   }

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from 'typeorm';
-import { Post } from '../../src/entity';
+import { Post, PostTag } from '../../src/entity';
 
 export const postsFixture: DeepPartial<Post>[] = [
   {
@@ -41,5 +41,16 @@ export const postsFixture: DeepPartial<Post>[] = [
     timeDecay: 0,
     score: 0,
     sourceId: 'b',
+  },
+];
+
+export const postTagsFixture: DeepPartial<PostTag>[] = [
+  {
+    postId: postsFixture[0].id,
+    tag: 'webdev',
+  },
+  {
+    postId: postsFixture[0].id,
+    tag: 'javascript',
   },
 ];

--- a/__tests__/fixture/sourceDisplay.ts
+++ b/__tests__/fixture/sourceDisplay.ts
@@ -1,0 +1,8 @@
+import { DeepPartial } from 'typeorm';
+import { SourceDisplay } from '../../src/entity';
+
+export const sourceDisplaysFixture: DeepPartial<SourceDisplay>[] = [
+  { sourceId: 'a', name: 'A', image: 'http://image.com/a', enabled: true },
+  { sourceId: 'b', name: 'B', image: 'http://image.com/b', enabled: true },
+  { sourceId: 'c', name: 'C', image: 'http://image.com/c', enabled: true },
+];

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -41,7 +41,7 @@ export default async function (config: Config): Promise<ApolloServer> {
     formatError: (error): GraphQLFormattedError => {
       if (error.originalError.name === 'EntityNotFound') {
         error.extensions.code = 'NOT_FOUND_ERROR';
-      } else {
+      } else if (error.originalError.name) {
         error.extensions.code = snakeCase(
           error.originalError.name,
         ).toUpperCase();

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -1,0 +1,126 @@
+import { SelectQueryBuilder } from 'typeorm';
+import { lowerFirst } from 'lodash';
+import { Post, PostTag, SourceDisplay, TagCount } from '../entity';
+import { GQLPost } from '../schema/posts';
+import { Context } from '../Context';
+import { forwardPagination, PaginationResponse } from '../schema/common';
+import { ConnectionArguments } from 'graphql-relay';
+import { IFieldResolver } from 'apollo-server-fastify';
+
+const nestChild = (obj: object, prefix: string): object => {
+  obj[prefix] = Object.keys(obj).reduce((acc, key) => {
+    if (key.startsWith(prefix)) {
+      const value = obj[key];
+      delete obj[key];
+      return { [lowerFirst(key.substr(prefix.length))]: value, ...acc };
+    }
+    return acc;
+  }, {});
+  return obj;
+};
+
+export const whereTags = (
+  tags: string[],
+  builder: SelectQueryBuilder<Post>,
+): string => {
+  const query = builder
+    .subQuery()
+    .select('1')
+    .from(PostTag, 't')
+    .where(`t.tag IN (:...tags)`, { tags })
+    .andWhere('t.postId = post.id')
+    .getQuery();
+  return `EXISTS${query}`;
+};
+
+export const selectTags = (
+  builder: SelectQueryBuilder<Post>,
+): SelectQueryBuilder<PostTag> =>
+  builder
+    .select(
+      "array_to_string(array_agg(tag.tag order by tcount.count DESC NULLS LAST, tag.tag ASC), ',')",
+      'tags',
+    )
+    .from(PostTag, 'tag')
+    .leftJoin(TagCount, 'tcount', 'tag.tag = tcount.tag')
+    .where('post.id = tag.postId')
+    .groupBy('tag.postId');
+
+export const selectSource = (
+  userId: string,
+  builder: SelectQueryBuilder<Post>,
+): SelectQueryBuilder<SourceDisplay> =>
+  builder
+    .distinctOn(['sd.sourceId'])
+    .addSelect('sd.sourceId', 'sourceId')
+    .addSelect('sd.name', 'sourceName')
+    .addSelect('sd.image', 'sourceImage')
+    .addSelect('sd.userId', 'sourcePublic')
+    .from(SourceDisplay, 'sd')
+    .orderBy('sd.sourceId')
+    .addOrderBy('sd.userId', 'ASC', 'NULLS LAST')
+    .where('sd.userId IS NULL OR sd.userId = :userId', {
+      userId,
+    });
+
+export const mapRawPost = (post: object): GQLPost => {
+  post = nestChild(post, 'source');
+  if (post['source']) {
+    post['source']['public'] = !post['source']['userId'];
+    delete post['source']['userId'];
+  }
+  post['tags'] = post['tags'] ? post['tags'].split(',') : [];
+  return post as GQLPost;
+};
+
+export const generateFeed = async (
+  ctx: Context,
+  limit: number,
+  offset: number,
+  query: (builder: SelectQueryBuilder<Post>) => SelectQueryBuilder<Post>,
+): Promise<PaginationResponse<GQLPost>> => {
+  const builder = query(
+    ctx.con
+      .createQueryBuilder()
+      .select('post.*')
+      .addSelect('source.*')
+      .addSelect('count(*) OVER() AS count')
+      .addSelect(selectTags)
+      .from(Post, 'post')
+      .leftJoin(
+        (subBuilder) => selectSource(ctx.userId, subBuilder),
+        'source',
+        'source."sourceId" = post."sourceId"',
+      )
+      .limit(limit)
+      .offset(offset),
+  );
+  const res = await builder.getRawMany();
+
+  return {
+    count: parseInt(res?.[0]?.count || 0),
+    nodes: res.map(mapRawPost),
+  };
+};
+
+export function feedResolver<TSource, TArgs extends ConnectionArguments>(
+  query: (
+    ctx: Context,
+    args: TArgs,
+    builder: SelectQueryBuilder<Post>,
+  ) => SelectQueryBuilder<Post>,
+): IFieldResolver<TSource, Context, TArgs> {
+  return forwardPagination(
+    async (
+      source,
+      args: TArgs,
+      ctx,
+      { limit, offset },
+    ): Promise<PaginationResponse<GQLPost>> => {
+      return generateFeed(ctx, limit, offset, (builder) =>
+        query(ctx, args, builder),
+      );
+    },
+    30,
+  );
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,5 +1,6 @@
 export * from './base64';
 export * from './cloudinary';
+export * from './feedGenerator';
 export * from './pagination';
 export * from './pubsub';
 export * from './superfeedr';

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1,4 +1,5 @@
 import { gql } from 'apollo-server-fastify';
+import { GQLSource } from './sources';
 
 export interface GQLPost {
   id: string;
@@ -10,6 +11,8 @@ export interface GQLPost {
   ratio?: number;
   placeholder?: string;
   readTime?: number;
+  source?: GQLSource;
+  tags?: string[];
 }
 
 export const typeDefs = gql`
@@ -61,6 +64,10 @@ export const typeDefs = gql`
     Estimation of time to read the article (in minutes)
     """
     readTime: Float
+
+    source: Source
+
+    tags: [String]
   }
 
   type PostConnection {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -111,7 +111,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           .getRawMany();
 
         return {
-          count: parseInt(res?.[0].count || 0),
+          count: parseInt(res?.[0]?.count || 0),
           nodes: res.map(sourceFromDisplay),
         };
       },

--- a/src/schema/trace.ts
+++ b/src/schema/trace.ts
@@ -36,7 +36,7 @@ export function traceResolver<TSource, TArgs, TReturn>(
   };
 }
 
-function traceResolverObject<TSource, TArgs>(
+export function traceResolverObject<TSource, TArgs>(
   object: IResolverObject<TSource, Context, TArgs>,
 ): IResolverObject<TSource, Context, TArgs> {
   for (const prop in object) {


### PR DESCRIPTION
To resolve efficiently tags and source, I created a `feedGenerator` utility which builds only one query to fetch both the feed and all the necessary information.