### PR TITLE
fix: anonymous feed support for logged in users

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -807,6 +807,56 @@ Object {
 }
 `;
 
+exports[`query anonymousFeed should return anonymous feed v2 and ignore existing filters 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
 exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
 Object {
   "anonymousFeed": Object {


### PR DESCRIPTION
Feed v2 introduced a bug where if the user is logged-in then it will automatically fetch the feed with the filters. This PR fixes the issue and adds support for anonymous feed for logged-in users.
