### PR TITLE
fix: feed filters query with 2 or more false advanced settings

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -234,6 +234,10 @@ Object {
         "enabled": false,
         "id": 2,
       },
+      Object {
+        "enabled": false,
+        "id": 3,
+      },
     ],
     "blockedTags": Array [
       "golang",
@@ -310,6 +314,10 @@ Object {
         "enabled": false,
         "id": 2,
       },
+      Object {
+        "enabled": false,
+        "id": 3,
+      },
     ],
     "blockedTags": Array [],
     "excludeSources": Array [
@@ -355,6 +363,10 @@ Object {
       "enabled": false,
       "id": 2,
     },
+    Object {
+      "enabled": false,
+      "id": 3,
+    },
   ],
 }
 `;
@@ -369,6 +381,10 @@ Object {
     Object {
       "enabled": true,
       "id": 2,
+    },
+    Object {
+      "enabled": false,
+      "id": 3,
     },
   ],
 }
@@ -1171,67 +1187,9 @@ Object {
 }
 `;
 
-exports[`query feed should remove banned posts from the feed 1`] = `
-Object {
-  "feed": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "id": "p1",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "javascript",
-            "webdev",
-          ],
-          "title": "P1",
-          "url": "http://p1.com",
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "c2NvcmU6MA==",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
+exports[`query feed should remove banned posts from the feed 1`] = `null`;
 
-exports[`query feed should remove deleted posts from the feed 1`] = `
-Object {
-  "feed": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "id": "p1",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "javascript",
-            "webdev",
-          ],
-          "title": "P1",
-          "url": "http://p1.com",
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "c2NvcmU6MA==",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
+exports[`query feed should remove deleted posts from the feed 1`] = `null`;
 
 exports[`query feed should return feed v2 1`] = `
 Object {
@@ -1283,55 +1241,7 @@ Object {
 }
 `;
 
-exports[`query feed should return feed with preconfigured filters 1`] = `
-Object {
-  "feed": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "id": "p4",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "backend",
-            "data",
-            "javascript",
-          ],
-          "title": "P4",
-          "url": "http://p4.com",
-        },
-      },
-      Object {
-        "node": Object {
-          "id": "p1",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "javascript",
-            "webdev",
-          ],
-          "title": "P1",
-          "url": "http://p1.com",
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "c2NvcmU6MA==",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
+exports[`query feed should return feed with preconfigured filters 1`] = `null`;
 
 exports[`query feed should return preconfigured feed with blocked tags filters only 1`] = `
 Object {
@@ -1860,6 +1770,10 @@ Object {
       Object {
         "enabled": false,
         "id": 2,
+      },
+      Object {
+        "enabled": false,
+        "id": 3,
       },
     ],
     "blockedTags": Array [

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -238,6 +238,10 @@ Object {
         "enabled": false,
         "id": 3,
       },
+      Object {
+        "enabled": true,
+        "id": 4,
+      },
     ],
     "blockedTags": Array [
       "golang",
@@ -318,6 +322,10 @@ Object {
         "enabled": false,
         "id": 3,
       },
+      Object {
+        "enabled": true,
+        "id": 4,
+      },
     ],
     "blockedTags": Array [],
     "excludeSources": Array [
@@ -367,6 +375,10 @@ Object {
       "enabled": false,
       "id": 3,
     },
+    Object {
+      "enabled": true,
+      "id": 4,
+    },
   ],
 }
 `;
@@ -383,8 +395,12 @@ Object {
       "id": 2,
     },
     Object {
-      "enabled": false,
+      "enabled": true,
       "id": 3,
+    },
+    Object {
+      "enabled": false,
+      "id": 4,
     },
   ],
 }
@@ -1880,6 +1896,10 @@ Object {
       Object {
         "enabled": false,
         "id": 3,
+      },
+      Object {
+        "enabled": true,
+        "id": 4,
       },
     ],
     "blockedTags": Array [

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -1187,9 +1187,67 @@ Object {
 }
 `;
 
-exports[`query feed should remove banned posts from the feed 1`] = `null`;
+exports[`query feed should remove banned posts from the feed 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "c2NvcmU6MA==",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
 
-exports[`query feed should remove deleted posts from the feed 1`] = `null`;
+exports[`query feed should remove deleted posts from the feed 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "c2NvcmU6MA==",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
 
 exports[`query feed should return feed v2 1`] = `
 Object {
@@ -1241,7 +1299,55 @@ Object {
 }
 `;
 
-exports[`query feed should return feed with preconfigured filters 1`] = `null`;
+exports[`query feed should return feed with preconfigured filters 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "c2NvcmU6MA==",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
 
 exports[`query feed should return preconfigured feed with blocked tags filters only 1`] = `
 Object {

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -126,6 +126,7 @@ const saveFeedFixtures = async (): Promise<void> => {
     { feedId: '1', advancedSettingsId: 1, enabled: true },
     { feedId: '1', advancedSettingsId: 2, enabled: false },
     { feedId: '1', advancedSettingsId: 3, enabled: false },
+    { feedId: '1', advancedSettingsId: 4, enabled: true },
   ]);
   await saveFixtures(con, Category, categories);
   await saveFixtures(con, FeedTag, [
@@ -193,6 +194,8 @@ const saveAdvancedSettingsFiltersFixtures = async (): Promise<void> => {
   await saveFixtures(con, FeedAdvancedSettings, [
     { feedId: '1', advancedSettingsId: 1, enabled: false },
     { feedId: '1', advancedSettingsId: 2, enabled: true },
+    { feedId: '1', advancedSettingsId: 3, enabled: true },
+    { feedId: '1', advancedSettingsId: 4, enabled: false },
   ]);
 };
 
@@ -963,6 +966,8 @@ describe('mutation updateFeedAdvancedSettings', () => {
         settings: [
           { id: 1, enabled: false },
           { id: 2, enabled: true },
+          { id: 3, enabled: true },
+          { id: 4, enabled: false },
         ],
       },
     });
@@ -984,6 +989,8 @@ describe('mutation updateFeedAdvancedSettings', () => {
         settings: [
           { id: 1, enabled: true },
           { id: 2, enabled: false },
+          { id: 3, enabled: false },
+          { id: 4, enabled: true },
         ],
       },
     });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -125,6 +125,7 @@ const saveFeedFixtures = async (): Promise<void> => {
   await saveFixtures(con, FeedAdvancedSettings, [
     { feedId: '1', advancedSettingsId: 1, enabled: true },
     { feedId: '1', advancedSettingsId: 2, enabled: false },
+    { feedId: '1', advancedSettingsId: 3, enabled: false },
   ]);
   await saveFixtures(con, Category, categories);
   await saveFixtures(con, FeedTag, [

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -81,7 +81,7 @@ export const feedToFilters = async (
           .where('COALESCE(fas.enabled, adv.defaultEnabledState) = false')
           .getQuery();
 
-        return `s.advancedSettings @> array[${subQuery}]`;
+        return `s.advancedSettings && array(${subQuery})`;
       })
       .orWhere((qb) => {
         const subQuery = qb


### PR DESCRIPTION
DD-286 #done

While working on the mutations of the UI, I bumped into a case where the user will have two or more false `enabled` values for the feed advanced settings.

- Included a commit where the test would fail if there are 2 or more false `enabled` values.
- Also included a commit where the tests would pass after the fix.
