### PR TITLE
fix: fix duplicate authors for featured comments

### DIFF
--- a/__tests__/cron/__snapshots__/updateFeaturedComments.ts.snap
+++ b/__tests__/cron/__snapshots__/updateFeaturedComments.ts.snap
@@ -31,7 +31,7 @@ Array [
 
 exports[`should update featured comments 2`] = `
 Array [
-  "c3",
   "c2",
+  "c3",
 ]
 `;

--- a/__tests__/cron/__snapshots__/updateFeaturedComments.ts.snap
+++ b/__tests__/cron/__snapshots__/updateFeaturedComments.ts.snap
@@ -26,6 +26,10 @@ Array [
     "featured": false,
     "id": "c6",
   },
+  Comment {
+    "featured": false,
+    "id": "c7",
+  },
 ]
 `;
 

--- a/__tests__/cron/updateFeaturedComments.ts
+++ b/__tests__/cron/updateFeaturedComments.ts
@@ -79,12 +79,14 @@ it('should update featured comments', async () => {
       featured: true,
       upvotes: 3,
     },
+    { id: 'c7', postId: 'p1', userId: '2', content: 'Comment', upvotes: 3 },
   ]);
   await con.getRepository(CommentUpvote).save([
     { commentId: 'c2', userId: '3', createdAt: now },
     { commentId: 'c3', userId: '1', createdAt: now },
     { commentId: 'c4', userId: '1', createdAt: now },
     { commentId: 'c5', userId: '2', createdAt: before },
+    { commentId: 'c7', userId: '1', createdAt: now },
   ]);
   await expectSuccessfulCron(app, cron);
   const comments = await con.getRepository(Comment).find({

--- a/src/cron/updateFeaturedComments.ts
+++ b/src/cron/updateFeaturedComments.ts
@@ -39,7 +39,7 @@ const cron: Cron = {
                 SELECT c.id "commentId"
                 FROM (${postsQuery}) p
                 INNER JOIN (
-                  SELECT c.id, c."postId", ROW_NUMBER() OVER (PARTITION BY c."postId" ORDER BY c.upvotes DESC) r
+                  SELECT DISTINCT ON (c."userId") c.id, c."postId", ROW_NUMBER() OVER (PARTITION BY c."postId" ORDER BY c.upvotes DESC) r
                   FROM "comment" c
                   WHERE c.upvotes >= 3
                 ) c ON c."postId" = p."postId"

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -80,7 +80,7 @@ const obj = new GraphORM({
       },
       featuredComments: {
         customQuery: (ctx, alias, qb): QueryBuilder =>
-          qb.andWhere(`"${alias}".featured is true`),
+          qb.distinctOn([`"userId"`]).andWhere(`"${alias}".featured is true`),
       },
       publication: {
         alias: { field: 'source', type: 'Source' },


### PR DESCRIPTION
Fixed the duplicate authors for featured comments.

![Screenshot 2021-11-16 at 11 46 18](https://user-images.githubusercontent.com/554874/141979029-516c8735-4dbd-48a5-a93f-a2b8ab020524.png)
![Screenshot 2021-11-16 at 11 46 24](https://user-images.githubusercontent.com/554874/141979034-d46293fd-ad59-429d-97d7-d1b0e407519c.png)
![Screenshot 2021-11-16 at 11 45 37](https://user-images.githubusercontent.com/554874/141979036-4ac11c21-13f3-4787-b704-48f62489c364.png)
![Screenshot 2021-11-16 at 11 45 48](https://user-images.githubusercontent.com/554874/141979017-93f86b22-8dfd-46f3-9a6d-59fb84fa812d.png)

Note: We need the " quotes hence the force backticks.

DD-307 #done