### PR TITLE
fix: reading history was failing on users with no timezone

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -327,9 +327,7 @@ export const resolvers: IResolvers<any, Context> = {
       ctx: Context,
       info,
     ): Promise<Connection<GQLView>> => {
-      const user = await ctx.con
-        .getRepository(User)
-        .findOneOrFail({ where: { id: ctx.userId }, select: ['timezone'] });
+      const user = await ctx.con.getRepository(User).findOneOrFail(ctx.userId);
       const queryBuilder = (builder: GraphORMBuilder): GraphORMBuilder => {
         builder.queryBuilder = builder.queryBuilder
           .andWhere(`"${builder.alias}"."userId" = :userId`, {


### PR DESCRIPTION
In the way I was loading the user before it would fail if the user didn't have a timezone set.
Meaning they wouldn't be able to load their reading history.

After fixing this issue it also seems that the removing started working locally again.
Will have to double check on merge.

DD-498 #done 