### PR TITLE
fix: uses HTTP headers for redirecting

### DIFF
--- a/src/routes/redirector.ts
+++ b/src/routes/redirector.ts
@@ -31,6 +31,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         );
       }
       return res
+        .header('Referrer-Policy', 'origin, origin-when-cross-origin')
         .status(302)
         .redirect(`${post.url}${req.query.a ? `#${req.query.a}` : ''}`);
     },

--- a/src/routes/redirector.ts
+++ b/src/routes/redirector.ts
@@ -31,12 +31,8 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         );
       }
       return res
-        .type('text/html')
-        .send(
-          `<html><head><meta http-equiv="refresh" content="0;URL=${post.url}${
-            req.query.a ? `#${req.query.a}` : ''
-          }"></head></html>`,
-        );
+        .status(302)
+        .redirect(`${post.url}${req.query.a ? `#${req.query.a}` : ''}`);
     },
   );
 }


### PR DESCRIPTION
This could potentionally save around ~150ms for each redirect, as the user does not need to load the page, wait for html to be processed and then do a refresh redirect.