### PR TITLE
feat: check user if exists by email

### DIFF
--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -308,6 +308,14 @@ Object {
 }
 `;
 
+exports[`query userByEmail should return user info with name, username, and image 1`] = `
+Object {
+  "image": "https://daily.dev/ido.jpg",
+  "name": "Ido",
+  "username": null,
+}
+`;
+
 exports[`query userMostReadTags should return the user most read tags 1`] = `
 Array [
   Object {

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -51,6 +51,7 @@ beforeEach(async () => {
       name: 'Ido',
       image: 'https://daily.dev/ido.jpg',
       timezone: 'utc',
+      email: 'ido@daily.dev',
     },
     {
       id: '2',
@@ -325,6 +326,23 @@ describe('query user', () => {
     const res = await client.query(QUERY, { variables: { id: requestUserId } });
     expect(res.errors).toBeFalsy();
     expect(res.data.user).toMatchSnapshot();
+  });
+});
+
+describe('query userByEmail', () => {
+  const QUERY = `query UserByEmail($email: String!) {
+    userByEmail(email: $email) {
+      name
+      username
+      image
+    }
+  }`;
+
+  it('should return user info with name, username, and image', async () => {
+    const email = 'ido@daily.dev';
+    const res = await client.query(QUERY, { variables: { email } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userByEmail).toMatchSnapshot();
   });
 });
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -194,6 +194,10 @@ export const typeDefs = /* GraphQL */ `
 
   extend type Query {
     """
+    Check if email exists
+    """
+    userByEmail(email: String!): User
+    """
     Get the statistics of the user
     """
     userStats(id: ID!): UserStats
@@ -349,6 +353,11 @@ const timestampAtTimezone = `"timestamp"::timestamptz ${userTimezone}`;
 export const resolvers: IResolvers<any, Context> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Query: traceResolverObject<any, any>({
+    userByEmail: (
+      _,
+      { email }: { email: string },
+      ctx: Context,
+    ): Promise<User> => ctx.con.getRepository(User).findOne({ email }),
     userStats: async (
       source,
       { id }: { id: string },


### PR DESCRIPTION
After working with the error management of the Ory Kratos for registration, it won't be possible for us to check if the email exists until the user has filled all the required fields. Unless we will create a custom endpoint to check it there.

Kratos would only allow us to check if the identity exists if we have filled all the other traits, but then if we have filled it (random values) and it is not found, it will proceed to create an account.
