### PR TITLE
refactor: update tags discovery mechanism

### DIFF
--- a/__tests__/__snapshots__/tags.ts.snap
+++ b/__tests__/__snapshots__/tags.ts.snap
@@ -11,6 +11,12 @@ Array [
   Object {
     "name": "webdev",
   },
+  Object {
+    "name": "golang",
+  },
+  Object {
+    "name": "rust",
+  },
 ]
 `;
 
@@ -39,6 +45,12 @@ Object {
     },
     Object {
       "name": "webdev",
+    },
+    Object {
+      "name": "golang",
+    },
+    Object {
+      "name": "rust",
     },
   ],
 }

--- a/__tests__/__snapshots__/updateTags.ts.snap
+++ b/__tests__/__snapshots__/updateTags.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should update tags count of posts from the last 30 days 1`] = `
+exports[`should update tags count of posts from the last 180 days 1`] = `
 Array [
   TagCount {
     "count": 1,

--- a/__tests__/updateTags.ts
+++ b/__tests__/updateTags.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
   await saveFixtures(con, PostTag, postTagsFixture);
 });
 
-it('should update tags count of posts from the last 30 days', async () => {
+it('should update tags count of posts from the last 180 days', async () => {
   const now = new Date();
   await saveFixtures(con, Post, [
     {
@@ -27,7 +27,7 @@ it('should update tags count of posts from the last 30 days', async () => {
       url: 'http://p100.com',
       score: 0,
       sourceId: 'a',
-      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 50),
+      createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 200),
     },
   ]);
   await saveFixtures(con, PostTag, [

--- a/helm/daily-api/templates/cronjobs.yaml
+++ b/helm/daily-api/templates/cronjobs.yaml
@@ -60,7 +60,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "7 1 * * *"
+  schedule: "33 3 * * 0"
   jobTemplate:
     spec:
       template:

--- a/src/cron/updateTags.ts
+++ b/src/cron/updateTags.ts
@@ -9,7 +9,7 @@ const cron: Cron = {
                                  SELECT t.tag tag, COUNT(*) count
                                  FROM "post_tag" t
                                         JOIN post p on t."postId" = p.id
-                                 WHERE EXTRACT(EPOCH FROM now() - p."createdAt")/86400 < 30
+                                 WHERE EXTRACT(EPOCH FROM now() - p."createdAt")/86400 < 180
                                  GROUP BY t.tag`);
     }),
 };

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -54,7 +54,6 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     popularTags: async (source, args, ctx): Promise<GQLTag[]> => {
       const hits = await ctx.getRepository(TagCount).find({
         select: ['tag'],
-        where: { count: MoreThan(50) },
         order: { count: 'DESC' },
         take: 50,
       });
@@ -68,11 +67,11 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       const hits = await ctx.getRepository(TagCount).find({
         select: ['tag'],
         where: {
-          count: MoreThan(50),
+          count: MoreThan(10),
           tag: Raw((alias) => `${alias} ILIKE '%${query}%'`),
         },
         order: { count: 'DESC' },
-        take: 10,
+        take: 50,
       });
       return {
         query,


### PR DESCRIPTION
Tags count table is now calculated every week and takes into account posts of the last 180 days.
The threshold for finding a tag was lowered to 10 posts from 50.
These changes should enable better discovery of tags.

Closes dailydotdev/daily#166