### PR TITLE
fix: upsert user on update instead of updating

### DIFF
--- a/__tests__/workers/__snapshots__/updateUser.ts.snap
+++ b/__tests__/workers/__snapshots__/updateUser.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should create user if does not exist 1`] = `
+User {
+  "id": "abc",
+  "image": "https://daily.dev/image.jpg",
+  "name": "Ido",
+  "profileConfirmed": false,
+  "reputation": 1,
+  "twitter": "idoshamun",
+  "username": "idoshamun",
+}
+`;
+
 exports[`should update an existing user 1`] = `
 User {
   "id": "abc",

--- a/__tests__/workers/updateUser.ts
+++ b/__tests__/workers/updateUser.ts
@@ -43,7 +43,7 @@ it('should update an existing user', async () => {
   expect(users[0]).toMatchSnapshot();
 });
 
-it('should ack message if user does not exist', async () => {
+it('should create user if does not exist', async () => {
   await expectSuccessfulBackground(app, worker, {
     user: {
       id: 'abc',
@@ -53,8 +53,13 @@ it('should ack message if user does not exist', async () => {
     },
     newProfile: {
       name: 'Ido',
+      image: 'https://daily.dev/image.jpg',
+      username: 'idoshamun',
+      twitter: 'idoshamun',
+      github: 'idoshamun',
     },
   });
   const users = await con.getRepository(User).find();
-  expect(users.length).toEqual(0);
+  expect(users.length).toEqual(1);
+  expect(users[0]).toMatchSnapshot();
 });

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -35,7 +35,7 @@ const worker: Worker = {
           timestamp: data.timestamp && new Date(data.timestamp as string),
         }),
       );
-      if (!didSave)  {
+      if (!didSave) {
         logger.debug(
           {
             view: data,

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -35,15 +35,7 @@ const worker: Worker = {
           timestamp: data.timestamp && new Date(data.timestamp as string),
         }),
       );
-      if (didSave) {
-        logger.info(
-          {
-            view: data,
-            messageId: message.id,
-          },
-          'added successfully view event',
-        );
-      } else {
+      if (!didSave)  {
         logger.debug(
           {
             view: data,

--- a/src/workers/updateUser.ts
+++ b/src/workers/updateUser.ts
@@ -39,9 +39,9 @@ const worker: Worker = {
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
     try {
-      await con.getRepository(User).update(
-        { id: data.user.id },
+      await con.getRepository(User).save(
         {
+          id: data.user.id,
           name: data.newProfile.name,
           image: data.newProfile.image,
           username: data.newProfile.username,

--- a/src/workers/updateUser.ts
+++ b/src/workers/updateUser.ts
@@ -39,16 +39,14 @@ const worker: Worker = {
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
     try {
-      await con.getRepository(User).save(
-        {
-          id: data.user.id,
-          name: data.newProfile.name,
-          image: data.newProfile.image,
-          username: data.newProfile.username,
-          twitter: data.newProfile.twitter,
-          profileConfirmed: false,
-        },
-      );
+      await con.getRepository(User).save({
+        id: data.user.id,
+        name: data.newProfile.name,
+        image: data.newProfile.image,
+        username: data.newProfile.username,
+        twitter: data.newProfile.twitter,
+        profileConfirmed: false,
+      });
       logger.info(
         {
           userId: data.user.id,


### PR DESCRIPTION
To prevent race conditioning, it is better to upsert the user instead of updating which can fail