### PR TITLE
feat: boot endpoint to retrieve number of unread notifications

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -25,6 +25,6 @@ config:
     typeormUser: postgres
     tz: UTC
     urlPrefix: http://api.local.com
-  api:image: api-image:tilt-a8bfab3ac1d9fecb
+  api:image: api-image:tilt-71bca7fd406d9a1c
   api:k8s:
     namespace: local

--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -16,4 +16,4 @@ debezium.transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
 debezium.transforms.Reroute.topic.regex=(.*)
 debezium.transforms.Reroute.topic.replacement=%topic%
 debezium.sink.type=pubsub
-quarkus.log.level=TRACE
+quarkus.log.level=ERROR

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,11 +7,13 @@ import redirector from './redirector';
 import devcards from './devcards';
 import privateRoutes from './private';
 import whoami from './whoami';
+import notifications from './notifications';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(rss, { prefix: '/rss' });
   fastify.register(alerts, { prefix: '/alerts' });
   fastify.register(settings, { prefix: '/settings' });
+  fastify.register(notifications, { prefix: '/notifications' });
   fastify.register(redirector, { prefix: '/r' });
   fastify.register(devcards, { prefix: '/devcards' });
   if (process.env.ENABLE_PRIVATE_ROUTES === 'true') {

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,0 +1,12 @@
+import { FastifyInstance } from 'fastify';
+import { injectGraphql } from '../compatibility/utils';
+
+export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.get('/', async (req, res) => {
+    const query = `{
+      notificationCount
+    }`;
+
+    return injectGraphql(fastify, { query }, (obj) => obj['data'], req, res);
+  });
+}

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -1,7 +1,8 @@
 import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
 import { Context } from '../Context';
-import { Banner } from '../entity';
+import { Banner, Notification } from '../entity';
+import { ConnectionArguments } from 'graphql-relay';
 
 interface GQLBanner {
   timestamp: Date;
@@ -127,6 +128,10 @@ export const typeDefs = /* GraphQL */ `
 
   extend type Query {
     """
+    Get the active notification count for a user
+    """
+    notificationCount: Int @auth
+    """
     Get a banner to show, if any
     """
     banner(
@@ -141,6 +146,17 @@ export const typeDefs = /* GraphQL */ `
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const resolvers: IResolvers<any, Context> = traceResolvers({
   Query: {
+    notificationCount: async (
+      source,
+      args: ConnectionArguments,
+      ctx,
+    ): Promise<number> =>
+      ctx.getRepository(Notification).count({
+        where: {
+          userId: ctx.userId,
+          public: true,
+        },
+      }),
     banner: async (
       source,
       { lastSeen }: { lastSeen: Date },


### PR DESCRIPTION
Added a new route endpoint and graphQL query to retrieve the number of unread notifications for a user.
This endpoint will be called by the boot endpoint if no redis cache is found (gateway PR incoming)

WT-784