### PR TITLE
refactor: community picks access granting email

### DIFF
--- a/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
+++ b/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
@@ -13,7 +13,7 @@ Array [
         "full_name": "Ido Shamun",
         "live_hours": 30,
         "post_comments": "1",
-        "post_image": "https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/5",
+        "post_image": "http://image.com/p2",
         "post_title": "P2",
         "post_upvotes": "5",
         "post_upvotes_total": "11",

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -24,7 +24,7 @@ import {
   notifySettingsUpdated,
   notifySubmissionRejected,
   notifySubmissionCreated,
-  // notifySubmissionGrantedAccess,
+  notifySubmissionGrantedAccess,
   sendEmail,
   baseNotificationEmailData,
   pickImageUrl,
@@ -474,27 +474,27 @@ describe('user', () => {
   });
 });
 
-// describe('user_state', () => {
-//   type ObjectType = UserState;
-//   it('should notify on user state is created with the right key', async () => {
-//     await expectSuccessfulBackground(
-//       worker,
-//       mockChangeMessage<ObjectType>({
-//         after: {
-//           userId: defaultUser.id,
-//           key: UserStateKey.CommunityLinkAccess,
-//           value: false,
-//         },
-//         op: 'c',
-//         table: 'user_state',
-//       }),
-//     );
-//     expect(notifySubmissionGrantedAccess).toBeCalledTimes(1);
-//     expect(
-//       jest.mocked(notifySubmissionGrantedAccess).mock.calls[0].slice(1),
-//     ).toEqual(['1']);
-//   });
-// });
+describe('user_state', () => {
+  type ObjectType = UserState;
+  it('should notify on user state is created with the right key', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: {
+          userId: defaultUser.id,
+          key: UserStateKey.CommunityLinkAccess,
+          value: false,
+        },
+        op: 'c',
+        table: 'user_state',
+      }),
+    );
+    expect(notifySubmissionGrantedAccess).toBeCalledTimes(1);
+    expect(
+      jest.mocked(notifySubmissionGrantedAccess).mock.calls[0].slice(1),
+    ).toEqual(['1']);
+  });
+});
 
 describe('comment mention', () => {
   type ObjectType = CommentMention;

--- a/__tests__/workers/sendAnalyticsReportMail.ts
+++ b/__tests__/workers/sendAnalyticsReportMail.ts
@@ -50,6 +50,7 @@ beforeEach(async () => {
       shortId: 'sp2',
       title: 'P2',
       url: 'http://p2.com',
+      image: 'http://image.com/p2',
       sourceId: 'a',
       createdAt: sub(now, { hours: 30 }),
       authorId: '1',

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -38,7 +38,7 @@ import {
   notifySubmissionRejected,
   notifyScoutMatched,
   notifySubmissionCreated,
-  // notifySubmissionGrantedAccess,
+  notifySubmissionGrantedAccess,
 } from '../common';
 import { ChangeMessage } from '../types';
 import { Connection } from 'typeorm';
@@ -364,7 +364,7 @@ const onUserStateChange = async (
 ) => {
   if (data.payload.op === 'c') {
     if (data.payload.after.key === UserStateKey.CommunityLinkAccess) {
-      // await notifySubmissionGrantedAccess(logger, data.payload.after.userId);
+      await notifySubmissionGrantedAccess(logger, data.payload.after.userId);
     }
   }
 };


### PR DESCRIPTION
As discussed, we are preparing the sending out of email once the user has reached such reputation points to be able to submit community picks article.

Relevant reverted commit: https://github.com/dailydotdev/daily-api/pull/968/commits/3eb35a297d41a22ce5ccc19a737d793980c7ce2c