### PR TITLE
fix(compat): POST /publications/request body schema

### DIFF
--- a/__tests__/sourceRequests.ts
+++ b/__tests__/sourceRequests.ts
@@ -397,7 +397,7 @@ describe('compatibility routes', () => {
     it('should not authorize when not logged in', () => {
       return request(app.server)
         .post('/v1/publications/request')
-        .send({ url: 'http://source.com' })
+        .send({ source: 'http://source.com' })
         .expect(401);
     });
 
@@ -406,7 +406,7 @@ describe('compatibility routes', () => {
       return authorizeRequest(
         request(app.server).post('/v1/publications/request'),
       )
-        .send({ url: 'invalid' })
+        .send({ source: 'invalid' })
         .expect(400);
     });
 
@@ -415,7 +415,7 @@ describe('compatibility routes', () => {
       return authorizeRequest(
         request(app.server).post('/v1/publications/request'),
       )
-        .send({ url: 'http://source.com' })
+        .send({ source: 'http://source.com' })
         .expect(204);
     });
 
@@ -424,7 +424,7 @@ describe('compatibility routes', () => {
       return authorizeRequest(
         request(app.server).post('/v1/publications/requests'),
       )
-        .send({ url: 'http://source.com' })
+        .send({ source: 'http://source.com' })
         .expect(204);
     });
   });

--- a/src/compatibility/publications.ts
+++ b/src/compatibility/publications.ts
@@ -46,7 +46,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
     return injectGraphql(
       fastify,
-      { query, variables: { data: { sourceUrl: req.body.url } } },
+      { query, variables: { data: { sourceUrl: req.body.source } } },
       () => undefined,
       req,
       res,


### PR DESCRIPTION
The correct body schema for the source request is `{source: ''}'`