### PR TITLE
fix: the approval link was messed up in formatting

### DIFF
--- a/src/workers/postScoutMatchedMail.ts
+++ b/src/workers/postScoutMatchedMail.ts
@@ -28,6 +28,7 @@ const worker: Worker = {
       const submission = await con
         .getRepository(Submission)
         .findOne({ url: post.url, userId: user.id });
+      const link = getDiscussionLink(post.id);
       await sendEmail({
         ...baseNotificationEmailData,
         to: user.email,
@@ -38,7 +39,7 @@ const worker: Worker = {
           submitted_at: formatMailDate(submission.createdAt),
           post_image: post.image || pickImageUrl(post),
           article_link: post.url,
-          discussion_link: getDiscussionLink(post.id),
+          discussion_link: link,
         },
       });
       logger.info(


### PR DESCRIPTION
Following our other email guidelines there seems to be some formatting issue in the way we send it.
This fixes the community links approval email to contain valid links.

Also formatted the image differently on the sendgrid side so it will reflect.

WT-225 #done 