### PR TITLE
refactor: change permissions for bookmark list field

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -97,7 +97,7 @@ export const typeDefs = gql`
     """
     If bookmarked, this is the list where it is saved
     """
-    bookmarkList: BookmarkList @auth(premium: true)
+    bookmarkList: BookmarkList
   }
 
   type PostConnection {


### PR DESCRIPTION
Remove the premium authorization for the bookmark list field as it breaks every query that request this field.
Instead just return null when not premium.