### PR TITLE
feat: get post by id query

### DIFF
--- a/__tests__/__snapshots__/posts.ts.snap
+++ b/__tests__/__snapshots__/posts.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`compatibility routes GET /posts/:id should return post by id 1`] = `
 Object {
-  "createdAt": "2020-05-05T07:01:31.730Z",
   "id": "p1",
   "image": null,
   "placeholder": null,

--- a/__tests__/__snapshots__/posts.ts.snap
+++ b/__tests__/__snapshots__/posts.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compatibility routes GET /posts/:id should return post by id 1`] = `
+Object {
+  "createdAt": "2020-05-05T07:01:31.730Z",
+  "id": "p1",
+  "image": null,
+  "placeholder": null,
+  "publishedAt": null,
+  "ratio": null,
+  "readTime": null,
+  "tags": Array [
+    "javascript",
+    "webdev",
+  ],
+  "title": "P1",
+  "url": "http://p1.com",
+}
+`;
+
+exports[`query post should return post by id 1`] = `
+Object {
+  "post": Object {
+    "id": "p1",
+    "image": null,
+    "placeholder": null,
+    "ratio": null,
+    "readTime": null,
+    "source": Object {
+      "id": "a",
+      "image": "http://image.com/a",
+      "name": "A",
+      "public": true,
+    },
+    "tags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "title": "P1",
+    "url": "http://p1.com",
+  },
+}
+`;

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1,0 +1,93 @@
+import { FastifyInstance } from 'fastify';
+import { Connection, getConnection } from 'typeorm';
+import { ApolloServer } from 'apollo-server-fastify';
+import {
+  ApolloServerTestClient,
+  createTestClient,
+} from 'apollo-server-testing';
+import * as request from 'supertest';
+
+import createApolloServer from '../src/apollo';
+import { Context } from '../src/Context';
+import { MockContext, saveFixtures, testQueryErrorCode } from './helpers';
+import appFunc from '../src';
+import { Post, PostTag, Source, SourceDisplay } from '../src/entity';
+import { sourcesFixture } from './fixture/source';
+import { sourceDisplaysFixture } from './fixture/sourceDisplay';
+import { postsFixture, postTagsFixture } from './fixture/post';
+
+let app: FastifyInstance;
+let con: Connection;
+let server: ApolloServer;
+let client: ApolloServerTestClient;
+let loggedUser: string = null;
+
+beforeAll(async () => {
+  con = await getConnection();
+  server = await createApolloServer({
+    context: (): Context => new MockContext(con, loggedUser),
+    playground: false,
+  });
+  client = createTestClient(server);
+  app = await appFunc();
+  return app.ready();
+});
+
+beforeEach(async () => {
+  loggedUser = null;
+
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, SourceDisplay, sourceDisplaysFixture);
+  await saveFixtures(con, Post, postsFixture);
+  await saveFixtures(con, PostTag, postTagsFixture);
+});
+
+afterAll(() => app.close());
+
+describe('query post', () => {
+  const QUERY = (id: string): string => `{
+    post(id: "${id}") {
+      id
+      url
+      title
+      image
+      ratio
+      placeholder
+      readTime
+      tags
+      source {
+        id
+        name
+        image
+        public
+      }
+    }
+  }`;
+
+  it('should throw not found when cannot find post', () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY('notfound') },
+      'NOT_FOUND_ERROR',
+    ));
+
+  it('should return post by id', async () => {
+    const res = await client.query({ query: QUERY('p1') });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('compatibility routes', () => {
+  describe('GET /posts/:id', () => {
+    it('should throw not found when cannot find post', () =>
+      request(app.server).get('/v1/posts/invalid').send().expect(404));
+
+    it('should return post by id', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/p1')
+        .send()
+        .expect(200);
+      expect(res.body).toMatchSnapshot();
+    });
+  });
+});

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -6,6 +6,7 @@ import {
   createTestClient,
 } from 'apollo-server-testing';
 import * as request from 'supertest';
+import * as _ from 'lodash';
 
 import createApolloServer from '../src/apollo';
 import { Context } from '../src/Context';
@@ -87,7 +88,7 @@ describe('compatibility routes', () => {
         .get('/v1/posts/p1')
         .send()
         .expect(200);
-      expect(res.body).toMatchSnapshot();
+      expect(_.omit(res.body, ['createdAt'])).toMatchSnapshot();
     });
   });
 });

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -33,6 +33,7 @@ export default async function (config: Config): Promise<ApolloServer> {
       bookmarks.resolvers,
       feed.resolvers,
       notifications.resolvers,
+      posts.resolvers,
       settings.resolvers,
       sourceRequests.resolvers,
       sources.resolvers,

--- a/src/compatibility/posts.ts
+++ b/src/compatibility/posts.ts
@@ -152,4 +152,19 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       res,
     );
   });
+
+  fastify.get('/:id', async (req, res) => {
+    const query = `{
+  post(id: "${req.params.id}") {
+    ${postFields}
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => obj['data']['post'],
+      req,
+      res,
+    );
+  });
 }

--- a/src/compatibility/utils.ts
+++ b/src/compatibility/utils.ts
@@ -42,6 +42,8 @@ export const injectGraphql = async (
     return res.status(401).send();
   } else if (code === 'VALIDATION_ERROR') {
     return res.status(400).send();
+  } else if (code === 'NOT_FOUND_ERROR') {
+    return res.status(404).send();
   } else if (code) {
     return res.status(500).send();
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,3 +24,11 @@ export class ValidationError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+
+export class NotFound extends Error {
+  constructor() {
+    super('Requested entity could not be found');
+    this.name = 'NotFoundError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}


### PR DESCRIPTION
`post` query returns a post by id. Compatibility route `GET /v1/posts/:id` added accordingly