### PR TITLE
feat: anonymous feed query

### DIFF
--- a/__tests__/__snapshots__/bookmarks.ts.snap
+++ b/__tests__/__snapshots__/bookmarks.ts.snap
@@ -4,9 +4,28 @@ exports[`compatibility routes GET /posts/bookmarks should return bookmarks order
 Array [
   Object {
     "id": "p3",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [],
+    "title": "P3",
+    "url": "http://p3.com",
   },
   Object {
     "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
   },
 ]
 `;

--- a/__tests__/__snapshots__/feed.ts.snap
+++ b/__tests__/__snapshots__/feed.ts.snap
@@ -1,0 +1,694 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compatibility routes GET /posts/latest should return anonymous feed filtered by sources 1`] = `
+Array [
+  Object {
+    "id": "p5",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "html",
+      "javascript",
+    ],
+    "title": "P5",
+    "url": "http://p5.com",
+  },
+  Object {
+    "id": "p2",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [],
+    "title": "P2",
+    "url": "http://p2.com",
+  },
+  Object {
+    "id": "p4",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "backend",
+      "data",
+      "javascript",
+    ],
+    "title": "P4",
+    "url": "http://p4.com",
+  },
+  Object {
+    "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
+  },
+]
+`;
+
+exports[`compatibility routes GET /posts/latest should return anonymous feed filtered by tags 1`] = `
+Array [
+  Object {
+    "id": "p5",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "html",
+      "javascript",
+    ],
+    "title": "P5",
+    "url": "http://p5.com",
+  },
+  Object {
+    "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
+  },
+]
+`;
+
+exports[`compatibility routes GET /posts/latest should return anonymous feed filtered by tags and sources 1`] = `
+Array [
+  Object {
+    "id": "p5",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "html",
+      "javascript",
+    ],
+    "title": "P5",
+    "url": "http://p5.com",
+  },
+  Object {
+    "id": "p4",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "backend",
+      "data",
+      "javascript",
+    ],
+    "title": "P4",
+    "url": "http://p4.com",
+  },
+  Object {
+    "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
+  },
+]
+`;
+
+exports[`compatibility routes GET /posts/latest should return anonymous feed with no filters ordered by popularity 1`] = `
+Array [
+  Object {
+    "id": "p5",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "html",
+      "javascript",
+    ],
+    "title": "P5",
+    "url": "http://p5.com",
+  },
+  Object {
+    "id": "p2",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [],
+    "title": "P2",
+    "url": "http://p2.com",
+  },
+]
+`;
+
+exports[`query anonymousFeed should return anonymous feed filtered by sources 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjM=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query anonymousFeed should return anonymous feed filtered by tags 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query anonymousFeed should return anonymous feed filtered by tags and sources 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query anonymousFeed should return anonymous feed with no filters ordered by popularity 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query anonymousFeed should return anonymous feed with no filters ordered by time 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;

--- a/__tests__/feed.ts
+++ b/__tests__/feed.ts
@@ -1,0 +1,173 @@
+import { FastifyInstance } from 'fastify';
+import { Connection, getConnection } from 'typeorm';
+import { ApolloServer } from 'apollo-server-fastify';
+import {
+  ApolloServerTestClient,
+  createTestClient,
+} from 'apollo-server-testing';
+import * as request from 'supertest';
+import * as _ from 'lodash';
+
+import createApolloServer from '../src/apollo';
+import { Context } from '../src/Context';
+import { MockContext, saveFixtures } from './helpers';
+import appFunc from '../src';
+import { Post, PostTag, Source, SourceDisplay } from '../src/entity';
+import { sourcesFixture } from './fixture/source';
+import { postsFixture, postTagsFixture } from './fixture/post';
+import { sourceDisplaysFixture } from './fixture/sourceDisplay';
+import { Ranking } from '../src/schema/feed';
+
+let app: FastifyInstance;
+let con: Connection;
+let server: ApolloServer;
+let client: ApolloServerTestClient;
+let loggedUser: string = null;
+
+beforeAll(async () => {
+  con = await getConnection();
+  server = await createApolloServer({
+    context: (): Context => new MockContext(con, loggedUser),
+    playground: false,
+  });
+  client = createTestClient(server);
+  app = await appFunc();
+  return app.ready();
+});
+
+beforeEach(async () => {
+  loggedUser = null;
+
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, SourceDisplay, sourceDisplaysFixture);
+  await saveFixtures(con, Post, postsFixture);
+  await saveFixtures(con, PostTag, postTagsFixture);
+});
+
+afterAll(() => app.close());
+
+describe('query anonymousFeed', () => {
+  const QUERY = (
+    ranking: Ranking = Ranking.POPULARITY,
+    now = new Date(),
+    first = 10,
+  ): string => `
+  query AnonymousFeed($filters: FiltersInput) {
+    anonymousFeed(filters: $filters, ranking: ${ranking}, now: "${now.toISOString()}", first: ${first}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          id
+          url
+          title
+          image
+          ratio
+          placeholder
+          readTime
+          tags
+          source {
+            id
+            name
+            image
+            public
+          }
+        }
+      }
+    }
+  }
+`;
+
+  it('should return anonymous feed with no filters ordered by popularity', async () => {
+    const res = await client.query({ query: QUERY() });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return anonymous feed with no filters ordered by time', async () => {
+    const res = await client.query({ query: QUERY(Ranking.TIME) });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return anonymous feed filtered by sources', async () => {
+    const res = await client.query({
+      query: QUERY(),
+      variables: { filters: { includeSources: ['a', 'b'] } },
+    });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return anonymous feed filtered by tags', async () => {
+    const res = await client.query({
+      query: QUERY(),
+      variables: { filters: { includeTags: ['html', 'webdev'] } },
+    });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return anonymous feed while excluding sources', async () => {
+    const res = await client.query({
+      query: QUERY(),
+      variables: { filters: { excludeSources: ['a'] } },
+    });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return anonymous feed filtered by tags and sources', async () => {
+    const res = await client.query({
+      query: QUERY(),
+      variables: {
+        filters: {
+          includeTags: ['javascript'],
+          includeSources: ['a', 'b'],
+        },
+      },
+    });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('compatibility routes', () => {
+  describe('GET /posts/latest', () => {
+    it('should return anonymous feed with no filters ordered by popularity', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/latest')
+        .query({ latest: new Date(), pageSize: 2, page: 0 })
+        .send()
+        .expect(200);
+      expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();
+    });
+
+    it('should return anonymous feed filtered by sources', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/latest')
+        .query({ latest: new Date(), sources: ['a', 'b'] })
+        .send()
+        .expect(200);
+      expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();
+    });
+
+    it('should return anonymous feed filtered by tags', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/latest')
+        .query({ latest: new Date(), tags: ['html', 'webdev'] })
+        .send()
+        .expect(200);
+      expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();
+    });
+
+    it('should return anonymous feed filtered by tags and sources', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/latest')
+        .query({
+          latest: new Date(),
+          tags: ['javascript'],
+          sources: ['a', 'b'],
+        })
+        .send()
+        .expect(200);
+      expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();
+    });
+  });
+});

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -1,6 +1,8 @@
 import { DeepPartial } from 'typeorm';
 import { Post, PostTag } from '../../src/entity';
 
+const now = new Date();
+
 export const postsFixture: DeepPartial<Post>[] = [
   {
     id: 'p1',
@@ -9,38 +11,43 @@ export const postsFixture: DeepPartial<Post>[] = [
     timeDecay: 0,
     score: 0,
     sourceId: 'a',
+    createdAt: now,
   },
   {
     id: 'p2',
     title: 'P2',
     url: 'http://p2.com',
     timeDecay: 0,
-    score: 0,
+    score: 7,
     sourceId: 'b',
+    createdAt: new Date(now.getTime() - 1000),
   },
   {
     id: 'p3',
     title: 'P3',
     url: 'http://p3.com',
     timeDecay: 0,
-    score: 0,
+    score: 4,
     sourceId: 'c',
+    createdAt: new Date(now.getTime() - 2000),
   },
   {
     id: 'p4',
     title: 'P4',
     url: 'http://p4.com',
     timeDecay: 0,
-    score: 0,
+    score: 3,
     sourceId: 'a',
+    createdAt: new Date(now.getTime() - 3000),
   },
   {
     id: 'p5',
     title: 'P5',
     url: 'http://p5.com',
     timeDecay: 0,
-    score: 0,
+    score: 10,
     sourceId: 'b',
+    createdAt: new Date(now.getTime() - 4000),
   },
 ];
 
@@ -51,6 +58,26 @@ export const postTagsFixture: DeepPartial<PostTag>[] = [
   },
   {
     postId: postsFixture[0].id,
+    tag: 'javascript',
+  },
+  {
+    postId: postsFixture[3].id,
+    tag: 'backend',
+  },
+  {
+    postId: postsFixture[3].id,
+    tag: 'javascript',
+  },
+  {
+    postId: postsFixture[3].id,
+    tag: 'data',
+  },
+  {
+    postId: postsFixture[4].id,
+    tag: 'html',
+  },
+  {
+    postId: postsFixture[4].id,
     tag: 'javascript',
   },
 ];

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,6 +1,6 @@
 import { mock, MockProxy } from 'jest-mock-extended';
 import { FastifyRequest, Logger } from 'fastify';
-import { Connection } from 'typeorm';
+import { Connection, DeepPartial, ObjectType } from 'typeorm';
 import * as request from 'supertest';
 import {
   RootSpan,
@@ -92,3 +92,13 @@ export const testQueryErrorCode = async (
     expect(errors.length).toEqual(1);
     expect(errors[0].extensions.code).toEqual(code);
   });
+
+export async function saveFixtures<Entity>(
+  con: Connection,
+  target: ObjectType<Entity>,
+  entities: DeepPartial<Entity>[],
+): Promise<void> {
+  await con
+    .getRepository(target)
+    .save(entities.map((e) => con.getRepository(target).create(e)));
+}

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -5,6 +5,7 @@ import { snakeCase } from 'snake-case';
 
 import * as common from './schema/common';
 import * as bookmarks from './schema/bookmarks';
+import * as feed from './schema/feed';
 import * as notifications from './schema/notifications';
 import * as posts from './schema/posts';
 import * as settings from './schema/settings';
@@ -18,6 +19,7 @@ export default async function (config: Config): Promise<ApolloServer> {
     typeDefs: [
       common.typeDefs,
       bookmarks.typeDefs,
+      feed.typeDefs,
       notifications.typeDefs,
       posts.typeDefs,
       settings.typeDefs,
@@ -27,6 +29,7 @@ export default async function (config: Config): Promise<ApolloServer> {
     resolvers: merge(
       common.resolvers,
       bookmarks.resolvers,
+      feed.resolvers,
       notifications.resolvers,
       settings.resolvers,
       sourceRequests.resolvers,

--- a/src/entity/Post.ts
+++ b/src/entity/Post.ts
@@ -1,6 +1,5 @@
 import {
   Column,
-  CreateDateColumn,
   Entity,
   Index,
   ManyToOne,
@@ -18,7 +17,7 @@ export class Post {
   @Column({ nullable: true })
   publishedAt?: Date;
 
-  @CreateDateColumn()
+  @Column({ default: () => 'now()' })
   @Index()
   createdAt: Date;
 

--- a/src/schema/feed.ts
+++ b/src/schema/feed.ts
@@ -1,0 +1,110 @@
+import { gql, IResolvers } from 'apollo-server-fastify';
+import { ConnectionArguments } from 'graphql-relay';
+import { Context } from '../Context';
+import { traceResolvers } from './trace';
+import { feedResolver, whereTags } from '../common';
+
+export const typeDefs = gql`
+  enum Ranking {
+    """
+    Rank by a combination of time and views
+    """
+    POPULARITY
+    """
+    Rank by time only
+    """
+    TIME
+  }
+
+  input FiltersInput {
+    """
+    Include posts of these sources
+    """
+    includeSources: [String!]
+
+    """
+    Exclude posts of these sources
+    """
+    excludeSources: [String!]
+
+    """
+    Posts must include at least one tag from this list
+    """
+    includeTags: [String!]
+  }
+
+  extend type Query {
+    anonymousFeed(
+      """
+      Time the pagination started to ignore new items
+      """
+      now: DateTime!
+
+      """
+      Paginate after opaque cursor
+      """
+      after: String
+
+      """
+      Paginate first
+      """
+      first: Int
+
+      """
+      Ranking criteria for the feed
+      """
+      ranking: Ranking = POPULARITY
+
+      filters: FiltersInput
+    ): PostConnection!
+  }
+`;
+
+export enum Ranking {
+  POPULARITY = 'POPULARITY',
+  TIME = 'TIME',
+}
+
+interface FiltersInput {
+  includeSources?: string[];
+  excludeSources?: string[];
+  includeTags?: string[];
+}
+
+interface AnonymousFeedArgs extends ConnectionArguments {
+  now: Date;
+  ranking: Ranking;
+  filters?: FiltersInput;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const resolvers: IResolvers<any, Context> = traceResolvers({
+  Query: {
+    anonymousFeed: feedResolver(
+      (ctx, { now, filters, ranking }: AnonymousFeedArgs, builder) => {
+        let newBuilder = builder
+          .where('post.createdAt < :now', { now })
+          .orderBy(
+            ranking === Ranking.POPULARITY ? 'post.score' : 'post.createdAt',
+            'DESC',
+          );
+        if (filters?.includeSources?.length) {
+          newBuilder = newBuilder.andWhere(`post.sourceId IN (:...sources)`, {
+            sources: filters.includeSources,
+          });
+        } else if (filters?.excludeSources?.length) {
+          newBuilder = newBuilder.andWhere(
+            `post.sourceId NOT IN (:...sources)`,
+            { sources: filters.excludeSources },
+          );
+        }
+        if (filters?.includeTags?.length) {
+          newBuilder = newBuilder.andWhere((builder) =>
+            whereTags(filters.includeTags, builder),
+          );
+        }
+        return newBuilder;
+      },
+    ),
+  },
+});


### PR DESCRIPTION
`anonymousFeed` query returns feed for unregistered users. It allows to generate ad-hoc feeds by sources and tags. Compatibility route `GET /v1/posts/latest` added accordingly.