### PR TITLE
refactor: add comments count to tweets to make it unique

### DIFF
--- a/__tests__/postCommentedAuthorTweet.ts
+++ b/__tests__/postCommentedAuthorTweet.ts
@@ -41,7 +41,7 @@ it('should tweet about the new comment', async () => {
     commentId: 'c1',
   });
 
-  await con.getRepository(Post).update('p1', { creatorTwitter: '@idoshamun' });
+  await con.getRepository(Post).update('p1', { creatorTwitter: '@idoshamun', comments: 23 });
   await worker.handler(message, con, app.log, new PubSub());
   expect(message.ack).toBeCalledTimes(1);
   expect(tweet).toBeCalledTimes(1);
@@ -49,6 +49,7 @@ it('should tweet about the new comment', async () => {
   expect(mocked(tweet).mock.calls[0][0]).toContain(
     'http://localhost:5002/posts/p1?author=true',
   );
+  expect(mocked(tweet).mock.calls[0][0]).toContain('23');
   expect(mocked(tweet).mock.calls[0][1]).toEqual('AUTHOR_TWITTER');
 });
 

--- a/__tests__/postCommentedAuthorTweet.ts
+++ b/__tests__/postCommentedAuthorTweet.ts
@@ -41,7 +41,9 @@ it('should tweet about the new comment', async () => {
     commentId: 'c1',
   });
 
-  await con.getRepository(Post).update('p1', { creatorTwitter: '@idoshamun', comments: 23 });
+  await con
+    .getRepository(Post)
+    .update('p1', { creatorTwitter: '@idoshamun', comments: 23 });
   await worker.handler(message, con, app.log, new PubSub());
   expect(message.ack).toBeCalledTimes(1);
   expect(tweet).toBeCalledTimes(1);

--- a/src/workers/postCommentedAuthorTweet.ts
+++ b/src/workers/postCommentedAuthorTweet.ts
@@ -20,13 +20,16 @@ const worker: Worker = {
         const link = `${getDiscussionLink(post.id)}?author=true`;
         const handle = post.creatorTwitter;
         const version = Math.floor(Math.random() * 3);
+        const plural = post.comments > 1;
+        const comments = `comment${plural ? 's' : ''}`;
+        const are = plural ? 'are' : 'is';
         let status = `${handle} `;
         if (version === 0) {
-          status += `You have a new comment on “${title}” ✏️`;
+          status += `You have ${post.comments} new ${comments} on “${title}” ✏️`;
         } else if (version === 1) {
-          status += `A new comment on “${title}” is waiting for you 🤓`;
+          status += `${post.comments} new ${comments} on “${title}” ${are} waiting for you 🤓`;
         } else {
-          status += `There’s a new comment on your article “${title}” 🎉`;
+          status += `There ${are} ${post.comments} new ${comments} on your article “${title}” 🎉`;
         }
         status += `\n\nLet your readers know you’re there: ${link}`;
         await tweet(status, 'AUTHOR_TWITTER');


### PR DESCRIPTION
The old format used to create a lot of duplicate tweets which is not allowed by the Twitter API.
The new format contains the number of comments which makes it unique.