### PR TITLE
fix: use the correct timezone for calculating tags

### DIFF
--- a/src/common/devcard.ts
+++ b/src/common/devcard.ts
@@ -1,8 +1,7 @@
 import { subYears } from 'date-fns';
-import { getUserReadingRank, ReadingRank, getUserReadingDays } from './users';
-import { Post, Source, View } from '../entity';
+import { getUserReadingRank, ReadingRank, getUserReadingTags } from './users';
+import { Post, Source, View, User } from '../entity';
 import { Connection } from 'typeorm';
-import { User } from '../entity/User';
 import { ReadingDaysArgs } from './users';
 
 export interface MostReadTag {
@@ -15,7 +14,7 @@ export const getMostReadTags = async (
   con: Connection,
   args: ReadingDaysArgs,
 ): Promise<MostReadTag[]> => {
-  const result = await getUserReadingDays(con, args);
+  const result = await getUserReadingTags(con, args);
 
   return result.map(({ tag, readingDays, ...props }) => ({
     value: tag,


### PR DESCRIPTION
Before, we use the functions `startOfWeek` and `endOfWeek` to calculate the date range for the user tags reading rank.
These functions don't take into account the user's timezone.
This fix uses postgres timezone function before truncating to week.

DD-547 #done