### PR TITLE
feat: anonymous feed and user feed v2

### DIFF
--- a/.env
+++ b/.env
@@ -29,3 +29,5 @@ REDIS_PORT=6379
 
 FLAGSMITH_KEY=key
 AMPLITUDE_KEY=key
+
+TINYBIRD_FEED=http://localhost:6000/feed.json?token=token

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -560,6 +560,56 @@ Object {
 }
 `;
 
+exports[`query anonymousFeed should return anonymous feed v2 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
 exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
 Object {
   "anonymousFeed": Object {
@@ -887,6 +937,56 @@ Object {
     ],
     "pageInfo": Object {
       "endCursor": "c2NvcmU6MA==",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should return feed v2 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
       "hasNextPage": false,
     },
   },

--- a/__tests__/personalizedFeed.ts
+++ b/__tests__/personalizedFeed.ts
@@ -1,0 +1,81 @@
+import { Connection, getConnection } from 'typeorm';
+import nock from 'nock';
+import { deleteKeysByPattern, redisClient } from '../src/redis';
+import {
+  generatePersonalizedFeed,
+  getPersonalizedFeedKey,
+} from '../src/personalizedFeed';
+import { Feed, FeedSource, FeedTag, Source } from '../src/entity';
+import { saveFixtures } from './helpers';
+import { sourcesFixture } from './fixture/source';
+
+let con: Connection;
+
+const tinybirdResponse = {
+  data: [
+    { post_id: '1' },
+    { post_id: '2' },
+    { post_id: '3' },
+    { post_id: '4' },
+    { post_id: '5' },
+    { post_id: '6' },
+  ],
+};
+
+beforeAll(async () => {
+  con = await getConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+  await deleteKeysByPattern('feeds:*');
+  await saveFixtures(con, Source, sourcesFixture);
+});
+
+it('should fetch anonymous feed and serve consequent pages from cache', async () => {
+  nock('http://localhost:6000')
+    .get('/feed.json?token=token&page_size=2&fresh_page_size=1')
+    .reply(200, tinybirdResponse);
+  const page0 = await generatePersonalizedFeed(con, 2, 0);
+  expect(page0).toEqual(['1', '2']);
+  expect(nock.isDone()).toEqual(true);
+  const page1 = await generatePersonalizedFeed(con, 2, 2);
+  expect(page1).toEqual(['3', '4']);
+});
+
+it('should fetch anonymous feed even when cache is present', async () => {
+  const key = getPersonalizedFeedKey();
+  const pipeline = redisClient.pipeline();
+  ['7', '8'].forEach((id, i) => pipeline.zadd(key, i, id));
+  await pipeline.exec();
+
+  nock('http://localhost:6000')
+    .get('/feed.json?token=token&page_size=2&fresh_page_size=1')
+    .reply(200, tinybirdResponse);
+  const page0 = await generatePersonalizedFeed(con, 2, 0);
+  expect(page0).toEqual(['1', '2']);
+  expect(nock.isDone()).toEqual(true);
+});
+
+it('should set the correct query parameters', async () => {
+  await con.getRepository(Feed).save({ id: '1', userId: 'u1' });
+  await con.getRepository(FeedTag).save([
+    { feedId: '1', tag: 'javascript' },
+    { feedId: '1', tag: 'golang' },
+    { feedId: '1', tag: 'python', blocked: true },
+    { feedId: '1', tag: 'java', blocked: true },
+  ]);
+  await con.getRepository(FeedSource).save([
+    { feedId: '1', sourceId: 'a' },
+    { feedId: '1', sourceId: 'b' },
+  ]);
+  nock('http://localhost:6000')
+    .get(
+      '/feed.json?token=token&page_size=2&fresh_page_size=1&user_id=u1&allowed_tags=javascript,golang&blocked_tags=python,java&blocked_sources=a,b',
+    )
+    .reply(200, tinybirdResponse);
+  const page0 = await generatePersonalizedFeed(con, 2, 0, 'u1', '1');
+  expect(page0).toEqual(['1', '2']);
+  expect(nock.isDone()).toEqual(true);
+});

--- a/__tests__/workers/checkDevCardEligibility.ts
+++ b/__tests__/workers/checkDevCardEligibility.ts
@@ -8,7 +8,7 @@ import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { Post, Source, User, View } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
-import { redisClient } from '../../src/redis';
+import { deleteKeysByPattern } from '../../src/redis';
 
 let con: Connection;
 let app: FastifyInstance;
@@ -22,7 +22,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   jest.clearAllMocks();
   nock.cleanAll();
-  await redisClient.del(`flagsmith:flags-u1`);
+  await deleteKeysByPattern('flagsmith:*');
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, Post, postsFixture);
   await con.getRepository(User).save({

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -61,6 +61,8 @@ config:
       secure: AAABAJwPYRU11H3rzyBBw/SejgxYXAax/0qA9Pmqh+9DyCzZlNb8gIk5gaDRj4ILG3xTE7w9Nb1GUlu5TDJ9ug==
     superfeedrUser:
       secure: AAABADKUZKSoWAtFvFpES4O5CWtdc2/SyNQu/MFEeJ+tBRnK/kzjdDg=
+    tinybirdFeed:
+      secure: AAABAOBzmGhgLEiSUamPST9V1A2UCuhdoXq20+g6FBA/H1XRSNc20AzI1XMvnRu8rDG6O+SUxdul/vNvxvePxf6WLE1ygF7I1BrgzuWpA/7Ylm6Hp/I1eIqPjxmes3/sbESgX+RIobmPm7zMWfGKLAEmzfsgDvRIRkn8JgDpas99hsfVaFetyyUzvN+E8Wo6F1pueaETQ16vo8kHLBi+QQKJEaOmfGsGKE/tmOPA3tjTeFH14+mWey92+96Nuap11OWiulC4y5FSMIqy09pWLEVidHXJCJ525Y8ne2WpRXhmhoAkgyQ1F/ZuH3awRkYs8AQa+l84bS5l
     twitterAccessTokenKey:
       secure: AAABAM4p+Bnbw3S7QDYqNNSFJzbPMsD8TQbvhNGr2Y9nU+lM1bFrLCB1Ra/NEG5YzHpVINf4/4PPMBhNJk85hK0CZ7fcS23t02CZgoJeJO6CsQ==
     twitterAccessTokenSecret:

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -19,6 +19,10 @@ export class Context {
     return this.req.userId;
   }
 
+  get trackingId(): string | null {
+    return this.req.cookies.da2;
+  }
+
   get premium(): boolean {
     return this.req.premium;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export default async function app(): Promise<FastifyInstance> {
     }: ContextParams): Context => {
       return new Context(request ?? wsConnection?.context?.req, connection);
     },
-    playground: false
+    playground: isProd
       ? false
       : { settings: { 'request.credentials': 'include' } },
     logger: app.log,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export default async function app(): Promise<FastifyInstance> {
     }: ContextParams): Context => {
       return new Context(request ?? wsConnection?.context?.req, connection);
     },
-    playground: isProd
+    playground: false
       ? false
       : { settings: { 'request.credentials': 'include' } },
     logger: app.log,

--- a/src/personalizedFeed.ts
+++ b/src/personalizedFeed.ts
@@ -1,0 +1,81 @@
+import { Connection } from 'typeorm';
+import { feedToFilters } from './common';
+import fetch from 'node-fetch';
+import { redisClient } from './redis';
+
+interface TinybirdResponse<T> {
+  data: T[];
+}
+
+async function fetchTinybirdFeed(
+  con: Connection,
+  pageSize: number,
+  userId?: string,
+  feedId?: string,
+): Promise<{ post_id: string }[]> {
+  const freshPageSize = Math.ceil(pageSize / 4).toFixed(0);
+  let url = `${process.env.TINYBIRD_FEED}&page_size=${pageSize}&fresh_page_size=${freshPageSize}`;
+  if (userId) {
+    url += `&user_id=${userId}`;
+  }
+  if (feedId) {
+    const filters = await feedToFilters(con, feedId);
+    if (filters.includeTags?.length) {
+      url += `&allowed_tags=${filters.includeTags.join(',')}`;
+    }
+    if (filters.blockedTags?.length) {
+      url += `&blocked_tags=${filters.blockedTags.join(',')}`;
+    }
+    if (filters.excludeSources?.length) {
+      url += `&blocked_sources=${filters.excludeSources.join(',')}`;
+    }
+  }
+  const res = await fetch(url);
+  const body: TinybirdResponse<{ post_id: string }> = await res.json();
+  return body.data;
+}
+
+export const getPersonalizedFeedKey = (
+  userId?: string,
+  feedId?: string,
+): string => `feeds:${feedId || 'global'}:${userId || 'anonymous'}`;
+
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+async function cacheFeed(
+  con: Connection,
+  pageSize: number,
+  userId?: string,
+  feedId?: string,
+): Promise<{ post_id: string }[]> {
+  const key = getPersonalizedFeedKey(userId, feedId);
+  const postIds = await fetchTinybirdFeed(con, pageSize, userId, feedId);
+  const pipeline = redisClient.pipeline();
+  pipeline.del(key);
+  pipeline.expire(key, ONE_DAY_SECONDS);
+  postIds.forEach(({ post_id }, i) => pipeline.zadd(key, i, post_id));
+  await pipeline.exec();
+  return postIds;
+}
+
+export async function generatePersonalizedFeed(
+  con: Connection,
+  pageSize: number,
+  offset: number,
+  userId?: string,
+  feedId?: string,
+): Promise<string[]> {
+  const key = getPersonalizedFeedKey(userId, feedId);
+  if (offset) {
+    const postIds = await redisClient.zrange(
+      key,
+      offset,
+      pageSize + offset - 1,
+    );
+    if (postIds.length) {
+      return postIds;
+    }
+  }
+  const postIds = await cacheFeed(con, pageSize, userId, feedId);
+  return postIds.slice(offset, pageSize + offset).map(({ post_id }) => post_id);
+}

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -13,3 +13,16 @@ export const redisPubSub = new RedisPubSub({
   publisher: new Redis(redisOptions),
   subscriber: new Redis(redisOptions),
 });
+
+export function deleteKeysByPattern(pattern: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const stream = redisClient.scanStream({ match: pattern });
+    stream.on('data', (keys) => {
+      if (keys.length) {
+        redisClient.unlink(keys);
+      }
+    });
+    stream.on('end', resolve);
+    stream.on('error', reject);
+  });
+}


### PR DESCRIPTION
Add a new version field to the anonymous feed and user feed queries.
The new field allows running a/b tests on the feeds and optimizing the algorithm.
Version 2 uses Tinybird's API to fetch the feed and cache it.

DD-189