### PR TITLE
fix: setting the default to started

### DIFF
--- a/__tests__/__snapshots__/submissions.ts.snap
+++ b/__tests__/__snapshots__/submissions.ts.snap
@@ -8,7 +8,7 @@ Object {
     "result": "succeed",
     "submission": Object {
       "id": Any<String>,
-      "status": "NOT_STARTED",
+      "status": "STARTED",
       "userId": "1",
     },
   },

--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -119,7 +119,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: `Article has been submitted already! Current status: NOT_STARTED`,
+        reason: `Article has been submitted already! Current status: STARTED`,
         post: null,
         submission: null,
       },

--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -91,7 +91,6 @@ describe('mutation submitArticle', () => {
         reason
         post {
           id
-          deleted
         }
         submission {
           id
@@ -188,7 +187,6 @@ describe('mutation submitArticle', () => {
         result: 'exists',
         reason: null,
         post: {
-          deleted: false,
           id: 'p1',
         },
         submission: null,

--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -248,7 +248,7 @@ describe('mutation submitArticle', () => {
     const submission = await con
       .getRepository(Submission)
       .findOne({ url: request });
-    expect(submission.status).toEqual(SubmissionStatus.NotStarted);
+    expect(submission.status).toEqual(SubmissionStatus.Started);
     expect(res.data).toMatchSnapshot({
       submitArticle: {
         submission: {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -1084,7 +1084,7 @@ describe('submission', () => {
     userId: '1',
     url: '',
     reason: '',
-    status: SubmissionStatus.NotStarted,
+    status: SubmissionStatus.Started,
     createdAt: Date.now(),
   };
 

--- a/src/entity/Submission.ts
+++ b/src/entity/Submission.ts
@@ -10,7 +10,6 @@ import { User } from './User';
 import { AddPostData } from './Post';
 
 export enum SubmissionStatus {
-  NotStarted = 'NOT_STARTED',
   Started = 'STARTED',
   Accepted = 'ACCEPTED',
   Rejected = 'REJECTED',
@@ -31,7 +30,7 @@ export class Submission {
   @Column({ default: () => 'now()' })
   createdAt: Date;
 
-  @Column({ default: SubmissionStatus.NotStarted })
+  @Column({ default: SubmissionStatus.Started })
   status: string;
 
   @Column({ type: 'text' })

--- a/src/migration/1655452252620-ChangeSubmissionStatus.ts
+++ b/src/migration/1655452252620-ChangeSubmissionStatus.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChangeSubmissionStatus1655452252620 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submission" ALTER COLUMN "status" SET DEFAULT 'STARTED'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "submission" ALTER COLUMN "status" SET DEFAULT 'NOT_STARTED'`,
+    );
+  }
+}

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -284,11 +284,6 @@ export const typeDefs = /* GraphQL */ `
     Whether the user is the scout
     """
     isScout: Int
-
-    """
-    Whether post is deleted
-    """
-    deleted: Boolean
   }
 
   type PostConnection {
@@ -532,6 +527,7 @@ export const getPostByUrl = async (
     ['post'],
     (builder) => ({
       queryBuilder: builder.queryBuilder
+        .addSelect(`"${builder.alias}"."deleted"`)
         .where(
           `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url)`,
           { url },


### PR DESCRIPTION
The not start status was unneeded as we always start on adding it, so we can simply change the default to `Started`.