### PR TITLE
feat: match author to post

### DIFF
--- a/__tests__/__snapshots__/newPost.ts.snap
+++ b/__tests__/__snapshots__/newPost.ts.snap
@@ -1,7 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should match post to author 1`] = `
+Object {
+  "authorId": "1",
+  "canonicalUrl": null,
+  "comments": 0,
+  "createdAt": Any<Date>,
+  "creatorTwitter": "idoshamun",
+  "id": Any<String>,
+  "image": null,
+  "placeholder": null,
+  "publishedAt": null,
+  "ratio": null,
+  "readTime": null,
+  "score": Any<Number>,
+  "shortId": Any<String>,
+  "siteTwitter": null,
+  "sourceId": "a",
+  "tagsStr": null,
+  "title": "Title",
+  "tweeted": false,
+  "upvotes": 0,
+  "url": "https://post.com",
+  "views": 0,
+}
+`;
+
+exports[`should not match post to author 1`] = `
+Object {
+  "authorId": null,
+  "canonicalUrl": null,
+  "comments": 0,
+  "createdAt": Any<Date>,
+  "creatorTwitter": "nouser",
+  "id": Any<String>,
+  "image": null,
+  "placeholder": null,
+  "publishedAt": null,
+  "ratio": null,
+  "readTime": null,
+  "score": Any<Number>,
+  "shortId": Any<String>,
+  "siteTwitter": null,
+  "sourceId": "a",
+  "tagsStr": null,
+  "title": "Title",
+  "tweeted": false,
+  "upvotes": 0,
+  "url": "https://post.com",
+  "views": 0,
+}
+`;
+
 exports[`should save a new post with basic information 1`] = `
 Object {
+  "authorId": null,
   "canonicalUrl": null,
   "comments": 0,
   "createdAt": Any<Date>,
@@ -27,6 +80,7 @@ Object {
 
 exports[`should save a new post with full information 1`] = `
 Object {
+  "authorId": null,
   "canonicalUrl": null,
   "comments": 0,
   "createdAt": Any<Date>,

--- a/__tests__/__snapshots__/newUser.ts.snap
+++ b/__tests__/__snapshots__/newUser.ts.snap
@@ -5,6 +5,7 @@ User {
   "id": "abc",
   "image": "https://daily.dev/image.jpg",
   "name": "Ido",
+  "profileConfirmed": false,
   "reputation": 0,
   "twitter": null,
   "username": null,

--- a/__tests__/__snapshots__/posts.ts.snap
+++ b/__tests__/__snapshots__/posts.ts.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`author field should return null when author is not set 1`] = `
+Object {
+  "post": Object {
+    "author": null,
+  },
+}
+`;
+
+exports[`author field should return the author when set 1`] = `
+Object {
+  "post": Object {
+    "author": Object {
+      "id": "1",
+      "name": "Ido",
+    },
+  },
+}
+`;
+
 exports[`compatibility routes GET /posts/:id should return post by id 1`] = `
 Object {
   "id": "p1",

--- a/__tests__/__snapshots__/updateUser.ts.snap
+++ b/__tests__/__snapshots__/updateUser.ts.snap
@@ -5,6 +5,7 @@ User {
   "id": "abc",
   "image": "https://daily.dev/image.jpg",
   "name": "Ido",
+  "profileConfirmed": false,
   "reputation": 0,
   "twitter": "idoshamun",
   "username": "idoshamun",

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -427,6 +427,31 @@ describe('featuredComments field', () => {
   });
 });
 
+describe('author field', () => {
+  const QUERY = `{
+    post(id: "p1") {
+      author {
+        id
+        name
+      }
+    }
+  }`;
+
+  it('should return null when author is not set', async () => {
+    const res = await client.query({ query: QUERY });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return the author when set', async () => {
+    await con
+      .getRepository(User)
+      .save([{ id: '1', name: 'Ido', image: 'https://daily.dev/ido.jpg' }]);
+    await con.getRepository(Post).update('p1', { authorId: '1' });
+    const res = await client.query({ query: QUERY });
+    expect(res.data).toMatchSnapshot();
+  });
+});
+
 describe('query post', () => {
   const QUERY = (id: string): string => `{
     post(id: "${id}") {

--- a/__tests__/updateUser.ts
+++ b/__tests__/updateUser.ts
@@ -21,6 +21,7 @@ it('should update an existing user', async () => {
     id: 'abc',
     name: 'ido',
     image: 'https://daily.dev/image.jpg',
+    profileConfirmed: true,
   });
 
   const message = mockMessage({

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -12,6 +12,7 @@ const commentCommentedTopic = pubsub.topic('comment-commented');
 const commentFeaturedTopic = pubsub.topic('comment-featured');
 const userReputationUpdatedTopic = pubsub.topic('user-reputation-updated');
 const commentUpvoteCanceledTopic = pubsub.topic('comment-upvote-canceled');
+const postAuthorMatchedTopic = pubsub.topic('post-author-matched');
 
 type NotificationReason = 'new' | 'publish' | 'approve' | 'decline';
 // Need to support console as well
@@ -116,4 +117,14 @@ export const notifyCommentUpvoteCanceled = async (
   publishEvent(log, commentUpvoteCanceledTopic, {
     commentId,
     userId,
+  });
+
+export const notifyPostAuthorMatched = async (
+  log: EventLogger,
+  postId: string,
+  authorId: string,
+): Promise<void> =>
+  publishEvent(log, postAuthorMatchedTopic, {
+    postId,
+    authorId,
   });

--- a/src/entity/Post.ts
+++ b/src/entity/Post.ts
@@ -10,6 +10,7 @@ import { SearchOptions } from '@algolia/client-search';
 import { PostTag } from './PostTag';
 import { Source } from './Source';
 import { getPostsIndex, trackSearch } from '../common';
+import { User } from './User';
 
 @Entity()
 export class Post {
@@ -91,6 +92,16 @@ export class Post {
   @Column({ type: 'integer', default: 0 })
   @Index('IDX_post_comments')
   comments: number;
+
+  @Column({ length: 36, nullable: true })
+  @Index('IDX_post_author')
+  authorId: string | null;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'SET NULL',
+  })
+  author: Promise<User>;
 }
 
 export interface SearchPostsResult {

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, OneToMany, PrimaryColumn } from 'typeorm';
+import { Post } from './Post';
 
 @Entity()
 export class User {
@@ -21,4 +22,11 @@ export class User {
   @Column({ length: 15, nullable: true })
   @Index()
   twitter: string | null;
+
+  @Column({ default: false })
+  @Index('IDX_user_profileConfirmed')
+  profileConfirmed: boolean | null;
+
+  @OneToMany(() => Post, (post) => post.author, { lazy: true })
+  posts: Promise<Post[]>;
 }

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -85,7 +85,7 @@ export class GraphORM {
     const relation = childMetadata.relations.find(
       (rel) => rel.inverseEntityMetadata.name === parentMetadata.name,
     );
-    if (relation) {
+    if (relation?.foreignKeys?.[0]) {
       const fk = relation.foreignKeys[0];
       return {
         isMany: relation.relationType === 'many-to-one',

--- a/src/migration/1602572107385-PostAuthor.ts
+++ b/src/migration/1602572107385-PostAuthor.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class PostAuthor1602572107385 implements MigrationInterface {
+    name = 'PostAuthor1602572107385'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."user" ADD "profileConfirmed" boolean NOT NULL DEFAULT false`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" ADD "authorId" character varying(36)`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_user_profileConfirmed" ON "public"."user" ("profileConfirmed") `, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_post_author" ON "public"."post" ("authorId") `, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" ADD CONSTRAINT "FK_f1bb0e9a2279673a76520d2adc5" FOREIGN KEY ("authorId") REFERENCES "public"."user"("id") ON DELETE SET NULL ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."post" DROP CONSTRAINT "FK_f1bb0e9a2279673a76520d2adc5"`, undefined);
+        await queryRunner.query(`DROP INDEX "public"."IDX_post_author"`, undefined);
+        await queryRunner.query(`DROP INDEX "public"."IDX_user_profileConfirmed"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."post" DROP COLUMN "authorId"`, undefined);
+        await queryRunner.query(`ALTER TABLE "public"."user" DROP COLUMN "profileConfirmed"`, undefined);
+    }
+
+}

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -16,6 +16,7 @@ import { NotFoundError } from '../errors';
 import { GQLBookmarkList } from './bookmarks';
 import { GQLComment } from './comments';
 import graphorm from '../graphorm';
+import { GQLUser } from './users';
 
 export interface GQLPost {
   id: string;
@@ -41,6 +42,7 @@ export interface GQLPost {
   // Used only for pagination (not part of the schema)
   score: number;
   bookmarkedAt: Date;
+  author?: GQLUser;
 }
 
 export const typeDefs = gql`
@@ -157,6 +159,11 @@ export const typeDefs = gql`
     Featured comments for the post
     """
     featuredComments: [Comment!]
+
+    """
+    Author of the post (if they have a daily.dev account)
+    """
+    author: User
   }
 
   type PostConnection {

--- a/src/workers/updateUser.ts
+++ b/src/workers/updateUser.ts
@@ -47,6 +47,7 @@ const worker: Worker = {
           image: data.newProfile.image,
           username: data.newProfile.username,
           twitter: data.newProfile.twitter,
+          profileConfirmed: false,
         },
       );
       logger.info(


### PR DESCRIPTION
When a post is added, the twitter handle is matched against our database to find the user who wrote the post.
If the user is found, it is saved in the database and send a pub/sub message