### PR TITLE
feat: get popular tags and search tags queries

### DIFF
--- a/__tests__/__snapshots__/tags.ts.snap
+++ b/__tests__/__snapshots__/tags.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compatibility routes GET /tags/latest should return most popular tags ordered by count 1`] = `
+Array [
+  Object {
+    "name": "fullstack",
+  },
+  Object {
+    "name": "development",
+  },
+  Object {
+    "name": "webdev",
+  },
+]
+`;
+
+exports[`compatibility routes GET /tags/search should search for tags and order by count 1`] = `
+Object {
+  "hits": Array [
+    Object {
+      "name": "development",
+    },
+    Object {
+      "name": "webdev",
+    },
+  ],
+  "query": "dev",
+}
+`;
+
+exports[`query popularTags should return most popular tags ordered by count 1`] = `
+Object {
+  "popularTags": Array [
+    Object {
+      "name": "fullstack",
+    },
+    Object {
+      "name": "development",
+    },
+    Object {
+      "name": "webdev",
+    },
+  ],
+}
+`;
+
+exports[`query searchTags should search for tags and order by count 1`] = `
+Object {
+  "searchTags": Object {
+    "hits": Array [
+      Object {
+        "name": "development",
+      },
+      Object {
+        "name": "webdev",
+      },
+    ],
+    "query": "dev",
+  },
+}
+`;

--- a/__tests__/fixture/tagCount.ts
+++ b/__tests__/fixture/tagCount.ts
@@ -1,0 +1,10 @@
+import { DeepPartial } from 'typeorm';
+import { TagCount } from '../../src/entity';
+
+export const tagCountsFixture: DeepPartial<TagCount>[] = [
+  { tag: 'webdev', count: 100 },
+  { tag: 'development', count: 200 },
+  { tag: 'fullstack', count: 300 },
+  { tag: 'rust', count: 5 },
+  { tag: 'golang', count: 10 },
+];

--- a/__tests__/tags.ts
+++ b/__tests__/tags.ts
@@ -1,0 +1,91 @@
+import { FastifyInstance } from 'fastify';
+import { Connection, getConnection } from 'typeorm';
+import { ApolloServer } from 'apollo-server-fastify';
+import {
+  ApolloServerTestClient,
+  createTestClient,
+} from 'apollo-server-testing';
+import * as request from 'supertest';
+
+import createApolloServer from '../src/apollo';
+import { Context } from '../src/Context';
+import { MockContext, saveFixtures } from './helpers';
+import appFunc from '../src';
+import { TagCount } from '../src/entity';
+import { tagCountsFixture } from './fixture/tagCount';
+
+let app: FastifyInstance;
+let con: Connection;
+let server: ApolloServer;
+let client: ApolloServerTestClient;
+let loggedUser: string = null;
+
+beforeAll(async () => {
+  con = await getConnection();
+  server = await createApolloServer({
+    context: (): Context => new MockContext(con, loggedUser),
+    playground: false,
+  });
+  client = createTestClient(server);
+  app = await appFunc();
+  return app.ready();
+});
+
+beforeEach(async () => {
+  loggedUser = null;
+
+  await saveFixtures(con, TagCount, tagCountsFixture);
+});
+
+afterAll(() => app.close());
+
+describe('query popularTags', () => {
+  const QUERY = `{
+    popularTags {
+      name
+    }
+  }`;
+
+  it('should return most popular tags ordered by count', async () => {
+    const res = await client.query({ query: QUERY });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('query searchTags', () => {
+  const QUERY = (query: string): string => `{
+    searchTags(query: "${query}") {
+      query
+      hits {
+        name
+      }
+    }
+  }`;
+
+  it('should search for tags and order by count', async () => {
+    const res = await client.query({ query: QUERY('dev') });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('compatibility routes', () => {
+  describe('GET /tags/latest', () => {
+    it('should return most popular tags ordered by count', async () => {
+      const res = await request(app.server)
+        .get('/v1/tags/popular')
+        .send()
+        .expect(200);
+      expect(res.body).toMatchSnapshot();
+    });
+  });
+
+  describe('GET /tags/search', () => {
+    it('should search for tags and order by count', async () => {
+      const res = await request(app.server)
+        .get('/v1/tags/search?query=dev')
+        .send()
+        .expect(200);
+      expect(res.body).toMatchSnapshot();
+    });
+  });
+});

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -11,6 +11,7 @@ import * as posts from './schema/posts';
 import * as settings from './schema/settings';
 import * as sourceRequests from './schema/sourceRequests';
 import * as sources from './schema/sources';
+import * as tags from './schema/tags';
 import { AuthDirective } from './directive';
 import { UrlDirective } from './directive/UrlDirective';
 
@@ -25,6 +26,7 @@ export default async function (config: Config): Promise<ApolloServer> {
       settings.typeDefs,
       sourceRequests.typeDefs,
       sources.typeDefs,
+      tags.typeDefs,
     ],
     resolvers: merge(
       common.resolvers,
@@ -34,6 +36,7 @@ export default async function (config: Config): Promise<ApolloServer> {
       settings.resolvers,
       sourceRequests.resolvers,
       sources.resolvers,
+      tags.resolvers,
     ),
     schemaDirectives: {
       auth: AuthDirective,

--- a/src/compatibility/index.ts
+++ b/src/compatibility/index.ts
@@ -4,10 +4,12 @@ import notifications from './notifications';
 import posts from './posts';
 import publications from './publications';
 import settings from './settings';
+import tags from './tags';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(notifications, { prefix: '/notifications' });
   fastify.register(posts, { prefix: '/posts' });
   fastify.register(publications, { prefix: '/publications' });
   fastify.register(settings, { prefix: '/settings' });
+  fastify.register(tags, { prefix: '/tags' });
 }

--- a/src/compatibility/tags.ts
+++ b/src/compatibility/tags.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance } from 'fastify';
+import { injectGraphql } from './utils';
+
+export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.get('/popular', async (req, res) => {
+    const query = `{
+  popularTags {
+    name
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => obj['data']['popularTags'],
+      req,
+      res,
+    );
+  });
+
+  fastify.get('/search', async (req, res) => {
+    const query = `{
+  searchTags(query: "${req.query.query}") {
+    query
+    hits {
+      name
+    }
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => obj['data']['searchTags'],
+      req,
+      res,
+    );
+  });
+}

--- a/src/entity/Bookmark.ts
+++ b/src/entity/Bookmark.ts
@@ -2,7 +2,7 @@ import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Post } from './Post';
 
 @Entity()
-@Index('ignored_index', { synchronize: false })
+@Index('IDX_bookmark_userId_createdAt', { synchronize: false })
 export class Bookmark {
   @PrimaryColumn({ type: 'text' })
   @Index()

--- a/src/entity/Post.ts
+++ b/src/entity/Post.ts
@@ -18,7 +18,7 @@ export class Post {
   publishedAt?: Date;
 
   @Column({ default: () => 'now()' })
-  @Index('ignored_index', { synchronize: false })
+  @Index('IDX_post_createdAt', { synchronize: false })
   createdAt: Date;
 
   @Column({ type: 'text' })
@@ -62,7 +62,7 @@ export class Post {
   timeDecay: number;
 
   @Column({ type: 'float' })
-  @Index('ignored_index', { synchronize: false })
+  @Index('IDX_post_score', { synchronize: false })
   score: number;
 
   @Column({ type: 'text', nullable: true })

--- a/src/entity/TagCount.ts
+++ b/src/entity/TagCount.ts
@@ -3,9 +3,10 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 @Entity()
 export class TagCount {
   @PrimaryColumn({ type: 'text' })
+  @Index('IDX_tag_count_tag_search', { synchronize: false })
   tag: string;
 
   @Column()
-  @Index()
+  @Index('IDX_tag_count_count', { synchronize: false })
   count: number;
 }

--- a/src/migration/1588607400115-TagCountIndex.ts
+++ b/src/migration/1588607400115-TagCountIndex.ts
@@ -1,0 +1,44 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class TagCountIndex1588607400115 implements MigrationInterface {
+    name = 'TagCountIndex1588607400115'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."post_tag" DROP CONSTRAINT "FK_f3c0b831daae119196482c99379"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_display" DROP CONSTRAINT "FK_ad5e759962cd86ff322cb480d09"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_feed" DROP CONSTRAINT "FK_4f708e773c1df9c288180fbb555"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" DROP CONSTRAINT "FK_83c8ae07417cd6de65b8b994587"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."bookmark" DROP CONSTRAINT "FK_b0df46b7939819e8bc14cf9f45c"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."view" DROP CONSTRAINT "FK_82db04e5b5686aec67abf4577e9"`, undefined);
+        await queryRunner.query(`DROP INDEX "public"."IDX_9bfb14c3ca97adcf27ad3e6637"`, undefined);
+        await queryRunner.query(`CREATE EXTENSION pg_trgm`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_tag_count_count" ON "public"."tag_count" ("count" DESC)`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_tag_count_tag_search" ON "public"."tag_count" USING gin("tag" gin_trgm_ops)`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post_tag" ADD CONSTRAINT "FK_f3c0b831daae119196482c99379" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_display" ADD CONSTRAINT "FK_ad5e759962cd86ff322cb480d09" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_feed" ADD CONSTRAINT "FK_4f708e773c1df9c288180fbb555" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" ADD CONSTRAINT "FK_83c8ae07417cd6de65b8b994587" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."bookmark" ADD CONSTRAINT "FK_b0df46b7939819e8bc14cf9f45c" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."view" ADD CONSTRAINT "FK_82db04e5b5686aec67abf4577e9" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."view" DROP CONSTRAINT "FK_82db04e5b5686aec67abf4577e9"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."bookmark" DROP CONSTRAINT "FK_b0df46b7939819e8bc14cf9f45c"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" DROP CONSTRAINT "FK_83c8ae07417cd6de65b8b994587"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_feed" DROP CONSTRAINT "FK_4f708e773c1df9c288180fbb555"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_display" DROP CONSTRAINT "FK_ad5e759962cd86ff322cb480d09"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post_tag" DROP CONSTRAINT "FK_f3c0b831daae119196482c99379"`, undefined);
+        await queryRunner.query(`DROP INDEX "IDX_tag_count_count"`, undefined);
+        await queryRunner.query(`DROP INDEX "IDX_tag_count_tag_search"`, undefined);
+        await queryRunner.query(`DROP EXTENSION pg_trgm`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_9bfb14c3ca97adcf27ad3e6637" ON "public"."tag_count" ("count") `, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."view" ADD CONSTRAINT "FK_82db04e5b5686aec67abf4577e9" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."bookmark" ADD CONSTRAINT "FK_b0df46b7939819e8bc14cf9f45c" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" ADD CONSTRAINT "FK_83c8ae07417cd6de65b8b994587" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_feed" ADD CONSTRAINT "FK_4f708e773c1df9c288180fbb555" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source_display" ADD CONSTRAINT "FK_ad5e759962cd86ff322cb480d09" FOREIGN KEY ("sourceId") REFERENCES "public"."source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post_tag" ADD CONSTRAINT "FK_f3c0b831daae119196482c99379" FOREIGN KEY ("postId") REFERENCES "public"."post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+    }
+
+}

--- a/src/schema/feed.ts
+++ b/src/schema/feed.ts
@@ -133,7 +133,7 @@ export enum Ranking {
   TIME = 'TIME',
 }
 
-interface FiltersInput {
+interface GQLFiltersInput {
   includeSources?: string[];
   excludeSources?: string[];
   includeTags?: string[];
@@ -145,7 +145,7 @@ interface FeedArgs extends ConnectionArguments {
 }
 
 interface AnonymousFeedArgs extends FeedArgs {
-  filters?: FiltersInput;
+  filters?: GQLFiltersInput;
 }
 
 interface SourceFeedArgs extends FeedArgs {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -17,7 +17,7 @@ export interface GQLPost {
 
 export const typeDefs = gql`
   """
-  Entity for saving reference to blog posts
+  Blog post
   """
   type Post {
     """

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -1,0 +1,83 @@
+import { gql, IResolvers } from 'apollo-server-fastify';
+import { Context } from '../Context';
+import { traceResolvers } from './trace';
+import { TagCount } from '../entity';
+import { MoreThan, Raw } from 'typeorm';
+
+interface GQLTag {
+  name: string;
+}
+
+interface GQLTagSearchResults {
+  query: string;
+  hits: GQLTag[];
+}
+
+export const typeDefs = gql`
+  """
+  Post tag
+  """
+  type Tag {
+    """
+    The actual text of the tag
+    """
+    name: String!
+  }
+
+  """
+  Tag search results
+  """
+  type TagSearchResults {
+    """
+    Query that was searched
+    """
+    query: String!
+    """
+    Search results
+    """
+    hits: [Tag]!
+  }
+
+  extend type Query {
+    """
+    Get the most popular tags
+    """
+    popularTags: [Tag]
+
+    searchTags(query: String!): TagSearchResults
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const resolvers: IResolvers<any, Context> = traceResolvers({
+  Query: {
+    popularTags: async (source, args, ctx): Promise<GQLTag[]> => {
+      const hits = await ctx.getRepository(TagCount).find({
+        select: ['tag'],
+        where: { count: MoreThan(50) },
+        order: { count: 'DESC' },
+        take: 50,
+      });
+      return hits.map((x) => ({ name: x.tag }));
+    },
+    searchTags: async (
+      source,
+      { query }: { query: string },
+      ctx,
+    ): Promise<GQLTagSearchResults> => {
+      const hits = await ctx.getRepository(TagCount).find({
+        select: ['tag'],
+        where: {
+          count: MoreThan(50),
+          tag: Raw((alias) => `${alias} ILIKE '%${query}%'`),
+        },
+        order: { count: 'DESC' },
+        take: 10,
+      });
+      return {
+        query,
+        hits: hits.map((x) => ({ name: x.tag })),
+      };
+    },
+  },
+});


### PR DESCRIPTION
`popularTags` and `searchTags` are new queries to get the most popular tags and search. Compatibility routes `GET /v1/tags/popular` and `/v1/tags/search` added accordingly.