### PR TITLE
fix: complete adding private source even if superfeedr fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
       "graphql-upload": "^10.0.0",
       "lodash": "^4.17.15",
       "node-fetch": "^2.6.0",
+      "p-retry": "^4.2.0",
       "pg": "^8.0.2",
       "reflect-metadata": "^0.1.13",
       "rss": "^1.2.2",


### PR DESCRIPTION
In case superfeedr fails while adding a private source, the request still has to succeed.
If it fails, an error log should be written so a manual action can be taken to fix this issue.

Closes #105