### PR TITLE
refactor: settings entity - additional property (autoDismissNotifications)

### DIFF
--- a/__tests__/__snapshots__/settings.ts.snap
+++ b/__tests__/__snapshots__/settings.ts.snap
@@ -99,6 +99,7 @@ Object {
 exports[`query userSettings should create default settings if not exist 1`] = `
 Object {
   "appInsaneMode": true,
+  "autoDismissNotifications": true,
   "customLinks": null,
   "enableCardAnimations": true,
   "insaneMode": false,

--- a/__tests__/settings.ts
+++ b/__tests__/settings.ts
@@ -54,6 +54,7 @@ describe('query userSettings', () => {
     customLinks
     optOutWeeklyGoal
     optOutCompanion
+    autoDismissNotifications
   }
 }`;
 

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -801,6 +801,7 @@ describe('settings', () => {
     customLinks: null,
     optOutWeeklyGoal: false,
     optOutCompanion: false,
+    autoDismissNotifications: true,
     updatedAt: date.getTime(),
   };
 

--- a/src/compatibility/settings.ts
+++ b/src/compatibility/settings.ts
@@ -28,6 +28,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     sidebarExpanded
     sortingEnabled
     customLinks
+    autoDismissNotifications
   }
 }`;
     return injectGraphql(

--- a/src/entity/Settings.ts
+++ b/src/entity/Settings.ts
@@ -48,6 +48,9 @@ export class Settings {
   @Column({ type: 'text', array: true, default: null })
   customLinks: string[];
 
+  @Column({ default: true })
+  autoDismissNotifications: boolean;
+
   @UpdateDateColumn()
   updatedAt: Date;
 }

--- a/src/migration/1651214210491-AutoDismissSettings.ts
+++ b/src/migration/1651214210491-AutoDismissSettings.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AutoDismissSettings1651214210491 implements MigrationInterface {
+  name = 'AutoDismissSettings1651214210491';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "settings" ADD "autoDismissNotifications" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "settings" DROP COLUMN "autoDismissNotifications"`,
+    );
+  }
+}

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -16,6 +16,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         customLinks
         optOutWeeklyGoal
         optOutCompanion
+        autoDismissNotifications
       }
     }`;
 

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -17,6 +17,7 @@ interface GQLSettings {
   openNewTab: boolean;
   sidebarExpanded: boolean;
   sortingEnabled: boolean;
+  autoDismissNotifications: boolean;
   updatedAt: Date;
 }
 
@@ -35,6 +36,7 @@ interface GQLUpdateSettingsInput extends Partial<GQLSettings> {
   openNewTab?: boolean;
   sidebarExpanded?: boolean;
   sortingEnabled?: boolean;
+  autoDismissNotifications?: boolean;
   customLinks?: string[];
 }
 
@@ -114,6 +116,11 @@ export const typeDefs = /* GraphQL */ `
     optOutCompanion: Boolean!
 
     """
+    Whether to automatically dismiss notifications
+    """
+    autoDismissNotifications: Boolean!
+
+    """
     Time of last update
     """
     updatedAt: DateTime!
@@ -190,6 +197,11 @@ export const typeDefs = /* GraphQL */ `
     Whether the user opted out from the companion app
     """
     optOutCompanion: Boolean
+
+    """
+    Whether to automatically dismiss notifications
+    """
+    autoDismissNotifications: Boolean
   }
 
   extend type Mutation {


### PR DESCRIPTION
As part of our accessibility compliance, we will have to allow the user to decide whether they want to automatically dismiss notifications or not.
- The property is known as `autoDismissNotifications`
- Default value is true. The false value is intended for users that might not be able to react quickly enough and click the action button inside our notifs.