### PR TITLE
refactor: keep created at when adding bookmarks to list

### DIFF
--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -153,7 +153,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         .into(Bookmark)
         .values([{ userId: ctx.userId, postId: id, listId }])
         .onConflict(
-          `("postId", "userId") DO UPDATE SET "listId" = EXCLUDED."listId", "createdAt" = now()`,
+          `("postId", "userId") DO UPDATE SET "listId" = EXCLUDED."listId"`,
         )
         .execute();
       return { _: true };


### PR DESCRIPTION
Before this commit the created at field was updated upon changing the bookmark list.
Now it remains the same so it will not affect the order of the bookmarks.