### PR TITLE
refactor: disable graphql subscriptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,10 +83,10 @@ export default async function app(
     context:
       contextFn ?? ((request): Context => new Context(request, connection)),
     queryDepth: 10,
-    subscription: {
-      context: (wsConnection, request): Context =>
-        new Context(request, connection),
-    },
+    // subscription: {
+    //   context: (wsConnection, request): Context =>
+    //     new Context(request, connection),
+    // },
     graphiql: !isProd,
     errorFormatter(execution) {
       if (execution.errors?.length > 0) {


### PR DESCRIPTION
Disable GraphQL subscriptions due to the memory and CPU overload which caused performance regression.
We can evaluate separating subscriptions to a new deployable unit