### PR TITLE
feat: add new route to add posts

### DIFF
--- a/__tests__/__snapshots__/newPost.ts.snap
+++ b/__tests__/__snapshots__/newPost.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`POST /p/newPost should save a new post with basic information 1`] = `
+Object {
+  "authorId": null,
+  "banned": false,
+  "canonicalUrl": "https://post.com",
+  "comments": 0,
+  "createdAt": Any<Date>,
+  "creatorTwitter": null,
+  "deleted": false,
+  "description": null,
+  "discussionScore": null,
+  "id": Any<String>,
+  "image": null,
+  "lastTrending": null,
+  "metadataChangedAt": Any<Date>,
+  "placeholder": null,
+  "publishedAt": null,
+  "ratio": null,
+  "readTime": null,
+  "score": Any<Number>,
+  "sentAnalyticsReport": true,
+  "shortId": Any<String>,
+  "siteTwitter": null,
+  "sourceId": "a",
+  "summary": null,
+  "tagsStr": null,
+  "title": "Title",
+  "toc": null,
+  "trending": null,
+  "tweeted": false,
+  "upvotes": 0,
+  "url": "https://post.com",
+  "views": 0,
+  "viewsThreshold": 0,
+}
+`;

--- a/__tests__/newPost.ts
+++ b/__tests__/newPost.ts
@@ -1,0 +1,64 @@
+import { Connection, getConnection } from 'typeorm';
+import appFunc from '../src';
+import { FastifyInstance } from 'fastify';
+import { saveFixtures } from './helpers';
+import { Post, Source } from '../src/entity';
+import { sourcesFixture } from './fixture/source';
+import request from 'supertest';
+
+let app: FastifyInstance;
+let con: Connection;
+
+beforeAll(async () => {
+  con = await getConnection();
+  app = await appFunc();
+  return app.ready();
+});
+
+afterAll(() => app.close());
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, Source, sourcesFixture);
+});
+
+describe('POST /p/newPost', () => {
+  it('should return not found when not authorized', () => {
+    return request(app.server).post('/p/newPost').expect(404);
+  });
+
+  it('should save a new post with basic information', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newPost')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: 'p1',
+        title: 'Title',
+        url: 'https://post.com',
+        publicationId: 'a',
+      })
+      .expect(200);
+    const posts = await con.getRepository(Post).find();
+    expect(posts.length).toEqual(1);
+    expect(body).toEqual({ status: 'ok', postId: posts[0].id });
+    expect(posts[0]).toMatchSnapshot({
+      createdAt: expect.any(Date),
+      metadataChangedAt: expect.any(Date),
+      score: expect.any(Number),
+      id: expect.any(String),
+      shortId: expect.any(String),
+    });
+  });
+
+  it('should handle empty body', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newPost')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send()
+      .expect(200);
+    const posts = await con.getRepository(Post).find();
+    expect(posts.length).toEqual(0);
+    expect(body).toEqual({ status: 'failed', reason: 'missing fields' });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -13,6 +13,7 @@ declare module 'fastify' {
     userId?: string;
     premium?: boolean;
     roles?: Roles[];
+    service?: boolean;
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */
 }
@@ -54,15 +55,14 @@ const plugin = async (
   fastify.decorateRequest('roles', null);
   // Machine-to-machine authentication
   fastify.addHook('preHandler', async (req) => {
-    if (
-      req.headers['authorization'] === `Service ${opts.secret}` &&
-      req.headers['user-id'] &&
-      req.headers['logged-in'] === 'true'
-    ) {
-      req.userId = req.headers['user-id'] as string;
-      req.premium = req.headers.premium === 'true';
-      req.roles =
-        ((req.headers['roles'] as string)?.split(',') as Roles[]) ?? [];
+    if (req.headers['authorization'] === `Service ${opts.secret}`) {
+      req.service = true;
+      if (req.headers['user-id'] && req.headers['logged-in'] === 'true') {
+        req.userId = req.headers['user-id'] as string;
+        req.premium = req.headers.premium === 'true';
+        req.roles =
+          ((req.headers['roles'] as string)?.split(',') as Roles[]) ?? [];
+      }
     } else {
       delete req.headers['user-id'];
       delete req.headers['logged-in'];

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -12,3 +12,7 @@ export * from './users';
 export * from './mailing';
 export * from './post';
 export * from './links';
+
+export const uniqueifyArray = <T>(array: T[]): T[] => {
+  return [...new Set(array)];
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,9 +3,11 @@ import { FastifyInstance } from 'fastify';
 import rss from './rss';
 import redirector from './redirector';
 import devcards from './devcards';
+import privateRoutes from './private';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(rss, { prefix: '/rss' });
   fastify.register(redirector, { prefix: '/r' });
   fastify.register(devcards, { prefix: '/devcards' });
+  fastify.register(privateRoutes, { prefix: '/p' });
 }

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from 'fastify';
+import { addNewPost, AddPostData } from '../entity';
+import { getConnection } from 'typeorm';
+
+export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.post<{ Body: AddPostData }>('/newPost', async (req, res) => {
+    if (!req.service) {
+      return res.status(404).send();
+    }
+    const con = getConnection();
+    const operationResult = await addNewPost(con, req.body);
+    return res.status(200).send(operationResult);
+  });
+}

--- a/src/workers/newPost.ts
+++ b/src/workers/newPost.ts
@@ -1,212 +1,46 @@
-import shortid from 'shortid';
-import { Connection, In } from 'typeorm';
-import * as he from 'he';
-import { Keyword, Post, PostKeyword, PostTag, Toc, User } from '../entity';
+import { addNewPost, AddPostData } from '../entity';
 import { messageToJson, Worker } from './worker';
-
-interface AddPostData {
-  id: string;
-  title: string;
-  url: string;
-  publicationId: string;
-  publishedAt?: string | Date;
-  createdAt?: Date;
-  image?: string;
-  ratio?: number;
-  placeholder?: string;
-  tags?: string[];
-  siteTwitter?: string;
-  creatorTwitter?: string;
-  readTime?: number;
-  canonicalUrl?: string;
-  keywords?: string[];
-  description?: string;
-  toc?: Toc;
-  summary?: string;
-}
-
-type Result = { postId: string; authorId?: string };
-
-const addPost = async (con: Connection, data: AddPostData): Promise<void> => {
-  await con.transaction(async (entityManager): Promise<Result> => {
-    let keywords: string[] = null;
-    if (data.keywords?.length > 0) {
-      const synonymKeywords = await entityManager.getRepository(Keyword).find({
-        where: {
-          status: 'synonym',
-          value: In(data.keywords),
-        },
-      });
-      keywords = Array.from(
-        new Set(
-          data.keywords
-            .map((keyword) => {
-              const synonym = synonymKeywords.find(
-                (synonym) => synonym.value === keyword && synonym.synonym,
-              );
-              return synonym?.synonym ?? keyword;
-            })
-            .filter((keyword) => !keyword.match(/^\d+$/)),
-        ),
-      );
-    }
-    const tags =
-      keywords?.length > 0
-        ? await entityManager.getRepository(Keyword).find({
-            where: {
-              status: 'allow',
-              value: In(keywords),
-            },
-            order: { occurrences: 'DESC' },
-          })
-        : null;
-    let authorId = null;
-    if (data.creatorTwitter && typeof data.creatorTwitter === 'string') {
-      const twitter = (
-        data.creatorTwitter[0] === '@'
-          ? data.creatorTwitter.substr(1)
-          : data.creatorTwitter
-      ).toLowerCase();
-      const author = await entityManager
-        .getRepository(User)
-        .createQueryBuilder()
-        .select('id')
-        .where(
-          `lower(twitter) = :twitter or (lower(username) = :twitter and username = 'addyosmani')`,
-          {
-            twitter,
-          },
-        )
-        .getRawOne();
-      if (author) {
-        authorId = author.id;
-      }
-    }
-    await entityManager.getRepository(Post).insert({
-      id: data.id,
-      shortId: data.id,
-      publishedAt: data.publishedAt && new Date(data.publishedAt),
-      createdAt: data.createdAt,
-      sourceId: data.publicationId,
-      url: data.url,
-      title: data.title,
-      image: data.image,
-      ratio: data.ratio,
-      placeholder: data.placeholder,
-      score: Math.floor(data.createdAt.getTime() / (1000 * 60)),
-      siteTwitter: data.siteTwitter,
-      creatorTwitter: data.creatorTwitter,
-      readTime: data.readTime,
-      tagsStr: tags?.map((t) => t.value).join(',') || null,
-      canonicalUrl: data.canonicalUrl,
-      authorId,
-      sentAnalyticsReport: !authorId,
-      description: data.description,
-      toc: data.toc,
-      summary: data.summary,
-    });
-    if (data.tags?.length) {
-      await entityManager.getRepository(PostTag).insert(
-        data.tags.map((t) => ({
-          tag: t,
-          postId: data.id,
-        })),
-      );
-    }
-    if (keywords?.length) {
-      await entityManager
-        .createQueryBuilder()
-        .insert()
-        .into(Keyword)
-        .values(keywords.map((keyword) => ({ value: keyword })))
-        .onConflict(
-          `("value") DO UPDATE SET occurrences = keyword.occurrences + 1`,
-        )
-        .execute();
-      await entityManager.getRepository(PostKeyword).insert(
-        keywords.map((keyword) => ({
-          keyword,
-          postId: data.id,
-        })),
-      );
-    }
-    return {
-      postId: data.id,
-      authorId,
-    };
-  });
-};
-
-const parseReadTime = (
-  readTime: number | string | undefined,
-): number | undefined => {
-  if (!readTime) {
-    return undefined;
-  }
-  if (typeof readTime == 'number') {
-    return Math.floor(readTime);
-  }
-  return Math.floor(parseInt(readTime));
-};
 
 const worker: Worker = {
   subscription: 'add-posts-v2',
   handler: async (message, con, logger): Promise<void> => {
     const data: AddPostData = messageToJson(message);
-    if (!data.canonicalUrl?.length) {
-      data.canonicalUrl = data.url;
-    }
-
-    const p = await con
-      .getRepository(Post)
-      .createQueryBuilder()
-      .select('id')
-      .where(
-        'url = :url or url = :canonicalUrl or "canonicalUrl" = :url or "canonicalUrl" = :canonicalUrl',
-        { url: data.url, canonicalUrl: data.canonicalUrl },
-      )
-      .getRawOne();
-    if (p) {
-      logger.info(
-        {
-          post: data,
-          messageId: message.messageId,
-        },
-        'post url already exists',
-      );
-      return;
-    }
-    if (data.creatorTwitter === '@NewGenDeveloper') {
-      logger.info(
-        {
-          post: data,
-          messageId: message.messageId,
-        },
-        'author is banned',
-      );
-      return;
-    }
-
-    if (!data.title) {
-      return;
-    }
-
-    data.id = shortid.generate();
-    data.title = he.decode(data.title);
-    data.createdAt = new Date();
-    data.readTime = parseReadTime(data.readTime);
-    if (data.creatorTwitter === '' || data.creatorTwitter === '@') {
-      data.creatorTwitter = null;
-    }
     try {
-      await addPost(con, data);
-      logger.info(
-        {
-          post: data,
-          messageId: message.messageId,
-        },
-        'added successfully post',
-      );
+      const res = await addNewPost(con, data);
+      if (res.status === 'ok') {
+        logger.info(
+          {
+            post: data,
+            messageId: message.messageId,
+          },
+          'added successfully post',
+        );
+      } else if (res.error) {
+        logger.error(
+          {
+            post: data,
+            messageId: message.messageId,
+            err: res.error,
+          },
+          'failed to add post to db',
+        );
+      } else if (res.reason === 'exists') {
+        logger.info(
+          {
+            post: data,
+            messageId: message.messageId,
+          },
+          'post url already exists',
+        );
+      } else if (res.reason === 'author banned') {
+        logger.info(
+          {
+            post: data,
+            messageId: message.messageId,
+          },
+          'author is banned',
+        );
+      }
     } catch (err) {
       logger.error(
         {
@@ -216,13 +50,8 @@ const worker: Worker = {
         },
         'failed to add post to db',
       );
-      // Foreign / unique / null violation / index row size
-      if (
-        err?.code === '23502' ||
-        err?.code === '23503' ||
-        err?.code === '23505' ||
-        err?.code === '54000'
-      ) {
+      // Foreign / index row size
+      if (err?.code === '23503' || err?.code === '54000') {
         return;
       }
       throw err;


### PR DESCRIPTION
The new route will be used by our new Gatekeeper service to push new content to the database.
Currently, adding new articles is supported only through Pub/Sub and the Gatekeeper requires a synchronous solution so Pub/Sub is not suited for this.