### PR TITLE
fix: user mention beside a special character

### DIFF
--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -157,6 +157,11 @@ exports[`query commentPreview should return markdown equivalent of the content w
 "
 `;
 
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 11`] = `
+"<p>Hi <a href=\\"http://localhost:5002/Solevilla\\" data-mention-id=\\"7\\" data-mention-username=\\"Solevilla\\">@Solevilla</a>! This is normal comment, let’s tag <a href=\\"http://localhost:5002/Lee\\" data-mention-id=\\"4\\" data-mention-username=\\"Lee\\">@Lee</a> as well</p>
+"
+`;
+
 exports[`query commentUpvotes should return users that upvoted the comment by id in descending order 1`] = `
 Object {
   "commentUpvotes": Object {

--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -148,7 +148,12 @@ exports[`query commentPreview should return markdown equivalent of the content w
 `;
 
 exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 9`] = `
-"<p>Hi@Solevilla</p>
+"<p>Hi <a href=\\"http://localhost:5002/Solevilla\\" data-mention-id=\\"7\\" data-mention-username=\\"Solevilla\\">@Solevilla</a></p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 10`] = `
+"<p>Hi <a href=\\"http://localhost:5002/Solevilla\\" data-mention-id=\\"7\\" data-mention-username=\\"Solevilla\\">@Solevilla</a>!</p>
 "
 `;
 

--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -107,6 +107,46 @@ exports[`query commentPreview should return markdown equivalent of the content 2
 "
 `;
 
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 1`] = `
+"<h1>Test</h1>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 2`] = `
+"<p><a href=\\"http://localhost:5002/Lee\\" data-mention-id=\\"4\\" data-mention-username=\\"Lee\\">@Lee</a></p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 3`] = `
+"<p><a href=\\"http://localhost:5002/Lee\\" data-mention-id=\\"4\\" data-mention-username=\\"Lee\\">@Lee</a>.</p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 4`] = `
+"<p><a href=\\"http://localhost:5002/Lee\\" data-mention-id=\\"4\\" data-mention-username=\\"Lee\\">@Lee</a>/<a href=\\"http://localhost:5002/Hansel\\" data-mention-id=\\"5\\" data-mention-username=\\"Hansel\\">@Hansel</a></p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 5`] = `
+"<p><a href=\\"http://localhost:5002/Lee\\" data-mention-id=\\"4\\" data-mention-username=\\"Lee\\">@Lee</a>,<a href=\\"http://localhost:5002/Hansel\\" data-mention-id=\\"5\\" data-mention-username=\\"Hansel\\">@Hansel</a>,<a href=\\"http://localhost:5002/Solevilla\\" data-mention-id=\\"7\\" data-mention-username=\\"Solevilla\\">@Solevilla</a></p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 6`] = `
+"<p>@Lee@Hansel@Solevilla</p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 7`] = `
+"<p>Hi@Solevilla</p>
+"
+`;
+
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 8`] = `
+"<p>Hi!<a href=\\"http://localhost:5002/Solevilla\\" data-mention-id=\\"7\\" data-mention-username=\\"Solevilla\\">@Solevilla</a></p>
+"
+`;
+
 exports[`query commentUpvotes should return users that upvoted the comment by id in descending order 1`] = `
 Object {
   "commentUpvotes": Object {
@@ -368,11 +408,6 @@ Array [
     "username": "Hansel",
   },
   Object {
-    "image": "https://daily.dev/lee.jpg",
-    "name": "Lee",
-    "username": "Lee",
-  },
-  Object {
     "image": "https://daily.dev/nimrod.jpg",
     "name": "Nimrod",
     "username": "Nimrod",
@@ -381,6 +416,11 @@ Array [
     "image": "https://daily.dev/samson.jpg",
     "name": "Samson",
     "username": "Samson",
+  },
+  Object {
+    "image": "https://daily.dev/solevilla.jpg",
+    "name": "Solevilla",
+    "username": "Solevilla",
   },
   Object {
     "image": "https://daily.dev/tsahi.jpg",

--- a/__tests__/__snapshots__/comments.ts.snap
+++ b/__tests__/__snapshots__/comments.ts.snap
@@ -147,6 +147,11 @@ exports[`query commentPreview should return markdown equivalent of the content w
 "
 `;
 
+exports[`query commentPreview should return markdown equivalent of the content with special characters on mention 9`] = `
+"<p>Hi@Solevilla</p>
+"
+`;
+
 exports[`query commentUpvotes should return users that upvoted the comment by id in descending order 1`] = `
 Object {
   "commentUpvotes": Object {
@@ -408,6 +413,11 @@ Array [
     "username": "Hansel",
   },
   Object {
+    "image": "https://daily.dev/lee.jpg",
+    "name": "Lee",
+    "username": "Lee",
+  },
+  Object {
     "image": "https://daily.dev/nimrod.jpg",
     "name": "Nimrod",
     "username": "Nimrod",
@@ -416,11 +426,6 @@ Array [
     "image": "https://daily.dev/samson.jpg",
     "name": "Samson",
     "username": "Samson",
-  },
-  Object {
-    "image": "https://daily.dev/solevilla.jpg",
-    "name": "Solevilla",
-    "username": "Solevilla",
   },
   Object {
     "image": "https://daily.dev/tsahi.jpg",

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -319,7 +319,13 @@ describe('query commentPreview', () => {
       variables: { content: 'Hi!@Solevilla' },
     });
     expect(mention6.errors).toBeFalsy();
-    expect(mention6.data.commentPreview).toMatchSnapshot(); // expect to display no mention
+    expect(mention6.data.commentPreview).toMatchSnapshot();
+
+    const mention7 = await client.query(QUERY, {
+      variables: { content: 'Hi@Solevilla' },
+    });
+    expect(mention7.errors).toBeFalsy();
+    expect(mention7.data.commentPreview).toMatchSnapshot(); // expect to display no mention
   });
 
   it('should only render markdown not HTML', async () => {

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -271,6 +271,57 @@ describe('query commentPreview', () => {
     expect(withMention.data.commentPreview).toMatchSnapshot();
   });
 
+  it('should return markdown equivalent of the content with special characters on mention', async () => {
+    loggedUser = '1';
+    await saveCommentMentionFixtures();
+    const content = '# Test';
+    const res = await client.query(QUERY, { variables: { content } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.commentPreview).toMatchSnapshot();
+
+    const mention0 = await client.query(QUERY, {
+      variables: { content: '@Lee' },
+    });
+    expect(mention0.errors).toBeFalsy();
+    expect(mention0.data.commentPreview).toMatchSnapshot();
+
+    const mention1 = await client.query(QUERY, {
+      variables: { content: '@Lee.' },
+    });
+    expect(mention1.errors).toBeFalsy();
+    expect(mention1.data.commentPreview).toMatchSnapshot();
+
+    const mention2 = await client.query(QUERY, {
+      variables: { content: '@Lee/@Hansel' },
+    });
+    expect(mention2.errors).toBeFalsy();
+    expect(mention2.data.commentPreview).toMatchSnapshot();
+
+    const mention3 = await client.query(QUERY, {
+      variables: { content: '@Lee,@Hansel,@Solevilla' },
+    });
+    expect(mention3.errors).toBeFalsy();
+    expect(mention3.data.commentPreview).toMatchSnapshot();
+
+    const mention4 = await client.query(QUERY, {
+      variables: { content: '@Lee@Hansel@Solevilla' },
+    });
+    expect(mention4.errors).toBeFalsy();
+    expect(mention4.data.commentPreview).toMatchSnapshot(); // expect to display no mention
+
+    const mention5 = await client.query(QUERY, {
+      variables: { content: 'Hi@Solevilla' },
+    });
+    expect(mention5.errors).toBeFalsy();
+    expect(mention5.data.commentPreview).toMatchSnapshot(); // expect to display no mention
+
+    const mention6 = await client.query(QUERY, {
+      variables: { content: 'Hi!@Solevilla' },
+    });
+    expect(mention6.errors).toBeFalsy();
+    expect(mention6.data.commentPreview).toMatchSnapshot(); // expect to display no mention
+  });
+
   it('should only render markdown not HTML', async () => {
     loggedUser = '1';
     await saveCommentMentionFixtures();

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -322,10 +322,16 @@ describe('query commentPreview', () => {
     expect(mention6.data.commentPreview).toMatchSnapshot();
 
     const mention7 = await client.query(QUERY, {
-      variables: { content: 'Hi@Solevilla' },
+      variables: { content: 'Hi @Solevilla' },
     });
     expect(mention7.errors).toBeFalsy();
-    expect(mention7.data.commentPreview).toMatchSnapshot(); // expect to display no mention
+    expect(mention7.data.commentPreview).toMatchSnapshot();
+
+    const mention8 = await client.query(QUERY, {
+      variables: { content: 'Hi @Solevilla!' },
+    });
+    expect(mention8.errors).toBeFalsy();
+    expect(mention8.data.commentPreview).toMatchSnapshot();
   });
 
   it('should only render markdown not HTML', async () => {

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -332,6 +332,15 @@ describe('query commentPreview', () => {
     });
     expect(mention8.errors).toBeFalsy();
     expect(mention8.data.commentPreview).toMatchSnapshot();
+
+    const mention9 = await client.query(QUERY, {
+      variables: {
+        content:
+          "Hi @Solevilla! This is normal comment, let's tag @Lee as well",
+      },
+    });
+    expect(mention9.errors).toBeFalsy();
+    expect(mention9.data.commentPreview).toMatchSnapshot();
   });
 
   it('should only render markdown not HTML', async () => {

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -47,18 +47,16 @@ export const mentionSpecialCharacters = new RegExp('[^a-zA-Z0-9_@]', 'g');
 
 type ReplacedCharacters = string[];
 
+// in order to easily identify whether a comment mention is valid or not, we replace special characters with space
+// then while we reconstruct the word as the length changes afterwards, we passed the reference to which were those replaced characters
 const getReplacedCharacters = (word: string): [string, ReplacedCharacters] => {
   const specialCharacters = [];
-  word.split('').forEach((char) => {
-    const matched = char.match(mentionSpecialCharacters);
-    if (matched?.[0]?.length) {
-      specialCharacters.push(char);
-    }
-  });
+  let match: RegExpExecArray;
+  while ((match = mentionSpecialCharacters.exec(word)) != null) {
+    specialCharacters.push(word.charAt(match.index));
+  }
 
-  const result = word.replace(mentionSpecialCharacters, ' ');
-
-  return [result, specialCharacters];
+  return [word.replace(mentionSpecialCharacters, ' '), specialCharacters];
 };
 
 markdown.renderer.rules.text = function (tokens, idx, options, env, self) {

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -23,6 +23,12 @@ export const getMentionLink = ({ id, username }: MarkdownMention): string => {
   return `<a href="${href}" data-mention-id="${id}" data-mention-username="${username}">@${username}</a>`;
 };
 
+export const isValidUsernameChar = (char: string): boolean => {
+  const match = char.match(/^[a-z0-9_]+$/i);
+
+  return match && match[0].length === 1;
+};
+
 const defaultRender =
   markdown.renderer.rules.link_open ||
   function (tokens, idx, options, env, self) {
@@ -43,6 +49,86 @@ const defaultTextRender = markdown.renderer.rules.text;
 
 type MarkdownMention = Pick<User, 'id' | 'username'>;
 
+export const splitBySpecialChars = (word: string, index: number): string[] => {
+  const sections = [];
+
+  if (index > 0) {
+    sections.push(word.substring(0, index));
+  }
+
+  for (let i = index, current = word.substring(index); i >= 0; ) {
+    const nextIndex = current
+      .substring(i + 1)
+      .split('')
+      .findIndex((char) => !isValidUsernameChar(char));
+
+    if (nextIndex === -1) {
+      sections.push(current);
+      break;
+    }
+
+    i = 0;
+    if (nextIndex === 0) {
+      sections.push(current.charAt(0));
+      current = current.substring(1);
+    } else {
+      sections.push(current.substring(0, nextIndex + 1));
+      current = current.substring(nextIndex + 1);
+    }
+  }
+
+  return sections;
+};
+
+const findValidMention = (
+  sections: string[],
+  mentions: MarkdownMention[],
+  i: number,
+): MarkdownMention => {
+  const section = sections[i];
+  if (section.length === 1 || section.charAt(0) !== '@') {
+    return null;
+  }
+
+  if (i === 0) {
+    const after = sections[i + 1];
+    if (after?.charAt(0) === '@') {
+      return null;
+    }
+
+    return mentions.find(({ username }) => `@${username}` === section);
+  }
+
+  const before = sections[i - 1];
+  const beforeLastChar = before.charAt(before.length - 1);
+  const after = sections[i + 1];
+
+  if (
+    beforeLastChar === '@' ||
+    isValidUsernameChar(beforeLastChar) ||
+    after?.charAt(0) === '@'
+  ) {
+    return null;
+  }
+
+  return mentions.find(({ username }) => `@${username}` === section);
+};
+
+const reconstructWord = (sections: string[], mentions: MarkdownMention[]) => {
+  const reconstructed = [];
+
+  sections.forEach((section, i) => {
+    if (section.length === 1 || section.charAt(0) !== '@') {
+      return reconstructed.push(section);
+    }
+
+    const mention = findValidMention(sections, mentions, i);
+    return reconstructed.push(mention ? getMentionLink(mention) : section);
+  });
+
+  return reconstructed.join('');
+};
+
 markdown.renderer.rules.text = function (tokens, idx, options, env, self) {
   const content = defaultTextRender(tokens, idx, options, env, self);
   const mentions = env?.mentions as MarkdownMention[];
@@ -50,9 +136,16 @@ markdown.renderer.rules.text = function (tokens, idx, options, env, self) {
     return content;
   }
 
-  const words = content.split(' ').map((word) => {
-    const mention = mentions.find(({ username }) => word === `@${username}`);
-    return mention ? getMentionLink(mention) : word;
+  const words = content.split(' ').map((word: string) => {
+    const mentionIndex = word.indexOf('@');
+
+    if (mentionIndex === -1) {
+      return word;
+    }
+
+    const sections = splitBySpecialChars(word, mentionIndex);
+
+    return reconstructWord(sections, mentions);
   });
 
   return words.join(' ');

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -20,7 +20,7 @@ import graphorm from '../graphorm';
 import { GQLPost } from './posts';
 import { Roles } from '../roles';
 import { queryPaginatedByDate } from '../common/datePageGenerator';
-import { markdown, splitBySpecialChars } from '../common/markdown';
+import { markdown, mentionSpecialCharacters } from '../common/markdown';
 
 export interface GQLComment {
   id: string;
@@ -318,20 +318,14 @@ const getMentions = async (
   content: string,
   userId: string,
 ): Promise<MentionedUser[]> => {
-  const words = content.split(' ');
+  const replaced = content.replace(mentionSpecialCharacters, ' ');
+  const words = replaced.split(' ');
   const result = words.reduce((list, word) => {
-    const mentionIndex = word.indexOf('@');
-
-    if (mentionIndex === -1 || word.length === 1) {
+    if (word.length === 1 || word.charAt(0) !== '@') {
       return list;
     }
 
-    const sections = splitBySpecialChars(word, mentionIndex);
-    const mentions = sections
-      .filter((section) => section.charAt(0) === '@' && section.length > 1)
-      .map((mention) => mention.substring(1));
-
-    return list.concat(mentions);
+    return list.concat(word.substring(1));
   }, []);
 
   if (result.length === 0) {

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -20,7 +20,7 @@ import graphorm from '../graphorm';
 import { GQLPost } from './posts';
 import { Roles } from '../roles';
 import { queryPaginatedByDate } from '../common/datePageGenerator';
-import { markdown } from '../common/markdown';
+import { markdown, splitBySpecialChars } from '../common/markdown';
 
 export interface GQLComment {
   id: string;
@@ -320,11 +320,18 @@ const getMentions = async (
 ): Promise<MentionedUser[]> => {
   const words = content.split(' ');
   const result = words.reduce((list, word) => {
-    if (word[0] !== '@' || word.length === 1) {
+    const mentionIndex = word.indexOf('@');
+
+    if (mentionIndex === -1 || word.length === 1) {
       return list;
     }
 
-    return list.concat(word.substring(1));
+    const sections = splitBySpecialChars(word, mentionIndex);
+    const mentions = sections
+      .filter((section) => section.charAt(0) === '@' && section.length > 1)
+      .map((mention) => mention.substring(1));
+
+    return list.concat(mentions);
   }, []);
 
   if (result.length === 0) {


### PR DESCRIPTION
I have written numerous test cases to ensure all the edge cases will be covered. The behavior of when to allow the mention of what special character it was beside, was based on Twitter. On Twitter, they allow any special character so long as it is not the at (@) sign.

First, we replace the special characters with spaces to figure out which ones are valid mentions of users.

Then while we check each word for any mention, we replace again the special characters but this time we store them in an array so we can easily reconstruct the word for which one was replaced.

If the mention was found we will generate the anchor tag with it.