### PR TITLE
fix: convert unix timestamp to actual dates

### DIFF
--- a/__tests__/workers/communityLinkRejectedMail.ts
+++ b/__tests__/workers/communityLinkRejectedMail.ts
@@ -39,7 +39,7 @@ it('should send mail when the submission status is rejected', async () => {
   await expectSuccessfulBackground(worker, {
     url: 'http://sample.abc.com',
     userId: '1',
-    createdAt: new Date(2020, 8, 27),
+    createdAt: 1601187916999999,
     status: SubmissionStatus.Rejected,
   });
   expect(sendEmail).toBeCalledTimes(1);

--- a/src/workers/communityLinkRejectedMail.ts
+++ b/src/workers/communityLinkRejectedMail.ts
@@ -12,6 +12,7 @@ const worker: Worker = {
   subscription: 'community-link-rejected-mail',
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
+    const date = new Date(data.createdAt);
     try {
       const user = await fetchUser(data.userId);
       await sendEmail({
@@ -19,7 +20,7 @@ const worker: Worker = {
         to: user.email,
         templateId: templateId.communityLinkRejected,
         dynamicTemplateData: {
-          submitted_at: formatMailDate(new Date(data.createdAt)),
+          submitted_at: formatMailDate(new Date(date.getTime() / 1000)),
           first_name: user.name.split(' ')[0],
           article_link: data.url,
           reason:


### PR DESCRIPTION
After deploying the fix it still seemed to give issues on production.
Inspected the subscription payload and noticed it actually gets send as a unix timestamp. (microseconds)

<img width="525" alt="Screenshot 2022-07-05 at 10 01 33" src="https://user-images.githubusercontent.com/554874/177284918-4991217b-96d2-44c9-acef-82243ea7ffe2.png">

Decided to have the test reflect the same value so this won't happen in the future.

WT-200 #done 