### PR TITLE
feat: introducing generic error messages for community links

### DIFF
--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -127,14 +127,14 @@ describe('POST /p/newPost', () => {
       .expect(200);
     expect(body).toEqual({
       status: 'failed',
-      reason: 'scout and author are the same',
+      reason: 'SCOUT_IS_AUTHOR',
     });
     const submissions = await con.getRepository(Submission).find();
     const [submission] = submissions;
     expect(submissions.length).toEqual(1);
     expect(submission.id).toEqual(uuid);
     expect(submission.status).toEqual(SubmissionStatus.Rejected);
-    expect(submission.reason).toEqual('scout and author are the same');
+    expect(submission.reason).toEqual('SCOUT_IS_AUTHOR');
   });
 
   it('should handle empty body', async () => {
@@ -145,7 +145,7 @@ describe('POST /p/newPost', () => {
       .expect(200);
     const posts = await con.getRepository(Post).find();
     expect(posts.length).toEqual(0);
-    expect(body).toEqual({ status: 'failed', reason: 'missing fields' });
+    expect(body).toEqual({ status: 'failed', reason: 'MISSING_FIELDS' });
   });
 });
 

--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -13,6 +13,7 @@ import {
 import { DEFAULT_SUBMISSION_LIMIT } from '../src/schema/submissions';
 import { subDays } from 'date-fns';
 import { sourcesFixture } from './fixture/source';
+import { SubmissionFailErrorMessage } from '../src/errors';
 
 let con: Connection;
 let state: GraphQLTestingState;
@@ -119,7 +120,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: `Article has been submitted already! Current status: STARTED`,
+        reason: SubmissionFailErrorMessage.EXISTS_STARTED,
         post: null,
         submission: null,
       },
@@ -139,7 +140,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: 'Submission limit reached',
+        reason: SubmissionFailErrorMessage.LIMIT_REACHED,
         post: null,
         submission: null,
       },
@@ -155,7 +156,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: 'Access denied',
+        reason: SubmissionFailErrorMessage.ACCESS_DENIED,
         post: null,
         submission: null,
       },
@@ -218,7 +219,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: 'post is deleted',
+        reason: SubmissionFailErrorMessage.POST_DELETED,
         post: null,
         submission: null,
       },
@@ -233,7 +234,7 @@ describe('mutation submitArticle', () => {
     expect(res.data).toEqual({
       submitArticle: {
         result: 'rejected',
-        reason: 'invalid URL',
+        reason: SubmissionFailErrorMessage.INVALID_URL,
         post: null,
         submission: null,
       },

--- a/__tests__/workers/__snapshots__/communityLinkRejectedMail.ts.snap
+++ b/__tests__/workers/__snapshots__/communityLinkRejectedMail.ts.snap
@@ -10,6 +10,7 @@ Array [
     "dynamicTemplateData": Object {
       "article_link": "http://sample.abc.com",
       "first_name": "Lee",
+      "reason": "Unfortunately there was an error and we were unable to gather the required information from the URL submitted to add",
       "submitted_at": "Sep 27, 2020",
     },
     "from": Object {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -1083,7 +1083,7 @@ describe('submission', () => {
     id,
     userId: '1',
     url: '',
-    reason: '',
+    reason: null,
     status: SubmissionStatus.Started,
     createdAt: Date.now(),
   };

--- a/src/entity/Submission.ts
+++ b/src/entity/Submission.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { User } from './User';
 import { AddPostData } from './Post';
+import { SubmissionFailErrorKeys } from '../errors';
 
 export enum SubmissionStatus {
   Started = 'STARTED',
@@ -34,7 +35,7 @@ export class Submission {
   status: string;
 
   @Column({ type: 'text' })
-  reason: string;
+  reason: SubmissionFailErrorKeys;
 
   @ManyToOne(() => User, {
     lazy: true,
@@ -63,7 +64,7 @@ export const validateAndApproveSubmission = async (
       { id: data.submissionId },
       {
         status: SubmissionStatus.Rejected,
-        reason: 'scout and author are the same',
+        reason: 'SCOUT_IS_AUTHOR',
       },
     );
     return { rejected: true };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,51 @@
 import { ApolloError } from 'apollo-server-errors';
 
+export type SubmissionFailErrorKeys =
+  | 'GENERIC_ERROR'
+  | 'PAYWALL'
+  | 'MISSING_FIELDS'
+  | 'SCOUT_IS_AUTHOR'
+  | 'POST_EXISTS'
+  | 'AUTHOR_BANNED'
+  | 'ACCESS_DENIED'
+  | 'LIMIT_REACHED'
+  | 'INVALID_URL'
+  | 'POST_DELETED'
+  | 'EXISTS_STARTED'
+  | 'EXISTS_ACCEPTED'
+  | 'EXISTS_REJECTED';
+
+export const SubmissionFailErrorMessage: Record<
+  SubmissionFailErrorKeys,
+  string
+> = {
+  GENERIC_ERROR:
+    'Unfortunately there was an error and we were unable to gather the required information from the URL submitted to add',
+  PAYWALL:
+    'Unfortunately the article submitted is behind a paywall, so we cannot add it to the daily.dev feed.',
+  MISSING_FIELDS:
+    'Unfortunately we ran into a problem adding this article, our team is looking into it.',
+  SCOUT_IS_AUTHOR:
+    'You can’t submit your own articles as community picks, please suggest articles by other people.',
+  POST_EXISTS: 'This post is already on daily.dev!',
+  AUTHOR_BANNED:
+    'Unfortunately the article submitted is written by an author who violated our community guidelines and is banned. We no longer accept submissions from this author.',
+  ACCESS_DENIED:
+    'You do not have sufficient permissions and or reputation to submit a community link yet.',
+  LIMIT_REACHED:
+    'You can only submit 3 links per day and have reached your limit. Please try again tomorrow.',
+  INVALID_URL:
+    'The URL you submitted is not valid, please check and try again.',
+  POST_DELETED:
+    'This post has previously appeared in the daily.dev feed but was deleted and cannot be added to the feed again.',
+  EXISTS_STARTED:
+    'This article has already been submitted and is currently being processed. Current status: Started',
+  EXISTS_ACCEPTED:
+    'This article has already been submitted and is currently being processed. Current status: Accepted',
+  EXISTS_REJECTED:
+    'This article has already been submitted and is currently being processed. Current status: Rejected',
+};
+
 export class NotFoundError extends ApolloError {
   constructor(message: string) {
     super(message, 'NOT_FOUND');

--- a/src/workers/communityLinkRejectedMail.ts
+++ b/src/workers/communityLinkRejectedMail.ts
@@ -3,12 +3,10 @@ import { templateId } from '../common/mailing';
 import { messageToJson, Worker } from './worker';
 import { fetchUser } from '../common';
 import { baseNotificationEmailData, sendEmail } from '../common';
+import { SubmissionFailErrorMessage } from '../errors';
+import { Submission } from '../entity';
 
-interface Data {
-  url: string;
-  userId: string;
-  createdAt: string;
-}
+type Data = Pick<Submission, 'url' | 'userId' | 'createdAt' | 'reason'>;
 
 const worker: Worker = {
   subscription: 'community-link-rejected-mail',
@@ -25,6 +23,9 @@ const worker: Worker = {
           submitted_at: formatMailDate(new Date(data.createdAt)),
           first_name: user.name.split(' ')[0],
           article_link: data.url,
+          reason:
+            SubmissionFailErrorMessage[data?.reason] ??
+            SubmissionFailErrorMessage.GENERIC_ERROR,
         },
       });
       logger.info(

--- a/src/workers/newPost.ts
+++ b/src/workers/newPost.ts
@@ -24,7 +24,7 @@ const worker: Worker = {
           },
           'failed to add post to db',
         );
-      } else if (res.reason === 'exists') {
+      } else if (res.reason === 'POST_EXISTS') {
         logger.info(
           {
             post: data,
@@ -32,7 +32,7 @@ const worker: Worker = {
           },
           'post url already exists',
         );
-      } else if (res.reason === 'author banned') {
+      } else if (res.reason === 'AUTHOR_BANNED') {
         logger.info(
           {
             post: data,


### PR DESCRIPTION
We decided to remove string variants of error messages for community links.

As we don't have a clear plan for error codes we decided to move forward with the introduction of generic error keys.
The API manages these API keys, and we made a first start by introducing community links related keys.

Related PR:
Gatekeeper: https://github.com/dailydotdev/gatekeeper/pull/184