### PR TITLE
fix: prevent duplicate rejection

### DIFF
--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -172,7 +172,7 @@ describe('POST /p/rejectPost', () => {
     expect(submission.status).toEqual(SubmissionStatus.Rejected);
   });
 
-  it('should not update already rejected post', async () => {
+  it('should not update already approved post', async () => {
     const uuid = randomUUID();
     await createDefaultUser();
     const repo = con.getRepository(Submission);

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -31,13 +31,11 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     }
 
     try {
-      await con.getRepository(Submission).update(
-        { id: data.submissionId },
-        {
-          status: SubmissionStatus.Rejected,
-          reason: data.reason,
-        },
-      );
+      const repo = con.getRepository(Submission);
+      const submission = await repo.findOne({ id: data.submissionId });
+      if (submission.status === SubmissionStatus.Started) {
+        await repo.save({ ...submission, status: SubmissionStatus.Rejected });
+      }
       return res
         .status(200)
         .send({ status: 'ok', submissionId: data.submissionId });


### PR DESCRIPTION
Currently it's possible for the gatekeeper to send duplicate request to addNewPost and rejectPost routes.
The addNewPost will simply return that the post already exists.

However with the rejection we kept updating the status to Rejected even if it already was approved or rejected.
This fix prevents duplicate resets.

WT-174 #done 