### PR TITLE
refactor: tags limit on reading rank

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -273,8 +273,8 @@ describe('query userMostReadTags', () => {
 });
 
 describe('query userReadingRank', () => {
-  const QUERY = `query UserReadingRank($id: ID!, $version: Int){
-    userReadingRank(id: $id, version: $version) {
+  const QUERY = `query UserReadingRank($id: ID!, $version: Int, $limit: Int){
+    userReadingRank(id: $id, version: $version, limit: $limit) {
       rankThisWeek
       rankLastWeek
       currentRank
@@ -418,13 +418,25 @@ describe('query userReadingRank', () => {
       },
     ]);
     const res = await client.query(QUERY, {
-      variables: { id: '1', version: 2 },
+      variables: { id: '1', version: 2, limit: 8 },
     });
     expect(res.errors).toBeFalsy();
     const { tags } = res.data.userReadingRank;
     expect(tags.length).toEqual(8);
     const sum = tags.reduce((total, { readingDays }) => total + readingDays, 0);
     expect(sum).toEqual(12);
+
+    const limited = await client.query(QUERY, {
+      variables: { id: '1', version: 2, limit: 6 },
+    });
+    expect(limited.errors).toBeFalsy();
+    const { tags: limitedTags } = limited.data.userReadingRank;
+    expect(limitedTags.length).toEqual(6);
+    const limitedSum = limitedTags.reduce(
+      (total, { readingDays }) => total + readingDays,
+      0,
+    );
+    expect(limitedSum).toEqual(10);
   });
 
   it('should return the last read time accurately', async () => {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -148,6 +148,7 @@ export const getUserReadingRank = async (
   userId: string,
   timezone = 'utc',
   includeTags = false,
+  limit = 6,
 ): Promise<ReadingRank> => {
   if (!timezone || timezone === null) {
     timezone = 'utc';
@@ -180,6 +181,7 @@ export const getUserReadingRank = async (
     const end = new Date(endOfWeek(now).getTime()).toISOString();
 
     return getUserReadingDays(con, {
+      limit,
       userId,
       dateRange: { start, end },
     });

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -68,6 +68,7 @@ export interface GQLMostReadTag {
 export interface ReadingRankArgs {
   id: string;
   version?: number;
+  limit?: number;
 }
 
 export const typeDefs = /* GraphQL */ `
@@ -185,7 +186,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get the reading rank of the user
     """
-    userReadingRank(id: ID!, version: Int): ReadingRank
+    userReadingRank(id: ID!, version: Int, limit: Int): ReadingRank
     """
     Get the most read tags of the user
     """
@@ -281,7 +282,7 @@ export const resolvers: IResolvers<any, Context> = {
     },
     userReadingRank: async (
       _,
-      { id, version }: ReadingRankArgs,
+      { id, version, limit }: ReadingRankArgs,
       ctx: Context,
     ): Promise<GQLReadingRank> => {
       const isSameUser = ctx.userId === id;
@@ -291,6 +292,7 @@ export const resolvers: IResolvers<any, Context> = {
         id,
         user?.timezone,
         version > 1,
+        limit ?? 6,
       );
 
       return isSameUser ? rank : { currentRank: rank.currentRank };

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -282,7 +282,7 @@ export const resolvers: IResolvers<any, Context> = {
     },
     userReadingRank: async (
       _,
-      { id, version, limit }: ReadingRankArgs,
+      { id, version, limit = 6 }: ReadingRankArgs,
       ctx: Context,
     ): Promise<GQLReadingRank> => {
       const isSameUser = ctx.userId === id;
@@ -292,7 +292,7 @@ export const resolvers: IResolvers<any, Context> = {
         id,
         user?.timezone,
         version > 1,
-        limit ?? 6,
+        limit,
       );
 
       return isSameUser ? rank : { currentRank: rank.currentRank };


### PR DESCRIPTION
The `userReadingRank` now accepts a `limit` param for the number of tags to return but the default value is 6.