### PR TITLE
feat: API user deletion

### DIFF
--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -13,6 +13,7 @@ const commentCommentedTopic = pubsub.topic('comment-commented');
 const commentFeaturedTopic = pubsub.topic('comment-featured');
 const commentsUpdateTopic = pubsub.topic('update-comments');
 const userReputationUpdatedTopic = pubsub.topic('user-reputation-updated');
+const userDeletedTopic = pubsub.topic('user-deleted');
 const alertsUpdatedTopic = pubsub.topic('alerts-updated');
 const settingsUpdatedTopic = pubsub.topic('settings-updated');
 const commentUpvoteCanceledTopic = pubsub.topic('comment-upvote-canceled');
@@ -157,6 +158,16 @@ export const notifyUserReputationUpdated = async (
   publishEvent(log, userReputationUpdatedTopic, {
     userId,
     reputation,
+  });
+
+export const notifyUserDeleted = async (
+  log: EventLogger,
+  userId: string,
+  kratosUser = false,
+): Promise<void> =>
+  publishEvent(log, userDeletedTopic, {
+    id: userId,
+    kratosUser,
   });
 
 export const notifyAlertsUpdated = (

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -10,6 +10,17 @@ import {
   getAuthorPostStats,
   PostStats,
   View,
+  Alerts,
+  BookmarkList,
+  Bookmark,
+  CommentUpvote,
+  Feed,
+  HiddenPost,
+  PostReport,
+  Settings,
+  SourceDisplay,
+  SourceRequest,
+  Upvote,
 } from '../entity';
 import {
   AuthenticationError,
@@ -404,6 +415,11 @@ export const typeDefs = /* GraphQL */ `
     Hide user's read history
     """
     hideReadHistory(postId: String!, timestamp: DateTime!): EmptyResponse @auth
+
+    """
+    Delete user's account
+    """
+    deleteUser: EmptyResponse @auth
   }
 `;
 
@@ -745,6 +761,35 @@ export const resolvers: IResolvers<any, Context> = {
             );
           }
         }
+        throw err;
+      }
+    },
+    deleteUser: async (_, __, ctx: Context): Promise<unknown> => {
+      const userId = ctx.userId;
+      console.log('deletign user: ', userId);
+      try {
+        await ctx.con.transaction(async (entityManager): Promise<void> => {
+          await entityManager.getRepository(View).delete({ userId });
+          await entityManager.getRepository(Alerts).delete({ userId });
+          await entityManager.getRepository(BookmarkList).delete({ userId });
+          await entityManager.getRepository(Bookmark).delete({ userId });
+          await entityManager.getRepository(CommentUpvote).delete({ userId });
+          await entityManager.getRepository(Comment).delete({ userId });
+          await entityManager.getRepository(DevCard).delete({ userId });
+          await entityManager.getRepository(Feed).delete({ userId });
+          await entityManager.getRepository(HiddenPost).delete({ userId });
+          await entityManager.getRepository(PostReport).delete({ userId });
+          await entityManager.getRepository(Settings).delete({ userId });
+          await entityManager.getRepository(SourceDisplay).delete({ userId });
+          await entityManager.getRepository(SourceRequest).delete({ userId });
+          await entityManager.getRepository(Upvote).delete({ userId });
+          await entityManager
+            .getRepository(Post)
+            .update({ authorId: userId }, { authorId: null });
+          await entityManager.getRepository(User).delete(userId);
+        });
+        return true;
+      } catch (err) {
         throw err;
       }
     },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -10,17 +10,6 @@ import {
   getAuthorPostStats,
   PostStats,
   View,
-  Alerts,
-  BookmarkList,
-  Bookmark,
-  CommentUpvote,
-  Feed,
-  HiddenPost,
-  PostReport,
-  Settings,
-  SourceDisplay,
-  SourceRequest,
-  Upvote,
 } from '../entity';
 import {
   AuthenticationError,
@@ -44,6 +33,7 @@ import { ActiveView } from '../entity/ActiveView';
 import graphorm from '../graphorm';
 import { GraphQLResolveInfo } from 'graphql';
 import { TypeOrmError, NotFoundError } from '../errors';
+import { deleteUser } from '../workers/deleteUser';
 
 export interface GQLUpdateUserInput {
   name: string;
@@ -766,32 +756,7 @@ export const resolvers: IResolvers<any, Context> = {
     },
     deleteUser: async (_, __, ctx: Context): Promise<unknown> => {
       const userId = ctx.userId;
-      console.log('deletign user: ', userId);
-      try {
-        await ctx.con.transaction(async (entityManager): Promise<void> => {
-          await entityManager.getRepository(View).delete({ userId });
-          await entityManager.getRepository(Alerts).delete({ userId });
-          await entityManager.getRepository(BookmarkList).delete({ userId });
-          await entityManager.getRepository(Bookmark).delete({ userId });
-          await entityManager.getRepository(CommentUpvote).delete({ userId });
-          await entityManager.getRepository(Comment).delete({ userId });
-          await entityManager.getRepository(DevCard).delete({ userId });
-          await entityManager.getRepository(Feed).delete({ userId });
-          await entityManager.getRepository(HiddenPost).delete({ userId });
-          await entityManager.getRepository(PostReport).delete({ userId });
-          await entityManager.getRepository(Settings).delete({ userId });
-          await entityManager.getRepository(SourceDisplay).delete({ userId });
-          await entityManager.getRepository(SourceRequest).delete({ userId });
-          await entityManager.getRepository(Upvote).delete({ userId });
-          await entityManager
-            .getRepository(Post)
-            .update({ authorId: userId }, { authorId: null });
-          await entityManager.getRepository(User).delete(userId);
-        });
-        return true;
-      } catch (err) {
-        throw err;
-      }
+      return await deleteUser(ctx.con, ctx.log, userId);
     },
     hideReadHistory: (
       _,

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -41,6 +41,7 @@ import {
   notifySubmissionCreated,
   notifySubmissionGrantedAccess,
   NotificationReason,
+  notifyUserDeleted,
 } from '../common';
 import { ChangeMessage } from '../types';
 import { Connection } from 'typeorm';
@@ -384,6 +385,9 @@ const onUserStateChange = async (
     if (data.payload.after.key === UserStateKey.CommunityLinkAccess) {
       await notifySubmissionGrantedAccess(logger, data.payload.after.userId);
     }
+  }
+  if (data.payload.op === 'd') {
+    await notifyUserDeleted(logger, data.payload.before.userId, true);
   }
 };
 

--- a/src/workers/deleteUser.ts
+++ b/src/workers/deleteUser.ts
@@ -65,6 +65,9 @@ export const deleteUser = async (
       await entityManager
         .getRepository(Post)
         .update({ authorId: userId }, { authorId: null });
+      await entityManager
+        .getRepository(Post)
+        .update({ scoutId: userId }, { scoutId: null });
       await entityManager.getRepository(User).delete(userId);
     });
     if (logger) {

--- a/src/workers/deleteUser.ts
+++ b/src/workers/deleteUser.ts
@@ -35,12 +35,15 @@ interface UserData {
   portfolio?: string;
   hashnode?: string;
   timezone?: string;
+  kratosUser?: boolean;
 }
 
 const worker: Worker = {
   subscription: 'user-deleted-api',
   handler: async (message, con, logger): Promise<void> => {
     const data: UserData = messageToJson(message);
+    // Kratos users are already deleted, this is only to support gateway deletion
+    if (data.kratosUser) return;
     try {
       await con.transaction(async (entityManager): Promise<void> => {
         await entityManager.getRepository(View).delete({ userId: data.id });


### PR DESCRIPTION
Introduces API user deletion.
Since we have foreign key constraints on userId's we have to follow the existing deletion flow.

We also need to support existing deletion from the Gateway side of things.
Thus added a Kratos flow to not duplicate run queries when the user is already deleted.

WT-333