### PR TITLE
fix: invalidate v2 cache correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
         environment:
           - POSTGRES_DB: api_test
           - POSTGRES_PASSWORD: 12345
-      - image: redis:5.0.10
+      - image: redis:6
     steps:
       - checkout
       - restore_cache:

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -44,7 +44,10 @@ import {
 import { Ranking } from '../src/common';
 import nock from 'nock';
 import { deleteKeysByPattern, redisClient } from '../src/redis';
-import { getPersonalizedFeedKey } from '../src/personalizedFeed';
+import {
+  getPersonalizedFeedKey,
+  getPersonalizedFeedKeyPrefix,
+} from '../src/personalizedFeed';
 
 let app: FastifyInstance;
 let con: Connection;
@@ -948,11 +951,8 @@ describe('mutation updateFeedAdvancedSettings', () => {
 
     expect(res.data).toMatchSnapshot();
     expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '1')}:time`),
-    ).toBeFalsy();
-    expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '2')}:time`),
-    ).toEqual('2');
+      await redisClient.get(`${getPersonalizedFeedKeyPrefix('1')}:update`),
+    ).toBeTruthy();
   });
 
   it('should not fail if feed entity does not exists', async () => {
@@ -989,11 +989,8 @@ describe('mutation updateFeedAdvancedSettings', () => {
     });
     expect(res.data).toMatchSnapshot();
     expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '1')}:time`),
-    ).toBeFalsy();
-    expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '2')}:time`),
-    ).toEqual('2');
+      await redisClient.get(`${getPersonalizedFeedKeyPrefix('1')}:update`),
+    ).toBeTruthy();
   });
 
   it('should ignore duplicates', async () => {
@@ -1063,11 +1060,8 @@ describe('mutation addFiltersToFeed', () => {
     });
     expect(res.data).toMatchSnapshot();
     expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '1')}:time`),
-    ).toBeFalsy();
-    expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '2')}:time`),
-    ).toEqual('2');
+      await redisClient.get(`${getPersonalizedFeedKeyPrefix('1')}:update`),
+    ).toBeTruthy();
   });
 
   it('should ignore duplicates', async () => {
@@ -1149,11 +1143,8 @@ describe('mutation removeFiltersFromFeed', () => {
     });
     expect(res.data).toMatchSnapshot();
     expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '1')}:time`),
-    ).toBeFalsy();
-    expect(
-      await redisClient.get(`${getPersonalizedFeedKey('2', '2')}:time`),
-    ).toEqual('2');
+      await redisClient.get(`${getPersonalizedFeedKeyPrefix('1')}:update`),
+    ).toBeTruthy();
   });
 });
 

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -15,11 +15,9 @@ export const redisPubSub = new RedisPubSub({
 });
 
 export function deleteKeysByPattern(pattern: string): Promise<void> {
-  const now = new Date().getTime();
   return new Promise((resolve, reject) => {
     const stream = redisClient.scanStream({ match: pattern });
     stream.on('data', (keys) => {
-      console.log(`[${now}] found data: ${keys.length}`);
       if (keys.length) {
         redisClient.unlink(keys);
       } else {
@@ -27,10 +25,7 @@ export function deleteKeysByPattern(pattern: string): Promise<void> {
         resolve();
       }
     });
-    stream.on('end', () => {
-      console.log(`[${now}] done!`);
-      resolve();
-    });
+    stream.on('end', resolve);
     stream.on('error', reject);
   });
 }


### PR DESCRIPTION
We change the way we invalidate v2 cache by presenting a new key that indicates when was the last update to a given feed.
Comparing the new timestamp with the last generated timestamp indicates if we need to invalidate the cache.
