### PR TITLE
fix: new slack comment format

### DIFF
--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -15,7 +15,7 @@ export const notifyNewComment = async (
     text: 'New comment',
     attachments: [
       {
-        title: post.title,
+        title: comment,
         title_link: getDiscussionLink(post.id),
         fields: [
           {
@@ -23,8 +23,8 @@ export const notifyNewComment = async (
             value: userId,
           },
           {
-            title: 'Comment',
-            value: comment,
+            title: 'Post title',
+            value: post.title,
           },
         ],
         color: '#1DDC6F',


### PR DESCRIPTION
Swapped around the title and the comment field for the slack message.

New format:

![Screenshot 2022-01-17 at 13 31 16](https://user-images.githubusercontent.com/554874/149762170-4b4ea69c-ec6b-4ffe-b2a7-61a9839bd415.png)