### PR TITLE
feat: Add companion helper alert

### DIFF
--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -3,6 +3,7 @@
 exports[`mutation updateUserAlerts should create user alerts when does not exist 1`] = `
 Object {
   "updateUserAlerts": Object {
+    "companionHelper": true,
     "filter": false,
     "myFeed": null,
     "rankLastSeen": null,
@@ -13,6 +14,7 @@ Object {
 exports[`mutation updateUserAlerts should update alerts of user 1`] = `
 Object {
   "updateUserAlerts": Object {
+    "companionHelper": false,
     "filter": false,
     "myFeed": "created",
     "rankLastSeen": "2020-09-22T12:15:51.247Z",

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -39,6 +39,7 @@ describe('query userAlerts', () => {
       filter
       rankLastSeen
       myFeed
+      companionHelper
     }
   }`;
 
@@ -72,6 +73,7 @@ describe('mutation updateUserAlerts', () => {
         filter
         rankLastSeen
         myFeed
+        companionHelper
       }
     }
   `;
@@ -105,6 +107,7 @@ describe('mutation updateUserAlerts', () => {
         filter: true,
         rankLastSeen: rankLastSeenOld,
         myFeed: 'created',
+        companionHelper: true,
       }),
     );
 
@@ -115,6 +118,7 @@ describe('mutation updateUserAlerts', () => {
           filter: false,
           rankLastSeen: rankLastSeen.toISOString(),
           myFeed: 'created',
+          companionHelper: false,
         },
       },
     });

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -681,6 +681,7 @@ describe('alerts', () => {
     filter: true,
     rankLastSeen: rankLastSeen.getTime(),
     myFeed: 'created',
+    companionHelper: true,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -14,10 +14,14 @@ export class Alerts {
 
   @Column({ type: 'text', default: null })
   myFeed: string;
+
+  @Column({ type: 'bool', default: true })
+  companionHelper: boolean;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   filter: true,
   rankLastSeen: null,
   myFeed: null,
+  companionHelper: true,
 };

--- a/src/migration/1649851992869-AddCompanionHelper.ts
+++ b/src/migration/1649851992869-AddCompanionHelper.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCompanionHelper1649851992869 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "public"."alerts" ADD "companionHelper" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "public"."alerts" DROP COLUMN "companionHelper"`,
+    );
+  }
+}

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -8,6 +8,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         filter
         rankLastSeen
         myFeed
+        companionHelper
       }
     }`;
 

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -36,6 +36,13 @@ export const typeDefs = /* GraphQL */ `
     null: The user clicked to not show the alert anymore
     """
     myFeed: String
+
+    """
+    Wether to show the companion helper
+    Default = true, meaning yes show it
+    Once the user has seen it once, we set this value to false
+    """
+    companionHelper: Boolean!
   }
 
   input UpdateAlertsInput {
@@ -53,6 +60,11 @@ export const typeDefs = /* GraphQL */ `
     Status for the My Feed alert
     """
     myFeed: String
+
+    """
+    Status to display for companion helper
+    """
+    companionHelper: Boolean
   }
 
   extend type Mutation {


### PR DESCRIPTION
Added a companion helper alert.
This alert will keep track of wether someone has opened the companion before (if so we don't show the helper again)

The default is true: meaning companion helper should be shown
If it's set to false we don't show the companion helper.

We can possibly event update this alert in the boot query for the companion to update to false, since it's a once-off thing.

DD-458