### PR TITLE
feat: unhide and removal of report on post

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -876,48 +876,6 @@ describe('mutation reportPost', () => {
   });
 });
 
-describe('mutation removePostReport', () => {
-  const MUTATION = `
-    mutation RemovePostReport($id: ID!) {
-      removePostReport(id: $id) {
-        _
-      }
-    }
-  `;
-
-  it('should not authorize when not logged in', () =>
-    testMutationErrorCode(
-      client,
-      { mutation: MUTATION, variables: { id: 'p1' } },
-      'UNAUTHENTICATED',
-    ));
-
-  it('should unreport post', async () => {
-    loggedUser = '1';
-    const hideRepo = con.getRepository(HiddenPost);
-    await hideRepo.save(hideRepo.create({ postId: 'p1', userId: loggedUser }));
-    const reportRepo = con.getRepository(PostReport);
-    await reportRepo.save(
-      reportRepo.create({
-        postId: 'p1',
-        userId: '1',
-        reason: 'BROKEN',
-        comment: null,
-      }),
-    );
-    const initialHidden = await hideRepo.find({ userId: loggedUser });
-    expect(initialHidden.length).toBeGreaterThan(0);
-    const initialReports = await reportRepo.find({ userId: loggedUser });
-    expect(initialReports.length).toBeGreaterThan(0);
-    const res = await client.mutate(MUTATION, { variables: { id: 'p1' } });
-    expect(res.errors).toBeFalsy();
-    const hidden = await hideRepo.find({ userId: loggedUser });
-    const reports = await reportRepo.find({ userId: loggedUser });
-    expect(hidden.length).toEqual(0);
-    expect(reports.length).toEqual(0);
-  });
-});
-
 describe('mutation upvote', () => {
   const MUTATION = `
   mutation Upvote($id: ID!) {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -412,16 +412,6 @@ export const typeDefs = /* GraphQL */ `
     ): EmptyResponse @auth
 
     """
-    Undo a report from post by removing the report itself
-    """
-    removePostReport(
-      """
-      Id of the post to report
-      """
-      id: ID
-    ): EmptyResponse @auth
-
-    """
     Delete a post permanently
     """
     deletePost(
@@ -620,22 +610,6 @@ export const resolvers: IResolvers<any, Context> = {
           }
         }
       }
-      return { _: true };
-    },
-    removePostReport: async (
-      _,
-      { id }: { id: string },
-      ctx: Context,
-    ): Promise<GQLEmptyResponse> => {
-      await ctx.con.transaction(async (transaction) => {
-        await transaction
-          .getRepository(HiddenPost)
-          .delete({ postId: id, userId: ctx.userId });
-        await transaction
-          .getRepository(PostReport)
-          .delete({ postId: id, userId: ctx.userId });
-      });
-
       return { _: true };
     },
     deletePost: async (


### PR DESCRIPTION
In line with the toast component having an undo button - we don't have yet a way to actually remove a report or unhide a post once saved.