### PR TITLE
refactor: unnecessary subscription

### DIFF
--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -51,10 +51,6 @@ export const workers: Worker[] = [
     subscription: 'post-author-matched-mail',
   },
   {
-    topic: 'community-link-accepted',
-    subscription: 'community-link-accepted-mail',
-  },
-  {
     topic: 'community-link-rejected',
     subscription: 'community-link-rejected-mail',
   },


### PR DESCRIPTION
There's an error with the current `pulumi-up` as it tried to register a subscription to a non-existent topic.