### PR TITLE
fix: allow access to posts of a private source

### DIFF
--- a/__tests__/__snapshots__/posts.ts.snap
+++ b/__tests__/__snapshots__/posts.ts.snap
@@ -6,6 +6,12 @@ Object {
 }
 `;
 
+exports[`compatibility routes GET /posts/:id should return private post by id 1`] = `
+Object {
+  "id": "p6",
+}
+`;
+
 exports[`compatibility routes POST /posts/:id/hide should hide the post 1`] = `
 Array [
   HiddenPost {

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -44,6 +44,14 @@ export const postsFixture: DeepPartial<Post>[] = [
     sourceId: 'b',
     createdAt: new Date(now.getTime() - 4000),
   },
+  {
+    id: 'p6',
+    title: 'P6',
+    url: 'http://p6.com',
+    score: 10,
+    sourceId: 'p',
+    createdAt: new Date(now.getTime() - 5000),
+  },
 ];
 
 export const postTagsFixture: DeepPartial<PostTag>[] = [

--- a/__tests__/fixture/source.ts
+++ b/__tests__/fixture/source.ts
@@ -5,4 +5,5 @@ export const sourcesFixture: DeepPartial<Source>[] = [
   { id: 'a' },
   { id: 'b' },
   { id: 'c' },
+  { id: 'p' },
 ];

--- a/__tests__/fixture/sourceDisplay.ts
+++ b/__tests__/fixture/sourceDisplay.ts
@@ -5,4 +5,11 @@ export const sourceDisplaysFixture: DeepPartial<SourceDisplay>[] = [
   { sourceId: 'a', name: 'A', image: 'http://image.com/a', enabled: true },
   { sourceId: 'b', name: 'B', image: 'http://image.com/b', enabled: true },
   { sourceId: 'c', name: 'C', image: 'http://image.com/c', enabled: true },
+  {
+    sourceId: 'p',
+    name: 'Private',
+    image: 'http://image.com/p',
+    enabled: true,
+    userId: '2',
+  },
 ];

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -443,6 +443,14 @@ describe('compatibility routes', () => {
         .expect(200);
       expect(_.pick(res.body, ['id'])).toMatchSnapshot();
     });
+
+    it('should return private post by id', async () => {
+      const res = await request(app.server)
+        .get('/v1/posts/p6')
+        .send()
+        .expect(200);
+      expect(_.pick(res.body, ['id'])).toMatchSnapshot();
+    });
   });
 
   describe('POST /posts/:id/hide', () => {

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -183,7 +183,6 @@ export const generateFeed = async (
       .innerJoin(
         (subBuilder) => selectSource(ctx.userId, subBuilder),
         'source',
-        // TODO: add test case with private source that not belongs to the user
         'source."sourceId" = post."sourceId"',
       )
       .limit(clampLimit)

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -444,7 +444,6 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         .innerJoin(
           (subBuilder) => selectSource(ctx.userId, subBuilder),
           'source',
-          // TODO: add test case with private source that not belongs to the user
           'source."sourceId" = feed."sourceId"',
         )
         .where('feed.feedId = :feedId', { feedId: source.id })


### PR DESCRIPTION
Allow access to any post by id. Currently, there is nothing personal in posts of private sources.
This commit fixes the issue of throwing 404 when trying to navigate to posts of private sources.

Closes #109