### PR TITLE
feat: clean zombie users 🧟

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -37,4 +37,8 @@ export const crons: CronPubSub[] = [
     name: 'export-to-tinybird',
     schedule: '* * * * *',
   },
+  {
+    name: 'clean-zombie-users',
+    schedule: '32 */1 * * *',
+  },
 ];

--- a/__tests__/cron/cleanZombieUsers.ts
+++ b/__tests__/cron/cleanZombieUsers.ts
@@ -1,0 +1,29 @@
+import { Connection, getConnection, Not } from 'typeorm';
+
+import cron from '../../src/cron/cleanZombieUsers';
+import { expectSuccessfulCron, saveFixtures } from '../helpers';
+import { User } from '../../src/entity';
+import { usersFixture } from '../fixture/user';
+
+let con: Connection;
+
+beforeAll(async () => {
+  con = await getConnection();
+});
+
+beforeEach(async () => {
+  await saveFixtures(con, User, usersFixture);
+});
+
+it('should delete users with info confirmed false that are older than one hour', async () => {
+  await con
+    .getRepository(User)
+    .update({ id: Not('1') }, { infoConfirmed: false });
+  await con.getRepository(User).update({ id: '2' }, { createdAt: new Date() });
+
+  await expectSuccessfulCron(cron);
+  const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
+  expect(users.length).toEqual(2);
+  expect(users[0].id).toEqual('1');
+  expect(users[1].id).toEqual('2');
+});

--- a/src/cron/cleanZombieUsers.ts
+++ b/src/cron/cleanZombieUsers.ts
@@ -1,0 +1,19 @@
+import { Cron } from './cron';
+import { User } from '../entity';
+import { LessThan } from 'typeorm';
+import { subHours } from 'date-fns';
+
+const cron: Cron = {
+  subscription: 'clean-zombie-users',
+  handler: async (con, logger) => {
+    logger.info('cleaning zombie users...');
+    const timeThreshold = subHours(new Date(), 1);
+    const { affected } = await con.getRepository(User).delete({
+      infoConfirmed: false,
+      createdAt: LessThan(timeThreshold.toISOString()),
+    });
+    logger.info({ count: affected }, 'zombies users cleaned! 🧟');
+  },
+};
+
+export default cron;

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -6,6 +6,7 @@ import updateTrending from './updateTrending';
 import updateTagsStr from './updateTagsStr';
 import updateDiscussionScore from './updateDiscussionScore';
 import exportToTinybird from './exportToTinybird';
+import cleanZombieUsers from './cleanZombieUsers';
 
 export const crons: Cron[] = [
   updateViews,
@@ -15,4 +16,5 @@ export const crons: Cron[] = [
   updateTagsStr,
   updateDiscussionScore,
   exportToTinybird,
+  cleanZombieUsers,
 ];


### PR DESCRIPTION
Zombie users are users that have `infoConfirmed = false` and are older than one hour. A new cron job is added to remove zombie users from the database.

WT-486#done