### PR TITLE
feat: feed query to fetch preconfigured feed

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -90,6 +90,17 @@ Array [
 ]
 `;
 
+exports[`compatibility routes GET /posts/latest should return preconfigured feed when logged-in 1`] = `
+Array [
+  Object {
+    "id": "p4",
+  },
+  Object {
+    "id": "p1",
+  },
+]
+`;
+
 exports[`compatibility routes GET /posts/publication should return single source feed 1`] = `
 Array [
   Object {
@@ -685,6 +696,326 @@ Object {
     ],
     "pageInfo": Object {
       "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return feed with preconfigured filters 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return preconfigured feed with no filters 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return preconfigured feed with sources filters only 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return preconfigured feed with tags filters only 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return unread posts from preconfigured feed 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p5",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [
+            "html",
+            "javascript",
+          ],
+          "title": "P5",
+          "url": "http://p5.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p2",
+          "readTime": null,
+          "source": Object {
+            "id": "b",
+            "image": "http://image.com/b",
+            "name": "B",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P2",
+          "url": "http://p2.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p3",
+          "readTime": null,
+          "source": Object {
+            "id": "c",
+            "image": "http://image.com/c",
+            "name": "C",
+            "public": true,
+          },
+          "tags": Array [],
+          "title": "P3",
+          "url": "http://p3.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjM=",
       "hasNextPage": false,
     },
   },

--- a/src/compatibility/utils.ts
+++ b/src/compatibility/utils.ts
@@ -4,7 +4,7 @@ import { ServerResponse } from 'http';
 import { generateTraceContext } from '@google-cloud/trace-agent/build/src/util';
 import { Constants } from '@google-cloud/trace-agent/build/src/constants';
 
-interface GraphqlPayload {
+export interface GraphqlPayload {
   query: string;
   operationName?: string;
   variables?: object;


### PR DESCRIPTION
`feed` query fetches a preconfigured feed. Compatibility route `/v1/posts/latest` updated to return preconfigured feed when logged-in.