### PR TITLE
fix: other reason was missing from report reasons

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -433,6 +433,7 @@ export const reportReasons = new Map([
   ['NSFW', '🔞 Post is NSFW'],
   ['CLICKBAIT', '🎣 Clickbait!!!'],
   ['LOW', '💩 Low quality content'],
+  ['OTHER', '🤷‍♂️ Other reason'],
 ]);
 
 const pageGenerator = new GQLDatePageGenerator();


### PR DESCRIPTION
Forgot to add Other as a reason on the API side.

DD-299 