### PR TITLE
refactor: disable penalization for community picks

### DIFF
--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -3,6 +3,7 @@ import appFunc from '../src';
 import { FastifyInstance } from 'fastify';
 import { saveFixtures } from './helpers';
 import {
+  COMMUNITY_PICKS_SOURCE,
   Post,
   Source,
   Submission,
@@ -78,7 +79,7 @@ describe('POST /p/newPost', () => {
     const uuid = randomUUID();
     await saveFixtures(con, Source, [
       {
-        id: 'community',
+        id: COMMUNITY_PICKS_SOURCE,
         name: 'Community recommendations',
         image: 'sample.image.com',
       },
@@ -93,7 +94,7 @@ describe('POST /p/newPost', () => {
         id: 'p1',
         title: 'Title',
         url: 'https://post.com',
-        publicationId: 'community',
+        publicationId: COMMUNITY_PICKS_SOURCE,
         submissionId: uuid,
       })
       .expect(200);

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -41,6 +41,7 @@ import {
   Comment,
   CommentMention,
   CommentUpvote,
+  COMMUNITY_PICKS_SOURCE,
   Feed,
   Post,
   Settings,
@@ -1079,7 +1080,13 @@ describe('submission', () => {
     );
     expect(notifySubmissionCreated).toBeCalledTimes(1);
     expect(jest.mocked(notifySubmissionCreated).mock.calls[0].slice(1)).toEqual(
-      [{ url: after.url, submissionId: after.id, sourceId: 'community' }],
+      [
+        {
+          url: after.url,
+          submissionId: after.id,
+          sourceId: COMMUNITY_PICKS_SOURCE,
+        },
+      ],
     );
   });
 

--- a/__tests__/workers/postBannedRep.ts
+++ b/__tests__/workers/postBannedRep.ts
@@ -3,7 +3,7 @@ import { Connection, getConnection } from 'typeorm';
 
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/postBannedRep';
-import { Post, Source, User } from '../../src/entity';
+import { COMMUNITY_PICKS_SOURCE, Post, Source, User } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { PostReport } from '../../src/entity/PostReport';
@@ -48,4 +48,16 @@ it('should create a reputation event that increases reputation', async () => {
     .find({ where: { targetId: 'p1', grantById: '' } });
   expect(events[0].amount).toEqual(100);
   expect(events[1].amount).toEqual(100);
+});
+
+it('should ignore banning of community picks', async () => {
+  const post = await con.getRepository(Post).findOne('p1');
+  post.sourceId = COMMUNITY_PICKS_SOURCE;
+  await expectSuccessfulBackground(worker, {
+    post,
+  });
+  const events = await con
+    .getRepository(ReputationEvent)
+    .find({ where: { targetId: 'p1', grantById: '' } });
+  expect(events.length).toEqual(0);
 });

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -3,6 +3,8 @@ import { SourceDisplay } from './SourceDisplay';
 import { SourceFeed } from './SourceFeed';
 import { Post } from './Post';
 
+export const COMMUNITY_PICKS_SOURCE = 'community';
+
 @Entity()
 export class Source {
   @PrimaryColumn({ type: 'text' })

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -5,6 +5,7 @@ import { messageToJson, Worker } from './worker';
 import {
   Comment,
   CommentUpvote,
+  COMMUNITY_PICKS_SOURCE,
   Feed,
   Post,
   Settings,
@@ -346,7 +347,7 @@ const onSubmissionChange = async (
   const entity = data.payload.after;
   if (data.payload.op === 'c') {
     await notifySubmissionCreated(logger, {
-      sourceId: 'community',
+      sourceId: COMMUNITY_PICKS_SOURCE,
       url: entity.url,
       submissionId: entity.id,
     });

--- a/src/workers/postBannedRep.ts
+++ b/src/workers/postBannedRep.ts
@@ -5,7 +5,7 @@ import {
 } from './../entity/ReputationEvent';
 import { messageToJson, Worker } from './worker';
 import { PostReport } from '../entity/PostReport';
-import { Post } from '../entity';
+import { COMMUNITY_PICKS_SOURCE, Post } from '../entity';
 import { ChangeObject } from '../types';
 
 interface Data {
@@ -17,6 +17,10 @@ const worker: Worker = {
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
     const { id, authorId, scoutId } = data.post;
+    // Skipping penalizing community picks during the beta phase
+    if (data.post.sourceId === COMMUNITY_PICKS_SOURCE) {
+      return;
+    }
     try {
       await con.transaction(async (transaction) => {
         const reports = await transaction


### PR DESCRIPTION
During beta we don't want to penalize scouts when banning or deleting their posts.