### PR TITLE
fix: remove exposed deleted property

### DIFF
--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -91,7 +91,6 @@ describe('mutation submitArticle', () => {
         reason
         post {
           id
-          deleted
         }
         submission {
           id

--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -188,7 +188,6 @@ describe('mutation submitArticle', () => {
         result: 'exists',
         reason: null,
         post: {
-          deleted: false,
           id: 'p1',
         },
         submission: null,

--- a/infra/workers.ts
+++ b/infra/workers.ts
@@ -51,10 +51,6 @@ export const workers: Worker[] = [
     subscription: 'post-author-matched-mail',
   },
   {
-    topic: 'community-link-accepted',
-    subscription: 'community-link-accepted-mail',
-  },
-  {
     topic: 'community-link-rejected',
     subscription: 'community-link-rejected-mail',
   },

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -284,11 +284,6 @@ export const typeDefs = /* GraphQL */ `
     Whether the user is the scout
     """
     isScout: Int
-
-    """
-    Whether post is deleted
-    """
-    deleted: Boolean
   }
 
   type PostConnection {
@@ -532,6 +527,7 @@ export const getPostByUrl = async (
     ['post'],
     (builder) => ({
       queryBuilder: builder.queryBuilder
+        .addSelect(`"${builder.alias}"."deleted"`)
         .where(
           `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url)`,
           { url },


### PR DESCRIPTION
We exposed the deleted property, in this fix we change it to be only selected for the specific query and not open.