### PR TITLE
fix: generic page generator order condition based on parameter

### DIFF
--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -303,15 +303,16 @@ export const resolvers: IResolvers<any, Context> = {
       ctx,
       info,
     ): Promise<Connection<GQLComment>> => {
-      return pageGenerator.queryPaginated(ctx, info, args, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.postId = :postId`, {
-            postId: args.postId,
-          })
-          .andWhere(`${builder.alias}.parentId is null`)
-          .orderBy(`${builder.alias}."createdAt"`);
+      return pageGenerator.queryPaginated(ctx, info, args, {
+        queryBuilder: (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .andWhere(`${builder.alias}.postId = :postId`, {
+              postId: args.postId,
+            })
+            .andWhere(`${builder.alias}.parentId is null`);
 
-        return builder;
+          return builder;
+        },
       });
     },
     userComments: async (
@@ -320,14 +321,16 @@ export const resolvers: IResolvers<any, Context> = {
       ctx,
       info,
     ): Promise<Connection<GQLComment>> => {
-      return pageGenerator.queryPaginated(ctx, info, args, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}."userId" = :userId`, {
-            userId: args.userId,
-          })
-          .orderBy(`${builder.alias}."createdAt"`, 'DESC');
+      return pageGenerator.queryPaginated(ctx, info, args, {
+        queryBuilder: (builder) => {
+          builder.queryBuilder = builder.queryBuilder.andWhere(
+            `${builder.alias}."userId" = :userId`,
+            { userId: args.userId },
+          );
 
-        return builder;
+          return builder;
+        },
+        orderByCreatedAt: 'DESC',
       });
     },
     commentUpvotes: async (
@@ -336,14 +339,16 @@ export const resolvers: IResolvers<any, Context> = {
       ctx,
       info,
     ): Promise<Connection<GQLCommentUpvote>> => {
-      return pageGenerator.queryPaginated(ctx, info, args, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.commentId = :commentId`, {
-            commentId: args.id,
-          })
-          .orderBy(`${builder.alias}."createdAt"`, 'DESC');
+      return pageGenerator.queryPaginated(ctx, info, args, {
+        queryBuilder: (builder) => {
+          builder.queryBuilder = builder.queryBuilder.andWhere(
+            `${builder.alias}.commentId = :commentId`,
+            { commentId: args.id },
+          );
 
-        return builder;
+          return builder;
+        },
+        orderByCreatedAt: 'DESC',
       });
     },
   }),

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -450,14 +450,16 @@ export const resolvers: IResolvers<any, Context> = {
       ctx,
       info,
     ): Promise<ConnectionRelay<GQLPostUpvote>> => {
-      return pageGenerator.queryPaginated(ctx, info, args, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.postId = :postId`, {
-            postId: args.id,
-          })
-          .orderBy(`${builder.alias}."createdAt"`, 'DESC');
+      return pageGenerator.queryPaginated(ctx, info, args, {
+        queryBuilder: (builder) => {
+          builder.queryBuilder = builder.queryBuilder.andWhere(
+            `${builder.alias}.postId = :postId`,
+            { postId: args.id },
+          );
 
-        return builder;
+          return builder;
+        },
+        orderByCreatedAt: 'DESC',
       });
     },
   }),


### PR DESCRIPTION
DD-219#done

The Generic Page Generator is reliant on the order of the actual query. So the condition must come from the parameter that the consumer would send.

Since `orderBy` overrides the existing parameters, I used `addOrderBy` so consumers would still be able to apply their own set of rules for the order in the query builder.