### PR TITLE
fix: markdown links target and rel

### DIFF
--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -3,7 +3,7 @@
 exports[`mutation commentOnComment should comment on a comment 1`] = `
 Object {
   "comments": 0,
-  "content": "# my comment",
+  "content": "# my comment http://daily.dev",
   "id": Any<String>,
   "parentId": "c1",
   "postId": "p1",
@@ -12,8 +12,8 @@ Object {
 
 exports[`mutation commentOnPost should comment markdown on a post 1`] = `
 Object {
-  "content": "# my comment",
-  "contentHtml": "<h1>my comment</h1>
+  "content": "# my comment http://daily.dev",
+  "contentHtml": "<h1>my comment <a href=\\"http://daily.dev\\" target=\\"_blank\\" rel=\\"noopener nofollow\\">http://daily.dev</a></h1>
 ",
   "id": Any<String>,
   "parentId": null,

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -240,7 +240,7 @@ describe('mutation commentOnPost', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { postId: 'p1', content: '# my comment' },
+        variables: { postId: 'p1', content: '# my comment http://daily.dev' },
       },
       'UNAUTHENTICATED',
     ));
@@ -251,7 +251,10 @@ describe('mutation commentOnPost', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { postId: 'invalid', content: '# my comment' },
+        variables: {
+          postId: 'invalid',
+          content: '# my comment http://daily.dev',
+        },
       },
       'NOT_FOUND',
     );
@@ -263,7 +266,7 @@ describe('mutation commentOnPost', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { postId: 'p1', content: '# my comment' },
+        variables: { postId: 'p1', content: '# my comment http://daily.dev' },
       },
       'NOT_FOUND',
     );
@@ -273,7 +276,7 @@ describe('mutation commentOnPost', () => {
     loggedUser = '1';
     const res = await client.mutate({
       mutation: MUTATION,
-      variables: { postId: 'p1', content: '# my comment' },
+      variables: { postId: 'p1', content: '# my comment http://daily.dev' },
     });
     expect(res.errors).toBeFalsy();
     const actual = await con.getRepository(Comment).find({
@@ -282,9 +285,10 @@ describe('mutation commentOnPost', () => {
       where: { postId: 'p1' },
     });
     expect(actual.length).toEqual(6);
+    console.log(actual[0]);
     expect(actual[0]).toMatchSnapshot({
       id: expect.any(String),
-      contentHtml: `<h1>my comment</h1>\n`,
+      contentHtml: `<h1>my comment <a href=\"http://daily.dev\" target=\"_blank\" rel=\"noopener nofollow\">http://daily.dev</a></h1>\n`,
     });
     expect(res.data.commentOnPost.id).toEqual(actual[0].id);
     const post = await con.getRepository(Post).findOne('p1');
@@ -305,7 +309,10 @@ describe('mutation commentOnComment', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { commentId: 'c1', content: '# my comment' },
+        variables: {
+          commentId: 'c1',
+          content: '# my comment http://daily.dev',
+        },
       },
       'UNAUTHENTICATED',
     ));
@@ -316,7 +323,10 @@ describe('mutation commentOnComment', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { commentId: 'invalid', content: '# my comment' },
+        variables: {
+          commentId: 'invalid',
+          content: '# my comment http://daily.dev',
+        },
       },
       'NOT_FOUND',
     );
@@ -328,7 +338,10 @@ describe('mutation commentOnComment', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { commentId: 'c1', content: '# my comment' },
+        variables: {
+          commentId: 'c1',
+          content: '# my comment http://daily.dev',
+        },
       },
       'NOT_FOUND',
     );
@@ -340,7 +353,10 @@ describe('mutation commentOnComment', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { commentId: 'c2', content: '# my comment' },
+        variables: {
+          commentId: 'c2',
+          content: '# my comment http://daily.dev',
+        },
       },
       'FORBIDDEN',
     );
@@ -350,7 +366,7 @@ describe('mutation commentOnComment', () => {
     loggedUser = '1';
     const res = await client.mutate({
       mutation: MUTATION,
-      variables: { content: '# my comment', commentId: 'c1' },
+      variables: { content: '# my comment http://daily.dev', commentId: 'c1' },
     });
     expect(res.errors).toBeFalsy();
     const actual = await con.getRepository(Comment).find({
@@ -573,7 +589,7 @@ describe('permalink field', () => {
     loggedUser = '1';
     const res = await client.mutate({
       mutation: MUTATION,
-      variables: { postId: 'p1', content: '# my comment' },
+      variables: { postId: 'p1', content: '# my comment http://daily.dev' },
     });
     expect(res.errors).toBeFalsy();
     expect(res.data.commentOnPost.permalink).toEqual(

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -285,7 +285,6 @@ describe('mutation commentOnPost', () => {
       where: { postId: 'p1' },
     });
     expect(actual.length).toEqual(6);
-    console.log(actual[0]);
     expect(actual[0]).toMatchSnapshot({
       id: expect.any(String),
       contentHtml: `<h1>my comment <a href=\"http://daily.dev\" target=\"_blank\" rel=\"noopener nofollow\">http://daily.dev</a></h1>\n`,

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -21,20 +21,18 @@ const defaultRender =
     return self.renderToken(tokens, idx, options);
   };
 
+const setTokenAttribute = (tokens, attribute, attributeValue) => {
+  const attributeIndex = tokens.attrIndex('attribute');
+  if (attributeIndex < 0) {
+    tokens.attrPush([attribute, attributeValue]);
+  } else {
+    tokens.attrs[attributeIndex][1] = attributeValue;
+  }
+  return tokens;
+};
+
 markdown.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-  const targetIndex = tokens[idx].attrIndex('target');
-  if (targetIndex < 0) {
-    tokens[idx].attrPush(['target', '_blank']);
-  } else {
-    tokens[idx].attrs[targetIndex][1] = '_blank';
-  }
-
-  const relIndex = tokens[idx].attrIndex('rel');
-  if (relIndex < 0) {
-    tokens[idx].attrPush(['rel', 'noopener nofollow']);
-  } else {
-    tokens[idx].attrs[relIndex][1] = 'noopener nofollow';
-  }
-
+  tokens[idx] = setTokenAttribute(tokens[idx], 'target', '_blank');
+  tokens[idx] = setTokenAttribute(tokens[idx], 'rel', 'noopener nofollow');
   return defaultRender(tokens, idx, options, env, self);
 };

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -14,3 +14,27 @@ export const markdown: MarkdownIt = MarkdownIt({
     return str;
   },
 });
+
+const defaultRender =
+  markdown.renderer.rules.link_open ||
+  function (tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options);
+  };
+
+markdown.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+  const targetIndex = tokens[idx].attrIndex('target');
+  if (targetIndex < 0) {
+    tokens[idx].attrPush(['target', '_blank']);
+  } else {
+    tokens[idx].attrs[targetIndex][1] = '_blank';
+  }
+
+  const relIndex = tokens[idx].attrIndex('rel');
+  if (relIndex < 0) {
+    tokens[idx].attrPush(['rel', 'noopener nofollow']);
+  } else {
+    tokens[idx].attrs[relIndex][1] = 'noopener nofollow';
+  }
+
+  return defaultRender(tokens, idx, options, env, self);
+};


### PR DESCRIPTION
Make sure markdown links get target blank and rel attribute.

Note: When pushing life, we have to re-seed the comments.
- Remove all existing content_html and run the helper again.