### PR TITLE
refactor: alert property for add companion popup

### DIFF
--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -3,8 +3,8 @@
 exports[`mutation updateUserAlerts should create user alerts when does not exist 1`] = `
 Object {
   "updateUserAlerts": Object {
-    "addCompanion": null,
     "companionHelper": true,
+    "displayCompanionPopup": null,
     "filter": false,
     "myFeed": null,
     "rankLastSeen": null,
@@ -15,8 +15,8 @@ Object {
 exports[`mutation updateUserAlerts should update alerts of user 1`] = `
 Object {
   "updateUserAlerts": Object {
-    "addCompanion": null,
     "companionHelper": false,
+    "displayCompanionPopup": null,
     "filter": false,
     "myFeed": "created",
     "rankLastSeen": "2020-09-22T12:15:51.247Z",

--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -3,6 +3,7 @@
 exports[`mutation updateUserAlerts should create user alerts when does not exist 1`] = `
 Object {
   "updateUserAlerts": Object {
+    "addCompanion": true,
     "companionHelper": true,
     "filter": false,
     "myFeed": null,
@@ -14,6 +15,7 @@ Object {
 exports[`mutation updateUserAlerts should update alerts of user 1`] = `
 Object {
   "updateUserAlerts": Object {
+    "addCompanion": true,
     "companionHelper": false,
     "filter": false,
     "myFeed": "created",

--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -3,7 +3,7 @@
 exports[`mutation updateUserAlerts should create user alerts when does not exist 1`] = `
 Object {
   "updateUserAlerts": Object {
-    "addCompanion": true,
+    "addCompanion": null,
     "companionHelper": true,
     "filter": false,
     "myFeed": null,
@@ -15,7 +15,7 @@ Object {
 exports[`mutation updateUserAlerts should update alerts of user 1`] = `
 Object {
   "updateUserAlerts": Object {
-    "addCompanion": true,
+    "addCompanion": null,
     "companionHelper": false,
     "filter": false,
     "myFeed": "created",

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -40,6 +40,7 @@ describe('query userAlerts', () => {
       rankLastSeen
       myFeed
       companionHelper
+      addCompanion
     }
   }`;
 
@@ -74,6 +75,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen
         myFeed
         companionHelper
+        addCompanion
       }
     }
   `;

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -40,7 +40,7 @@ describe('query userAlerts', () => {
       rankLastSeen
       myFeed
       companionHelper
-      addCompanion
+      displayCompanionPopup
     }
   }`;
 
@@ -75,7 +75,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen
         myFeed
         companionHelper
-        addCompanion
+        displayCompanionPopup
       }
     }
   `;

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -687,7 +687,7 @@ describe('alerts', () => {
     rankLastSeen: rankLastSeen.getTime(),
     myFeed: 'created',
     companionHelper: true,
-    addCompanion: true,
+    addCompanion: null,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -687,7 +687,7 @@ describe('alerts', () => {
     rankLastSeen: rankLastSeen.getTime(),
     myFeed: 'created',
     companionHelper: true,
-    addCompanion: null,
+    displayCompanionPopup: null,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -687,6 +687,7 @@ describe('alerts', () => {
     rankLastSeen: rankLastSeen.getTime(),
     myFeed: 'created',
     companionHelper: true,
+    addCompanion: true,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -17,6 +17,9 @@ export class Alerts {
 
   @Column({ type: 'bool', default: true })
   companionHelper: boolean;
+
+  @Column({ type: 'bool', default: true })
+  addCompanion: boolean;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
@@ -24,4 +27,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   rankLastSeen: null,
   myFeed: null,
   companionHelper: true,
+  addCompanion: true,
 };

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -18,8 +18,8 @@ export class Alerts {
   @Column({ type: 'bool', default: true })
   companionHelper: boolean;
 
-  @Column({ type: 'bool', default: true })
-  addCompanion: boolean;
+  @Column({ type: 'bool', default: null })
+  addCompanion: boolean | null;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
@@ -27,5 +27,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   rankLastSeen: null,
   myFeed: null,
   companionHelper: true,
-  addCompanion: true,
+  addCompanion: null,
 };

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -19,7 +19,7 @@ export class Alerts {
   companionHelper: boolean;
 
   @Column({ type: 'bool', default: null })
-  addCompanion: boolean | null;
+  displayCompanionPopup: boolean | null;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
@@ -27,5 +27,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   rankLastSeen: null,
   myFeed: null,
   companionHelper: true,
-  addCompanion: null,
+  displayCompanionPopup: null,
 };

--- a/src/migration/1653461379025-AlertsAddCompanion.ts
+++ b/src/migration/1653461379025-AlertsAddCompanion.ts
@@ -1,18 +1,22 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AlertsAddCompanion1653461379025 implements MigrationInterface {
-  name = 'AlertsAddCompanion1653461379025';
+export class AlertsDisplayCompanionPopup1653461379025
+  implements MigrationInterface
+{
+  name = 'AlertsDisplayCompanionPopup1653461379025';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "alerts" ADD "addCompanion" boolean NULL`,
+      `ALTER TABLE "alerts" ADD "displayCompanionPopup" boolean NULL`,
     );
     await queryRunner.query(
-      `update "public"."alerts" set "addCompanion" = TRUE`,
+      `update "public"."alerts" set "displayCompanionPopup" = TRUE`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "addCompanion"`);
+    await queryRunner.query(
+      `ALTER TABLE "alerts" DROP COLUMN "displayCompanionPopup"`,
+    );
   }
 }

--- a/src/migration/1653461379025-AlertsAddCompanion.ts
+++ b/src/migration/1653461379025-AlertsAddCompanion.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlertsAddCompanion1653461379025 implements MigrationInterface {
+  name = 'AlertsAddCompanion1653461379025';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "addCompanion" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "addCompanion"`);
+  }
+}

--- a/src/migration/1653461379025-AlertsAddCompanion.ts
+++ b/src/migration/1653461379025-AlertsAddCompanion.ts
@@ -5,7 +5,10 @@ export class AlertsAddCompanion1653461379025 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "alerts" ADD "addCompanion" boolean NOT NULL DEFAULT true`,
+      `ALTER TABLE "alerts" ADD "addCompanion" boolean NULL`,
+    );
+    await queryRunner.query(
+      `update "public"."alerts" set "addCompanion" = TRUE`,
     );
   }
 

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -9,6 +9,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         rankLastSeen
         myFeed
         companionHelper
+        addCompanion
       }
     }`;
 

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -9,7 +9,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         rankLastSeen
         myFeed
         companionHelper
-        addCompanion
+        displayCompanionPopup
       }
     }`;
 

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -47,7 +47,7 @@ export const typeDefs = /* GraphQL */ `
     """
     For existing users, we will display the companion popup onload
     """
-    addCompanion: Boolean
+    displayCompanionPopup: Boolean
   }
 
   input UpdateAlertsInput {
@@ -74,7 +74,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Status for displaying the companion popup onload
     """
-    addCompanion: Boolean
+    displayCompanionPopup: Boolean
   }
 
   extend type Mutation {

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -70,6 +70,11 @@ export const typeDefs = /* GraphQL */ `
     Status to display for companion helper
     """
     companionHelper: Boolean
+
+    """
+    Status for displaying the companion popup onload
+    """
+    addCompanion: Boolean
   }
 
   extend type Mutation {

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -47,7 +47,7 @@ export const typeDefs = /* GraphQL */ `
     """
     For existing users, we will display the companion popup onload
     """
-    addCompanion: Boolean!
+    addCompanion: Boolean
   }
 
   input UpdateAlertsInput {

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -43,6 +43,11 @@ export const typeDefs = /* GraphQL */ `
     Once the user has seen it once, we set this value to false
     """
     companionHelper: Boolean!
+
+    """
+    For existing users, we will display the companion popup onload
+    """
+    addCompanion: Boolean!
   }
 
   input UpdateAlertsInput {


### PR DESCRIPTION
The add companion popup requires to be shown on load for logged-in users but must go back to default once closed or any action was taken inside.