### PR TITLE
fix: timezone was not actively used for the reading history overview

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -327,13 +327,19 @@ export const resolvers: IResolvers<any, Context> = {
       ctx: Context,
       info,
     ): Promise<Connection<GQLView>> => {
+      const user = await ctx.con
+        .getRepository(User)
+        .findOneOrFail({ where: { id: ctx.userId }, select: ['timezone'] });
       const queryBuilder = (builder: GraphORMBuilder): GraphORMBuilder => {
         builder.queryBuilder = builder.queryBuilder
           .andWhere(`"${builder.alias}"."userId" = :userId`, {
             userId: ctx.userId,
           })
-          .andWhere(`"${builder.alias}"."hidden" = false`);
-
+          .andWhere(`"${builder.alias}"."hidden" = false`)
+          .addSelect(
+            `"timestamp" at time zone '${user.timezone ?? 'utc'}'`,
+            'timestamp',
+          );
         return builder;
       };
 


### PR DESCRIPTION
We introduced the timezone for all reading history queries, but not the actual overview.
This fix makes sure we convert the timezone to the user's set timezone.

DD-497 #done 