### PR TITLE
refactor: post comments max size

### DIFF
--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -444,7 +444,7 @@ export const resolvers: IResolvers<any, Context> = {
         ctx,
         info,
         args,
-        { key: 'createdAt' },
+        { key: 'createdAt', maxSize: 500 },
         {
           queryBuilder: (builder) => {
             builder.queryBuilder = builder.queryBuilder


### PR DESCRIPTION
Our default max size for every paginated query is 100 (and the default page size is 100), though our function can accept a `maxSize` parameter to change it. Do you think we should change our default max size or the change we have here should be the go-to change whenever we face something like this again?