### PR TITLE
fix: timezone was parsed as null in the latest change

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -84,6 +84,9 @@ export const getUserReadingRank = async (
   userId: string,
   timezone = 'utc',
 ): Promise<ReadingRank> => {
+  if (!timezone || timezone === null) {
+    timezone = 'utc';
+  }
   const now = `timezone('${timezone}', now())`;
   const res = await con
     .createQueryBuilder()


### PR DESCRIPTION
The timezone was parsed as null instead of fallback to UTC.
This double check makes sure it's either a timezone or default back to UTC.

Related issue: https://github.com/dailydotdev/daily/issues/349