### PR TITLE
fix: pagination edge case where response size equals the page size

### DIFF
--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -149,7 +149,7 @@ export function feedResolver<
 ): IFieldResolver<TSource, Context, TArgs> {
   return async (source, args, context, info): Promise<Connection<GQLPost>> => {
     const page = pageGenerator.connArgsToPage(args);
-    return graphorm.queryPaginated(
+    const res = await graphorm.queryPaginated<GQLPost>(
       context,
       info,
       (nodeSize) => pageGenerator.hasPreviousPage(page, nodeSize),
@@ -171,6 +171,10 @@ export function feedResolver<
         return builder;
       },
     );
+    if (pageGenerator.transformEdges) {
+      res.edges = pageGenerator.transformEdges(page, res.edges);
+    }
+    return res;
   };
 }
 

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -126,6 +126,7 @@ export interface PageGenerator<
   ) => string;
   hasNextPage: (page: TPage, nodesSize: number, total?: number) => boolean;
   hasPreviousPage: (page: TPage, nodesSize: number, total?: number) => boolean;
+  transformEdges?: (page: TPage, edges: Edge<TReturn>[]) => Edge<TReturn>[];
 }
 
 export const offsetPageGenerator = <TReturn>(

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -362,7 +362,8 @@ interface FeedPage extends Page {
 const feedPageGenerator: PageGenerator<GQLPost, FeedArgs, FeedPage> = {
   connArgsToPage: ({ ranking, first, after }: FeedArgs) => {
     const cursor = getCursorFromAfter(after);
-    const limit = Math.min(first || 30, 50);
+    // Increment by one to determine if there's one more page
+    const limit = Math.min(first || 30, 50) + 1;
     if (cursor) {
       if (ranking === Ranking.POPULARITY) {
         return { limit, score: parseInt(cursor) };
@@ -379,6 +380,7 @@ const feedPageGenerator: PageGenerator<GQLPost, FeedArgs, FeedPage> = {
   },
   hasNextPage: (page, nodesSize) => page.limit === nodesSize,
   hasPreviousPage: (page) => !!(page.score || page.timestamp),
+  transformEdges: (page, edges) => edges.slice(0, page.limit - 1),
 };
 
 const applyFeedPaging = (


### PR DESCRIPTION
If the response size equals the page size, the `hasNextPage` property will be set to true which is wrong.
The new implementation limits the query to the pageSize+1 and checks if indeed this was the response size

Closes dailydotdev/daily-webapp#174