### PR TITLE
fix: ignore the github handle if it already exists when adding new user

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,5 +7,5 @@ dotenv.config({ path: '.env' });
 
 export const fallbackImages = {
   avatar:
-    'https://daily-now-res.cloudinary.com/image/upload/t_logo,f_auto/v1664367305/placeholders/placeholder3',
+    'https://daily-now-res.cloudinary.com/image/upload/f_auto/v1664367305/placeholders/placeholder3',
 };


### PR DESCRIPTION
When a user signs up with GitHub we prepopulate the GitHub handle. This may yield a unique key violation which we want to prevent.

WT-621 #done