### PR TITLE
ci: change docker registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,12 @@ jobs:
       - gcp-gcr/build-image:
           image: $CIRCLE_PROJECT_REPONAME
           tag: $CIRCLE_SHA1
+          registry-url: us.gcr.io
       - gcp-gcr/gcr-auth
       - gcp-gcr/push-image:
           image: $CIRCLE_PROJECT_REPONAME
           tag: $CIRCLE_SHA1
+          registry-url: us.gcr.io
   pulumi_preview:
     docker:
       - image: circleci/node:14
@@ -154,6 +156,7 @@ workflows:
           image: $CIRCLE_PROJECT_REPONAME
           source-tag: $CIRCLE_SHA1
           target-tag: latest
+          registry-url: us.gcr.io
           filters:
             branches:
               only:

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -92,7 +92,7 @@ createKubernetesSecretFromRecord({
   namespace,
 });
 
-const image = `gcr.io/daily-ops/daily-${name}:${imageTag}`;
+const image = `us.gcr.io/daily-ops/daily-${name}:${imageTag}`;
 
 const k8sServiceAccount = bindK8sServiceAccountToGCP(
   '',


### PR DESCRIPTION
We now use `us.gcr.io` as our public registry.
`gcr.io` will be turned private soon.

DD-235