### PR TITLE
fix: settings create conflict on same transaction

### DIFF
--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -1,4 +1,4 @@
-import { IResolvers } from 'graphql-tools';
+import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
 import { Context } from '../Context';
 import { Settings } from '../entity';

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -295,7 +295,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
 
         return repo.save(repo.merge(settings, data));
       });
-    },,
+    },
     setBookmarksSharing: async (
       _,
       { enabled }: { enabled: boolean },

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -243,7 +243,7 @@ const getOrCreateSettings = async (
   userId: string,
 ): Promise<Settings> => {
   const repo = manager.getRepository(Settings);
-  const settings = await repo.findOne(userId);
+  const settings = await repo.findOneBy({ userId });
 
   if (!settings) {
     return repo.save({ userId });

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -4,7 +4,6 @@ import { Context } from '../Context';
 import { Settings } from '../entity';
 import { isValidHttpUrl } from '../common';
 import { ValidationError } from 'apollo-server-errors';
-import { Connection, EntityManager } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 
 interface GQLSettings {

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -238,20 +238,6 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
-const getOrCreateSettings = async (
-  manager: Connection | EntityManager,
-  userId: string,
-): Promise<Settings> => {
-  const repo = manager.getRepository(Settings);
-  const settings = await repo.findOneBy({ userId });
-
-  if (!settings) {
-    return repo.save({ userId });
-  }
-
-  return settings;
-};
-
 const getBookmarkSettings = async (
   con: Connection | EntityManager,
   userId: string,


### PR DESCRIPTION
~~WIP: still spooling up my local env to test the changes.~~

Running 2 save commands in the same transaction seems to result in conflict with one another even though we used upsert. Probably the ORM has thought the same command should use the insert as the first save is deferred due to being in the same transaction.
