### PR TITLE
feat: tag feed query

### DIFF
--- a/__tests__/__snapshots__/feed.ts.snap
+++ b/__tests__/__snapshots__/feed.ts.snap
@@ -200,6 +200,54 @@ Array [
 ]
 `;
 
+exports[`compatibility routes GET /posts/tag should return single tag feed 1`] = `
+Array [
+  Object {
+    "id": "p5",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "html",
+      "javascript",
+    ],
+    "title": "P5",
+    "url": "http://p5.com",
+  },
+  Object {
+    "id": "p4",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "backend",
+      "data",
+      "javascript",
+    ],
+    "title": "P4",
+    "url": "http://p4.com",
+  },
+  Object {
+    "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "publishedAt": null,
+    "ratio": null,
+    "readTime": null,
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
+  },
+]
+`;
+
 exports[`query anonymousFeed should return anonymous feed filtered by sources 1`] = `
 Object {
   "anonymousFeed": Object {
@@ -769,6 +817,83 @@ Object {
     ],
     "pageInfo": Object {
       "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query tagFeed should return a single tag feed 1`] = `
+Object {
+  "tagFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "image": null,
+          "placeholder": null,
+          "ratio": null,
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
       "hasNextPage": false,
     },
   },

--- a/__tests__/feed.ts
+++ b/__tests__/feed.ts
@@ -149,6 +149,24 @@ describe('query sourceFeed', () => {
   });
 });
 
+describe('query tagFeed', () => {
+  const QUERY = (
+    tag: string,
+    ranking: Ranking = Ranking.POPULARITY,
+    now = new Date(),
+    first = 10,
+  ): string => `{
+    tagFeed(tag: "${tag}", ranking: ${ranking}, now: "${now.toISOString()}", first: ${first}) {
+      ${feedFields}
+    }
+  }`;
+
+  it('should return a single tag feed', async () => {
+    const res = await client.query({ query: QUERY('javascript') });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
 describe('compatibility routes', () => {
   describe('GET /posts/latest', () => {
     it('should return anonymous feed with no filters ordered by popularity', async () => {
@@ -197,6 +215,17 @@ describe('compatibility routes', () => {
       const res = await request(app.server)
         .get('/v1/posts/publication')
         .query({ latest: new Date(), pub: 'b' })
+        .send()
+        .expect(200);
+      expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();
+    });
+  });
+
+  describe('GET /posts/tag', () => {
+    it('should return single tag feed', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/tag')
+        .query({ latest: new Date(), tag: 'javascript' })
         .send()
         .expect(200);
       expect(res.body.map((x) => _.omit(x, ['createdAt']))).toMatchSnapshot();

--- a/src/compatibility/posts.ts
+++ b/src/compatibility/posts.ts
@@ -132,4 +132,24 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       res,
     );
   });
+
+  fastify.get('/tag', async (req, res) => {
+    const pageParams = getPaginationParams(req);
+    const query = `{
+  tagFeed(tag: "${req.query.tag}", ${pageParams}) {
+    edges {
+      node {
+        ${postFields}
+      }
+    }
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => obj['data']['tagFeed']['edges'].map((e) => e['node']),
+      req,
+      res,
+    );
+  });
 }

--- a/src/schema/feed.ts
+++ b/src/schema/feed.ts
@@ -95,6 +95,36 @@ export const typeDefs = gql`
       """
       ranking: Ranking = POPULARITY
     ): PostConnection!
+
+    """
+    Get a single tag feed
+    """
+    tagFeed(
+      """
+      The tag to fetch
+      """
+      tag: String!
+
+      """
+      Time the pagination started to ignore new items
+      """
+      now: DateTime!
+
+      """
+      Paginate after opaque cursor
+      """
+      after: String
+
+      """
+      Paginate first
+      """
+      first: Int
+
+      """
+      Ranking criteria for the feed
+      """
+      ranking: Ranking = POPULARITY
+    ): PostConnection!
   }
 `;
 
@@ -120,6 +150,10 @@ interface AnonymousFeedArgs extends FeedArgs {
 
 interface SourceFeedArgs extends FeedArgs {
   source: string;
+}
+
+interface TagFeedArgs extends FeedArgs {
+  tag: string;
 }
 
 const applyFeedArgs = (
@@ -163,6 +197,12 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           now,
           ranking,
         }).andWhere(`post.sourceId = :source`, { source }),
+    ),
+    tagFeed: feedResolver((ctx, { now, ranking, tag }: TagFeedArgs, builder) =>
+      applyFeedArgs(builder, {
+        now,
+        ranking,
+      }).andWhere((subBuilder) => whereTags([tag], subBuilder)),
     ),
   },
 });


### PR DESCRIPTION
`tagFeed` query generates a dedicated feed for a single tag. Compatibility route `GET /v1/posts/tag` added accordingly.