### PR TITLE
refactor: parse data received from client

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -360,7 +360,7 @@ export const resolvers: IResolvers<any, Context> = {
         .set({ hidden: true })
         .where('"postId" = :postId', { postId })
         .andWhere(`date_trunc('second', "timestamp"::timestamp) = :param`, {
-          param: timestamp,
+          param: new Date(timestamp).toJSON().split('.')[0],
         })
         .andWhere('"userId" = :userId', { userId: ctx.userId })
         .execute(),


### PR DESCRIPTION
Instead of FE worrying about the actual date format to send, whether it should have milliseconds or not, I have thought the BE must be the one to decide that better.