### PR TITLE
refactor: migrate feed settings to graphorm

### DIFF
--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -1,5 +1,4 @@
 import { SelectQueryBuilder } from 'typeorm';
-import { lowerFirst } from 'lodash';
 import { Connection, ConnectionArguments } from 'graphql-relay';
 import { IFieldResolver } from 'apollo-server-fastify';
 import {
@@ -17,41 +16,6 @@ import { GQLPost } from '../schema/posts';
 import { Context } from '../Context';
 import { Page, PageGenerator } from '../schema/common';
 import graphorm from '../graphorm';
-
-export const nestChild = (obj: object, prefix: string): object => {
-  obj[prefix] = Object.keys(obj).reduce((acc, key) => {
-    if (key.startsWith(prefix)) {
-      const value = obj[key];
-      delete obj[key];
-      return { [lowerFirst(key.substr(prefix.length))]: value, ...acc };
-    }
-    return acc;
-  }, {});
-  return obj;
-};
-
-export const selectSource = (
-  userId: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  builder: SelectQueryBuilder<any>,
-): SelectQueryBuilder<SourceDisplay> => {
-  let newBuilder = builder
-    .distinctOn(['sd.sourceId'])
-    .addSelect('sd.sourceId', 'sourceId')
-    .addSelect('sd.name', 'sourceName')
-    .addSelect('sd.image', 'sourceImage')
-    .addSelect('sd.userId IS NULL', 'sourcePublic')
-    .from(SourceDisplay, 'sd')
-    .orderBy('sd.sourceId')
-    .addOrderBy('sd.userId', 'ASC', 'NULLS LAST')
-    .where('sd.userId IS NULL');
-  if (userId) {
-    newBuilder = newBuilder.orWhere('sd.userId = :userId', {
-      userId,
-    });
-  }
-  return newBuilder;
-};
 
 export const whereTags = (
   tags: string[],

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -114,7 +114,7 @@ export class GraphORM {
       this.mappings?.[type]?.fields?.[field.name]?.relation ||
       this.findRelation(metadata, ctx.con.getMetadata(childType));
     if (!relation) {
-      throw new Error('Could not find relation');
+      throw new Error(`Could not find relation ${type}.${field.name}`);
     }
     const select = relation.isMany
       ? `coalesce(jsonb_agg(res), '[]'::jsonb)`
@@ -208,7 +208,7 @@ export class GraphORM {
       const { select } = mapping;
       if (select) {
         if (typeof select === 'string') {
-          return builder.addSelect(select, field.alias);
+          return builder.addSelect(`"${alias}"."${select}"`, field.alias);
         }
         return builder.addSelect(
           (subBuilder) => select(ctx, alias, subBuilder),

--- a/src/routes/rss.ts
+++ b/src/routes/rss.ts
@@ -10,7 +10,6 @@ import rateLimit from 'fastify-rate-limit';
 import RSS from 'rss';
 import {
   fetchUser,
-  selectSource,
   User,
   whereSourcesInFeed,
   whereTagsInFeed,
@@ -129,11 +128,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       (req, user, builder) =>
         builder
           .addSelect('post."createdAt"', 'publishedAt')
-          .innerJoin(
-            (subBuilder) => selectSource(user.id, subBuilder),
-            'source',
-            'source."sourceId" = post."sourceId"',
-          )
           .where((subBuilder) =>
             whereSourcesInFeed(req.params.feedId, subBuilder),
           )


### PR DESCRIPTION
Use GraphORM to fetch the user`s feed settings in one almighty resolver