### PR TITLE
refactor: pagination optimization

### DIFF
--- a/__tests__/__snapshots__/bookmarks.ts.snap
+++ b/__tests__/__snapshots__/bookmarks.ts.snap
@@ -83,7 +83,6 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       "hasNextPage": true,
     },
   },
@@ -123,7 +122,6 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       "hasNextPage": true,
     },
   },
@@ -166,7 +164,6 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       "hasNextPage": true,
     },
   },

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -321,7 +321,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjM=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -370,7 +370,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -438,7 +438,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -499,7 +499,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "endCursor": "c2NvcmU6NA==",
       "hasNextPage": false,
     },
   },
@@ -597,7 +597,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -695,7 +695,6 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
       "hasNextPage": false,
     },
   },
@@ -745,7 +744,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -843,7 +842,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjQ=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },
@@ -904,7 +903,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "endCursor": "c2NvcmU6NA==",
       "hasNextPage": false,
     },
   },
@@ -935,7 +934,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+      "endCursor": "c2NvcmU6MTA=",
       "hasNextPage": false,
     },
   },
@@ -1015,7 +1014,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjM=",
+      "endCursor": "c2NvcmU6Mw==",
       "hasNextPage": false,
     },
   },
@@ -1148,7 +1147,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "endCursor": "c2NvcmU6Nw==",
       "hasNextPage": false,
     },
   },
@@ -1216,7 +1215,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
+      "endCursor": "c2NvcmU6MA==",
       "hasNextPage": false,
     },
   },

--- a/__tests__/bookmarks.ts
+++ b/__tests__/bookmarks.ts
@@ -467,6 +467,7 @@ describe('query bookmarks', () => {
     loggedUser = '1';
     await saveFixtures(con, Bookmark, bookmarksFixture);
     const res = await client.query({ query: QUERY(false, null, now, 2) });
+    delete res.data.bookmarksFeed.pageInfo.endCursor;
     expect(res.data).toMatchSnapshot();
   });
 
@@ -475,6 +476,7 @@ describe('query bookmarks', () => {
     await saveFixtures(con, Bookmark, bookmarksFixture);
     await con.getRepository(View).save([{ userId: '1', postId: 'p3' }]);
     const res = await client.query({ query: QUERY(true, null, now, 2) });
+    delete res.data.bookmarksFeed.pageInfo.endCursor;
     expect(res.data).toMatchSnapshot();
   });
 
@@ -495,6 +497,7 @@ describe('query bookmarks', () => {
       { listId: list.id },
     );
     const res = await client.query({ query: QUERY(false, list.id, now, 2) });
+    delete res.data.bookmarksFeed.pageInfo.endCursor;
     expect(res.data).toMatchSnapshot();
   });
 });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -122,6 +122,7 @@ describe('query anonymousFeed', () => {
 
   it('should return anonymous feed with no filters ordered by time', async () => {
     const res = await client.query({ query: QUERY(Ranking.TIME) });
+    delete res.data.anonymousFeed.pageInfo.endCursor;
     expect(res.data).toMatchSnapshot();
   });
 

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -16,7 +16,12 @@ import {
 } from '../entity';
 import { GQLPost } from '../schema/posts';
 import { Context } from '../Context';
-import { forwardPagination, PaginationResponse } from '../schema/common';
+import {
+  forwardPagination,
+  Page,
+  PageGenerator,
+  PaginationResponse,
+} from '../schema/common';
 
 export const nestChild = (obj: object, prefix: string): object => {
   obj[prefix] = Object.keys(obj).reduce((acc, key) => {
@@ -136,44 +141,26 @@ export enum Ranking {
 }
 
 export interface FeedOptions {
-  now: Date;
   ranking: Ranking;
 }
 
 export type FeedArgs = ConnectionArguments & FeedOptions;
 
-export const applyFeedOptions = (
-  builder: SelectQueryBuilder<Post>,
-  { now, ranking }: FeedOptions,
-): SelectQueryBuilder<Post> =>
-  builder
-    .where('post.createdAt < :now', { now })
-    .orderBy(
-      ranking === Ranking.POPULARITY ? 'post.score' : 'post.createdAt',
-      'DESC',
-    );
-
-export const generateFeed = async (
+export const generateFeed = async <TPage extends Page>(
   ctx: Context,
-  limit: number,
-  offset: number,
   query: (builder: SelectQueryBuilder<Post>) => SelectQueryBuilder<Post>,
 ): Promise<PaginationResponse<GQLPost>> => {
-  const clampLimit = Math.min(limit, 50);
-  let builder = query(
-    ctx.con
-      .createQueryBuilder()
-      .select('post.*')
-      .addSelect('source.*')
-      .from(Post, 'post')
-      .innerJoin(
-        (subBuilder) => selectSource(ctx.userId, subBuilder),
-        'source',
-        'source."sourceId" = post."sourceId"',
-      )
-      .limit(clampLimit)
-      .offset(offset),
-  );
+  let builder = ctx.con
+    .createQueryBuilder()
+    .select('post.*')
+    .addSelect('source.*')
+    .from(Post, 'post')
+    .innerJoin(
+      (subBuilder) => selectSource(ctx.userId, subBuilder),
+      'source',
+      'source."sourceId" = post."sourceId"',
+    );
+  builder = query(builder);
   if (ctx.userId) {
     builder = builder
       .addSelect(selectRead(ctx.userId, builder.subQuery()), 'read')
@@ -204,16 +191,24 @@ export const generateFeed = async (
   }
   const res = await builder.getRawMany();
 
-  return {
-    hasNextPage: res.length === clampLimit,
-    nodes: res.map(mapRawPost),
-  };
+  return { nodes: res.map(mapRawPost) };
 };
 
-export function feedResolver<TSource, TArgs extends ConnectionArguments>(
+export function feedResolver<
+  TSource,
+  TArgs extends ConnectionArguments,
+  TPage extends Page
+>(
   query: (
     ctx: Context,
     args: TArgs,
+    builder: SelectQueryBuilder<Post>,
+  ) => SelectQueryBuilder<Post>,
+  pageGenerator: PageGenerator<GQLPost, TArgs, TPage>,
+  applyPaging: (
+    ctx: Context,
+    args: TArgs,
+    page: TPage,
     builder: SelectQueryBuilder<Post>,
   ) => SelectQueryBuilder<Post>,
 ): IFieldResolver<TSource, Context, TArgs> {
@@ -222,13 +217,12 @@ export function feedResolver<TSource, TArgs extends ConnectionArguments>(
       source,
       args: TArgs,
       ctx,
-      { limit, offset },
-    ): Promise<PaginationResponse<GQLPost>> => {
-      return generateFeed(ctx, limit, offset, (builder) =>
-        query(ctx, args, builder),
-      );
-    },
-    30,
+      page,
+    ): Promise<PaginationResponse<GQLPost>> =>
+      generateFeed(ctx, (builder) =>
+        applyPaging(ctx, args, page, query(ctx, args, builder)),
+      ),
+    pageGenerator,
   );
 }
 
@@ -244,11 +238,10 @@ export interface AnonymousFeedFilters {
 
 export const anonymousFeedBuilder = (
   ctx: Context,
-  { now, ranking }: FeedOptions,
   filters: AnonymousFeedFilters,
   builder: SelectQueryBuilder<Post>,
 ): SelectQueryBuilder<Post> => {
-  let newBuilder = applyFeedOptions(builder, { now, ranking });
+  let newBuilder = builder;
   if (filters?.includeSources?.length) {
     newBuilder = newBuilder.andWhere(`post.sourceId IN (:...sources)`, {
       sources: filters.includeSources,
@@ -268,12 +261,11 @@ export const anonymousFeedBuilder = (
 
 export const configuredFeedBuilder = (
   ctx: Context,
-  { now, ranking }: FeedOptions,
   feedId: string,
   unreadOnly: boolean,
   builder: SelectQueryBuilder<Post>,
 ): SelectQueryBuilder<Post> => {
-  let newBuilder = applyFeedOptions(builder, { now, ranking });
+  let newBuilder = builder;
   newBuilder = newBuilder
     .andWhere((subBuilder) => whereSourcesInFeed(feedId, subBuilder))
     .andWhere((subBuilder) => whereTagsInFeed(feedId, subBuilder));
@@ -287,15 +279,13 @@ export const configuredFeedBuilder = (
 
 export const bookmarksFeedBuilder = (
   ctx: Context,
-  now: Date,
   unreadOnly: boolean,
   listId: string | null,
   builder: SelectQueryBuilder<Post>,
 ): SelectQueryBuilder<Post> => {
   let newBuilder = builder
-    .where('bookmark.postId IS NOT NULL')
-    .andWhere('bookmark.createdAt <= :now', { now })
-    .orderBy('bookmark.createdAt', 'DESC');
+    .addSelect('bookmark.createdAt', 'bookmarkedAt')
+    .where('bookmark.postId IS NOT NULL');
   if (unreadOnly) {
     newBuilder = newBuilder.andWhere((subBuilder) =>
       whereUnread(ctx.userId, subBuilder),
@@ -309,46 +299,38 @@ export const bookmarksFeedBuilder = (
 
 export const sourceFeedBuilder = (
   ctx: Context,
-  { now, ranking }: FeedOptions,
   sourceId: string,
   builder: SelectQueryBuilder<Post>,
 ): SelectQueryBuilder<Post> =>
-  applyFeedOptions(builder, {
-    now,
-    ranking,
-  }).andWhere(`post.sourceId = :sourceId`, { sourceId });
+  builder.andWhere(`post.sourceId = :sourceId`, {
+    sourceId,
+  });
 
 export const tagFeedBuilder = (
   ctx: Context,
-  { now, ranking }: FeedOptions,
   tag: string,
   builder: SelectQueryBuilder<Post>,
 ): SelectQueryBuilder<Post> =>
-  applyFeedOptions(builder, {
-    now,
-    ranking,
-  }).andWhere((subBuilder) => whereTags([tag], subBuilder));
+  builder.andWhere((subBuilder) => whereTags([tag], subBuilder));
 
 export const searchPostFeedBuilder = async (
   source,
-  { query, now }: FeedArgs & { query: string },
+  { query }: FeedArgs & { query: string },
   ctx,
   { limit, offset },
 ): Promise<PaginationResponse<GQLPost, { query: string }>> => {
-  const clampedLimit = Math.min(limit, 50);
   const hits = await searchPosts(
     query,
     {
-      filters: `createdAt < ${now.getTime()}`,
       offset,
-      length: clampedLimit,
+      length: limit,
       attributesToRetrieve: ['objectID'],
     },
     ctx.userId,
     ctx.req.ip,
   );
   const postIds = hits.map((h) => h.id);
-  const res = await generateFeed(ctx, clampedLimit, 0, (builder) =>
+  const res = await generateFeed(ctx, (builder) =>
     builder.where('post.id IN (:...postIds)', { postIds }),
   );
   const sorted = res.nodes.sort(
@@ -356,7 +338,6 @@ export const searchPostFeedBuilder = async (
   );
   return {
     nodes: sorted,
-    hasNextPage: res.hasNextPage,
     extra: { query },
   };
 };

--- a/src/common/pagination.ts
+++ b/src/common/pagination.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo, SelectionNode, FieldNode } from 'graphql';
 import { FieldNodeInfo } from '@mando75/typeorm-graphql-loader/dist/types';
+import { unbase64 } from './base64';
 
 /**
  * Finds a single node in the GraphQL AST to return the feed info for
@@ -25,3 +26,10 @@ export const getFieldNodeInfo = (
 
 export const getRelayNodeInfo = (info: GraphQLResolveInfo): FieldNodeInfo =>
   getFieldNodeInfo(getFieldNodeInfo(info, 'edges'), 'node');
+
+export const getCursorFromAfter = (after?: string): string => {
+  if (!after) {
+    return null;
+  }
+  return unbase64(after).split(':')[1];
+};

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -7,6 +7,7 @@ import { generateFeed, notifyPostReport } from '../common';
 import { HiddenPost, Post } from '../entity';
 import { GQLEmptyResponse } from './common';
 import { NotFoundError } from '../errors';
+import { GQLBookmarkList } from './bookmarks';
 
 export interface GQLPost {
   id: string;
@@ -22,6 +23,10 @@ export interface GQLPost {
   tags?: string[];
   read?: boolean;
   bookmarked?: boolean;
+  bookmarkList?: GQLBookmarkList;
+  // Used only for pagination (not part of the schema)
+  score: number;
+  bookmarkedAt: Date;
 }
 
 export const typeDefs = gql`
@@ -216,8 +221,8 @@ export const resolvers: IResolvers<any, Context> = {
       { id }: { id: string },
       ctx: Context,
     ): Promise<GQLPost> => {
-      const feed = await generateFeed(ctx, 1, 0, (builder) =>
-        builder.where('post.id = :id', { id }),
+      const feed = await generateFeed(ctx, (builder) =>
+        builder.where('post.id = :id', { id }).limit(1),
       );
       if (feed.nodes.length) {
         return feed.nodes[0];

--- a/src/schema/sourceRequests.ts
+++ b/src/schema/sourceRequests.ts
@@ -6,6 +6,7 @@ import {
   GQLDataInput,
   GQLDataIdInput,
   GQLIdInput,
+  offsetPageGenerator,
 } from './common';
 import { traceResolvers } from './trace';
 import { Context } from '../Context';
@@ -448,11 +449,11 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           { order: { '"createdAt"': 'ASC' } },
         );
         return {
-          count: total,
+          total,
           nodes: rows,
         };
       },
-      100,
+      offsetPageGenerator(100, 500),
     ),
   },
 });

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -6,7 +6,12 @@ import pRetry from 'p-retry';
 import { traceResolvers } from './trace';
 import { Context } from '../Context';
 import { SourceDisplay, Source, SourceFeed } from '../entity';
-import { forwardPagination, PaginationResponse, GQLDataInput } from './common';
+import {
+  forwardPagination,
+  PaginationResponse,
+  GQLDataInput,
+  offsetPageGenerator,
+} from './common';
 import { addOrRemoveSuperfeedrSubscription } from '../common';
 
 export interface GQLSource {
@@ -164,11 +169,10 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           .getRawMany();
 
         return {
-          hasNextPage: res.length === limit,
           nodes: res.map(sourceFromDisplay),
         };
       },
-      100,
+      offsetPageGenerator(100, 500),
     ),
     sourceByFeed: async (
       _,


### PR DESCRIPTION
To boost performance, I reimplemented the pagination mechanism to use `where` instead of `offset`.
`where` clause can utilize indexes and increase drastically the performance of the query compared to the traditional `offset` implementation.
This implementation is backward compatible thanks to the cursor pagination that is already implemented in the client.