### PR TITLE
fix: handle empty feed edge case in v2

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -866,6 +866,18 @@ Object {
 }
 `;
 
+exports[`query anonymousFeed should safetly handle a case where the feed is empty 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [],
+    "pageInfo": Object {
+      "endCursor": null,
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
 exports[`query authorFeed should return a single author feed 1`] = `
 Object {
   "authorFeed": Object {

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1,4 +1,4 @@
-import { Category } from './../src/entity/Category';
+import { Category } from '../src/entity/Category';
 import { FastifyInstance } from 'fastify';
 import { Connection, getConnection, In } from 'typeorm';
 import { ApolloServer } from 'apollo-server-fastify';
@@ -204,6 +204,20 @@ describe('query anonymousFeed', () => {
       query: QUERY,
       variables: { ...variables, version: 2 },
     });
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should safetly handle a case where the feed is empty', async () => {
+    nock('http://localhost:6000')
+      .get('/feed.json?token=token&page_size=11&fresh_page_size=4')
+      .reply(200, {
+        data: [],
+      });
+    const res = await client.query({
+      query: QUERY,
+      variables: { ...variables, version: 2 },
+    });
+    expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();
   });
 });

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -16,7 +16,7 @@ beforeAll(async () => {
   con = await createOrGetConnection();
 });
 
-afterEach(() => cleanDatabase());
+afterEach(cleanDatabase);
 
 afterAll(async () => {
   await con.close();

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -409,7 +409,10 @@ export const fixedIdsFeedBuilder = (
   builder: SelectQueryBuilder<Post>,
   alias: string,
 ): SelectQueryBuilder<Post> => {
-  const idsStr = ids.map((id) => `'${id}'`).join(',');
+  // In case ids is empty make sure the query does not fail
+  const idsStr = ids.length
+    ? ids.map((id) => `'${id}'`).join(',')
+    : `'nosuchid'`;
   return builder
     .andWhere(`${alias}.id IN (${idsStr})`)
     .orderBy(`array_position(array[${idsStr}], ${alias}.id)`);


### PR DESCRIPTION
The feed query used to break whenever it received an empty array of ids from Tinybird.
This commit fixes this issue and makes sure the server knows how to handle this situation.

DD-257 #done