### PR TITLE
fix: change slack message color for submissions

### DIFF
--- a/src/workers/postScoutMatchedSlack.ts
+++ b/src/workers/postScoutMatchedSlack.ts
@@ -30,7 +30,7 @@ const worker: Worker = {
                 value: post.scoutId,
               },
             ],
-            color: '#FF1E1F',
+            color: '#CE3DF3',
           },
         ],
       });


### PR DESCRIPTION
Change the slack color to our branded purple for submissions messages