### PR TITLE
feat: updating account profile

### DIFF
--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -48,10 +48,10 @@ Object {
   "image": "https://daily.dev/ido.jpg",
   "infoConfirmed": false,
   "name": "Ido",
-  "permalink": "http://localhost:5002/1",
+  "permalink": "http://localhost:5002/a1",
   "timezone": "Asia/Manila",
   "twitter": null,
-  "username": null,
+  "username": "a1",
 }
 `;
 

--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -38,6 +38,32 @@ Array [
 ]
 `;
 
+exports[`mutation updateUserProfile should update user profile 1`] = `
+User {
+  "acceptedMarketing": false,
+  "bio": null,
+  "company": null,
+  "createdAt": null,
+  "devcardEligible": false,
+  "email": null,
+  "github": null,
+  "hashnode": null,
+  "id": "1",
+  "image": "https://daily.dev/ido.jpg",
+  "infoConfirmed": false,
+  "name": "Ido",
+  "portfolio": null,
+  "profileConfirmed": false,
+  "referral": null,
+  "reputation": 10,
+  "timezone": "Asia/Manila",
+  "title": null,
+  "twitter": null,
+  "updatedAt": null,
+  "username": null,
+}
+`;
+
 exports[`query readHistory should return the reading history of user in descending order 1`] = `
 Object {
   "readHistory": Object {

--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -41,7 +41,7 @@ Array [
 exports[`mutation updateUserProfile should update user profile 1`] = `
 Object {
   "bio": null,
-  "createdAt": "2022-08-15T17:26:42.924Z",
+  "createdAt": Any<String>,
   "github": null,
   "hashnode": null,
   "id": "1",

--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -39,27 +39,18 @@ Array [
 `;
 
 exports[`mutation updateUserProfile should update user profile 1`] = `
-User {
-  "acceptedMarketing": false,
+Object {
   "bio": null,
-  "company": null,
-  "createdAt": null,
-  "devcardEligible": false,
-  "email": null,
+  "createdAt": "2022-08-15T17:26:42.924Z",
   "github": null,
   "hashnode": null,
   "id": "1",
   "image": "https://daily.dev/ido.jpg",
   "infoConfirmed": false,
   "name": "Ido",
-  "portfolio": null,
-  "profileConfirmed": false,
-  "referral": null,
-  "reputation": 10,
+  "permalink": "http://localhost:5002/1",
   "timezone": "Asia/Manila",
-  "title": null,
   "twitter": null,
-  "updatedAt": null,
   "username": null,
 }
 `;

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -51,6 +51,7 @@ beforeEach(async () => {
       name: 'Ido',
       image: 'https://daily.dev/ido.jpg',
       timezone: 'utc',
+      createdAt: new Date(),
     },
     {
       id: '2',
@@ -1491,7 +1492,18 @@ describe('mutation updateUserProfile', () => {
   const MUTATION = `
     mutation updateUserProfile($data: UpdateUserInput!) {
       updateUserProfile(data: $data) {
-        _
+        id
+        name
+        image
+        username
+        permalink
+        bio
+        twitter
+        github
+        hashnode
+        createdAt
+        infoConfirmed
+        timezone
       }
     }
   `;
@@ -1526,6 +1538,6 @@ describe('mutation updateUserProfile', () => {
     const updatedUser = await repo.findOne({ id: loggedUser });
     expect(updatedUser?.timezone).not.toEqual(user?.timezone);
     expect(updatedUser?.timezone).toEqual(timezone);
-    expect(updatedUser).toMatchSnapshot();
+    expect(res.data.updateUserProfile).toMatchSnapshot();
   });
 });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1565,6 +1565,46 @@ describe('mutation updateUserProfile', () => {
     );
   });
 
+  it('should not allow invalid github handle', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { github: '#a1' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow invalid twitter handle', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { twitter: '#a1' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow invalid hashnode handle', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { hashnode: '#a1' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow invalid username handle', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { username: '#a1' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should update user profile', async () => {
     loggedUser = '1';
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1538,6 +1538,8 @@ describe('mutation updateUserProfile', () => {
     const updatedUser = await repo.findOne({ id: loggedUser });
     expect(updatedUser?.timezone).not.toEqual(user?.timezone);
     expect(updatedUser?.timezone).toEqual(timezone);
-    expect(res.data.updateUserProfile).toMatchSnapshot();
+    expect(res.data.updateUserProfile).toMatchSnapshot({
+      createdAt: expect.any(String),
+    });
   });
 });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1572,7 +1572,7 @@ describe('mutation updateUserProfile', () => {
     const user = await repo.findOne({ id: loggedUser });
     const timezone = 'Asia/Manila';
     const res = await client.mutate(MUTATION, {
-      variables: { data: { timezone } },
+      variables: { data: { timezone, username: 'a1' } },
     });
     expect(res.errors?.length).toBeFalsy();
     const updatedUser = await repo.findOne({ id: loggedUser });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -59,6 +59,16 @@ beforeEach(async () => {
       image: 'https://daily.dev/tsahi.jpg',
       timezone: userTimezone,
     },
+    {
+      id: '3',
+      name: 'Lee',
+      image: 'https://daily.dev/lee.jpg',
+      timezone: userTimezone,
+      username: 'lee',
+      twitter: 'lee',
+      github: 'lee',
+      hashnode: 'lee',
+    },
   ]);
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, Post, [
@@ -1515,12 +1525,42 @@ describe('mutation updateUserProfile', () => {
       'UNAUTHENTICATED',
     ));
 
-  it('should not allow invalid user links', async () => {
+  it('should not allow duplicated github', async () => {
     loggedUser = '1';
 
     testMutationErrorCode(
       client,
-      { mutation: MUTATION, variables: { data: { twitter: 'http://' } } },
+      { mutation: MUTATION, variables: { data: { github: 'lee' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow duplicated twitter', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { twitter: 'lee' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow duplicated hashnode', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { hashnode: 'lee' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow duplicated username', async () => {
+    loggedUser = '1';
+
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { username: 'lee' } } },
       'GRAPHQL_VALIDATION_FAILED',
     );
   });

--- a/__tests__/whoami.ts
+++ b/__tests__/whoami.ts
@@ -47,6 +47,7 @@ describe('query whoami', () => {
       github
       hashnode
       infoConfirmed
+      timezone
     }
   }`;
 
@@ -64,6 +65,7 @@ describe('query whoami', () => {
     const { email, ...user } = usersFixture[0];
     expect(res.data.whoami).toEqual({
       ...user,
+      timezone: null,
       createdAt: userCreatedDate,
     });
   });
@@ -81,6 +83,7 @@ describe('dedicated api routes', () => {
       const { email, ...user } = usersFixture[0];
       expect(res.body).toEqual({
         ...user,
+        timezone: null,
         createdAt: userCreatedDate,
       });
     });

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -47,5 +47,5 @@ export const uploadDevCardBackground = (name: string, stream: Readable) =>
 
 const avatarPreset = 'avatar';
 
-export const uploadAvatar = (name: string, stream: Readable) =>
-  uploadFile(`${avatarPreset}_${name}`, avatarPreset, stream);
+export const uploadAvatar = (userId: string, stream: Readable) =>
+  uploadFile(`${avatarPreset}_${userId}`, avatarPreset, stream);

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -20,15 +20,16 @@ export const uploadLogo = (name: string, stream: Readable): Promise<string> =>
     stream.pipe(outStream);
   });
 
-export const uploadDevCardBackground = (
+export const uploadFile = (
   name: string,
+  preset: string,
   stream: Readable,
 ): Promise<string> =>
   new Promise((resolve, reject) => {
     const outStream = cloudinary.v2.uploader.upload_stream(
       {
         public_id: name,
-        upload_preset: 'devcard',
+        upload_preset: preset,
       },
       (err, callResult) => {
         if (err) {
@@ -40,3 +41,11 @@ export const uploadDevCardBackground = (
     );
     stream.pipe(outStream);
   });
+
+export const uploadDevCardBackground = (name: string, stream: Readable) =>
+  uploadFile(name, 'devcard', stream);
+
+const avatarPreset = 'avatar';
+
+export const uploadAvatar = (name: string, stream: Readable) =>
+  uploadFile(`${avatarPreset}_${name}`, avatarPreset, stream);

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -12,3 +12,6 @@ export const mapArrayToOjbect = <T extends ObjectLiteral>(
     }),
     {},
   );
+
+export const isNullOrUndefined = (value: unknown) =>
+  typeof value === 'undefined' || value === null;

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -15,3 +15,20 @@ export const mapArrayToOjbect = <T extends ObjectLiteral>(
 
 export const isNullOrUndefined = (value: unknown) =>
   typeof value === 'undefined' || value === null;
+
+type Key = string;
+type Value = string;
+type IsRequired = boolean;
+export type ValidateRegex = [Key, Value, RegExp, IsRequired?];
+
+export const validateRegex = (
+  params: ValidateRegex[],
+): Record<string, string> =>
+  params.reduce((result, [key, value, regex, isRequired]) => {
+    if (isNullOrUndefined(value)) {
+      return isRequired ? { ...result, [key]: `${key} is required!` } : result;
+    }
+
+    const isValid = regex.test(value);
+    return isValid ? result : { ...result, [key]: `${key} is invalid!` };
+  }, {});

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -42,23 +42,25 @@ export class User {
   reputation: number;
 
   @Column({ length: 39, nullable: true })
-  @Index()
+  @Index('users_username_unique', { unique: true })
   username?: string;
 
   @Column({ type: 'text', nullable: true })
   bio?: string;
 
   @Column({ length: 15, nullable: true })
-  @Index()
+  @Index('users_twitter_unique', { unique: true })
   twitter?: string;
 
   @Column({ length: 39, nullable: true })
+  @Index('users_github_unique', { unique: true })
   github?: string;
 
   @Column({ type: 'text', nullable: true })
   portfolio?: string;
 
   @Column({ length: 39, nullable: true })
+  @Index('users_hashnode_unique', { unique: true })
   hashnode?: string;
 
   @Column({ default: false })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,3 +59,7 @@ export class NotFoundError extends ApolloError {
     Object.defineProperty(this, 'name', { value: 'NotFoundError' });
   }
 }
+
+export enum TypeOrmError {
+  DUPLICATE_ENTRY = '23505',
+}

--- a/src/migration/1660640181400-UniqueSocialHandles.ts
+++ b/src/migration/1660640181400-UniqueSocialHandles.ts
@@ -5,6 +5,12 @@ export class UniqueSocialHandles1660640181400 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
+      `DROP INDEX "public"."IDX_b67337b7f8aa8406e936c2ff75"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d7820fad49c99eb918d92519e2"`,
+    );
+    await queryRunner.query(
       `CREATE UNIQUE INDEX "users_username_unique" ON "user" ("username") `,
     );
     await queryRunner.query(
@@ -23,5 +29,11 @@ export class UniqueSocialHandles1660640181400 implements MigrationInterface {
     await queryRunner.query(`DROP INDEX "public"."users_github_unique"`);
     await queryRunner.query(`DROP INDEX "public"."users_twitter_unique"`);
     await queryRunner.query(`DROP INDEX "public"."users_username_unique"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d7820fad49c99eb918d92519e2" ON "user" ("twitter") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b67337b7f8aa8406e936c2ff75" ON "user" ("username") `,
+    );
   }
 }

--- a/src/migration/1660640181400-UniqueSocialHandles.ts
+++ b/src/migration/1660640181400-UniqueSocialHandles.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UniqueSocialHandles1660640181400 implements MigrationInterface {
+  name = 'UniqueSocialHandles1660640181400';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "users_username_unique" ON "user" ("username") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "users_twitter_unique" ON "user" ("twitter") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "users_github_unique" ON "user" ("github") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "users_hashnode_unique" ON "user" ("hashnode") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."users_hashnode_unique"`);
+    await queryRunner.query(`DROP INDEX "public"."users_github_unique"`);
+    await queryRunner.query(`DROP INDEX "public"."users_twitter_unique"`);
+    await queryRunner.query(`DROP INDEX "public"."users_username_unique"`);
+  }
+}

--- a/src/routes/whoami.ts
+++ b/src/routes/whoami.ts
@@ -15,6 +15,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         github
         hashnode
         infoConfirmed
+        timezone
       }
     }`;
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -53,7 +53,7 @@ interface GQLUserParameters {
 export interface GQLUser {
   id: string;
   name: string;
-  image: string;
+  image?: string;
   infoConfirmed: boolean;
   createdAt?: Date;
   username?: string;
@@ -376,8 +376,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Update user profile information
     """
-    updateUserProfile(data: UpdateUserInput, upload: Upload): EmptyResponse
-      @auth
+    updateUserProfile(data: UpdateUserInput, upload: Upload): User @auth
 
     """
     Generates or updates the user's Dev Card preferences
@@ -653,7 +652,7 @@ export const resolvers: IResolvers<any, Context> = {
       _,
       { data }: GQLUserParameters,
       ctx,
-    ): Promise<void> => {
+    ): Promise<GQLUser> => {
       const repo = ctx.con.getRepository(User);
       const user = await repo.findOne({ id: ctx.userId });
 
@@ -685,7 +684,7 @@ export const resolvers: IResolvers<any, Context> = {
         throw new ValidationError(JSON.stringify(linksValidity));
       }
 
-      await ctx.con.getRepository(User).update({ id: ctx.userId }, data);
+      return ctx.con.getRepository(User).save({ ...user, ...data });
     },
     hideReadHistory: (
       _,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -663,7 +663,7 @@ export const resolvers: IResolvers<any, Context> = {
         );
       }
 
-      const isUsernameValid = new RegExp(/^@?(\w){1,15}$/).test(data.username);
+      const isUsernameValid = new RegExp(/^@?(\w){1,39}$/).test(data.username);
       const isGithubValid = new RegExp(/^@?([\w-]){1,39}$/i).test(data.github);
       const isTwitterValid = new RegExp(/^@?(\w){1,15}$/).test(data.twitter);
       const isHashnodeValid = new RegExp(/^@?([\w-]){1,39}$/i).test(

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -28,7 +28,7 @@ import { ActiveView } from '../entity/ActiveView';
 import graphorm from '../graphorm';
 import { GraphQLResolveInfo } from 'graphql';
 
-export interface GQLUserInput {
+export interface GQLUpdateUserInput {
   name: string;
   username?: string;
   bio?: string;
@@ -41,7 +41,7 @@ export interface GQLUserInput {
 }
 
 interface GQLUserParameters {
-  data: GQLUserInput;
+  data: GQLUpdateUserInput;
   upload: FileUpload;
 }
 
@@ -154,7 +154,7 @@ export const typeDefs = /* GraphQL */ `
   """
   Update user profile input
   """
-  input UserInput {
+  input UpdateUserInput {
     """
     Full name of the user
     """
@@ -371,7 +371,8 @@ export const typeDefs = /* GraphQL */ `
     """
     Update user profile information
     """
-    updateUserProfile(data: UserInput, upload: Upload): EmptyResponse @auth
+    updateUserProfile(data: UpdateUserInput, upload: Upload): EmptyResponse
+      @auth
 
     """
     Generates or updates the user's Dev Card preferences

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -25,6 +25,7 @@ import {
   getUserReadingRank,
   isValidHttpUrl,
   TagsReadingStatus,
+  uploadAvatar,
   uploadDevCardBackground,
 } from '../common';
 import { getSearchQuery } from './common';
@@ -650,7 +651,7 @@ export const resolvers: IResolvers<any, Context> = {
     },
     updateUserProfile: async (
       _,
-      { data }: GQLUserParameters,
+      { data, upload }: GQLUserParameters,
       ctx,
     ): Promise<GQLUser> => {
       const repo = ctx.con.getRepository(User);
@@ -662,10 +663,14 @@ export const resolvers: IResolvers<any, Context> = {
         );
       }
 
+      const avatar = upload
+        ? await uploadAvatar(user.id, upload.createReadStream())
+        : user.image;
+
       try {
         const result = await ctx.con
           .getRepository(User)
-          .save({ ...user, ...data });
+          .save({ ...user, ...data, avatar });
 
         return result;
       } catch (err) {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -678,9 +678,10 @@ export const resolvers: IResolvers<any, Context> = {
         throw new ValidationError(JSON.stringify(regexResult));
       }
 
-      const avatar = upload
-        ? await uploadAvatar(user.id, (await upload).createReadStream())
-        : user.image;
+      const avatar =
+        upload && process.env.CLOUDINARY_URL
+          ? await uploadAvatar(user.id, (await upload).createReadStream())
+          : user.image;
 
       try {
         const result = await ctx.con

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -45,6 +45,7 @@ export interface GQLUpdateUserInput {
   github?: string;
   hashnode?: string;
   portfolio?: string;
+  acceptedMarketing?: boolean;
 }
 
 interface GQLUserParameters {
@@ -206,6 +207,10 @@ export const typeDefs = /* GraphQL */ `
     User website
     """
     portfolio: String
+    """
+    If the user has accepted marketing
+    """
+    acceptedMarketing: Boolean
   }
 
   type TagsReadingStatus {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -50,7 +50,7 @@ export interface GQLUpdateUserInput {
 
 interface GQLUserParameters {
   data: GQLUpdateUserInput;
-  upload: FileUpload;
+  upload: Promise<FileUpload>;
 }
 
 export interface GQLUser {
@@ -679,7 +679,7 @@ export const resolvers: IResolvers<any, Context> = {
       }
 
       const avatar = upload
-        ? await uploadAvatar(user.id, upload.createReadStream())
+        ? await uploadAvatar(user.id, (await upload).createReadStream())
         : user.image;
 
       try {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -663,6 +663,37 @@ export const resolvers: IResolvers<any, Context> = {
         );
       }
 
+      const isUsernameValid = new RegExp(/^@?(\w){1,15}$/).test(data.username);
+      const isGithubValid = new RegExp(/^@?([\w-]){1,39}$/i).test(data.github);
+      const isTwitterValid = new RegExp(/^@?(\w){1,15}$/).test(data.twitter);
+      const isHashnodeValid = new RegExp(/^@?([\w-]){1,39}$/i).test(
+        data.hashnode,
+      );
+
+      if (data.username && !isUsernameValid) {
+        throw new ValidationError(
+          JSON.stringify({ username: 'username is invalid' }),
+        );
+      }
+
+      if (data.github && !isGithubValid) {
+        throw new ValidationError(
+          JSON.stringify({ github: 'github is invalid' }),
+        );
+      }
+
+      if (data.twitter && !isTwitterValid) {
+        throw new ValidationError(
+          JSON.stringify({ twitter: 'twitter is invalid' }),
+        );
+      }
+
+      if (data.hashnode && !isHashnodeValid) {
+        throw new ValidationError(
+          JSON.stringify({ hashnode: 'hashnode is invalid' }),
+        );
+      }
+
       const avatar = upload
         ? await uploadAvatar(user.id, upload.createReadStream())
         : user.image;

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -701,7 +701,7 @@ export const resolvers: IResolvers<any, Context> = {
       try {
         const result = await ctx.con
           .getRepository(User)
-          .save({ ...user, ...data, avatar });
+          .save({ ...user, ...data, image: avatar });
 
         return result;
       } catch (err) {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1,3 +1,4 @@
+import { validateRegex, ValidateRegex } from './../common/object';
 import { fetchUserById } from './../common/users';
 import { getMostReadTags } from './../common/devcard';
 import { GraphORMBuilder } from '../graphorm/graphorm';
@@ -663,35 +664,15 @@ export const resolvers: IResolvers<any, Context> = {
         );
       }
 
-      const isUsernameValid = new RegExp(/^@?(\w){1,39}$/).test(data.username);
-      const isGithubValid = new RegExp(/^@?([\w-]){1,39}$/i).test(data.github);
-      const isTwitterValid = new RegExp(/^@?(\w){1,15}$/).test(data.twitter);
-      const isHashnodeValid = new RegExp(/^@?([\w-]){1,39}$/i).test(
-        data.hashnode,
-      );
-
-      if (data.username && !isUsernameValid) {
-        throw new ValidationError(
-          JSON.stringify({ username: 'username is invalid' }),
-        );
-      }
-
-      if (data.github && !isGithubValid) {
-        throw new ValidationError(
-          JSON.stringify({ github: 'github is invalid' }),
-        );
-      }
-
-      if (data.twitter && !isTwitterValid) {
-        throw new ValidationError(
-          JSON.stringify({ twitter: 'twitter is invalid' }),
-        );
-      }
-
-      if (data.hashnode && !isHashnodeValid) {
-        throw new ValidationError(
-          JSON.stringify({ hashnode: 'hashnode is invalid' }),
-        );
+      const regexParams: ValidateRegex[] = [
+        ['username', data.username, new RegExp(/^@?(\w){1,39}$/)],
+        ['github', data.github, new RegExp(/^@?([\w-]){1,39}$/i)],
+        ['twitter', data.twitter, new RegExp(/^@?(\w){1,15}$/)],
+        ['hashnode', data.hashnode, new RegExp(/^@?([\w-]){1,39}$/i)],
+      ];
+      const regexResult = validateRegex(regexParams);
+      if (Object.keys(regexResult).length) {
+        throw new ValidationError(JSON.stringify(regexResult));
       }
 
       const avatar = upload

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -659,9 +659,7 @@ export const resolvers: IResolvers<any, Context> = {
       const user = await repo.findOne({ id: ctx.userId });
 
       if (!user) {
-        throw new AuthenticationError(
-          JSON.stringify({ auth: 'User not found' }),
-        );
+        throw new AuthenticationError('Unauthorized!');
       }
 
       const regexParams: ValidateRegex[] = [

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -27,6 +27,7 @@ import { getSearchQuery } from './common';
 import { ActiveView } from '../entity/ActiveView';
 import graphorm from '../graphorm';
 import { GraphQLResolveInfo } from 'graphql';
+import { isNullOrUndefined } from '../common/object';
 
 export interface GQLUpdateUserInput {
   name: string;
@@ -667,7 +668,7 @@ export const resolvers: IResolvers<any, Context> = {
       const links = ['twitter', 'github', 'hashnode', 'portfolio'];
       const linksValidity = links.reduce(
         (result, link) =>
-          data[link] === null || isValidHttpUrl(data[link])
+          isNullOrUndefined(data[link]) || isValidHttpUrl(data[link])
             ? result
             : { ...result, [link]: 'URL is invalid' },
         {},


### PR DESCRIPTION
Since the source of truth is now for the profile information, we will be having an API to allow updating it.

Question:
  - Should we now remove the subscription on the gateway for watching changes in the user?
  - Would we want to instead create a worker to send a post request to the Kratos server? (current one sends a post request in the FE)