### PR TITLE
feat: add authentication support for graphql subscriptions

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -1,5 +1,5 @@
 import { DataSource, EntitySchema, ObjectType, Repository } from 'typeorm';
-import { FastifyRequest, FastifyLoggerInstance } from 'fastify';
+import { FastifyRequest, FastifyBaseLogger } from 'fastify';
 import { RootSpan } from '@google-cloud/trace-agent/build/src/plugin-types';
 import { GraphQLDatabaseLoader } from '@mando75/typeorm-graphql-loader';
 import { Roles } from './roles';
@@ -35,7 +35,7 @@ export class Context {
     return this.req.roles ?? [];
   }
 
-  get log(): FastifyLoggerInstance {
+  get log(): FastifyBaseLogger {
     return this.req.log;
   }
 
@@ -49,3 +49,10 @@ export class Context {
     return this.con.getRepository(target);
   }
 }
+
+export type SubscriptionContext = {
+  req: FastifyRequest;
+  con: DataSource;
+  log: FastifyBaseLogger;
+  userId?: string;
+};

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,7 +29,7 @@ interface AuthPayload {
   roles?: Roles[];
 }
 
-const verifyJwt = (token: string): Promise<AuthPayload | null> =>
+export const verifyJwt = (token: string): Promise<AuthPayload | null> =>
   new Promise((resolve, reject) => {
     jwt.verify(
       token,


### PR DESCRIPTION
Cookies are not provided when using WebSocket in the extension. Hence, our authentication doesn't work in GraphQL Subscriptions from the extension. 
This PR adds another step in the connection to check the token provided by the client explicitly. 
This is required for the notifications.

Apps PR: https://github.com/dailydotdev/apps/pull/1394