### PR TITLE
fix: format reject mail date

### DIFF
--- a/src/workers/communityLinkRejectedMail.ts
+++ b/src/workers/communityLinkRejectedMail.ts
@@ -5,7 +5,6 @@ import { fetchUser } from '../common';
 import { baseNotificationEmailData, sendEmail } from '../common';
 
 interface Data {
-  id: string;
   url: string;
   userId: string;
   createdAt: Date;


### PR DESCRIPTION
The rejection date was date formatted to date causing a duplicate conversion to happen.

WT-199 #done 