### PR TITLE
feat: send pubsub event when new comment is featured

### DIFF
--- a/__tests__/__snapshots__/updateFeaturedComments.ts.snap
+++ b/__tests__/__snapshots__/updateFeaturedComments.ts.snap
@@ -3,11 +3,11 @@
 exports[`should update featured comments 1`] = `
 Array [
   Comment {
-    "featured": false,
+    "featured": true,
     "id": "c1",
   },
   Comment {
-    "featured": false,
+    "featured": true,
     "id": "c2",
   },
   Comment {
@@ -22,5 +22,16 @@ Array [
     "featured": true,
     "id": "c5",
   },
+  Comment {
+    "featured": false,
+    "id": "c6",
+  },
+]
+`;
+
+exports[`should update featured comments 2`] = `
+Array [
+  "c3",
+  "c2",
 ]
 `;

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -9,11 +9,14 @@ const postUpvotedTopic = pubsub.topic('post-upvoted');
 const commentUpvotedTopic = pubsub.topic('comment-upvoted');
 const postCommentedTopic = pubsub.topic('post-commented');
 const commentCommentedTopic = pubsub.topic('comment-commented');
+const commentFeaturedTopic = pubsub.topic('comment-featured');
 
 type NotificationReason = 'new' | 'publish' | 'approve' | 'decline';
+// Need to support console as well
+type EventLogger = Omit<Logger, 'fatal'>;
 
 const publishEvent = async (
-  log: Logger,
+  log: EventLogger,
   topic: Topic,
   payload: object,
 ): Promise<void> => {
@@ -30,7 +33,7 @@ const publishEvent = async (
 };
 
 export const notifySourceRequest = async (
-  log: Logger,
+  log: EventLogger,
   reason: NotificationReason,
   sourceReq: SourceRequest,
 ): Promise<void> =>
@@ -40,7 +43,7 @@ export const notifySourceRequest = async (
   });
 
 export const notifyPostUpvoted = async (
-  log: Logger,
+  log: EventLogger,
   postId: string,
   userId: string,
 ): Promise<void> =>
@@ -50,7 +53,7 @@ export const notifyPostUpvoted = async (
   });
 
 export const notifyCommentUpvoted = async (
-  log: Logger,
+  log: EventLogger,
   commentId: string,
   userId: string,
 ): Promise<void> =>
@@ -60,7 +63,7 @@ export const notifyCommentUpvoted = async (
   });
 
 export const notifyPostCommented = async (
-  log: Logger,
+  log: EventLogger,
   postId: string,
   userId: string,
   commentId: string,
@@ -72,7 +75,7 @@ export const notifyPostCommented = async (
   });
 
 export const notifyCommentCommented = async (
-  log: Logger,
+  log: EventLogger,
   postId: string,
   userId: string,
   parentCommentId: string,
@@ -83,4 +86,12 @@ export const notifyCommentCommented = async (
     userId,
     parentCommentId,
     childCommentId,
+  });
+
+export const notifyCommentFeatured = async (
+  log: EventLogger,
+  commentId: string,
+): Promise<void> =>
+  publishEvent(log, commentFeaturedTopic, {
+    commentId,
   });

--- a/src/compatibility/utils.ts
+++ b/src/compatibility/utils.ts
@@ -49,14 +49,17 @@ export const injectGraphql = async (
   const code = errors?.[0]?.extensions?.code;
   if (code === 'UNAUTHENTICATED') {
     return res.status(401).send();
-  } else if (
-    code === 'VALIDATION_ERROR' ||
-    code === 'GRAPHQL_VALIDATION_FAILED'
-  ) {
+  }
+  if (code === 'FORBIDDEN') {
+    return res.status(403).send();
+  }
+  if (code === 'VALIDATION_ERROR' || code === 'GRAPHQL_VALIDATION_FAILED') {
     return res.status(400).send();
-  } else if (code === 'NOT_FOUND') {
+  }
+  if (code === 'NOT_FOUND') {
     return res.status(404).send();
-  } else if (code) {
+  }
+  if (code) {
     return res.status(500).send();
   }
 


### PR DESCRIPTION
Once a new comment is featured a Pub/Sub message is sent.
Max featured comments per article is set to 3.
This will enable sending emails and increasing reputation in the future.