### PR TITLE
fix: fix for the hiding of the read history

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -36,6 +36,7 @@ export interface GQLUser {
 export interface GQLView {
   post: Post;
   timestamp: Date;
+  timestamp_db: Date;
 }
 
 type CommentStats = { numComments: number; numCommentUpvotes: number };
@@ -142,6 +143,7 @@ export const typeDefs = /* GraphQL */ `
 
   type ReadingHistory {
     timestamp: DateTime!
+    timestamp_db: DateTime!
     post: Post!
   }
 
@@ -337,7 +339,8 @@ export const resolvers: IResolvers<any, Context> = {
           .addSelect(
             `"timestamp" at time zone '${user.timezone ?? 'utc'}'`,
             'timestamp',
-          );
+          )
+          .addSelect('timestamp', 'timestamp_db');
         return builder;
       };
 


### PR DESCRIPTION
Since we introduced the timezone in a local timezone for that specific user we needed to also send the database timezone as we use this to hide the view.

See related changes on frontend here:
