### PR TITLE
fix: if feed is missing on feed advanced settings mutation

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -383,6 +383,21 @@ Object {
 }
 `;
 
+exports[`mutation updateFeedAdvancedSettings should not fail if feed entity does not exists 1`] = `
+Object {
+  "updateFeedAdvancedSettings": Array [
+    Object {
+      "enabled": true,
+      "id": 1,
+    },
+    Object {
+      "enabled": false,
+      "id": 2,
+    },
+  ],
+}
+`;
+
 exports[`mutation updateFeedAdvancedSettings should update existing feed advanced settings 1`] = `
 Object {
   "updateFeedAdvancedSettings": Array [

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -955,6 +955,22 @@ describe('mutation updateFeedAdvancedSettings', () => {
     ).toEqual('2');
   });
 
+  it('should not fail if feed entity does not exists', async () => {
+    loggedUser = '1';
+    await saveFixtures(con, AdvancedSettings, advancedSettings);
+    const res = await client.mutate({
+      mutation: MUTATION,
+      variables: {
+        settings: [
+          { id: 1, enabled: true },
+          { id: 2, enabled: false },
+        ],
+      },
+    });
+
+    expect(res.data).toMatchSnapshot();
+  });
+
   it('should update existing feed advanced settings', async () => {
     loggedUser = '1';
     await redisClient.set(`${getPersonalizedFeedKey('2', '1')}:time`, '1');

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1105,9 +1105,15 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       ctx,
     ): Promise<GQLFeedAdvancedSettings[]> => {
       const feedId = ctx.userId;
-      const repo = ctx.con.getRepository(FeedAdvancedSettings);
+      const feedRepo = ctx.con.getRepository(Feed);
+      const feed = await feedRepo.find({ id: feedId });
+      const feedAdvSettingsrepo = ctx.con.getRepository(FeedAdvancedSettings);
 
-      await repo
+      if (!feed) {
+        await feedRepo.save({ userId: feedId, id: feedId });
+      }
+
+      await feedAdvSettingsrepo
         .createQueryBuilder()
         .insert()
         .into(FeedAdvancedSettings)
@@ -1125,7 +1131,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
 
       await clearFeedCache(feedId);
 
-      return repo
+      return feedAdvSettingsrepo
         .createQueryBuilder()
         .select('"advancedSettingsId" AS id, enabled')
         .where({ feedId })

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1106,7 +1106,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     ): Promise<GQLFeedAdvancedSettings[]> => {
       const feedId = ctx.userId;
       const feedRepo = ctx.con.getRepository(Feed);
-      const feed = await feedRepo.find({ id: feedId });
+      const feed = await feedRepo.findOne({ id: feedId });
       const feedAdvSettingsrepo = ctx.con.getRepository(FeedAdvancedSettings);
 
       if (!feed) {


### PR DESCRIPTION
DD-302 #done

For newly created users, when feed doesn't exist yet. The mutation might fail since the `feedId` is an FK at `FeedAdvancedSettings` entity going to `Feed` entity.