### PR TITLE
fix: In some cases the timezone was actually negative

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -154,7 +154,7 @@ export const getUserReadingRank = async (
   version = 1,
   limit = 6,
 ): Promise<ReadingRank> => {
-  if (!timezone || timezone === null) {
+  if (!timezone) {
     timezone = 'utc';
   }
   const nowTimezone = `timezone('${timezone}', now())`;
@@ -162,11 +162,11 @@ export const getUserReadingRank = async (
   const req = con
     .createQueryBuilder()
     .select(
-      `count(distinct (date_trunc('day', "timestamp"::timestamptz) ${atTimezone})) filter(where "timestamp" >= date_trunc('week', ${nowTimezone}) ${atTimezone})`,
+      `count(distinct ("timestamp"::timestamptz ${atTimezone})::date::text) filter(where "timestamp" >= date_trunc('week', ${nowTimezone}))`,
       'thisWeek',
     )
     .addSelect(
-      `count(distinct (date_trunc('day', "timestamp"::timestamptz) ${atTimezone})) filter(where "timestamp" BETWEEN (date_trunc('week', ${nowTimezone} - interval '7 days') ${atTimezone}) AND (date_trunc('week', ${nowTimezone}) ${atTimezone}))`,
+      `count(distinct ("timestamp"::timestamptz ${atTimezone})::date::text) filter(where "timestamp" BETWEEN (date_trunc('week', ${nowTimezone} - interval '7 days')) AND (date_trunc('week', ${nowTimezone})))`,
       'lastWeek',
     )
     .addSelect(`MAX("timestamp"::timestamptz ${atTimezone})`, 'lastReadTime')

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -162,11 +162,11 @@ export const getUserReadingRank = async (
   const req = con
     .createQueryBuilder()
     .select(
-      `count(distinct date_trunc('day', "timestamp"::timestamptz ${atTimezone}) ${atTimezone}) filter(where "timestamp" >= date_trunc('week', ${nowTimezone}) ${atTimezone})`,
+      `count(distinct (date_trunc('day', "timestamp"::timestamptz) ${atTimezone})) filter(where "timestamp" >= date_trunc('week', ${nowTimezone}) ${atTimezone})`,
       'thisWeek',
     )
     .addSelect(
-      `count(distinct date_trunc('day', "timestamp"::timestamptz ${atTimezone}) ${atTimezone}) filter(where "timestamp" BETWEEN (date_trunc('week', ${nowTimezone} - interval '7 days') ${atTimezone}) AND (date_trunc('week', ${nowTimezone}) ${atTimezone}))`,
+      `count(distinct (date_trunc('day', "timestamp"::timestamptz) ${atTimezone})) filter(where "timestamp" BETWEEN (date_trunc('week', ${nowTimezone} - interval '7 days') ${atTimezone}) AND (date_trunc('week', ${nowTimezone}) ${atTimezone}))`,
       'lastWeek',
     )
     .addSelect(`MAX("timestamp"::timestamptz ${atTimezone})`, 'lastReadTime')

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -332,7 +332,7 @@ const readHistoryResolver = async (
 };
 
 const userTimezone = `at time zone COALESCE(timezone, 'utc')`;
-const timestampAtTimezone = `"timestamp"::timestamptz`;
+const timestampAtTimezone = `"timestamp"::timestamptz ${userTimezone}`;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const resolvers: IResolvers<any, Context> = {
@@ -411,10 +411,10 @@ export const resolvers: IResolvers<any, Context> = {
         select ${rankColumn} as "rank",
                count(*)                                    as "count"
         from (
-               select date_trunc('week', ${timestampAtTimezone}) ${userTimezone} as "timestamp",
+               select date_trunc('week', "timestamp") as "timestamp",
                       count(*)                        as days
                from (
-                      select date_trunc('day', ${timestampAtTimezone}) ${userTimezone} AS "timestamp",
+                      select (${timestampAtTimezone})::date AS "timestamp",
                       min("user".timezone) as "timezone"
                       from "view"
                       join "user" on "user".id = view."userId"
@@ -438,7 +438,7 @@ export const resolvers: IResolvers<any, Context> = {
     ): Promise<GQLReadingRankHistory[]> => {
       return ctx.con.query(
         `
-          select (date_trunc('day', ${timestampAtTimezone}) ${userTimezone})::date::text as "date", count(*) as "reads"
+          select (${timestampAtTimezone})::date::text as "date", count(*) as "reads"
           from "view"
           join "user" on "user".id = view."userId"
           where "userId" = $1

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -332,7 +332,7 @@ const readHistoryResolver = async (
 };
 
 const userTimezone = `at time zone COALESCE(timezone, 'utc')`;
-const timestampAtTimezone = `"timestamp"::timestamptz ${userTimezone}`;
+const timestampAtTimezone = `"timestamp"::timestamptz`;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const resolvers: IResolvers<any, Context> = {


### PR DESCRIPTION
Let's take the following data as an example:
![Screenshot 2022-02-16 at 14 20 51](https://user-images.githubusercontent.com/554874/154266266-b3476ea9-4e69-4485-ada9-203b31940257.png)

In the current live version (double timezone) we actually reset the timezone back to UTC
![Screenshot 2022-02-16 at 14 22 16](https://user-images.githubusercontent.com/554874/154266320-e6cfbc78-52f4-451f-93b0-1fe6f15a9f6a.png)
 
When only using one timezone conversion it shows the time in that users zone:
![Screenshot 2022-02-16 at 14 21 59](https://user-images.githubusercontent.com/554874/154266382-7c78bd4f-7db0-48f7-9b44-4277e64d8e4e.png)

Let me know what you think.
I left the weekly rank, as this is based on the users week, which might start on a different day.

DD-550 #done 