### PR TITLE
fix: restrict mention on null username

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -179,7 +179,7 @@ export const getUserIdsByNameOrUsername = async (
     .getRepository(DbUser)
     .createQueryBuilder()
     .select('id')
-    .where('(name ILIKE :name OR username ILIKE :name)', {
+    .where(`(replace(name, ' ', '') ILIKE :name OR username ILIKE :name)`, {
       name: `${query}%`,
     })
     .andWhere('username IS NOT NULL')

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -182,6 +182,7 @@ export const getUserIdsByNameOrUsername = async (
     .where('(name ILIKE :name OR username ILIKE :name)', {
       name: `${query}%`,
     })
+    .andWhere('username IS NOT NULL')
     .limit(limit);
 
   if (excludeIds?.length) {


### PR DESCRIPTION
Since the name was the one used for searching the LIKE fails on username even being null.

This should explicitly restrict the result for users without usernames.