### PR TITLE
chore: refactor mocked to jest.mocked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           paths:
             - build
   test:
-    resource_class: medium
+    resource_class: medium+
     docker:
       - image: cimg/node:16.15
       - image: postgres:11.6-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           paths:
             - build
   test:
+    resource_class: large
     docker:
       - image: cimg/node:16.15
       - image: postgres:11.6-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           paths:
             - build
   test:
-    resource_class: large
+    resource_class: medium
     docker:
       - image: cimg/node:16.15
       - image: postgres:11.6-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           paths:
             - build
   test:
-    resource_class: medium+
+    resource_class: large
     docker:
       - image: cimg/node:16.15
       - image: postgres:11.6-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           name: Test
           command: npm run test -- --ci --reporters=default --reporters=jest-junit
           environment:
+            - NODE_OPTIONS: --max-old-space-size=4096
             - JEST_JUNIT_OUTPUT_DIR: ./test-results
       - store_test_results:
           path: ./test-results

--- a/__tests__/cron/tweetTrending.ts
+++ b/__tests__/cron/tweetTrending.ts
@@ -1,6 +1,4 @@
 import { Connection, getConnection } from 'typeorm';
-import { mocked } from 'ts-jest/utils';
-
 import cron from '../../src/cron/tweetTrending';
 import { expectSuccessfulCron, saveFixtures } from '../helpers';
 import { Post, Source } from '../../src/entity';
@@ -21,7 +19,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  mocked(tweet).mockClear();
+  jest.mocked(tweet).mockClear();
 });
 
 it('should tweet the latest post over the views threshold', async () => {
@@ -60,7 +58,7 @@ it('should tweet the latest post over the views threshold', async () => {
       createdAt: new Date(now.getTime() - 2000),
     },
   ]);
-  mocked(tweet).mockResolvedValue();
+  jest.mocked(tweet).mockResolvedValue();
   await expectSuccessfulCron(cron);
   expect(tweet).toBeCalledTimes(1);
   expect(tweet).toBeCalledWith('P2\n\n\nhttp://localhost:5002/posts/p2');
@@ -87,7 +85,7 @@ it('should tag the author and site and add hashtags', async () => {
       tagsStr: 'webdev,javascript',
     },
   ]);
-  mocked(tweet).mockResolvedValue();
+  jest.mocked(tweet).mockResolvedValue();
   await expectSuccessfulCron(cron);
   expect(tweet).toBeCalledTimes(1);
   expect(tweet).toBeCalledWith(
@@ -112,7 +110,7 @@ it('should fallback to source twitter', async () => {
       creatorTwitter: '@creator',
     },
   ]);
-  mocked(tweet).mockResolvedValue();
+  jest.mocked(tweet).mockResolvedValue();
   await expectSuccessfulCron(cron);
   expect(tweet).toBeCalledTimes(1);
   expect(tweet).toBeCalledWith(

--- a/__tests__/cron/updateFeaturedComments.ts
+++ b/__tests__/cron/updateFeaturedComments.ts
@@ -7,7 +7,6 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { Checkpoint } from '../../src/entity/Checkpoint';
 import { notifyCommentFeatured } from '../../src/common';
-import { mocked } from 'ts-jest/utils';
 
 let con: Connection;
 
@@ -90,6 +89,6 @@ it('should update featured comments', async () => {
   });
   expect(comments).toMatchSnapshot();
   expect(
-    mocked(notifyCommentFeatured).mock.calls.map((call) => call[1]),
+    jest.mocked(notifyCommentFeatured).mock.calls.map((call) => call[1]),
   ).toMatchSnapshot();
 });

--- a/__tests__/sourceRequests.ts
+++ b/__tests__/sourceRequests.ts
@@ -5,7 +5,6 @@ import { FastifyInstance } from 'fastify';
 import request from 'supertest';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { mocked } from 'ts-jest/utils';
 import {
   authorizeRequest,
   disposeGraphQLTesting,
@@ -258,7 +257,7 @@ describe('mutation uploadSourceRequestLogo', () => {
     const req = await con
       .getRepository(SourceRequest)
       .save(sourceRequestFixture[2]);
-    mocked(uploadLogo).mockResolvedValue('http://image.com');
+    jest.mocked(uploadLogo).mockResolvedValue('http://image.com');
     const res = await authorizeRequest(
       request(app.server)
         .post('/graphql')

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -55,7 +55,6 @@ import {
   UserState,
   UserStateKey,
 } from '../../src/entity';
-import { mocked } from 'ts-jest/utils';
 import { ChangeObject } from '../../src/types';
 import { PostReport } from '../../src/entity';
 import { Connection, getConnection } from 'typeorm';
@@ -165,7 +164,7 @@ describe('source request', () => {
       }),
     );
     expect(notifySourceRequest).toBeCalledTimes(1);
-    expect(mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
       'new',
       after,
     ]);
@@ -190,7 +189,7 @@ describe('source request', () => {
       }),
     );
     expect(notifySourceRequest).toBeCalledTimes(1);
-    expect(mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
       'publish',
       after,
     ]);
@@ -214,7 +213,7 @@ describe('source request', () => {
       }),
     );
     expect(notifySourceRequest).toBeCalledTimes(1);
-    expect(mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
       'decline',
       after,
     ]);
@@ -238,7 +237,7 @@ describe('source request', () => {
       }),
     );
     expect(notifySourceRequest).toBeCalledTimes(1);
-    expect(mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
       'approve',
       after,
     ]);
@@ -265,7 +264,7 @@ describe('post upvote', () => {
       }),
     );
     expect(notifyPostUpvoted).toBeCalledTimes(1);
-    expect(mocked(notifyPostUpvoted).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifyPostUpvoted).mock.calls[0].slice(1)).toEqual([
       'p1',
       '1',
     ]);
@@ -282,10 +281,9 @@ describe('post upvote', () => {
       }),
     );
     expect(notifyPostUpvoteCanceled).toBeCalledTimes(1);
-    expect(mocked(notifyPostUpvoteCanceled).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      '1',
-    ]);
+    expect(
+      jest.mocked(notifyPostUpvoteCanceled).mock.calls[0].slice(1),
+    ).toEqual(['p1', '1']);
   });
 });
 
@@ -309,7 +307,7 @@ describe('comment upvote', () => {
       }),
     );
     expect(notifyCommentUpvoted).toBeCalledTimes(1);
-    expect(mocked(notifyCommentUpvoted).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifyCommentUpvoted).mock.calls[0].slice(1)).toEqual([
       'c1',
       '1',
     ]);
@@ -326,10 +324,9 @@ describe('comment upvote', () => {
       }),
     );
     expect(notifyCommentUpvoteCanceled).toBeCalledTimes(1);
-    expect(mocked(notifyCommentUpvoteCanceled).mock.calls[0].slice(1)).toEqual([
-      'c1',
-      '1',
-    ]);
+    expect(
+      jest.mocked(notifyCommentUpvoteCanceled).mock.calls[0].slice(1),
+    ).toEqual(['c1', '1']);
   });
 });
 
@@ -361,7 +358,7 @@ describe('comment', () => {
       }),
     );
     expect(notifyPostCommented).toBeCalledTimes(1);
-    expect(mocked(notifyPostCommented).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifyPostCommented).mock.calls[0].slice(1)).toEqual([
       'p1',
       '1',
       'c1',
@@ -383,7 +380,7 @@ describe('comment', () => {
       }),
     );
     expect(notifyCommentCommented).toBeCalledTimes(1);
-    expect(mocked(notifyCommentCommented).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifyCommentCommented).mock.calls[0].slice(1)).toEqual([
       'p1',
       '1',
       'c2',
@@ -411,10 +408,9 @@ describe('user', () => {
       }),
     );
     expect(notifyUserReputationUpdated).toBeCalledTimes(1);
-    expect(mocked(notifyUserReputationUpdated).mock.calls[0].slice(1)).toEqual([
-      '1',
-      10,
-    ]);
+    expect(
+      jest.mocked(notifyUserReputationUpdated).mock.calls[0].slice(1),
+    ).toEqual(['1', 10]);
   });
 
   it('should notify on dev card eligibility', async () => {
@@ -432,7 +428,9 @@ describe('user', () => {
       }),
     );
     expect(notifyDevCardEligible).toBeCalledTimes(1);
-    expect(mocked(notifyDevCardEligible).mock.calls[0].slice(1)).toEqual(['1']);
+    expect(jest.mocked(notifyDevCardEligible).mock.calls[0].slice(1)).toEqual([
+      '1',
+    ]);
   });
 
   it('should create user state when the user had passed the reputation threshold for community link submission', async () => {
@@ -598,10 +596,9 @@ describe('post', () => {
       }),
     );
     expect(notifyPostAuthorMatched).toBeCalledTimes(1);
-    expect(mocked(notifyPostAuthorMatched).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      'u1',
-    ]);
+    expect(jest.mocked(notifyPostAuthorMatched).mock.calls[0].slice(1)).toEqual(
+      ['p1', 'u1'],
+    );
   });
 
   it('should notify on send analytics report', async () => {
@@ -619,9 +616,9 @@ describe('post', () => {
       }),
     );
     expect(notifySendAnalyticsReport).toBeCalledTimes(1);
-    expect(mocked(notifySendAnalyticsReport).mock.calls[0].slice(1)).toEqual([
-      'p1',
-    ]);
+    expect(
+      jest.mocked(notifySendAnalyticsReport).mock.calls[0].slice(1),
+    ).toEqual(['p1']);
   });
 
   it('should notify on views threshold reached', async () => {
@@ -659,9 +656,9 @@ describe('post', () => {
       }),
     );
     expect(notifyPostBannedOrRemoved).toBeCalledTimes(1);
-    expect(mocked(notifyPostBannedOrRemoved).mock.calls[0].slice(1)).toEqual([
-      after,
-    ]);
+    expect(
+      jest.mocked(notifyPostBannedOrRemoved).mock.calls[0].slice(1),
+    ).toEqual([after]);
   });
 
   it('should notify on post removed', async () => {
@@ -679,9 +676,9 @@ describe('post', () => {
       }),
     );
     expect(notifyPostBannedOrRemoved).toBeCalledTimes(1);
-    expect(mocked(notifyPostBannedOrRemoved).mock.calls[0].slice(1)).toEqual([
-      after,
-    ]);
+    expect(
+      jest.mocked(notifyPostBannedOrRemoved).mock.calls[0].slice(1),
+    ).toEqual([after]);
   });
 
   it('should not notify on post removed when banned already', async () => {
@@ -800,7 +797,9 @@ describe('alerts', () => {
       }),
     );
     expect(notifyAlertsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([after]);
+    expect(jest.mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([
+      after,
+    ]);
   });
 
   it('should notify on alert.rank changed', async () => {
@@ -818,7 +817,9 @@ describe('alerts', () => {
       }),
     );
     expect(notifyAlertsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([after]);
+    expect(jest.mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([
+      after,
+    ]);
   });
 
   it('should notify on alert.myFeed changed', async () => {
@@ -836,7 +837,9 @@ describe('alerts', () => {
       }),
     );
     expect(notifyAlertsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([after]);
+    expect(jest.mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([
+      after,
+    ]);
   });
 
   it('should notify on alerts created', async () => {
@@ -854,7 +857,9 @@ describe('alerts', () => {
       }),
     );
     expect(notifyAlertsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([after]);
+    expect(jest.mocked(notifyAlertsUpdated).mock.calls[0].slice(1)).toEqual([
+      after,
+    ]);
   });
 });
 
@@ -917,7 +922,7 @@ describe('settings', () => {
       }),
     );
     expect(notifySettingsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifySettingsUpdated).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySettingsUpdated).mock.calls[0].slice(1)).toEqual([
       after,
     ]);
   });
@@ -933,7 +938,7 @@ describe('settings', () => {
       }),
     );
     expect(notifySettingsUpdated).toBeCalledTimes(1);
-    expect(mocked(notifySettingsUpdated).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySettingsUpdated).mock.calls[0].slice(1)).toEqual([
       base,
     ]);
   });
@@ -959,7 +964,7 @@ describe('source feed', () => {
       }),
     );
     expect(notifySourceFeedAdded).toBeCalledTimes(1);
-    expect(mocked(notifySourceFeedAdded).mock.calls[0].slice(1)).toEqual([
+    expect(jest.mocked(notifySourceFeedAdded).mock.calls[0].slice(1)).toEqual([
       base.sourceId,
       base.feed,
     ]);
@@ -976,10 +981,9 @@ describe('source feed', () => {
       }),
     );
     expect(notifySourceFeedRemoved).toBeCalledTimes(1);
-    expect(mocked(notifySourceFeedRemoved).mock.calls[0].slice(1)).toEqual([
-      base.sourceId,
-      base.feed,
-    ]);
+    expect(jest.mocked(notifySourceFeedRemoved).mock.calls[0].slice(1)).toEqual(
+      [base.sourceId, base.feed],
+    );
   });
 });
 
@@ -1096,9 +1100,9 @@ describe('submission', () => {
       }),
     );
     expect(notifySubmissionCreated).toBeCalledTimes(1);
-    expect(mocked(notifySubmissionCreated).mock.calls[0].slice(1)).toEqual([
-      { url: after.url, submissionId: after.id, sourceId: 'community' },
-    ]);
+    expect(jest.mocked(notifySubmissionCreated).mock.calls[0].slice(1)).toEqual(
+      [{ url: after.url, submissionId: after.id, sourceId: 'community' }],
+    );
   });
 
   it('should notify when the status turns to rejected', async () => {
@@ -1117,8 +1121,8 @@ describe('submission', () => {
       }),
     );
     expect(notifySubmissionRejected).toBeCalledTimes(1);
-    expect(mocked(notifySubmissionRejected).mock.calls[0].slice(1)).toEqual([
-      after,
-    ]);
+    expect(
+      jest.mocked(notifySubmissionRejected).mock.calls[0].slice(1),
+    ).toEqual([after]);
   });
 });

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -513,7 +513,7 @@ describe('user_state', () => {
     );
     expect(notifySubmissionGrantedAccess).toBeCalledTimes(1);
     expect(
-      mocked(notifySubmissionGrantedAccess).mock.calls[0].slice(1),
+      jest.mocked(notifySubmissionGrantedAccess).mock.calls[0].slice(1),
     ).toEqual(['1']);
   });
 });
@@ -637,7 +637,7 @@ describe('post', () => {
     );
     expect(notifyPostReachedViewsThreshold).toBeCalledTimes(1);
     expect(
-      mocked(notifyPostReachedViewsThreshold).mock.calls[0].slice(1),
+      jest.mocked(notifyPostReachedViewsThreshold).mock.calls[0].slice(1),
     ).toEqual(['p1', 250]);
   });
 

--- a/__tests__/workers/commentCommented.ts
+++ b/__tests__/workers/commentCommented.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import worker from '../../src/workers/commentCommented';
@@ -94,7 +91,7 @@ it('should send mail to author', async () => {
     parentCommentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should not send mail when the author is the commenter user', async () => {

--- a/__tests__/workers/commentCommentedAuthor.ts
+++ b/__tests__/workers/commentCommentedAuthor.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import worker from '../../src/workers/commentCommentedAuthor';
@@ -98,7 +95,7 @@ it('should send mail to the post author', async () => {
     parentCommentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should not send mail when no post author', async () => {

--- a/__tests__/workers/commentCommentedThread.ts
+++ b/__tests__/workers/commentCommentedThread.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import { User as GatewayUser } from '../../src/common/users';
@@ -131,7 +128,7 @@ it('should send mail to the thread followers', async () => {
     parentCommentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should send mail to the thread followers without the post author', async () => {
@@ -179,5 +176,5 @@ it('should send mail to the thread followers without the post author', async () 
     parentCommentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/commentFeaturedMail.ts
+++ b/__tests__/workers/commentFeaturedMail.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/commentFeaturedMail';
@@ -87,5 +84,5 @@ it('should send featured comment mail', async () => {
     commentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/commentUpvoted.ts
+++ b/__tests__/workers/commentUpvoted.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import worker from '../../src/workers/commentUpvoted';
@@ -71,7 +68,7 @@ it('should send mail to author', async () => {
     commentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should not send mail when the author is the upvote user', async () => {

--- a/__tests__/workers/communityLinkAccessMail.ts
+++ b/__tests__/workers/communityLinkAccessMail.ts
@@ -1,5 +1,4 @@
 import nock from 'nock';
-import { mocked } from 'ts-jest/utils';
 import { expectSuccessfulBackground } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/communityLinkAccessMail';
@@ -43,5 +42,5 @@ it('should send mail when user has now the access to submit community links', as
     status: SubmissionStatus.Rejected,
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/communityLinkRejectedMail.ts
+++ b/__tests__/workers/communityLinkRejectedMail.ts
@@ -1,5 +1,4 @@
 import nock from 'nock';
-import { mocked } from 'ts-jest/utils';
 import { expectSuccessfulBackground } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/communityLinkRejectedMail';
@@ -44,5 +43,5 @@ it('should send mail when the submission status is rejected', async () => {
     status: SubmissionStatus.Rejected,
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/postAuthorMatchedMail.ts
+++ b/__tests__/workers/postAuthorMatchedMail.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/postAuthorMatchedMail';
@@ -65,5 +62,5 @@ it('should send post author matched mail', async () => {
     authorId: '1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/postBannedEmail.ts
+++ b/__tests__/workers/postBannedEmail.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import { User as GatewayUser } from '../../src/common/users';
@@ -84,5 +81,5 @@ it('should send mail to the reporters', async () => {
     post,
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/postCommentedAuthor.ts
+++ b/__tests__/workers/postCommentedAuthor.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail } from '../../src/common';
 import worker from '../../src/workers/postCommentedAuthor';
@@ -97,7 +94,7 @@ it('should send mail to the post author', async () => {
     commentId: 'c1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should not send mail when no post author', async () => {

--- a/__tests__/workers/postCommentedAuthorTweet.ts
+++ b/__tests__/workers/postCommentedAuthorTweet.ts
@@ -6,7 +6,6 @@ import worker from '../../src/workers/postCommentedAuthorTweet';
 import { Post, Source, User } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
-import { mocked } from 'ts-jest/utils';
 
 jest.mock('../../src/common/twitter', () => ({
   ...(jest.requireActual('../../src/common/twitter') as Record<
@@ -41,12 +40,12 @@ it('should tweet about the new comment', async () => {
     commentId: 'c1',
   });
   expect(tweet).toBeCalledTimes(1);
-  expect(mocked(tweet).mock.calls[0][0]).toContain('@idoshamun');
-  expect(mocked(tweet).mock.calls[0][0]).toContain(
+  expect(jest.mocked(tweet).mock.calls[0][0]).toContain('@idoshamun');
+  expect(jest.mocked(tweet).mock.calls[0][0]).toContain(
     'http://localhost:5002/posts/p1?author=true',
   );
-  expect(mocked(tweet).mock.calls[0][0]).toContain('23');
-  expect(mocked(tweet).mock.calls[0][1]).toEqual('AUTHOR_TWITTER');
+  expect(jest.mocked(tweet).mock.calls[0][0]).toContain('23');
+  expect(jest.mocked(tweet).mock.calls[0][1]).toEqual('AUTHOR_TWITTER');
 });
 
 it('should not tweet when no creator twitter', async () => {

--- a/__tests__/workers/postReachedViewsThresholdTweet.ts
+++ b/__tests__/workers/postReachedViewsThresholdTweet.ts
@@ -6,7 +6,6 @@ import worker from '../../src/workers/postReachedViewsThresholdTweet';
 import { Post, Source, User } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
-import { mocked } from 'ts-jest/utils';
 
 jest.mock('../../src/common/twitter', () => ({
   ...(jest.requireActual('../../src/common/twitter') as Record<
@@ -38,11 +37,11 @@ it('should tweet about the trending post', async () => {
     threshold: 250,
   });
   expect(tweet).toBeCalledTimes(1);
-  expect(mocked(tweet).mock.calls[0][0]).toContain('@idoshamun');
-  expect(mocked(tweet).mock.calls[0][0]).toContain(
+  expect(jest.mocked(tweet).mock.calls[0][0]).toContain('@idoshamun');
+  expect(jest.mocked(tweet).mock.calls[0][0]).toContain(
     'http://localhost:5002/posts/p1?author=true',
   );
-  expect(mocked(tweet).mock.calls[0][1]).toEqual('AUTHOR_TWITTER');
+  expect(jest.mocked(tweet).mock.calls[0][1]).toEqual('AUTHOR_TWITTER');
 });
 
 it('should not tweet when no creator twitter', async () => {

--- a/__tests__/workers/postScoutMatchedMail.ts
+++ b/__tests__/workers/postScoutMatchedMail.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/postScoutMatchedMail';
@@ -79,5 +76,5 @@ it('should send post scout matched mail', async () => {
     scoutId: '1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/__tests__/workers/sendAnalyticsReportMail.ts
+++ b/__tests__/workers/sendAnalyticsReportMail.ts
@@ -1,8 +1,5 @@
 import nock from 'nock';
 import { Connection, getConnection } from 'typeorm';
-
-import { mocked } from 'ts-jest/utils';
-
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import { sendEmail, User as GatewayUser } from '../../src/common';
 import worker from '../../src/workers/sendAnalyticsReportMail';
@@ -89,5 +86,5 @@ it('should send analytics reports', async () => {
     postId: 'p1',
   });
   expect(sendEmail).toBeCalledTimes(1);
-  expect(mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:background": "MODE=background npm run dev",
     "lint": "eslint . --ext .js,.ts --max-warnings 0",
     "start": "node index.js | pino-stackdriver",
-    "pretest": "cross-env NODE_OPTIONS=--max-old-space-size=8192 && npm run lint && cross-env NODE_ENV=test npm run db:migrate:reset",
+    "pretest": "cross-env NODE_OPTIONS=--max-old-space-size=4096 && npm run lint && cross-env NODE_ENV=test npm run db:migrate:reset",
     "test": "jest --testEnvironment=node --runInBand",
     "typeorm": "ts-node ./node_modules/typeorm/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:background": "MODE=background npm run dev",
     "lint": "eslint . --ext .js,.ts --max-warnings 0",
     "start": "node index.js | pino-stackdriver",
-    "pretest": "cross-env NODE_OPTIONS=--max-old-space-size=4096 && npm run lint && cross-env NODE_ENV=test npm run db:migrate:reset",
+    "pretest": "npm run lint && cross-env NODE_ENV=test npm run db:migrate:reset",
     "test": "jest --testEnvironment=node --runInBand",
     "typeorm": "ts-node ./node_modules/typeorm/cli.js"
   },


### PR DESCRIPTION
We where using the old implementation of `mocked` and should use `jest.mocked`.