### PR TITLE
feat: mutations to manage feed filters

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`compatibility routes DELETE /feeds/tags should remove existing feed tags filters 1`] = `
+Array [
+  Object {
+    "tag": "html",
+    "userId": "1",
+  },
+]
+`;
+
+exports[`compatibility routes GET /feeds/publications should return feed publications filters 1`] = `
+Array [
+  Object {
+    "enabled": false,
+    "publicationId": "b",
+    "userId": "1",
+  },
+  Object {
+    "enabled": false,
+    "publicationId": "c",
+    "userId": "1",
+  },
+]
+`;
+
+exports[`compatibility routes GET /feeds/tags should return feed tags filters 1`] = `
+Array [
+  Object {
+    "tag": "html",
+    "userId": "1",
+  },
+  Object {
+    "tag": "javascript",
+    "userId": "1",
+  },
+]
+`;
+
 exports[`compatibility routes GET /posts/latest should return anonymous feed filtered by sources 1`] = `
 Array [
   Object {
@@ -76,6 +113,125 @@ Array [
     "id": "p1",
   },
 ]
+`;
+
+exports[`compatibility routes POST /feeds/publications should add new feed publications filters 1`] = `
+Array [
+  Object {
+    "enabled": false,
+    "publicationId": "a",
+    "userId": "1",
+  },
+  Object {
+    "enabled": false,
+    "publicationId": "b",
+    "userId": "1",
+  },
+]
+`;
+
+exports[`compatibility routes POST /feeds/publications should remove existing feed publications filters 1`] = `
+Array [
+  Object {
+    "enabled": false,
+    "publicationId": "c",
+    "userId": "1",
+  },
+]
+`;
+
+exports[`compatibility routes POST /feeds/tags should add new feed tags filters 1`] = `
+Array [
+  Object {
+    "tag": "html",
+    "userId": "1",
+  },
+  Object {
+    "tag": "javascript",
+    "userId": "1",
+  },
+]
+`;
+
+exports[`mutation addFiltersToFeed should add the new feed settings 1`] = `
+Object {
+  "addFiltersToFeed": Object {
+    "excludeSources": Array [
+      Object {
+        "id": "a",
+        "image": "http://image.com/a",
+        "name": "A",
+        "public": true,
+      },
+      Object {
+        "id": "b",
+        "image": "http://image.com/b",
+        "name": "B",
+        "public": true,
+      },
+    ],
+    "id": "1",
+    "includeTags": Array [
+      "javascript",
+      "webdev",
+    ],
+    "userId": "1",
+  },
+}
+`;
+
+exports[`mutation addFiltersToFeed should ignore duplicates 1`] = `
+Object {
+  "addFiltersToFeed": Object {
+    "excludeSources": Array [
+      Object {
+        "id": "a",
+        "image": "http://image.com/a",
+        "name": "A",
+        "public": true,
+      },
+      Object {
+        "id": "b",
+        "image": "http://image.com/b",
+        "name": "B",
+        "public": true,
+      },
+      Object {
+        "id": "c",
+        "image": "http://image.com/c",
+        "name": "C",
+        "public": true,
+      },
+    ],
+    "id": "1",
+    "includeTags": Array [
+      "html",
+      "javascript",
+      "webdev",
+    ],
+    "userId": "1",
+  },
+}
+`;
+
+exports[`mutation removeFiltersFromFeed should remove existing filters 1`] = `
+Object {
+  "removeFiltersFromFeed": Object {
+    "excludeSources": Array [
+      Object {
+        "id": "c",
+        "image": "http://image.com/c",
+        "name": "C",
+        "public": true,
+      },
+    ],
+    "id": "1",
+    "includeTags": Array [
+      "html",
+    ],
+    "userId": "1",
+  },
+}
 `;
 
 exports[`query anonymousFeed should return anonymous feed filtered by sources 1`] = `
@@ -554,8 +710,8 @@ Object {
     ],
     "id": "1",
     "includeTags": Array [
+      "html",
       "javascript",
-      "webdev",
     ],
     "userId": "1",
   },

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -5,7 +5,7 @@ import { snakeCase } from 'snake-case';
 
 import * as common from './schema/common';
 import * as bookmarks from './schema/bookmarks';
-import * as feed from './schema/feed';
+import * as feed from './schema/feeds';
 import * as notifications from './schema/notifications';
 import * as posts from './schema/posts';
 import * as settings from './schema/settings';

--- a/src/compatibility/feeds.ts
+++ b/src/compatibility/feeds.ts
@@ -1,0 +1,148 @@
+import { FastifyInstance, FastifyReply } from 'fastify';
+import { upperFirst } from 'lodash';
+import { injectGraphql } from './utils';
+import { GQLFeedSettings } from '../schema/feeds';
+import { ServerResponse } from 'http';
+
+interface Publication {
+  publicationId: string;
+  userId?: string;
+  enabled: boolean;
+}
+
+interface Tag {
+  userId?: string;
+  tag: string;
+}
+
+const mapFeedToPublications = (feed: GQLFeedSettings): Publication[] =>
+  feed.excludeSources.map((s) => ({
+    userId: feed.userId,
+    publicationId: s.id,
+    enabled: false,
+  }));
+
+const mapFeedToTags = (feed: GQLFeedSettings): Tag[] =>
+  feed.includeTags.map((t) => ({
+    userId: feed.userId,
+    tag: t,
+  }));
+
+export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.get('/publications', async (req, res) => {
+    const query = `{
+  feedSettings {
+    userId
+    excludeSources {
+      id
+    }
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => mapFeedToPublications(obj['data']['feedSettings']),
+      req,
+      res,
+    );
+  });
+
+  fastify.post('/publications', async (req, res) => {
+    const updateFilters = (
+      mutation: string,
+      pubs: Publication[],
+    ): Promise<FastifyReply<ServerResponse>> => {
+      const query = `
+  mutation ${upperFirst(mutation)}($filters: FiltersInput!) {
+    ${mutation}(filters: $filters) {
+      userId
+      excludeSources {
+        id
+      }
+    }
+  }`;
+      return injectGraphql(
+        fastify,
+        {
+          query,
+          variables: {
+            filters: { excludeSources: pubs.map((p) => p.publicationId) },
+          },
+        },
+        (obj) => mapFeedToPublications(obj['data'][mutation]),
+        req,
+        res,
+      );
+    };
+
+    const pubs = req.body as Publication[];
+    const add = pubs.filter((p) => !p.enabled);
+    if (add.length) {
+      return updateFilters('addFiltersToFeed', add);
+    }
+    const remove = pubs.filter((p) => p.enabled);
+    return updateFilters('removeFiltersFromFeed', remove);
+  });
+
+  fastify.get('/tags', async (req, res) => {
+    const query = `{
+  feedSettings {
+    userId
+    includeTags
+  }
+}`;
+    return injectGraphql(
+      fastify,
+      { query },
+      (obj) => mapFeedToTags(obj['data']['feedSettings']),
+      req,
+      res,
+    );
+  });
+
+  fastify.post('/tags', async (req, res) => {
+    const query = `
+  mutation AddFiltersToFeed($filters: FiltersInput!) {
+    addFiltersToFeed(filters: $filters) {
+      userId
+      includeTags
+    }
+  }`;
+    const tags = req.body as Tag[];
+    return injectGraphql(
+      fastify,
+      {
+        query,
+        variables: {
+          filters: { includeTags: tags.map((t) => t.tag) },
+        },
+      },
+      (obj) => mapFeedToTags(obj['data']['addFiltersToFeed']),
+      req,
+      res,
+    );
+  });
+
+  fastify.delete('/tags', async (req, res) => {
+    const query = `
+  mutation RemoveFiltersFromFeed($filters: FiltersInput!) {
+    removeFiltersFromFeed(filters: $filters) {
+      userId
+      includeTags
+    }
+  }`;
+    const tags = req.body as Tag[];
+    return injectGraphql(
+      fastify,
+      {
+        query,
+        variables: {
+          filters: { includeTags: tags.map((t) => t.tag) },
+        },
+      },
+      (obj) => mapFeedToTags(obj['data']['removeFiltersFromFeed']),
+      req,
+      res,
+    );
+  });
+}

--- a/src/compatibility/index.ts
+++ b/src/compatibility/index.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
+import feeds from './feeds';
 import notifications from './notifications';
 import posts from './posts';
 import publications from './publications';
@@ -7,6 +8,7 @@ import settings from './settings';
 import tags from './tags';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.register(feeds, { prefix: '/feeds' });
   fastify.register(notifications, { prefix: '/notifications' });
   fastify.register(posts, { prefix: '/posts' });
   fastify.register(publications, { prefix: '/publications' });


### PR DESCRIPTION
Add two mutations to add and remove filters from user's feed. Compatibility routes added accordingly as well.