### PR TITLE
fix: use algolia offset/length pagination

### DIFF
--- a/src/common/algolia.ts
+++ b/src/common/algolia.ts
@@ -18,9 +18,9 @@ export const getPostsIndex = (): SearchIndex => {
 };
 
 export const trackSearch = (
-  trackingId: string,
+  trackingId: string | undefined,
   ip: string,
 ): Readonly<Record<string, string>> => ({
-  'X-Algolia-UserToken': trackingId,
   'X-Forwarded-For': ip,
+  ...(trackingId ? { 'X-Algolia-UserToken': trackingId } : {}),
 });

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -337,7 +337,7 @@ export const searchPostFeedBuilder = async (
     {
       filters: `createdAt < ${now.getTime()}`,
       offset,
-      hitsPerPage: clampedLimit,
+      length: clampedLimit,
       attributesToRetrieve: ['objectID'],
     },
     ctx.userId,


### PR DESCRIPTION
There are two ways to do pagination with Algolia page/hitsPerPage or offset/length, before we were mixing the two which caused wrong pagination.