### PR TITLE
fix: remove HTML option from markdown parser

### DIFF
--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -92,6 +92,11 @@ Array [
 ]
 `;
 
+exports[`query commentPreview should only render markdown not HTML 1`] = `
+"<h1>Test &lt;button&gt;Test&lt;/button&gt;</h1>
+"
+`;
+
 exports[`query commentPreview should return markdown equivalent of the content 1`] = `
 "<h1>Test</h1>
 "

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -270,6 +270,15 @@ describe('query commentPreview', () => {
     expect(withMention.errors).toBeFalsy();
     expect(withMention.data.commentPreview).toMatchSnapshot();
   });
+
+  it('should only render markdown not HTML', async () => {
+    loggedUser = '1';
+    await saveCommentMentionFixtures();
+    const content = '# Test <button>Test</button>';
+    const res = await client.query(QUERY, { variables: { content } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.commentPreview).toMatchSnapshot();
+  });
 });
 
 describe('query recommendedMentions', () => {
@@ -278,7 +287,7 @@ describe('query recommendedMentions', () => {
       recommendedMentions(postId: $postId, query: $query, limit: $limit) {
         name
         username
-        image      
+        image
       }
     }
   `;

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -4,7 +4,7 @@ import { getUserProfileUrl } from './users';
 import { User } from '../entity';
 
 export const markdown: MarkdownIt = MarkdownIt({
-  html: true,
+  html: false,
   linkify: true,
   typographer: true,
   highlight: function (str, lang) {


### PR DESCRIPTION
We had the HTML option enabled in the markdown parser, allowing all HTML to be valid.
We removed this so the rendered only renders markdown to HTML, and converts HTML into plain strings.

We also added a test case to validate this change, and tested it locally.

DD-595 #done 