### PR TITLE
refactor: author emails to send on scout

### DIFF
--- a/__tests__/workers/__snapshots__/commentCommentedAuthor.ts.snap
+++ b/__tests__/workers/__snapshots__/commentCommentedAuthor.ts.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should send mail to both post scout and author 1`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "tsahi@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`should send mail to both post scout and author 2`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "nimrod@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
 exports[`should send mail to the post author 1`] = `
 Array [
   Object {
@@ -14,6 +84,41 @@ Array [
       "post_image": "https://daily.dev/image.jpg",
       "post_title": "P1",
       "profile_image": "https://daily.dev/tsahi.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "nimrod@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`should send mail to the post scout 1`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
       "user_reputation": 3,
     },
     "from": Object {

--- a/__tests__/workers/__snapshots__/commentCommentedAuthor.ts.snap
+++ b/__tests__/workers/__snapshots__/commentCommentedAuthor.ts.snap
@@ -2,140 +2,141 @@
 
 exports[`should send mail to both post scout and author 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "tsahi@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "tsahi@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
-]
-`;
-
-exports[`should send mail to both post scout and author 2`] = `
-Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;
 
 exports[`should send mail to the post author 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Tsahi",
-      "new_comment": "sub comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/tsahi.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Tsahi",
+        "new_comment": "sub comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/tsahi.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;
 
 exports[`should send mail to the post scout 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;

--- a/__tests__/workers/__snapshots__/postCommentedAuthor.ts.snap
+++ b/__tests__/workers/__snapshots__/postCommentedAuthor.ts.snap
@@ -1,6 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should send mail to both post scout and author 1`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "tsahi@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`should send mail to both post scout and author 2`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "nimrod@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
 exports[`should send mail to the post author 1`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "discussion_link": "http://localhost:5002/posts/p1",
+      "full_name": "Ido",
+      "new_comment": "parent comment",
+      "post_image": "https://daily.dev/image.jpg",
+      "post_title": "P1",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "user_reputation": 3,
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+    "to": "nimrod@daily.dev",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`should send mail to the post scout 1`] = `
 Array [
   Object {
     "asm": Object {

--- a/__tests__/workers/__snapshots__/postCommentedAuthor.ts.snap
+++ b/__tests__/workers/__snapshots__/postCommentedAuthor.ts.snap
@@ -2,140 +2,141 @@
 
 exports[`should send mail to both post scout and author 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "tsahi@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "tsahi@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
-]
-`;
-
-exports[`should send mail to both post scout and author 2`] = `
-Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;
 
 exports[`should send mail to the post author 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;
 
 exports[`should send mail to the post scout 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "discussion_link": "http://localhost:5002/posts/p1",
-      "full_name": "Ido",
-      "new_comment": "parent comment",
-      "post_image": "https://daily.dev/image.jpg",
-      "post_title": "P1",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "user_reputation": 3,
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
-    "to": "nimrod@daily.dev",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "discussion_link": "http://localhost:5002/posts/p1",
+        "full_name": "Ido",
+        "new_comment": "parent comment",
+        "post_image": "https://daily.dev/image.jpg",
+        "post_title": "P1",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "user_reputation": 3,
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-aba78d1947b14307892713ad6c2cafc5",
+      "to": "nimrod@daily.dev",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;

--- a/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
+++ b/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
@@ -13,7 +13,7 @@ Array [
         "full_name": "Ido Shamun",
         "live_hours": 30,
         "post_comments": "1",
-        "post_image": "https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/7",
+        "post_image": "https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/5",
         "post_title": "P2",
         "post_upvotes": "5",
         "post_upvotes_total": "11",

--- a/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
+++ b/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
@@ -42,3 +42,89 @@ Array [
   },
 ]
 `;
+
+exports[`should send analytics reports to both scout and author 1`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "first_name": "Ido",
+      "full_name": "Ido Shamun",
+      "live_hours": 10,
+      "post_comments": "2",
+      "post_image": "http://image.com/p",
+      "post_title": "P1",
+      "post_upvotes": "6",
+      "post_upvotes_total": "11",
+      "post_views": "11",
+      "post_views_total": "21",
+      "profile_image": "https://daily.dev/ido.jpg",
+      "profile_link": "https://daily.dev/ido",
+      "source_image": "http://image.com/a",
+      "user_handle": "idoshamun",
+      "user_reputation": "5",
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-97c75b0e2cf847399d20233455736ba0",
+    "to": "ido@acme.com",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`should send analytics reports to both scout and author 2`] = `
+Array [
+  Object {
+    "asm": Object {
+      "groupId": 12850,
+    },
+    "category": "Notification",
+    "dynamicTemplateData": Object {
+      "first_name": "Lee",
+      "full_name": "Lee Solevilla",
+      "live_hours": 10,
+      "post_comments": "2",
+      "post_image": "http://image.com/p",
+      "post_title": "P1",
+      "post_upvotes": "6",
+      "post_upvotes_total": "6",
+      "post_views": "11",
+      "post_views_total": "11",
+      "profile_image": "https://daily.dev/lee.jpg",
+      "profile_link": "https://daily.dev/lee",
+      "source_image": "http://image.com/a",
+      "user_handle": "lee",
+      "user_reputation": "5",
+    },
+    "from": Object {
+      "email": "informer@daily.dev",
+      "name": "daily.dev",
+    },
+    "replyTo": Object {
+      "email": "hi@daily.dev",
+      "name": "daily.dev",
+    },
+    "templateId": "d-97c75b0e2cf847399d20233455736ba0",
+    "to": "lee@acme.com",
+    "trackingSettings": Object {
+      "openTracking": Object {
+        "enable": true,
+      },
+    },
+  },
+]
+`;

--- a/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
+++ b/__tests__/workers/__snapshots__/sendAnalyticsReportMail.ts.snap
@@ -2,129 +2,128 @@
 
 exports[`should send analytics reports 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "first_name": "Ido",
-      "full_name": "Ido Shamun",
-      "live_hours": 10,
-      "post_comments": "2",
-      "post_image": "http://image.com/p",
-      "post_title": "P1",
-      "post_upvotes": "6",
-      "post_upvotes_total": "11",
-      "post_views": "11",
-      "post_views_total": "21",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "profile_link": "https://daily.dev/ido",
-      "source_image": "http://image.com/a",
-      "user_handle": "idoshamun",
-      "user_reputation": "5",
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-97c75b0e2cf847399d20233455736ba0",
-    "to": "ido@acme.com",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "first_name": "Ido",
+        "full_name": "Ido Shamun",
+        "live_hours": 30,
+        "post_comments": "1",
+        "post_image": "https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/7",
+        "post_title": "P2",
+        "post_upvotes": "5",
+        "post_upvotes_total": "11",
+        "post_views": "10",
+        "post_views_total": "21",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "profile_link": "https://daily.dev/ido",
+        "source_image": "http://image.com/a",
+        "user_handle": "idoshamun",
+        "user_reputation": "5",
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-97c75b0e2cf847399d20233455736ba0",
+      "to": "ido@acme.com",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;
 
 exports[`should send analytics reports to both scout and author 1`] = `
 Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "first_name": "Ido",
-      "full_name": "Ido Shamun",
-      "live_hours": 10,
-      "post_comments": "2",
-      "post_image": "http://image.com/p",
-      "post_title": "P1",
-      "post_upvotes": "6",
-      "post_upvotes_total": "11",
-      "post_views": "11",
-      "post_views_total": "21",
-      "profile_image": "https://daily.dev/ido.jpg",
-      "profile_link": "https://daily.dev/ido",
-      "source_image": "http://image.com/a",
-      "user_handle": "idoshamun",
-      "user_reputation": "5",
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-97c75b0e2cf847399d20233455736ba0",
-    "to": "ido@acme.com",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+  Array [
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "first_name": "Ido",
+        "full_name": "Ido Shamun",
+        "live_hours": 10,
+        "post_comments": "2",
+        "post_image": "http://image.com/p",
+        "post_title": "P1",
+        "post_upvotes": "6",
+        "post_upvotes_total": "11",
+        "post_views": "11",
+        "post_views_total": "21",
+        "profile_image": "https://daily.dev/ido.jpg",
+        "profile_link": "https://daily.dev/ido",
+        "source_image": "http://image.com/a",
+        "user_handle": "idoshamun",
+        "user_reputation": "5",
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-97c75b0e2cf847399d20233455736ba0",
+      "to": "ido@acme.com",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
-]
-`;
-
-exports[`should send analytics reports to both scout and author 2`] = `
-Array [
-  Object {
-    "asm": Object {
-      "groupId": 12850,
-    },
-    "category": "Notification",
-    "dynamicTemplateData": Object {
-      "first_name": "Lee",
-      "full_name": "Lee Solevilla",
-      "live_hours": 10,
-      "post_comments": "2",
-      "post_image": "http://image.com/p",
-      "post_title": "P1",
-      "post_upvotes": "6",
-      "post_upvotes_total": "6",
-      "post_views": "11",
-      "post_views_total": "11",
-      "profile_image": "https://daily.dev/lee.jpg",
-      "profile_link": "https://daily.dev/lee",
-      "source_image": "http://image.com/a",
-      "user_handle": "lee",
-      "user_reputation": "5",
-    },
-    "from": Object {
-      "email": "informer@daily.dev",
-      "name": "daily.dev",
-    },
-    "replyTo": Object {
-      "email": "hi@daily.dev",
-      "name": "daily.dev",
-    },
-    "templateId": "d-97c75b0e2cf847399d20233455736ba0",
-    "to": "lee@acme.com",
-    "trackingSettings": Object {
-      "openTracking": Object {
-        "enable": true,
+    Object {
+      "asm": Object {
+        "groupId": 12850,
+      },
+      "category": "Notification",
+      "dynamicTemplateData": Object {
+        "first_name": "Lee",
+        "full_name": "Lee Solevilla",
+        "live_hours": 10,
+        "post_comments": "2",
+        "post_image": "http://image.com/p",
+        "post_title": "P1",
+        "post_upvotes": "6",
+        "post_upvotes_total": "6",
+        "post_views": "11",
+        "post_views_total": "11",
+        "profile_image": "https://daily.dev/lee.jpg",
+        "profile_link": "https://daily.dev/lee",
+        "source_image": "http://image.com/a",
+        "user_handle": "lee",
+        "user_reputation": "5",
+      },
+      "from": Object {
+        "email": "informer@daily.dev",
+        "name": "daily.dev",
+      },
+      "replyTo": Object {
+        "email": "hi@daily.dev",
+        "name": "daily.dev",
+      },
+      "templateId": "d-97c75b0e2cf847399d20233455736ba0",
+      "to": "lee@acme.com",
+      "trackingSettings": Object {
+        "openTracking": Object {
+          "enable": true,
+        },
       },
     },
-  },
+  ],
 ]
 `;

--- a/__tests__/workers/commentCommentedAuthor.ts
+++ b/__tests__/workers/commentCommentedAuthor.ts
@@ -187,9 +187,8 @@ it('should send mail to both post scout and author', async () => {
     userId: '1',
     commentId: 'c1',
   });
-  expect(sendEmail).toBeCalledTimes(2);
+  expect(sendEmail).toBeCalledTimes(1);
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
-  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
 });
 
 it('should not send mail when no post author', async () => {

--- a/__tests__/workers/commentCommentedAuthor.ts
+++ b/__tests__/workers/commentCommentedAuthor.ts
@@ -98,6 +98,100 @@ it('should send mail to the post author', async () => {
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
+it('should send mail to the post scout', async () => {
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '3')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '3',
+      email: 'nimrod@daily.dev',
+      name: 'Nimrod',
+      image: 'https://daily.dev/nimrod.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '1')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '1',
+      email: 'ido@daily.dev',
+      name: 'Ido',
+      image: 'https://daily.dev/ido.jpg',
+      reputation: 3,
+    });
+
+  await con
+    .getRepository(Post)
+    .update('p1', { scoutId: '3', image: 'https://daily.dev/image.jpg' });
+  await expectSuccessfulBackground(worker, {
+    postId: 'p1',
+    userId: '1',
+    commentId: 'c1',
+  });
+  expect(sendEmail).toBeCalledTimes(1);
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+});
+
+it('should send mail to both post scout and author', async () => {
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '3')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '3',
+      email: 'nimrod@daily.dev',
+      name: 'Nimrod',
+      image: 'https://daily.dev/nimrod.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '2')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '2',
+      email: 'tsahi@daily.dev',
+      name: 'Tsahi',
+      image: 'https://daily.dev/tsahi.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '1')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '1',
+      email: 'ido@daily.dev',
+      name: 'Ido',
+      image: 'https://daily.dev/ido.jpg',
+      reputation: 3,
+    });
+
+  await con.getRepository(Post).update('p1', {
+    authorId: '2',
+    scoutId: '3',
+    image: 'https://daily.dev/image.jpg',
+  });
+  await expectSuccessfulBackground(worker, {
+    postId: 'p1',
+    userId: '1',
+    commentId: 'c1',
+  });
+  expect(sendEmail).toBeCalledTimes(2);
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
+});
+
 it('should not send mail when no post author', async () => {
   await expectSuccessfulBackground(worker, {
     postId: 'p1',

--- a/__tests__/workers/postCommentedAuthor.ts
+++ b/__tests__/workers/postCommentedAuthor.ts
@@ -97,6 +97,100 @@ it('should send mail to the post author', async () => {
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
+it('should send mail to the post scout', async () => {
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '3')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '3',
+      email: 'nimrod@daily.dev',
+      name: 'Nimrod',
+      image: 'https://daily.dev/nimrod.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '1')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '1',
+      email: 'ido@daily.dev',
+      name: 'Ido',
+      image: 'https://daily.dev/ido.jpg',
+      reputation: 3,
+    });
+
+  await con
+    .getRepository(Post)
+    .update('p1', { scoutId: '3', image: 'https://daily.dev/image.jpg' });
+  await expectSuccessfulBackground(worker, {
+    postId: 'p1',
+    userId: '1',
+    commentId: 'c1',
+  });
+  expect(sendEmail).toBeCalledTimes(1);
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+});
+
+it('should send mail to both post scout and author', async () => {
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '3')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '3',
+      email: 'nimrod@daily.dev',
+      name: 'Nimrod',
+      image: 'https://daily.dev/nimrod.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '2')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '2',
+      email: 'tsahi@daily.dev',
+      name: 'Tsahi',
+      image: 'https://daily.dev/tsahi.jpg',
+      reputation: 5,
+    });
+
+  nock(process.env.GATEWAY_URL)
+    .get('/v1/users/me')
+    .matchHeader('authorization', `Service ${process.env.GATEWAY_SECRET}`)
+    .matchHeader('user-id', '1')
+    .matchHeader('logged-in', 'true')
+    .reply(200, {
+      id: '1',
+      email: 'ido@daily.dev',
+      name: 'Ido',
+      image: 'https://daily.dev/ido.jpg',
+      reputation: 3,
+    });
+
+  await con.getRepository(Post).update('p1', {
+    authorId: '2',
+    scoutId: '3',
+    image: 'https://daily.dev/image.jpg',
+  });
+  await expectSuccessfulBackground(worker, {
+    postId: 'p1',
+    userId: '1',
+    commentId: 'c1',
+  });
+  expect(sendEmail).toBeCalledTimes(2);
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
+});
+
 it('should not send mail when no post author', async () => {
   await expectSuccessfulBackground(worker, {
     postId: 'p1',

--- a/__tests__/workers/postCommentedAuthor.ts
+++ b/__tests__/workers/postCommentedAuthor.ts
@@ -186,9 +186,8 @@ it('should send mail to both post scout and author', async () => {
     userId: '1',
     commentId: 'c1',
   });
-  expect(sendEmail).toBeCalledTimes(2);
+  expect(sendEmail).toBeCalledTimes(1);
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
-  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
 });
 
 it('should not send mail when no post author', async () => {

--- a/__tests__/workers/sendAnalyticsReportMail.ts
+++ b/__tests__/workers/sendAnalyticsReportMail.ts
@@ -84,14 +84,16 @@ it('should send analytics reports', async () => {
   mockedUsers.forEach(mockUsersMe);
 
   await expectSuccessfulBackground(worker, {
-    postId: 'p1',
+    postId: 'p2',
   });
   expect(sendEmail).toBeCalledTimes(1);
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
 });
 
 it('should send analytics reports to both scout and author', async () => {
-  await con.getRepository(Post).update({ id: 'p1' }, { scoutId: '2' });
+  await con
+    .getRepository(Post)
+    .update({ id: 'p1' }, { scoutId: '2', sentAnalyticsReport: true });
   const mockedUsers: GatewayUser[] = [
     {
       id: '1',
@@ -117,7 +119,6 @@ it('should send analytics reports to both scout and author', async () => {
   await expectSuccessfulBackground(worker, {
     postId: 'p1',
   });
-  expect(sendEmail).toBeCalledTimes(2);
+  expect(sendEmail).toBeCalledTimes(1);
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
-  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
 });

--- a/__tests__/workers/sendAnalyticsReportMail.ts
+++ b/__tests__/workers/sendAnalyticsReportMail.ts
@@ -25,9 +25,10 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   jest.resetAllMocks();
-  await con
-    .getRepository(User)
-    .save([{ id: '1', name: 'Ido', image: 'https://daily.dev/ido.jpg' }]);
+  await con.getRepository(User).save([
+    { id: '1', name: 'Ido', image: 'https://daily.dev/ido.jpg' },
+    { id: '2', name: 'Lee', image: 'https://daily.dev/lee.jpg' },
+  ]);
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, Post, [
     {
@@ -87,4 +88,36 @@ it('should send analytics reports', async () => {
   });
   expect(sendEmail).toBeCalledTimes(1);
   expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+});
+
+it('should send analytics reports to both scout and author', async () => {
+  await con.getRepository(Post).update({ id: 'p1' }, { scoutId: '2' });
+  const mockedUsers: GatewayUser[] = [
+    {
+      id: '1',
+      email: 'ido@acme.com',
+      name: 'Ido Shamun',
+      image: 'https://daily.dev/ido.jpg',
+      reputation: 5,
+      permalink: 'https://daily.dev/ido',
+      username: 'idoshamun',
+    },
+    {
+      id: '2',
+      email: 'lee@acme.com',
+      name: 'Lee Solevilla',
+      image: 'https://daily.dev/lee.jpg',
+      reputation: 5,
+      permalink: 'https://daily.dev/lee',
+      username: 'lee',
+    },
+  ];
+  mockedUsers.forEach(mockUsersMe);
+
+  await expectSuccessfulBackground(worker, {
+    postId: 'p1',
+  });
+  expect(sendEmail).toBeCalledTimes(2);
+  expect(jest.mocked(sendEmail).mock.calls[0]).toMatchSnapshot();
+  expect(jest.mocked(sendEmail).mock.calls[1]).toMatchSnapshot();
 });

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -60,9 +60,9 @@ export const baseNotificationEmailData: Pick<
   category: 'Notification',
 };
 
-export const sendEmail = async (data: MailDataRequired): Promise<void> => {
+export const sendEmail: typeof sgMail.send = (data) => {
   if (process.env.SENDGRID_API_KEY) {
-    await sgMail.send(data);
+    return sgMail.send(data);
   }
 };
 

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -1,6 +1,6 @@
 import { User } from './../entity/User';
 import { Connection } from 'typeorm';
-import { Comment } from '../entity';
+import { Comment, Post } from '../entity';
 
 export const defaultImage = {
   urls: process.env.DEFAULT_IMAGE_URL.split(','),
@@ -46,3 +46,6 @@ export const getPostCommenterIds = async (
 
   return result.map((comment) => comment.userId);
 };
+
+export const hasAuthorScout = (post: Post): boolean =>
+  !!post?.authorId || !!post?.scoutId;

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -344,24 +344,18 @@ export const getUserReadingRank = async (
   };
 };
 
-export const getCommenterAuthorScout = (
-  commenterId: string,
+export const getAuthorScout = (
   post: Post,
+  excludeIds: string[] = [],
 ): Promise<User>[] => {
   const requests: Promise<User>[] = [];
-  if (post?.authorId && post?.authorId !== commenterId) {
+  if (post?.authorId && !excludeIds.includes(post?.authorId)) {
     requests.push(fetchUser(post.authorId));
   }
 
-  if (post?.scoutId && post?.scoutId !== commenterId) {
+  if (post?.scoutId && !excludeIds.includes(post?.scoutId)) {
     requests.push(fetchUser(post.scoutId));
   }
-
-  if (requests.length === 0) {
-    return [];
-  }
-
-  requests.unshift(fetchUser(commenterId));
 
   return requests;
 };

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -343,3 +343,25 @@ export const getUserReadingRank = async (
     tags,
   };
 };
+
+export const getCommenterAuthorScout = (
+  commenterId: string,
+  post: Post,
+): Promise<User>[] => {
+  const requests: Promise<User>[] = [];
+  if (post?.authorId && post?.authorId !== commenterId) {
+    requests.push(fetchUser(post.authorId));
+  }
+
+  if (post?.scoutId && post?.scoutId !== commenterId) {
+    requests.push(fetchUser(post.scoutId));
+  }
+
+  if (requests.length === 0) {
+    return [];
+  }
+
+  requests.unshift(fetchUser(commenterId));
+
+  return requests;
+};

--- a/src/workers/commentCommentedAuthor.ts
+++ b/src/workers/commentCommentedAuthor.ts
@@ -2,9 +2,10 @@ import { messageToJson, Worker } from './worker';
 import { Comment } from '../entity';
 import {
   getCommentedAuthorMailParams,
-  getCommenterAuthorScout,
+  getAuthorScout,
   hasAuthorScout,
   sendEmail,
+  fetchUser,
 } from '../common';
 
 interface Data {
@@ -29,12 +30,13 @@ const worker: Worker = {
         return;
       }
 
-      const requests = getCommenterAuthorScout(data.userId, post);
+      const requests = getAuthorScout(post, [data.userId]);
 
       if (requests.length === 0) {
         return;
       }
 
+      requests.unshift(fetchUser(data.userId));
       const [commenter, ...authorScout] = await Promise.all(requests);
 
       await Promise.all(

--- a/src/workers/commentCommentedAuthor.ts
+++ b/src/workers/commentCommentedAuthor.ts
@@ -38,14 +38,10 @@ const worker: Worker = {
 
       requests.unshift(fetchUser(data.userId));
       const [commenter, ...authorScout] = await Promise.all(requests);
-
-      await Promise.all(
-        authorScout.map((author) =>
-          sendEmail(
-            getCommentedAuthorMailParams(post, comment, author, commenter),
-          ),
-        ),
+      const emails = authorScout.map((author) =>
+        getCommentedAuthorMailParams(post, comment, author, commenter),
       );
+      await sendEmail(emails);
       logger.info(
         {
           data,

--- a/src/workers/postCommentedAuthor.ts
+++ b/src/workers/postCommentedAuthor.ts
@@ -2,9 +2,10 @@ import { messageToJson, Worker } from './worker';
 import { Comment } from '../entity';
 import {
   getCommentedAuthorMailParams,
-  getCommenterAuthorScout,
+  getAuthorScout,
   hasAuthorScout,
   sendEmail,
+  fetchUser,
 } from '../common';
 
 interface Data {
@@ -29,12 +30,13 @@ const worker: Worker = {
         return;
       }
 
-      const requests = getCommenterAuthorScout(data.userId, post);
+      const requests = getAuthorScout(post, [data.userId]);
 
       if (requests.length === 0) {
         return;
       }
 
+      requests.unshift(fetchUser(data.userId));
       const [commenter, ...authorScout] = await Promise.all(requests);
 
       await Promise.all(

--- a/src/workers/postCommentedAuthor.ts
+++ b/src/workers/postCommentedAuthor.ts
@@ -21,22 +21,33 @@ const worker: Worker = {
         return;
       }
       const post = await comment.post;
-      if (post?.authorId && post?.authorId !== data.userId) {
-        const [author, commenter] = await Promise.all([
-          fetchUser(post.authorId),
-          fetchUser(data.userId),
-        ]);
-        await sendEmail(
-          getCommentedAuthorMailParams(post, comment, author, commenter),
-        );
-        logger.info(
-          {
-            data,
-            messageId: message.messageId,
-          },
-          'post commented author email sent',
-        );
+      if (!post?.authorId && !post?.scoutId) {
+        return;
       }
+
+      const requests = [fetchUser(data.userId)];
+      if (post?.authorId && post?.authorId !== data.userId) {
+        requests.push(fetchUser(post.authorId));
+      }
+      if (post?.scoutId && post?.scoutId !== data.userId) {
+        requests.push(fetchUser(post.scoutId));
+      }
+      const [commenter, ...authorScout] = await Promise.all(requests);
+
+      await Promise.all(
+        authorScout.map((author) =>
+          sendEmail(
+            getCommentedAuthorMailParams(post, comment, author, commenter),
+          ),
+        ),
+      );
+      logger.info(
+        {
+          data,
+          messageId: message.messageId,
+        },
+        'post commented author email sent',
+      );
     } catch (err) {
       logger.error(
         {

--- a/src/workers/postCommentedAuthor.ts
+++ b/src/workers/postCommentedAuthor.ts
@@ -38,14 +38,10 @@ const worker: Worker = {
 
       requests.unshift(fetchUser(data.userId));
       const [commenter, ...authorScout] = await Promise.all(requests);
-
-      await Promise.all(
-        authorScout.map((author) =>
-          sendEmail(
-            getCommentedAuthorMailParams(post, comment, author, commenter),
-          ),
-        ),
+      const emails = authorScout.map((author) =>
+        getCommentedAuthorMailParams(post, comment, author, commenter),
       );
+      await sendEmail(emails);
       logger.info(
         {
           data,

--- a/src/workers/sendAnalyticsReportMail.ts
+++ b/src/workers/sendAnalyticsReportMail.ts
@@ -2,7 +2,7 @@ import { templateId } from './../common/mailing';
 import { differenceInHours } from 'date-fns';
 import { messageToJson, Worker } from './worker';
 import { getAuthorPostStats, Post } from '../entity';
-import { fetchUser, pickImageUrl } from '../common';
+import { fetchUser, pickImageUrl, User } from '../common';
 import {
   baseNotificationEmailData,
   sendEmail,
@@ -19,40 +19,58 @@ const worker: Worker = {
     const data: Data = messageToJson(message);
     try {
       const post = await con.getRepository(Post).findOne(data.postId);
-      if (!post.sentAnalyticsReport && post.authorId) {
-        const user = await fetchUser(post.authorId);
-        const source = await post.source;
-        const stats = await getAuthorPostStats(con, user.id);
-        await sendEmail({
-          ...baseNotificationEmailData,
-          to: user.email,
-          templateId: templateId.analyticsReport,
-          dynamicTemplateData: {
-            first_name: user.name.split(' ')[0],
-            source_image: source.image,
-            post_image: post.image || pickImageUrl(post),
-            post_title: truncatePostToTweet(post),
-            live_hours: differenceInHours(new Date(), post.createdAt),
-            post_views: post.views?.toLocaleString() ?? 0,
-            post_views_total: stats.numPostViews?.toLocaleString() ?? 0,
-            post_upvotes: post.upvotes?.toLocaleString() ?? 0,
-            post_upvotes_total: stats.numPostUpvotes?.toLocaleString() ?? 0,
-            post_comments: post.comments?.toLocaleString() ?? 0,
-            user_reputation: user.reputation?.toLocaleString() ?? 0,
-            profile_image: user.image,
-            full_name: user.name,
-            user_handle: user.username,
-            profile_link: user.permalink,
-          },
-        });
-        logger.info(
-          {
-            data,
-            messageId: message.messageId,
-          },
-          'analytics report sent',
-        );
+      if (!post.authorId && !post.scoutId) {
+        return;
       }
+
+      const requests: Promise<User>[] = [];
+      if (post.authorId) {
+        requests.push(fetchUser(post.authorId));
+      }
+
+      if (post.scoutId) {
+        requests.push(fetchUser(post.scoutId));
+      }
+
+      const users = await Promise.all(requests);
+      const source = await post.source;
+      const stats = await Promise.all(
+        users.map((user) => getAuthorPostStats(con, user.id)),
+      );
+      await Promise.all(
+        users.map((user, i) =>
+          sendEmail({
+            ...baseNotificationEmailData,
+            to: user.email,
+            templateId: templateId.analyticsReport,
+            dynamicTemplateData: {
+              first_name: user.name.split(' ')[0],
+              source_image: source.image,
+              post_image: post.image || pickImageUrl(post),
+              post_title: truncatePostToTweet(post),
+              live_hours: differenceInHours(new Date(), post.createdAt),
+              post_views: post.views?.toLocaleString() ?? 0,
+              post_views_total: stats[i].numPostViews?.toLocaleString() ?? 0,
+              post_upvotes: post.upvotes?.toLocaleString() ?? 0,
+              post_upvotes_total:
+                stats[i].numPostUpvotes?.toLocaleString() ?? 0,
+              post_comments: post.comments?.toLocaleString() ?? 0,
+              user_reputation: user.reputation?.toLocaleString() ?? 0,
+              profile_image: user.image,
+              full_name: user.name,
+              user_handle: user.username,
+              profile_link: user.permalink,
+            },
+          }),
+        ),
+      );
+      logger.info(
+        {
+          data,
+          messageId: message.messageId,
+        },
+        'analytics report sent',
+      );
     } catch (err) {
       logger.error(
         {

--- a/src/workers/sendAnalyticsReportMail.ts
+++ b/src/workers/sendAnalyticsReportMail.ts
@@ -29,33 +29,29 @@ const worker: Worker = {
       const stats = await Promise.all(
         users.map((user) => getAuthorPostStats(con, user.id)),
       );
-      await Promise.all(
-        users.map((user, i) =>
-          sendEmail({
-            ...baseNotificationEmailData,
-            to: user.email,
-            templateId: templateId.analyticsReport,
-            dynamicTemplateData: {
-              first_name: user.name.split(' ')[0],
-              source_image: source.image,
-              post_image: post.image || pickImageUrl(post),
-              post_title: truncatePostToTweet(post),
-              live_hours: differenceInHours(new Date(), post.createdAt),
-              post_views: post.views?.toLocaleString() ?? 0,
-              post_views_total: stats[i].numPostViews?.toLocaleString() ?? 0,
-              post_upvotes: post.upvotes?.toLocaleString() ?? 0,
-              post_upvotes_total:
-                stats[i].numPostUpvotes?.toLocaleString() ?? 0,
-              post_comments: post.comments?.toLocaleString() ?? 0,
-              user_reputation: user.reputation?.toLocaleString() ?? 0,
-              profile_image: user.image,
-              full_name: user.name,
-              user_handle: user.username,
-              profile_link: user.permalink,
-            },
-          }),
-        ),
-      );
+      const emails = users.map((user, i) => ({
+        ...baseNotificationEmailData,
+        to: user.email,
+        templateId: templateId.analyticsReport,
+        dynamicTemplateData: {
+          first_name: user.name.split(' ')[0],
+          source_image: source.image,
+          post_image: post.image || pickImageUrl(post),
+          post_title: truncatePostToTweet(post),
+          live_hours: differenceInHours(new Date(), post.createdAt),
+          post_views: post.views?.toLocaleString() ?? 0,
+          post_views_total: stats[i].numPostViews?.toLocaleString() ?? 0,
+          post_upvotes: post.upvotes?.toLocaleString() ?? 0,
+          post_upvotes_total: stats[i].numPostUpvotes?.toLocaleString() ?? 0,
+          post_comments: post.comments?.toLocaleString() ?? 0,
+          user_reputation: user.reputation?.toLocaleString() ?? 0,
+          profile_image: user.image,
+          full_name: user.name,
+          user_handle: user.username,
+          profile_link: user.permalink,
+        },
+      }));
+      await sendEmail(emails);
       logger.info(
         {
           data,

--- a/src/workers/sendAnalyticsReportMail.ts
+++ b/src/workers/sendAnalyticsReportMail.ts
@@ -19,7 +19,7 @@ const worker: Worker = {
     const data: Data = messageToJson(message);
     try {
       const post = await con.getRepository(Post).findOne(data.postId);
-      if (!hasAuthorScout(post)) {
+      if (!post.sentAnalyticsReport || !hasAuthorScout(post)) {
         return;
       }
 

--- a/src/workers/sendAnalyticsReportMail.ts
+++ b/src/workers/sendAnalyticsReportMail.ts
@@ -2,7 +2,7 @@ import { templateId } from './../common/mailing';
 import { differenceInHours } from 'date-fns';
 import { messageToJson, Worker } from './worker';
 import { getAuthorPostStats, Post } from '../entity';
-import { fetchUser, pickImageUrl, User } from '../common';
+import { getAuthorScout, hasAuthorScout, pickImageUrl } from '../common';
 import {
   baseNotificationEmailData,
   sendEmail,
@@ -19,19 +19,11 @@ const worker: Worker = {
     const data: Data = messageToJson(message);
     try {
       const post = await con.getRepository(Post).findOne(data.postId);
-      if (!post.authorId && !post.scoutId) {
+      if (!hasAuthorScout(post)) {
         return;
       }
 
-      const requests: Promise<User>[] = [];
-      if (post.authorId) {
-        requests.push(fetchUser(post.authorId));
-      }
-
-      if (post.scoutId) {
-        requests.push(fetchUser(post.scoutId));
-      }
-
+      const requests = getAuthorScout(post);
       const users = await Promise.all(requests);
       const source = await post.source;
       const stats = await Promise.all(


### PR DESCRIPTION
We send emails to authors whenever a user has commented on their post or commented in a comment. These emails must also be sent to the scout if there are any.

The reason why the analytics was not being sent since then is, that we have a cron job that checks for post analytics to send, and if it found any, it will automatically set the property `sentAnalyticsReport` to true. Which will then trigger a CDC pubsub notification to our worker.

But then on the actual worker, we have a condition it will only send if the value is false, but the actual reason why this worker was triggered, was due to the value being true.

https://github.com/dailydotdev/daily-api/pull/993/files#diff-21447dd107efb6a2c1bc5f6b8efd19a811618dbd67a092324739f5cccb954196L22
