### PR TITLE
feat: add active property to source

### DIFF
--- a/__tests__/__snapshots__/sourceRequests.ts.snap
+++ b/__tests__/__snapshots__/sourceRequests.ts.snap
@@ -94,6 +94,7 @@ Object {
 
 exports[`mutation publishSourceRequest should publish a source request 2`] = `
 Source {
+  "active": true,
   "id": "a",
   "twitter": "a",
   "website": "http://3.com",

--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -38,6 +38,35 @@ Object {
 }
 `;
 
+exports[`query sources should return only active sources 1`] = `
+Object {
+  "sources": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "a",
+          "image": "http://a.com",
+          "name": "A",
+          "public": true,
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "b",
+          "image": "http://b.com",
+          "name": "B",
+          "public": true,
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
 exports[`query sources should return only public sources 1`] = `
 Object {
   "sources": Object {

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -119,6 +119,15 @@ describe('query sources', () => {
     const res = await client.query({ query: QUERY(1) });
     expect(res.data).toMatchSnapshot();
   });
+
+  it('should return only active sources', async () => {
+    await con.getRepository(Source).save([{ id: 'd', active: false }]);
+    await con
+      .getRepository(SourceDisplay)
+      .save([createSourceDisplay('d', 'D', 'http://d.com')]);
+    const res = await client.query({ query: QUERY() });
+    expect(res.data).toMatchSnapshot();
+  });
 });
 
 describe('query sourceByFeed', () => {
@@ -263,6 +272,7 @@ describe('mutation addPrivateSource', () => {
       id: expect.anything(),
       twitter: null,
       website: null,
+      active: true,
     });
     expect(
       await con.getRepository(SourceDisplay).findOne({ sourceId: id }),
@@ -350,6 +360,7 @@ describe('mutation addPrivateSource', () => {
       id: expect.anything(),
       twitter: null,
       website: null,
+      active: true,
     });
     expect(
       await con.getRepository(SourceDisplay).findOne({ sourceId: id }),

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, OneToMany, PrimaryColumn } from 'typeorm';
 import { SourceDisplay } from './SourceDisplay';
 import { SourceFeed } from './SourceFeed';
 import { Post } from './Post';
@@ -13,6 +13,10 @@ export class Source {
 
   @Column({ type: 'text', nullable: true })
   website?: string;
+
+  @Column({ default: true })
+  @Index()
+  active: boolean;
 
   @OneToMany(() => SourceDisplay, (display) => display.source, { lazy: true })
   displays: Promise<SourceDisplay[]>;

--- a/src/migration/1602427333872-ActiveSources.ts
+++ b/src/migration/1602427333872-ActiveSources.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ActiveSources1602427333872 implements MigrationInterface {
+    name = 'ActiveSources1602427333872'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."source" ADD "active" boolean NOT NULL DEFAULT true`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_31d41971830ac861579df2b064" ON "public"."source" ("active") `, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_31d41971830ac861579df2b064"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."source" DROP COLUMN "active"`, undefined);
+    }
+
+}

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -162,6 +162,11 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           .createQueryBuilder()
           .select('sd.*')
           .from(fromSourceDisplay, 'sd')
+          .innerJoin(
+            Source,
+            'source',
+            'sd."sourceId" = source.id AND source.active = true',
+          )
           .setParameters({ userId: ctx.userId, enabled: true })
           .orderBy('sd.name', 'ASC')
           .limit(limit)


### PR DESCRIPTION
The active property indicates if the source is still active and should be returned in the sources list.
Inactive sources exist to keep posts that are already in the database and might be bookmarked