### PR TITLE
feat: generate notifications

### DIFF
--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -130,4 +130,61 @@ export const workers: Worker[] = [
     subscription: 'api-cdc',
     args: { enableMessageOrdering: true },
   },
+  {
+    topic: 'api.v1.new-comment-mention',
+    subscription: 'comment-mention-mail',
+  },
+  // Notifications
+  {
+    topic: 'community-link-rejected',
+    subscription: 'api.community-picks-failed-notification',
+  },
+  {
+    topic: 'post-scout-matched',
+    subscription: 'api.community-picks-succeeded-notification',
+  },
+  {
+    topic: 'community-link-access',
+    subscription: 'api.community-picks-granted-notification',
+  },
+  {
+    topic: 'post-author-matched',
+    subscription: 'api.article-picked-notification',
+  },
+  {
+    topic: 'post-commented',
+    subscription: 'api.article-new-comment-notification.post-commented',
+  },
+  {
+    topic: 'comment-commented',
+    subscription: 'api.article-new-comment-notification.comment-commented',
+  },
+  {
+    topic: 'post-upvoted',
+    subscription: 'api.article-upvote-milestone-notification',
+  },
+  {
+    topic: 'send-analytics-report',
+    subscription: 'api.article-analytics-notification',
+  },
+  {
+    topic: 'post-banned-or-removed',
+    subscription: 'api.article-report-approved-notification',
+  },
+  {
+    topic: 'pub-request',
+    subscription: 'api.source-request-notification',
+  },
+  {
+    topic: 'api.v1.new-comment-mention',
+    subscription: 'api.comment-mention-notification',
+  },
+  {
+    topic: 'comment-commented',
+    subscription: 'api.comment-reply-notification',
+  },
+  {
+    topic: 'comment-upvoted',
+    subscription: 'api.comment-upvote-milestone-notification',
+  },
 ];

--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -132,7 +132,7 @@ export const workers: Worker[] = [
   },
   {
     topic: 'api.v1.new-comment-mention',
-    subscription: 'comment-mention-mail',
+    subscription: 'api.comment-mention-mail',
   },
   // Notifications
   {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -25,6 +25,10 @@ import pino from 'pino';
 import { createMercuriusTestClient } from 'mercurius-integration-testing';
 import appFunc from '../src';
 import createOrGetConnection from '../src/db';
+import {
+  NotificationHandlerReturn,
+  NotificationWorker,
+} from '../src/workers/notifications/worker';
 
 export class MockContext extends Context {
   mockSpan: MockProxy<RootSpan> & RootSpan;
@@ -190,6 +194,15 @@ export const expectSuccessfulBackground = (
   worker: Worker,
   data: Record<string, unknown>,
 ): Promise<void> => invokeBackground(worker, data);
+
+export const invokeNotificationWorker = async (
+  worker: NotificationWorker,
+  data: Record<string, unknown>,
+): Promise<NotificationHandlerReturn> => {
+  const con = await createOrGetConnection();
+  const logger = pino();
+  return worker.handler(mockMessage(data).message, con, logger);
+};
 
 export const invokeCron = async (cron: Cron): Promise<void> => {
   const con = await createOrGetConnection();

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1,0 +1,432 @@
+import {
+  generateNotification,
+  NotificationBaseContext,
+  NotificationCommentContext,
+  NotificationCommenterContext,
+  NotificationPostContext,
+  NotificationSourceContext,
+  NotificationSourceRequestContext,
+  NotificationSubmissionContext,
+  NotificationUpvotersContext,
+  Reference,
+  storeNotificationBundle,
+} from '../../src/notifications';
+import { postsFixture } from '../fixture/post';
+import {
+  Comment,
+  Post,
+  User,
+  Source,
+  SourceRequest,
+  NotificationAttachment,
+  NotificationAvatar,
+  Notification,
+} from '../../src/entity';
+import { scoutArticleLink } from '../../src/common';
+import { usersFixture } from '../fixture/user';
+import createOrGetConnection from '../../src/db';
+import { DataSource } from 'typeorm';
+
+const userId = '1';
+const commentFixture: Reference<Comment> = {
+  id: 'c1',
+  postId: 'p1',
+  userId: '2',
+  content: 'Complex **markdown** comment that needs to be `simplified`',
+  contentHtml: '<p>parent comment</p>',
+  createdAt: new Date(2020, 1, 6, 0, 0),
+} as Reference<Comment>;
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+describe('generateNotification', () => {
+  it('should generate community_picks_failed notification', () => {
+    const type = 'community_picks_failed';
+    const ctx: NotificationSubmissionContext = {
+      userId,
+      submission: { id: 's1' },
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(false);
+    expect(actual.notification.referenceId).toEqual('s1');
+    expect(actual.notification.referenceType).toEqual('submission');
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate community_picks_succeeded notification', () => {
+    const type = 'community_picks_succeeded';
+    const ctx: NotificationSubmissionContext & NotificationPostContext = {
+      userId,
+      submission: { id: 's1' },
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1',
+    );
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments).toEqual([
+      {
+        image: 'https://daily.dev/image.jpg',
+        order: 0,
+        referenceId: 'p1',
+        title: 'P1',
+        type: 'post',
+      },
+    ]);
+  });
+
+  it('should generate community_picks_granted notification', () => {
+    const type = 'community_picks_granted';
+    const ctx: NotificationBaseContext = { userId };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('system');
+    expect(actual.notification.referenceType).toEqual('system');
+    expect(actual.notification.targetUrl).toEqual(scoutArticleLink);
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate article_picked notification', () => {
+    const type = 'article_picked';
+    const ctx: NotificationPostContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1',
+    );
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments).toEqual([
+      {
+        image: 'https://daily.dev/image.jpg',
+        order: 0,
+        referenceId: 'p1',
+        title: 'P1',
+        type: 'post',
+      },
+    ]);
+  });
+
+  it('should generate article_new_comment notification', () => {
+    const type = 'article_new_comment';
+    const ctx: NotificationCommenterContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      comment: commentFixture,
+      commenter: usersFixture[1] as Reference<User>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('c1');
+    expect(actual.notification.referenceType).toEqual('comment');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1#c-c1',
+    );
+    expect(actual.notification.description).toEqual(
+      'Complex markdown comment that needs to be simplified',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/tsahi.jpg',
+        name: 'Tsahi',
+        order: 0,
+        referenceId: '2',
+        targetUrl: 'http://localhost:5002/tsahidaily',
+        type: 'user',
+      },
+    ]);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate article_upvote_milestone notification', () => {
+    const type = 'article_upvote_milestone';
+    const ctx: NotificationPostContext & NotificationUpvotersContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      upvotes: 50,
+      upvoters: [usersFixture[1], usersFixture[2]] as Reference<User>[],
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.uniqueKey).toEqual('50');
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/tsahi.jpg',
+        name: 'Tsahi',
+        order: 0,
+        referenceId: '2',
+        targetUrl: 'http://localhost:5002/tsahidaily',
+        type: 'user',
+      },
+      {
+        image: 'https://daily.dev/nimrod.jpg',
+        name: 'Nimrod',
+        order: 1,
+        referenceId: '3',
+        targetUrl: 'http://localhost:5002/nimroddaily',
+        type: 'user',
+      },
+    ]);
+    expect(actual.attachments).toEqual([
+      {
+        image: 'https://daily.dev/image.jpg',
+        order: 0,
+        referenceId: 'p1',
+        title: 'P1',
+        type: 'post',
+      },
+    ]);
+  });
+
+  it('should generate article_report_approved notification', () => {
+    const type = 'article_report_approved';
+    const ctx: NotificationPostContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(false);
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate article_analytics notification', () => {
+    const type = 'article_analytics';
+    const ctx: NotificationPostContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(false);
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate source_approved notification', () => {
+    const type = 'source_approved';
+    const ctx: NotificationSourceRequestContext & NotificationSourceContext = {
+      userId,
+      source: {
+        id: 's1',
+        name: 'Source',
+        image: 'https://daily.dev/s1.jpg',
+      } as Reference<Source>,
+      sourceRequest: {
+        id: 'sr1',
+      } as Reference<SourceRequest>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('sr1');
+    expect(actual.notification.referenceType).toEqual('source_request');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/sources/s1',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/s1.jpg',
+        name: 'Source',
+        order: 0,
+        referenceId: 's1',
+        targetUrl: 'http://localhost:5002/sources/s1',
+        type: 'source',
+      },
+    ]);
+  });
+
+  it('should generate source_rejected notification', () => {
+    const type = 'source_rejected';
+    const ctx: NotificationSourceRequestContext = {
+      userId,
+      sourceRequest: {
+        id: 'sr1',
+      } as Reference<SourceRequest>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(false);
+    expect(actual.notification.referenceId).toEqual('sr1');
+    expect(actual.notification.referenceType).toEqual('source_request');
+    expect(actual.avatars.length).toEqual(0);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  it('should generate comment_mention notification', () => {
+    const type = 'comment_mention';
+    const ctx: NotificationCommenterContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      comment: commentFixture,
+      commenter: usersFixture[1] as Reference<User>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('c1');
+    expect(actual.notification.referenceType).toEqual('comment');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1#c-c1',
+    );
+    expect(actual.notification.description).toEqual(
+      'Complex markdown comment that needs to be simplified',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/tsahi.jpg',
+        name: 'Tsahi',
+        order: 0,
+        referenceId: '2',
+        targetUrl: 'http://localhost:5002/tsahidaily',
+        type: 'user',
+      },
+    ]);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
+  //TODO: fix the test once we finalize this notification
+  it('should generate comment_reply notification', () => {
+    const type = 'comment_reply';
+    const ctx: NotificationCommenterContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      comment: commentFixture,
+      commenter: usersFixture[1] as Reference<User>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+  });
+
+  it('should generate comment_upvote_milestone notification', () => {
+    const type = 'comment_upvote_milestone';
+    const ctx: NotificationCommentContext & NotificationUpvotersContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      comment: commentFixture,
+      upvotes: 50,
+      upvoters: [usersFixture[1], usersFixture[2]] as Reference<User>[],
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.uniqueKey).toEqual('50');
+    expect(actual.notification.referenceId).toEqual('c1');
+    expect(actual.notification.referenceType).toEqual('comment');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1#c-c1',
+    );
+    expect(actual.notification.description).toEqual(
+      'Complex markdown comment that needs to be simplified',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/tsahi.jpg',
+        name: 'Tsahi',
+        order: 0,
+        referenceId: '2',
+        targetUrl: 'http://localhost:5002/tsahidaily',
+        type: 'user',
+      },
+      {
+        image: 'https://daily.dev/nimrod.jpg',
+        name: 'Nimrod',
+        order: 1,
+        referenceId: '3',
+        targetUrl: 'http://localhost:5002/nimroddaily',
+        type: 'user',
+      },
+    ]);
+    expect(actual.attachments.length).toEqual(0);
+  });
+});
+
+describe('storeNotificationBundle', () => {
+  beforeEach(async () => {
+    await con.getRepository(User).save([usersFixture[0]]);
+  });
+
+  it('should save the notification and its children', async () => {
+    const ctx: NotificationPostContext & NotificationUpvotersContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      upvotes: 50,
+      upvoters: [usersFixture[1], usersFixture[2]] as Reference<User>[],
+    };
+    await con.transaction((manager) =>
+      storeNotificationBundle(manager, [
+        generateNotification('article_upvote_milestone', ctx),
+      ]),
+    );
+    const notifications = await con.getRepository(Notification).find();
+    expect(notifications.length).toEqual(1);
+    const attachments = await con.getRepository(NotificationAttachment).find();
+    expect(attachments.length).toEqual(1);
+    const avatars = await con.getRepository(NotificationAvatar).find();
+    expect(avatars.length).toEqual(2);
+  });
+
+  it('should ignore duplicates', async () => {
+    const ctx: NotificationPostContext & NotificationUpvotersContext = {
+      userId,
+      post: postsFixture[0] as Reference<Post>,
+      upvotes: 50,
+      upvoters: [usersFixture[1], usersFixture[2]] as Reference<User>[],
+    };
+    await con.transaction((manager) =>
+      storeNotificationBundle(manager, [
+        generateNotification('article_upvote_milestone', ctx),
+        generateNotification('article_upvote_milestone', ctx),
+      ]),
+    );
+    const notifications = await con.getRepository(Notification).find();
+    expect(notifications.length).toEqual(1);
+    const attachments = await con.getRepository(NotificationAttachment).find();
+    expect(attachments.length).toEqual(1);
+    const avatars = await con.getRepository(NotificationAvatar).find();
+    expect(avatars.length).toEqual(2);
+  });
+});

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -24,12 +24,8 @@ import {
   notifySubmissionRejected,
   notifySubmissionCreated,
   notifySubmissionGrantedAccess,
-  sendEmail,
-  baseNotificationEmailData,
-  pickImageUrl,
-  truncatePost,
-  getDiscussionLink,
   notifyUsernameChanged,
+  notifyNewCommentMention,
 } from '../../src/common';
 import worker from '../../src/workers/cdc';
 import {
@@ -87,7 +83,7 @@ jest.mock('../../src/common', () => ({
   notifySubmissionRejected: jest.fn(),
   notifySubmissionCreated: jest.fn(),
   notifySubmissionGrantedAccess: jest.fn(),
-  sendEmail: jest.fn(),
+  notifyNewCommentMention: jest.fn(),
 }));
 
 let con: DataSource;
@@ -114,31 +110,6 @@ const defaultUser: ChangeObject<User> = {
   username: 'idoshamun',
   infoConfirmed: true,
   acceptedMarketing: true,
-};
-const saveMentionCommentFixtures = async (base: ChangeObject<User>) => {
-  const usersFixture = [
-    base,
-    { id: '2', name: 'Tsahi', image: 'https://daily.dev/tsahi.jpg' },
-    { id: '3', name: 'Nimrod', image: 'https://daily.dev/nimrod.jpg' },
-    { id: '4', name: 'Lee', image: 'https://daily.dev/lee.jpg' },
-    { id: '5', name: 'Hansel', image: 'https://daily.dev/Hansel.jpg' },
-    { id: '6', name: 'Samson', image: 'https://daily.dev/samson.jpg' },
-    { id: '7', name: 'Solevilla', image: 'https://daily.dev/solevilla.jpg' },
-  ];
-  await saveFixtures(con, User, usersFixture);
-  await saveFixtures(con, Source, sourcesFixture);
-  await saveFixtures(con, Post, postsFixture);
-  await con.getRepository(Comment).save({
-    id: 'c1',
-    postId: 'p1',
-    userId: '2',
-    content: `parent comment @${base.username}`,
-    contentHtml: `<p>parent comment <a>${base.username}</a></p>`,
-    createdAt: new Date(2020, 1, 6, 0, 0),
-  });
-  await con
-    .getRepository(CommentMention)
-    .save({ commentId: 'c1', commentByUserId: '2', mentionedUserId: base.id });
 };
 
 describe('source request', () => {
@@ -510,11 +481,7 @@ describe('comment mention', () => {
     commentByUserId: '2',
   };
 
-  beforeEach(async () => {
-    await saveMentionCommentFixtures(defaultUser);
-  });
-
-  it('should send email for the mentioned user', async () => {
+  it('should notify on new comment mention', async () => {
     const after: ChangeObject<ObjectType> = base;
     await expectSuccessfulBackground(
       worker,
@@ -525,32 +492,10 @@ describe('comment mention', () => {
         table: 'comment_mention',
       }),
     );
-    const comment = await con
-      .getRepository(Comment)
-      .findOneBy({ id: base.commentId });
-    const post = await comment.post;
-    const commenter = await comment.user;
-    const mentioned = await con
-      .getRepository(User)
-      .findOneBy({ id: base.mentionedUserId });
-    const [first_name] = mentioned.name.split(' ');
-    const params = {
-      ...baseNotificationEmailData,
-      to: mentioned.email,
-      templateId: 'd-6949e2e50def4c6698900032973d469b',
-      dynamicTemplateData: {
-        first_name,
-        full_name: commenter.name,
-        comment: comment.content,
-        user_handle: mentioned.username,
-        commenter_profile_image: commenter.image,
-        post_title: truncatePost(post),
-        post_image: post.image || pickImageUrl(post),
-        post_link: getDiscussionLink(post.id),
-      },
-    };
-    expect(sendEmail).toBeCalledTimes(1);
-    expect(sendEmail).toBeCalledWith(params);
+    expect(notifyNewCommentMention).toBeCalledTimes(1);
+    expect(jest.mocked(notifyNewCommentMention).mock.calls[0].slice(1)).toEqual(
+      [after],
+    );
   });
 });
 

--- a/__tests__/workers/commentMentionEmail.ts
+++ b/__tests__/workers/commentMentionEmail.ts
@@ -1,0 +1,91 @@
+import worker from '../../src/workers/commentMentionMail';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { ChangeObject } from '../../src/types';
+import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import {
+  baseNotificationEmailData,
+  getDiscussionLink,
+  pickImageUrl,
+  sendEmail,
+  truncatePost,
+} from '../../src/common';
+import { Comment, CommentMention, Post, Source, User } from '../../src/entity';
+import { sourcesFixture } from '../fixture/source';
+import { postsFixture } from '../fixture/post';
+import { usersFixture } from '../fixture/user';
+
+jest.mock('../../src/common', () => ({
+  ...(jest.requireActual('../../src/common') as Record<string, unknown>),
+  // For some reason it's required to override truncatePost
+  truncatePost: () => 'truncate',
+  sendEmail: jest.fn(),
+}));
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+type ObjectType = CommentMention;
+const base: ChangeObject<ObjectType> = {
+  commentId: 'c1',
+  mentionedUserId: '1',
+  commentByUserId: '2',
+};
+
+const saveMentionCommentFixtures = async () => {
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, Post, postsFixture);
+  await con.getRepository(Comment).save({
+    id: 'c1',
+    postId: 'p1',
+    userId: '2',
+    content: `parent comment @idoshamun`,
+    contentHtml: `<p>parent comment <a>@idoshamun</a></p>`,
+    createdAt: new Date(2020, 1, 6, 0, 0),
+  });
+  await con
+    .getRepository(CommentMention)
+    .save({ commentId: 'c1', commentByUserId: '2', mentionedUserId: '1' });
+};
+
+beforeEach(async () => {
+  await saveMentionCommentFixtures();
+});
+
+it('should send email for the mentioned user', async () => {
+  await expectSuccessfulBackground(worker, { commentMention: base });
+  const comment = await con
+    .getRepository(Comment)
+    .findOneBy({ id: base.commentId });
+  const post = await comment.post;
+  const commenter = await comment.user;
+  const mentioned = await con
+    .getRepository(User)
+    .findOneBy({ id: base.mentionedUserId });
+  const [first_name] = mentioned.name.split(' ');
+  const params = {
+    ...baseNotificationEmailData,
+    to: mentioned.email,
+    templateId: 'd-6949e2e50def4c6698900032973d469b',
+    dynamicTemplateData: {
+      first_name,
+      full_name: commenter.name,
+      comment: comment.content,
+      user_handle: mentioned.username,
+      commenter_profile_image: commenter.image,
+      post_title: truncatePost(post),
+      post_image: post.image || pickImageUrl(post),
+      post_link: getDiscussionLink(post.id),
+    },
+  };
+  expect(sendEmail).toBeCalledTimes(1);
+  expect(sendEmail).toBeCalledWith(params);
+});

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -1,0 +1,560 @@
+import { invokeNotificationWorker } from '../helpers';
+import {
+  Comment,
+  CommentUpvote,
+  Post,
+  PostReport,
+  Source,
+  SubmissionStatus,
+  Upvote,
+  User,
+} from '../../src/entity';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { usersFixture } from '../fixture/user';
+import { postsFixture } from '../fixture/post';
+import { sourcesFixture } from '../fixture/source';
+import {
+  NotificationCommentContext,
+  NotificationCommenterContext,
+  NotificationPostContext,
+  NotificationSourceContext,
+  NotificationSourceRequestContext,
+  NotificationUpvotersContext,
+} from '../../src/notifications';
+import { NotificationReason } from '../../src/common';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await con.getRepository(User).save(usersFixture);
+  await con.getRepository(Source).save(sourcesFixture);
+  await con.getRepository(Post).save([postsFixture[0]]);
+  await con.getRepository(Comment).save([
+    {
+      id: 'c1',
+      postId: 'p1',
+      userId: '2',
+      content: 'comment',
+      contentHtml: '<p>comment</p>',
+    },
+  ]);
+});
+
+it('should add community picks failed notification', async () => {
+  const worker = await import(
+    '../../src/workers/notifications/communityPicksFailed'
+  );
+  const actual = await invokeNotificationWorker(worker.default, {
+    id: 'sr1',
+    url: 'http://sample.abc.com',
+    userId: '1',
+    createdAt: 1601187916999999,
+    status: SubmissionStatus.Rejected,
+  });
+  expect(actual.length).toEqual(1);
+  expect(actual[0].type).toEqual('community_picks_failed');
+  expect(actual[0].ctx).toEqual({
+    userId: '1',
+    submission: {
+      id: 'sr1',
+      url: 'http://sample.abc.com',
+      userId: '1',
+      createdAt: 1601187916999999,
+      status: SubmissionStatus.Rejected,
+    },
+  });
+});
+
+it('should add community picks succeeded notification', async () => {
+  const worker = await import(
+    '../../src/workers/notifications/communityPicksSucceeded'
+  );
+  const actual = await invokeNotificationWorker(worker.default, {
+    scoutId: '1',
+    postId: 'p1',
+  });
+  const posts = await con.getRepository(Post).find();
+  expect(actual.length).toEqual(1);
+  expect(actual[0].type).toEqual('community_picks_succeeded');
+  expect(actual[0].ctx).toEqual({
+    userId: '1',
+    post: posts[0],
+  });
+});
+
+it('should add community picks granted notification', async () => {
+  const worker = await import(
+    '../../src/workers/notifications/communityPicksGranted'
+  );
+  const actual = await invokeNotificationWorker(worker.default, {
+    userId: '1',
+  });
+  expect(actual.length).toEqual(1);
+  expect(actual[0].type).toEqual('community_picks_granted');
+  expect(actual[0].ctx).toEqual({
+    userId: '1',
+  });
+});
+
+it('should add article picked notification', async () => {
+  const worker = await import('../../src/workers/notifications/articlePicked');
+  const actual = await invokeNotificationWorker(worker.default, {
+    authorId: '1',
+    postId: 'p1',
+  });
+  const posts = await con.getRepository(Post).find();
+  expect(actual.length).toEqual(1);
+  expect(actual[0].type).toEqual('article_picked');
+  expect(actual[0].ctx).toEqual({
+    userId: '1',
+    post: posts[0],
+  });
+});
+
+describe('article new comment', () => {
+  it('should add notification for scout and author', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleNewCommentPostCommented'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '3',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+      commentId: 'c1',
+    });
+    expect(actual.length).toEqual(2);
+    actual.forEach((bundle) => {
+      expect(bundle.type).toEqual('article_new_comment');
+      expect((bundle.ctx as NotificationPostContext).post.id).toEqual('p1');
+      expect((bundle.ctx as NotificationCommentContext).comment.id).toEqual(
+        'c1',
+      );
+      expect((bundle.ctx as NotificationCommenterContext).commenter.id).toEqual(
+        '2',
+      );
+    });
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(actual[1].ctx.userId).toEqual('3');
+  });
+
+  it('should add one notification when scout and author are the same', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleNewCommentPostCommented'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '1',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+      commentId: 'c1',
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].ctx.userId).toEqual('1');
+  });
+
+  it('should not add notification when the author commented', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleNewCommentPostCommented'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: '1',
+      },
+    );
+    await con.getRepository(Comment).update(
+      { id: 'c1' },
+      {
+        userId: '1',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+      commentId: 'c1',
+    });
+    expect(actual).toBeFalsy();
+  });
+
+  it('should add notification for scout and author on new reply', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleNewCommentCommentCommented'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '3',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+      childCommentId: 'c1',
+    });
+    expect(actual.length).toEqual(2);
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(actual[1].ctx.userId).toEqual('3');
+  });
+});
+
+describe('article upvote milestone', () => {
+  it('should add notification for scout and author', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleUpvoteMilestone'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '3',
+        upvotes: 5,
+      },
+    );
+    await con.getRepository(Upvote).save([
+      {
+        userId: '2',
+        postId: 'p1',
+      },
+      { userId: '4', postId: 'p1' },
+    ]);
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '2',
+      postId: 'p1',
+    });
+    expect(actual.length).toEqual(2);
+    actual.forEach((bundle) => {
+      expect(bundle.type).toEqual('article_upvote_milestone');
+      expect((bundle.ctx as NotificationPostContext).post.id).toEqual('p1');
+      expect((bundle.ctx as NotificationUpvotersContext).upvotes).toEqual(5);
+      expect(
+        (bundle.ctx as NotificationUpvotersContext).upvoters.length,
+      ).toEqual(2);
+    });
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(actual[1].ctx.userId).toEqual('3');
+  });
+
+  it('should add one notification when scout and author are the same', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleUpvoteMilestone'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '1',
+        upvotes: 5,
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '2',
+      postId: 'p1',
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].ctx.userId).toEqual('1');
+  });
+
+  it('should not add notification when the author upvoted', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleUpvoteMilestone'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: '1',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+    });
+    expect(actual).toBeFalsy();
+  });
+
+  it('should not add notification if it is not milestone', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleUpvoteMilestone'
+    );
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: '1',
+        upvotes: 11,
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '2',
+      postId: 'p1',
+    });
+    expect(actual).toBeFalsy();
+  });
+});
+
+it('should add article report approved notification for every reporter', async () => {
+  const worker = await import(
+    '../../src/workers/notifications/articleReportApproved'
+  );
+  await con.getRepository(PostReport).save([
+    { userId: '1', postId: 'p1', reason: 'NSFW' },
+    { userId: '2', postId: 'p1', reason: 'CLICKBAIT' },
+  ]);
+  const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+  const actual = await invokeNotificationWorker(worker.default, {
+    post,
+  });
+  expect(actual.length).toEqual(2);
+  expect(actual[0].type).toEqual('article_report_approved');
+  expect(actual[0].ctx.userId).toEqual('1');
+  expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+  expect(actual[1].type).toEqual('article_report_approved');
+  expect(actual[1].ctx.userId).toEqual('2');
+  expect((actual[1].ctx as NotificationPostContext).post.id).toEqual('p1');
+});
+
+it('should add article analytics notification for scout and author', async () => {
+  const worker = await import(
+    '../../src/workers/notifications/articleAnalytics'
+  );
+  await con.getRepository(Post).update(
+    { id: 'p1' },
+    {
+      authorId: '1',
+      scoutId: '3',
+    },
+  );
+  const actual = await invokeNotificationWorker(worker.default, {
+    postId: 'p1',
+  });
+  expect(actual.length).toEqual(2);
+  expect(actual[0].type).toEqual('article_analytics');
+  expect(actual[0].ctx.userId).toEqual('3');
+  expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+  expect(actual[1].type).toEqual('article_analytics');
+  expect(actual[1].ctx.userId).toEqual('1');
+  expect((actual[1].ctx as NotificationPostContext).post.id).toEqual('p1');
+});
+
+describe('source request', () => {
+  it('should add source approved notification', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/sourceRequest'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      reason: NotificationReason.Publish,
+      sourceRequest: {
+        id: 'sr1',
+        userId: '1',
+        sourceId: sourcesFixture[0].id,
+      },
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].type).toEqual('source_approved');
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(
+      (actual[0].ctx as NotificationSourceRequestContext).sourceRequest.id,
+    ).toEqual('sr1');
+    expect((actual[0].ctx as NotificationSourceContext).source.id).toEqual('a');
+  });
+
+  it('should add source rejected notification', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/sourceRequest'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      reason: NotificationReason.Decline,
+      sourceRequest: {
+        id: 'sr1',
+        userId: '1',
+        sourceId: sourcesFixture[0].id,
+      },
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].type).toEqual('source_rejected');
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(
+      (actual[0].ctx as NotificationSourceRequestContext).sourceRequest.id,
+    ).toEqual('sr1');
+  });
+
+  it('should add source rejected notification on existing source', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/sourceRequest'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      reason: NotificationReason.Exists,
+      sourceRequest: {
+        id: 'sr1',
+        userId: '1',
+        sourceId: sourcesFixture[0].id,
+      },
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].type).toEqual('source_rejected');
+    expect(actual[0].ctx.userId).toEqual('1');
+    expect(
+      (actual[0].ctx as NotificationSourceRequestContext).sourceRequest.id,
+    ).toEqual('sr1');
+  });
+
+  it('should do nothing otherwise', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/sourceRequest'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      reason: NotificationReason.New,
+      sourceRequest: {
+        id: 'sr1',
+        userId: '1',
+        sourceId: sourcesFixture[0].id,
+      },
+    });
+    expect(actual).toBeFalsy();
+  });
+});
+
+it('should add comment mention notification', async () => {
+  const worker = await import('../../src/workers/notifications/commentMention');
+  const actual = await invokeNotificationWorker(worker.default, {
+    commentMention: {
+      commentId: 'c1',
+      mentionedUserId: '1',
+      commentUserId: '2',
+    },
+  });
+  expect(actual.length).toEqual(1);
+  expect(actual[0].type).toEqual('comment_mention');
+  expect(actual[0].ctx.userId).toEqual('1');
+  expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+  expect((actual[0].ctx as NotificationCommentContext).comment.id).toEqual(
+    'c1',
+  );
+  expect((actual[0].ctx as NotificationCommenterContext).commenter.id).toEqual(
+    '2',
+  );
+});
+
+it('should add comment reply notification', async () => {
+  await con.getRepository(Comment).save([
+    {
+      id: 'c2',
+      postId: 'p1',
+      userId: '2',
+      content: 'sub comment',
+      createdAt: new Date(2020, 1, 6, 0, 0),
+      parentId: 'c1',
+    },
+    {
+      id: 'c3',
+      postId: 'p1',
+      userId: '1',
+      content: 'sub comment2',
+      createdAt: new Date(2020, 1, 6, 0, 0),
+      parentId: 'c1',
+    },
+    {
+      id: 'c4',
+      postId: 'p1',
+      userId: '3',
+      content: 'sub comment3',
+      createdAt: new Date(2020, 1, 6, 0, 0),
+      parentId: 'c1',
+    },
+    {
+      id: 'c5',
+      postId: 'p1',
+      userId: '4',
+      content: 'sub comment4',
+      createdAt: new Date(2020, 1, 6, 0, 0),
+      parentId: 'c1',
+    },
+  ]);
+  const worker = await import('../../src/workers/notifications/commentReply');
+  const actual = await invokeNotificationWorker(worker.default, {
+    postId: 'p1',
+    userId: '4',
+    childCommentId: 'c5',
+  });
+  expect(actual.length).toEqual(3);
+  actual.forEach((bundle) => {
+    expect(bundle.type).toEqual('comment_reply');
+    expect((bundle.ctx as NotificationPostContext).post.id).toEqual('p1');
+    expect((bundle.ctx as NotificationCommentContext).comment.id).toEqual('c5');
+    expect((bundle.ctx as NotificationCommenterContext).commenter.id).toEqual(
+      '4',
+    );
+  });
+  expect(actual.map((bundle) => bundle.ctx.userId)).toEqual(['2', '1', '3']);
+});
+
+describe('comment upvote milestone', () => {
+  it('should add notification for author', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/commentUpvoteMilestone'
+    );
+    await con.getRepository(Comment).update({ id: 'c1' }, { upvotes: 5 });
+    await con.getRepository(CommentUpvote).save([
+      {
+        userId: '1',
+        commentId: 'c1',
+      },
+      { userId: '4', commentId: 'c1' },
+    ]);
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      commentId: 'c1',
+    });
+    expect(actual.length).toEqual(1);
+    expect(actual[0].type).toEqual('comment_upvote_milestone');
+    expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+    expect((actual[0].ctx as NotificationCommentContext).comment.id).toEqual(
+      'c1',
+    );
+    expect((actual[0].ctx as NotificationUpvotersContext).upvotes).toEqual(5);
+    expect(
+      (actual[0].ctx as NotificationUpvotersContext).upvoters.length,
+    ).toEqual(2);
+    expect(actual[0].ctx.userId).toEqual('2');
+  });
+
+  it('should not add notification when the author upvoted', async () => {
+    await con.getRepository(Comment).update({ id: 'c1' }, { upvotes: 5 });
+    const worker = await import(
+      '../../src/workers/notifications/commentUpvoteMilestone'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '2',
+      commentId: 'c1',
+    });
+    expect(actual).toBeFalsy();
+  });
+
+  it('should not add notification if it is not milestone', async () => {
+    await con.getRepository(Comment).update({ id: 'c1' }, { upvotes: 11 });
+    const worker = await import(
+      '../../src/workers/notifications/commentUpvoteMilestone'
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      commentId: 'c1',
+    });
+    expect(actual).toBeFalsy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
         "markdown-it": "^13.0.1",
+        "markdown-to-txt": "^2.0.1",
         "mercurius": "^11.3.0",
         "mercurius-cache": "^3.0.1",
         "mercurius-upload": "^5.0.0",
@@ -6733,6 +6734,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6792,6 +6798,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
     },
     "node_modules/log-driver": {
       "version": "1.2.7",
@@ -6908,6 +6919,16 @@
       "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dependencies": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdown-to-txt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-2.0.1.tgz",
+      "integrity": "sha512-Hsj7KTN8k1gutlLum3vosHwVZGnv8/cbYKWVkUyo/D1rzOYddbDesILebRfOsaVfjIBJank/AVOySBlHAYqfZw==",
+      "dependencies": {
+        "lodash.escape": "^4.0.1",
+        "lodash.unescape": "^4.0.1",
+        "marked": "^4.0.14"
       }
     },
     "node_modules/marked": {
@@ -15286,6 +15307,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -15345,6 +15371,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -15435,6 +15466,16 @@
       "version": "8.6.5",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
       "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ=="
+    },
+    "markdown-to-txt": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-2.0.1.tgz",
+      "integrity": "sha512-Hsj7KTN8k1gutlLum3vosHwVZGnv8/cbYKWVkUyo/D1rzOYddbDesILebRfOsaVfjIBJank/AVOySBlHAYqfZw==",
+      "requires": {
+        "lodash.escape": "^4.0.1",
+        "lodash.unescape": "^4.0.1",
+        "marked": "^4.0.14"
+      }
     },
     "marked": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "markdown-it": "^13.0.1",
+    "markdown-to-txt": "^2.0.1",
     "mercurius": "^11.3.0",
     "mercurius-cache": "^3.0.1",
     "mercurius-upload": "^5.0.0",

--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -20,6 +20,11 @@ export const getDiscussionLink = (postId: string, commentId = ''): string =>
     commentId && `#c-${commentId}`
   }`;
 
+export const getSourceLink = (sourceId: string): string =>
+  `${process.env.COMMENTS_PREFIX}/sources/${sourceId}`;
+
+export const scoutArticleLink = `${process.env.COMMENTS_PREFIX}/scout`;
+
 export const standardizeURL = (url: string): string => {
   const domain = subtractDomain(url);
   if (!isExcluded(domain)) {

--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -23,7 +23,7 @@ export const getDiscussionLink = (postId: string, commentId = ''): string =>
 export const getSourceLink = (sourceId: string): string =>
   `${process.env.COMMENTS_PREFIX}/sources/${sourceId}`;
 
-export const scoutArticleLink = `${process.env.COMMENTS_PREFIX}/scout`;
+export const scoutArticleLink = `${process.env.COMMENTS_PREFIX}?scout=true`;
 
 export const standardizeURL = (url: string): string => {
   const domain = subtractDomain(url);

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -7,6 +7,7 @@ import {
   Settings,
   Submission,
   User,
+  CommentMention,
 } from '../entity';
 import { ChangeObject } from '../types';
 
@@ -39,6 +40,7 @@ const sourceFeedRemovedTopic = pubsub.topic('source-feed-removed');
 const communityLinkAccessTopic = pubsub.topic('community-link-access');
 const communityLinkRejectedTopic = pubsub.topic('community-link-rejected');
 const communityLinkSubmittedTopic = pubsub.topic('community-link-submitted');
+const newCommentMentionTopic = pubsub.topic('api.v1.new-comment-mention');
 
 export enum NotificationReason {
   New = 'new',
@@ -311,3 +313,9 @@ export const notifySubmissionGrantedAccess = async (
   log: EventLogger,
   userId: string,
 ): Promise<void> => publishEvent(log, communityLinkAccessTopic, { userId });
+
+export const notifyNewCommentMention = async (
+  log: EventLogger,
+  commentMention: ChangeObject<CommentMention>,
+): Promise<void> =>
+  publishEvent(log, newCommentMentionTopic, { commentMention });

--- a/src/entity/Notification.ts
+++ b/src/entity/Notification.ts
@@ -23,14 +23,26 @@ export type NotificationType =
   | 'article_analytics'
   | 'source_approved'
   | 'source_rejected'
-  | 'new_badge'
   | 'comment_mention'
   | 'comment_reply'
   | 'comment_upvote_milestone';
 
+export type NotificationReferenceType =
+  | 'source_request'
+  | 'post'
+  | 'submission'
+  | 'comment'
+  | 'system';
+
 @Entity()
 @Index('IDX_notification_user_id_created_at', ['userId', 'public', 'createdAt'])
 @Index('IDX_notification_user_id_read_at', ['userId', 'readAt'])
+@Index('ID_notification_reference', ['referenceId', 'referenceType'])
+@Index(
+  'ID_notification_uniqueness',
+  ['type', 'userId', 'referenceId', 'referenceType', 'uniqueKey'],
+  { unique: true },
+)
 export class Notification {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -62,6 +74,15 @@ export class Notification {
 
   @Column({ default: true })
   public: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  referenceId?: string;
+
+  @Column({ type: 'text', nullable: true })
+  referenceType?: NotificationReferenceType;
+
+  @Column({ type: 'text', default: '0' })
+  uniqueKey?: string;
 
   @ManyToOne(() => User, {
     lazy: true,

--- a/src/migration/1670243653439-NotificationReference.ts
+++ b/src/migration/1670243653439-NotificationReference.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationReference1670243653439 implements MigrationInterface {
+  name = 'NotificationReference1670243653439';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "notification"
+      ADD "referenceId" text`);
+    await queryRunner.query(`ALTER TABLE "notification"
+      ADD "referenceType" text`);
+    await queryRunner.query(`ALTER TABLE "notification"
+      ADD "uniqueKey" text DEFAULT '0'`);
+    await queryRunner.query(`CREATE UNIQUE INDEX "ID_notification_uniqueness" ON "notification" ("type",
+                                                                                                 "userId",
+                                                                                                 "referenceId",
+                                                                                                 "referenceType",
+                                                                                                 "uniqueKey") `);
+    await queryRunner.query(
+      `CREATE INDEX "ID_notification_reference" ON "notification" ("referenceId", "referenceType") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."ID_notification_reference"`);
+    await queryRunner.query(`DROP INDEX "public"."ID_notification_uniqueness"`);
+    await queryRunner.query(
+      `ALTER TABLE "notification" DROP COLUMN "uniqueKey"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification" DROP COLUMN "referenceType"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification" DROP COLUMN "referenceId"`,
+    );
+  }
+}

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -1,0 +1,184 @@
+import { DeepPartial } from 'typeorm';
+import {
+  Comment,
+  Notification,
+  NotificationAttachment,
+  NotificationAvatar,
+  NotificationType,
+  Post,
+  Source,
+  SourceRequest,
+  Submission,
+  User,
+} from '../entity';
+import { getDiscussionLink, getSourceLink, pickImageUrl } from '../common';
+import { getUserPermalink } from '../schema/users';
+import { markdownToTxt } from 'markdown-to-txt';
+import { NotificationBundle, Reference } from './types';
+import { NotificationIcon } from './icons';
+
+const MAX_COMMENT_LENGTH = 320;
+
+const simplifyComment = (comment: string): string => {
+  const simplified = markdownToTxt(comment);
+  return simplified.length <= MAX_COMMENT_LENGTH
+    ? simplified
+    : `${simplified.substring(0, MAX_COMMENT_LENGTH - 3)}...`;
+};
+
+export class NotificationBuilder {
+  notification: DeepPartial<Notification> = {};
+  avatars: DeepPartial<NotificationAvatar>[] = [];
+  attachments: DeepPartial<NotificationAttachment>[] = [];
+
+  constructor(type: NotificationType, userId: string) {
+    this.notification = { type, userId, public: true };
+  }
+
+  static new(type: NotificationType, userId: string): NotificationBuilder {
+    return new NotificationBuilder(type, userId);
+  }
+
+  build(): NotificationBundle {
+    return {
+      notification: this.notification,
+      avatars: this.avatars,
+      attachments: this.attachments,
+    };
+  }
+
+  systemNotification(): NotificationBuilder {
+    return this.enrichNotification({
+      icon: 'system',
+      title: 'System',
+      targetUrl: 'system',
+      public: false,
+    });
+  }
+
+  referenceSubmission(submission: Pick<Submission, 'id'>): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: submission.id,
+      referenceType: 'submission',
+    });
+  }
+
+  referencePost(post: Reference<Post>): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: post.id,
+      referenceType: 'post',
+    });
+  }
+
+  referenceComment(comment: Reference<Comment>): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: comment.id,
+      referenceType: 'comment',
+    });
+  }
+
+  referenceSystem(): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: 'system',
+      referenceType: 'system',
+    });
+  }
+
+  referenceSourceRequest(
+    sourceRequest: Reference<SourceRequest>,
+  ): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: sourceRequest.id,
+      referenceType: 'source_request',
+    });
+  }
+
+  icon(icon: NotificationIcon): NotificationBuilder {
+    return this.enrichNotification({ icon });
+  }
+
+  title(title: string): NotificationBuilder {
+    return this.enrichNotification({ title });
+  }
+
+  description(description: string): NotificationBuilder {
+    return this.enrichNotification({ description });
+  }
+
+  targetUrl(targetUrl: string): NotificationBuilder {
+    return this.enrichNotification({ targetUrl });
+  }
+
+  targetPost(
+    post: Reference<Post>,
+    comment?: Reference<Comment>,
+  ): NotificationBuilder {
+    return this.enrichNotification({
+      targetUrl: getDiscussionLink(post.id, comment?.id),
+    });
+  }
+
+  targetSource(source: Reference<Source>): NotificationBuilder {
+    return this.enrichNotification({
+      targetUrl: getSourceLink(source.id),
+    });
+  }
+
+  attachmentPost(post: Reference<Post>): NotificationBuilder {
+    this.attachments.push({
+      order: this.attachments.length,
+      type: 'post',
+      image: post.image || pickImageUrl(post),
+      title: post.title,
+      referenceId: post.id,
+    });
+    return this;
+  }
+
+  avatarSource(source: Reference<Source>): NotificationBuilder {
+    this.avatars.push({
+      order: this.attachments.length,
+      type: 'source',
+      referenceId: source.id,
+      image: source.image,
+      name: source.name,
+      targetUrl: getSourceLink(source.id),
+    });
+    return this;
+  }
+
+  avatarManyUsers(users: Reference<User>[]): NotificationBuilder {
+    const newAvatars = users.map(
+      (user, i): DeepPartial<NotificationAvatar> => ({
+        order: i + this.avatars.length,
+        type: 'user',
+        referenceId: user.id,
+        image: user.image,
+        name: user.name,
+        targetUrl: getUserPermalink(user),
+      }),
+    );
+    this.avatars = this.avatars.concat(newAvatars);
+    return this;
+  }
+
+  descriptionComment(comment: Reference<Comment>): NotificationBuilder {
+    return this.enrichNotification({
+      description: simplifyComment(comment.content),
+    });
+  }
+
+  upvotes(upvotes: number, upvoters: Reference<User>[]): NotificationBuilder {
+    return this.enrichNotification({
+      uniqueKey: upvotes.toString(),
+      icon: NotificationIcon.Upvote,
+    }).avatarManyUsers(upvoters);
+  }
+
+  private enrichNotification(
+    addition: DeepPartial<Notification>,
+  ): NotificationBuilder {
+    this.notification = { ...this.notification, ...addition };
+    return this;
+  }
+}

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -1,0 +1,125 @@
+import { NotificationType } from '../entity';
+import { NotificationBuilder } from './builder';
+import { NotificationIcon } from './icons';
+import { scoutArticleLink } from '../common';
+import {
+  NotificationBaseContext,
+  NotificationCommentContext,
+  NotificationCommenterContext,
+  NotificationPostContext,
+  NotificationSourceContext,
+  NotificationSourceRequestContext,
+  NotificationSubmissionContext,
+  NotificationUpvotersContext,
+} from './types';
+
+export const generateNotificationMap: Record<
+  NotificationType,
+  (
+    builder: NotificationBuilder,
+    ctx: NotificationBaseContext,
+  ) => NotificationBuilder
+> = {
+  community_picks_failed: (builder, ctx: NotificationSubmissionContext) =>
+    builder.systemNotification().referenceSubmission(ctx.submission),
+  community_picks_succeeded: (builder, ctx: NotificationPostContext) =>
+    builder
+      .referencePost(ctx.post)
+      .icon(NotificationIcon.CommunityPicks)
+      .title(
+        `<b>Community picks:</b> An article you Scouted was accepted and is now <span class="text-theme-color-cabbage">live</span> on the daily.dev feed!`,
+      )
+      .targetPost(ctx.post)
+      .attachmentPost(ctx.post),
+  community_picks_granted: (builder) =>
+    builder
+      .referenceSystem()
+      .icon(NotificationIcon.DailyDev)
+      .title(
+        `<b>Community picks:</b> You have earned enough reputation to <span class="text-theme-color-cabbage">Scout and submit</span> articles.`,
+      )
+      .description(`<u>Submit your first article now!</u>`)
+      //TODO: validate with web team that this is going to be supported!
+      .targetUrl(scoutArticleLink),
+  article_picked: (builder, ctx: NotificationPostContext) =>
+    builder
+      .referencePost(ctx.post)
+      .icon(NotificationIcon.DailyDev)
+      .title(
+        `Congratulations! <b>Your article</b> got <span class="text-theme-color-cabbage">listed</span> on the daily.dev feed!`,
+      )
+      .targetPost(ctx.post)
+      .attachmentPost(ctx.post),
+  article_new_comment: (builder, ctx: NotificationCommenterContext) =>
+    builder
+      .referenceComment(ctx.comment)
+      .icon(NotificationIcon.Comment)
+      .title(
+        `<b>${ctx.commenter.name}</b> posted a <span class="text-theme-color-blueCheese">comment</span> on your article.`,
+      )
+      .descriptionComment(ctx.comment)
+      .targetPost(ctx.post, ctx.comment)
+      .avatarManyUsers([ctx.commenter]),
+  article_upvote_milestone: (
+    builder,
+    ctx: NotificationPostContext & NotificationUpvotersContext,
+  ) =>
+    builder
+      .referencePost(ctx.post)
+      .upvotes(ctx.upvotes, ctx.upvoters)
+      .title(
+        `<b>You rock!</b> Your article <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
+      )
+      .targetPost(ctx.post)
+      .attachmentPost(ctx.post),
+  article_report_approved: (builder, ctx: NotificationPostContext) =>
+    builder.referencePost(ctx.post).systemNotification(),
+  article_analytics: (builder, ctx: NotificationPostContext) =>
+    builder.referencePost(ctx.post).systemNotification(),
+  source_approved: (
+    builder,
+    ctx: NotificationSourceRequestContext & NotificationSourceContext,
+  ) =>
+    builder
+      .referenceSourceRequest(ctx.sourceRequest)
+      .icon(NotificationIcon.DailyDev)
+      .title(
+        `<b>The source you requested was</b> <span class="text-theme-color-cabbage">approved!</span> Articles from ${ctx.source.name} will start appearing in the daily.dev feed in the next few days!`,
+      )
+      .targetSource(ctx.source)
+      .avatarSource(ctx.source),
+  source_rejected: (builder, ctx: NotificationSourceRequestContext) =>
+    builder.systemNotification().referenceSourceRequest(ctx.sourceRequest),
+  comment_mention: (builder, ctx: NotificationCommenterContext) =>
+    builder
+      .referenceComment(ctx.comment)
+      .icon(NotificationIcon.Comment)
+      .title(
+        `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">mentioned you</span> in a comment.`,
+      )
+      .descriptionComment(ctx.comment)
+      .targetPost(ctx.post, ctx.comment)
+      .avatarManyUsers([ctx.commenter]),
+  comment_reply: (builder, ctx: NotificationCommenterContext) =>
+    builder
+      .referenceComment(ctx.comment)
+      .icon(NotificationIcon.Comment)
+      .title(
+        `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">replied</span> to your comment.`,
+      )
+      .descriptionComment(ctx.comment)
+      .targetPost(ctx.post, ctx.comment)
+      .avatarManyUsers([ctx.commenter]),
+  comment_upvote_milestone: (
+    builder,
+    ctx: NotificationCommentContext & NotificationUpvotersContext,
+  ) =>
+    builder
+      .referenceComment(ctx.comment)
+      .upvotes(ctx.upvotes, ctx.upvoters)
+      .title(
+        `<b>You rock!</b> Your comment <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
+      )
+      .descriptionComment(ctx.comment)
+      .targetPost(ctx.post, ctx.comment),
+};

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -13,6 +13,42 @@ import {
   NotificationUpvotersContext,
 } from './types';
 
+const systemTitle = () => undefined;
+
+export const notificationTitleMap: Record<
+  NotificationType,
+  (ctx: NotificationBaseContext) => string | undefined
+> = {
+  community_picks_failed: systemTitle,
+  community_picks_succeeded: () =>
+    `<b>Community picks:</b> An article you Scouted was accepted and is now <span class="text-theme-color-cabbage">live</span> on the daily.dev feed!`,
+  community_picks_granted: () =>
+    `<b>Community picks:</b> You have earned enough reputation to <span class="text-theme-color-cabbage">Scout and submit</span> articles.`,
+  article_picked: () =>
+    `Congratulations! <b>Your article</b> got <span class="text-theme-color-cabbage">listed</span> on the daily.dev feed!`,
+  article_new_comment: (ctx: NotificationCommenterContext) =>
+    `<b>${ctx.commenter.name}</b> posted a <span class="text-theme-color-blueCheese">comment</span> on your article.`,
+  article_upvote_milestone: (
+    ctx: NotificationPostContext & NotificationUpvotersContext,
+  ) =>
+    `<b>You rock!</b> Your article <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
+  article_report_approved: systemTitle,
+  article_analytics: systemTitle,
+  source_approved: (
+    ctx: NotificationSourceRequestContext & NotificationSourceContext,
+  ) =>
+    `<b>The source you requested was</b> <span class="text-theme-color-cabbage">approved!</span> Articles from ${ctx.source.name} will start appearing in the daily.dev feed in the next few days!`,
+  source_rejected: systemTitle,
+  comment_mention: (ctx: NotificationCommenterContext) =>
+    `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">mentioned you</span> in a comment.`,
+  comment_reply: (ctx: NotificationCommenterContext) =>
+    `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">replied</span> to your comment.`,
+  comment_upvote_milestone: (
+    ctx: NotificationCommentContext & NotificationUpvotersContext,
+  ) =>
+    `<b>You rock!</b> Your comment <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
+};
+
 export const generateNotificationMap: Record<
   NotificationType,
   (
@@ -26,37 +62,24 @@ export const generateNotificationMap: Record<
     builder
       .referencePost(ctx.post)
       .icon(NotificationIcon.CommunityPicks)
-      .title(
-        `<b>Community picks:</b> An article you Scouted was accepted and is now <span class="text-theme-color-cabbage">live</span> on the daily.dev feed!`,
-      )
       .targetPost(ctx.post)
       .attachmentPost(ctx.post),
   community_picks_granted: (builder) =>
     builder
       .referenceSystem()
       .icon(NotificationIcon.DailyDev)
-      .title(
-        `<b>Community picks:</b> You have earned enough reputation to <span class="text-theme-color-cabbage">Scout and submit</span> articles.`,
-      )
       .description(`<u>Submit your first article now!</u>`)
-      //TODO: validate with web team that this is going to be supported!
       .targetUrl(scoutArticleLink),
   article_picked: (builder, ctx: NotificationPostContext) =>
     builder
       .referencePost(ctx.post)
       .icon(NotificationIcon.DailyDev)
-      .title(
-        `Congratulations! <b>Your article</b> got <span class="text-theme-color-cabbage">listed</span> on the daily.dev feed!`,
-      )
       .targetPost(ctx.post)
       .attachmentPost(ctx.post),
   article_new_comment: (builder, ctx: NotificationCommenterContext) =>
     builder
       .referenceComment(ctx.comment)
       .icon(NotificationIcon.Comment)
-      .title(
-        `<b>${ctx.commenter.name}</b> posted a <span class="text-theme-color-blueCheese">comment</span> on your article.`,
-      )
       .descriptionComment(ctx.comment)
       .targetPost(ctx.post, ctx.comment)
       .avatarManyUsers([ctx.commenter]),
@@ -67,9 +90,6 @@ export const generateNotificationMap: Record<
     builder
       .referencePost(ctx.post)
       .upvotes(ctx.upvotes, ctx.upvoters)
-      .title(
-        `<b>You rock!</b> Your article <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
-      )
       .targetPost(ctx.post)
       .attachmentPost(ctx.post),
   article_report_approved: (builder, ctx: NotificationPostContext) =>
@@ -83,9 +103,6 @@ export const generateNotificationMap: Record<
     builder
       .referenceSourceRequest(ctx.sourceRequest)
       .icon(NotificationIcon.DailyDev)
-      .title(
-        `<b>The source you requested was</b> <span class="text-theme-color-cabbage">approved!</span> Articles from ${ctx.source.name} will start appearing in the daily.dev feed in the next few days!`,
-      )
       .targetSource(ctx.source)
       .avatarSource(ctx.source),
   source_rejected: (builder, ctx: NotificationSourceRequestContext) =>
@@ -94,9 +111,6 @@ export const generateNotificationMap: Record<
     builder
       .referenceComment(ctx.comment)
       .icon(NotificationIcon.Comment)
-      .title(
-        `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">mentioned you</span> in a comment.`,
-      )
       .descriptionComment(ctx.comment)
       .targetPost(ctx.post, ctx.comment)
       .avatarManyUsers([ctx.commenter]),
@@ -104,9 +118,6 @@ export const generateNotificationMap: Record<
     builder
       .referenceComment(ctx.comment)
       .icon(NotificationIcon.Comment)
-      .title(
-        `<b>${ctx.commenter.name}</b> <span class="text-theme-color-blueCheese">replied</span> to your comment.`,
-      )
       .descriptionComment(ctx.comment)
       .targetPost(ctx.post, ctx.comment)
       .avatarManyUsers([ctx.commenter]),
@@ -117,9 +128,6 @@ export const generateNotificationMap: Record<
     builder
       .referenceComment(ctx.comment)
       .upvotes(ctx.upvotes, ctx.upvoters)
-      .title(
-        `<b>You rock!</b> Your comment <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
-      )
       .descriptionComment(ctx.comment)
       .targetPost(ctx.post, ctx.comment),
 };

--- a/src/notifications/icons.ts
+++ b/src/notifications/icons.ts
@@ -1,0 +1,7 @@
+export enum NotificationIcon {
+  DailyDev = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/daily.svg',
+  //TODO: set proper icon url
+  CommunityPicks = '',
+  Comment = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/discuss.svg',
+  Upvote = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/upvote.svg',
+}

--- a/src/notifications/icons.ts
+++ b/src/notifications/icons.ts
@@ -1,7 +1,6 @@
 export enum NotificationIcon {
-  DailyDev = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/daily.svg',
-  //TODO: set proper icon url
-  CommunityPicks = '',
-  Comment = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/discuss.svg',
-  Upvote = 'https://daily-now-res.cloudinary.com/image/upload/v1670251800/notifications/icons/upvote.svg',
+  DailyDev = 'DailyDev',
+  CommunityPicks = 'CommunityPicks',
+  Comment = 'Comment',
+  Upvote = 'Upvote',
 }

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -1,0 +1,74 @@
+import {
+  Notification,
+  NotificationAttachment,
+  NotificationAvatar,
+  NotificationType,
+} from '../entity';
+import { DeepPartial, EntityManager } from 'typeorm';
+import { NotificationBuilder } from './builder';
+import { NotificationBaseContext, NotificationBundle } from './types';
+import { generateNotificationMap } from './generate';
+
+export * from './types';
+
+export function generateNotification(
+  type: NotificationType,
+  ctx: NotificationBaseContext,
+): NotificationBundle {
+  return generateNotificationMap[type](
+    NotificationBuilder.new(type, ctx.userId),
+    ctx,
+  ).build();
+}
+
+const concatNotificationChildren = <
+  T extends DeepPartial<{ notificationId: string }>,
+>(
+  array: T[],
+  notificationId: string,
+  newItems: T[],
+): T[] =>
+  array.concat(
+    newItems.map((item) => ({
+      ...item,
+      notificationId,
+    })),
+  );
+
+export async function storeNotificationBundle(
+  entityManager: EntityManager,
+  bundles: NotificationBundle[],
+): Promise<void> {
+  const { identifiers } = await entityManager
+    .createQueryBuilder()
+    .insert()
+    .into(Notification)
+    .values(bundles.map(({ notification }) => notification))
+    .orIgnore()
+    .execute();
+  let attachments: DeepPartial<NotificationAttachment>[] = [];
+  let avatars: DeepPartial<NotificationAvatar>[] = [];
+  for (let i = 0; i < identifiers.length && i < bundles.length; i++) {
+    // If the notification was not ignored due to duplication
+    if (identifiers[i]) {
+      if (bundles[i].attachments) {
+        attachments = concatNotificationChildren(
+          attachments,
+          identifiers[i].id,
+          bundles[i].attachments,
+        );
+      }
+      if (bundles[i].avatars) {
+        avatars = concatNotificationChildren(
+          avatars,
+          identifiers[i].id,
+          bundles[i].avatars,
+        );
+      }
+    }
+  }
+  await Promise.all([
+    entityManager.insert(NotificationAttachment, attachments),
+    entityManager.insert(NotificationAvatar, avatars),
+  ]);
+}

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -7,7 +7,7 @@ import {
 import { DeepPartial, EntityManager } from 'typeorm';
 import { NotificationBuilder } from './builder';
 import { NotificationBaseContext, NotificationBundle } from './types';
-import { generateNotificationMap } from './generate';
+import { generateNotificationMap, notificationTitleMap } from './generate';
 
 export * from './types';
 
@@ -15,10 +15,10 @@ export function generateNotification(
   type: NotificationType,
   ctx: NotificationBaseContext,
 ): NotificationBundle {
-  return generateNotificationMap[type](
-    NotificationBuilder.new(type, ctx.userId),
-    ctx,
-  ).build();
+  const builder = NotificationBuilder.new(type, ctx.userId).title(
+    notificationTitleMap[type](ctx),
+  );
+  return generateNotificationMap[type](builder, ctx).build();
 }
 
 const concatNotificationChildren = <

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,0 +1,50 @@
+import {
+  Comment,
+  Notification,
+  NotificationAttachment,
+  NotificationAvatar,
+  Post,
+  Source,
+  SourceRequest,
+  Submission,
+  User,
+} from '../entity';
+import { ChangeObject } from '../types';
+import { DeepPartial } from 'typeorm';
+
+export type Reference<T> = ChangeObject<T> | T;
+
+export type NotificationBundle = {
+  notification: DeepPartial<Notification>;
+  avatars?: DeepPartial<NotificationAvatar>[];
+  attachments?: DeepPartial<NotificationAttachment>[];
+};
+
+export type NotificationBaseContext = { userId: string };
+export type NotificationSubmissionContext = NotificationBaseContext & {
+  submission: Pick<Submission, 'id'>;
+};
+export type NotificationPostContext = NotificationBaseContext & {
+  post: Reference<Post>;
+};
+
+export type NotificationCommentContext = NotificationPostContext & {
+  comment: Reference<Comment>;
+};
+
+export type NotificationCommenterContext = NotificationCommentContext & {
+  commenter: Reference<User>;
+};
+
+export type NotificationUpvotersContext = NotificationBaseContext & {
+  upvotes: number;
+  upvoters: Reference<User>[];
+};
+
+export type NotificationSourceRequestContext = NotificationBaseContext & {
+  sourceRequest: Reference<SourceRequest>;
+};
+
+export type NotificationSourceContext = NotificationBaseContext & {
+  source: Reference<Source>;
+};

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -46,6 +46,7 @@ import {
   notifyUserUpdated,
   notifyUsernameChanged,
   notifyNotificationsRead,
+  notifyNewCommentMention,
 } from '../common';
 import { ChangeMessage } from '../types';
 import { Connection, DataSource } from 'typeorm';
@@ -55,7 +56,6 @@ import { viewsThresholds } from '../cron/viewsThreshold';
 import { PostReport, Alerts } from '../entity';
 import { reportReasons } from '../schema/posts';
 import { updateAlerts } from '../schema/alerts';
-import { sendEmailToMentionedUser } from './commentMentionEmail';
 import { submissionAccessThreshold } from '../schema/submissions';
 
 const isChanged = <T>(before: T, after: T, property: keyof T): boolean =>
@@ -147,7 +147,7 @@ const onCommentMentionChange = async (
   data: ChangeMessage<CommentMention>,
 ): Promise<void> => {
   if (data.payload.op === 'c') {
-    await sendEmailToMentionedUser(con, data.payload.after, logger);
+    await notifyNewCommentMention(logger, data.payload.after);
   }
 };
 

--- a/src/workers/commentMentionMail.ts
+++ b/src/workers/commentMentionMail.ts
@@ -72,7 +72,7 @@ interface Data {
 }
 
 const worker: Worker = {
-  subscription: 'comment-mention-mail',
+  subscription: 'api.comment-mention-mail',
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
     await sendEmailToMentionedUser(con, data.commentMention, logger);

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -30,6 +30,8 @@ import cdc from './cdc';
 import sourceRequestMail from './sourceRequestMail';
 import updateMailingList from './updateMailingList';
 import deleteUserFromMailingList from './deleteUserFromMailingList';
+import commentMentionMail from './commentMentionMail';
+import { workers as notificationWorkers } from './notifications';
 
 export { Worker } from './worker';
 
@@ -65,4 +67,6 @@ export const workers: Worker[] = [
   usernameChanged,
   updateComments,
   cdc,
+  commentMentionMail,
+  ...notificationWorkers,
 ];

--- a/src/workers/notifications/articleAnalytics.ts
+++ b/src/workers/notifications/articleAnalytics.ts
@@ -1,0 +1,30 @@
+import { messageToJson } from '../worker';
+import { Post } from '../../entity';
+import { NotificationPostContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+import { uniquePostOwners } from './utils';
+
+interface Data {
+  postId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-analytics-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const post = await con
+      .getRepository(Post)
+      .findOne({ where: { id: data.postId } });
+    const users = uniquePostOwners(post);
+    if (!users.length) {
+      return;
+    }
+    const ctx: Omit<NotificationPostContext, 'userId'> = { post };
+    return users.map((userId) => ({
+      type: 'article_analytics',
+      ctx: { ...ctx, userId },
+    }));
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/articleNewCommentCommentCommented.ts
+++ b/src/workers/notifications/articleNewCommentCommentCommented.ts
@@ -1,0 +1,19 @@
+import { messageToJson } from '../worker';
+import { NotificationWorker } from './worker';
+import { articleNewCommentHandler } from './utils';
+
+interface Data {
+  userId: string;
+  childCommentId: string;
+  postId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-new-comment-notification.comment-commented',
+  handler: (message, con) => {
+    const data: Data = messageToJson(message);
+    return articleNewCommentHandler(con, data.childCommentId);
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/articleNewCommentPostCommented.ts
+++ b/src/workers/notifications/articleNewCommentPostCommented.ts
@@ -1,0 +1,19 @@
+import { messageToJson } from '../worker';
+import { NotificationWorker } from './worker';
+import { articleNewCommentHandler } from './utils';
+
+interface Data {
+  userId: string;
+  commentId: string;
+  postId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-new-comment-notification.post-commented',
+  handler: (message, con) => {
+    const data: Data = messageToJson(message);
+    return articleNewCommentHandler(con, data.commentId);
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/articlePicked.ts
+++ b/src/workers/notifications/articlePicked.ts
@@ -1,0 +1,26 @@
+import { messageToJson } from '../worker';
+import { Post } from '../../entity';
+import { NotificationPostContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+
+interface Data {
+  postId: string;
+  authorId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-picked-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const post = await con
+      .getRepository(Post)
+      .findOne({ where: { id: data.postId } });
+    const ctx: NotificationPostContext = {
+      userId: data.authorId,
+      post,
+    };
+    return [{ type: 'article_picked', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/articleReportApproved.ts
+++ b/src/workers/notifications/articleReportApproved.ts
@@ -1,0 +1,31 @@
+import { messageToJson } from '../worker';
+import { Post, PostReport } from '../../entity';
+import { NotificationPostContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+import { ChangeObject } from '../../types';
+
+interface Data {
+  post: ChangeObject<Post>;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-report-approved-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const { post } = data;
+    const reports = await con
+      .getRepository(PostReport)
+      .findBy({ postId: post.id });
+    const users = [...new Set(reports.map(({ userId }) => userId))];
+    if (!users.length) {
+      return;
+    }
+    const ctx: Omit<NotificationPostContext, 'userId'> = { post };
+    return users.map((userId) => ({
+      type: 'article_report_approved',
+      ctx: { ...ctx, userId },
+    }));
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/articleUpvoteMilestone.ts
+++ b/src/workers/notifications/articleUpvoteMilestone.ts
@@ -1,0 +1,48 @@
+import { messageToJson } from '../worker';
+import { Post, Upvote } from '../../entity';
+import {
+  NotificationPostContext,
+  NotificationUpvotersContext,
+} from '../../notifications';
+import { NotificationWorker } from './worker';
+import { uniquePostOwners, UPVOTE_MILESTONES } from './utils';
+
+interface Data {
+  userId: string;
+  postId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.article-upvote-milestone-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const post = await con
+      .getRepository(Post)
+      .findOne({ where: { id: data.postId } });
+    const users = uniquePostOwners(post, data.userId);
+    if (!users.length || !UPVOTE_MILESTONES.includes(post.upvotes)) {
+      return;
+    }
+    const upvotes = await con.getRepository(Upvote).find({
+      where: { postId: post.id },
+      take: 5,
+      order: { createdAt: 'desc' },
+      relations: ['user'],
+    });
+    const upvoters = await Promise.all(upvotes.map((upvote) => upvote.user));
+    const ctx: Omit<
+      NotificationPostContext & NotificationUpvotersContext,
+      'userId'
+    > = {
+      post,
+      upvoters,
+      upvotes: post.upvotes,
+    };
+    return users.map((userId) => ({
+      type: 'article_upvote_milestone',
+      ctx: { ...ctx, userId },
+    }));
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/commentMention.ts
+++ b/src/workers/notifications/commentMention.ts
@@ -1,0 +1,34 @@
+import { messageToJson } from '../worker';
+import { Comment, CommentMention } from '../../entity';
+import { NotificationCommenterContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+import { ChangeObject } from '../../types';
+
+interface Data {
+  commentMention: ChangeObject<CommentMention>;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.comment-mention-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const comment = await con.getRepository(Comment).findOne({
+      where: { id: data.commentMention.commentId },
+      relations: ['post', 'user'],
+    });
+    if (!comment) {
+      return;
+    }
+    const post = await comment.post;
+    const commenter = await comment.user;
+    const ctx: NotificationCommenterContext = {
+      userId: data.commentMention.mentionedUserId,
+      post,
+      commenter,
+      comment,
+    };
+    return [{ type: 'comment_mention', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/commentReply.ts
+++ b/src/workers/notifications/commentReply.ts
@@ -1,0 +1,55 @@
+import { messageToJson } from '../worker';
+import { Comment } from '../../entity';
+import { NotificationCommenterContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+
+interface Data {
+  userId: string;
+  childCommentId: string;
+  postId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.comment-reply-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const comment = await con.getRepository(Comment).findOne({
+      where: { id: data.childCommentId },
+      relations: ['post', 'parent', 'user'],
+    });
+    if (!comment) {
+      return;
+    }
+    const parent = await comment.parent;
+    const post = await comment.post;
+    const commenter = await comment.user;
+    const threadFollowers = await con
+      .getRepository(Comment)
+      .createQueryBuilder()
+      .select('"userId"')
+      .distinct(true)
+      .where('"parentId" = :parentId', { parentId: parent.id })
+      .andWhere('"userId" not in (:...exclude)', {
+        exclude: [
+          parent.userId,
+          comment.userId,
+          post.authorId ?? '',
+          post.scoutId ?? '',
+        ],
+      })
+      .getRawMany();
+    const ctx: Omit<NotificationCommenterContext, 'userId'> = {
+      post,
+      comment,
+      commenter,
+    };
+    return [parent.userId, ...threadFollowers.map(({ userId }) => userId)].map(
+      (userId) => ({
+        type: 'comment_reply',
+        ctx: { ...ctx, userId },
+      }),
+    );
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/commentUpvoteMilestone.ts
+++ b/src/workers/notifications/commentUpvoteMilestone.ts
@@ -1,0 +1,47 @@
+import { messageToJson } from '../worker';
+import { Comment, CommentUpvote } from '../../entity';
+import {
+  NotificationCommentContext,
+  NotificationUpvotersContext,
+} from '../../notifications';
+import { NotificationWorker } from './worker';
+import { UPVOTE_MILESTONES } from './utils';
+
+interface Data {
+  userId: string;
+  commentId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.comment-upvote-milestone-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const comment = await con
+      .getRepository(Comment)
+      .findOne({ where: { id: data.commentId }, relations: ['post'] });
+    if (
+      comment.userId === data.userId ||
+      !UPVOTE_MILESTONES.includes(comment.upvotes)
+    ) {
+      return;
+    }
+    const upvotes = await con.getRepository(CommentUpvote).find({
+      where: { commentId: comment.id },
+      take: 5,
+      order: { createdAt: 'desc' },
+      relations: ['user'],
+    });
+    const post = await comment.post;
+    const upvoters = await Promise.all(upvotes.map((upvote) => upvote.user));
+    const ctx: NotificationCommentContext & NotificationUpvotersContext = {
+      post,
+      comment,
+      upvoters,
+      upvotes: comment.upvotes,
+      userId: comment.userId,
+    };
+    return [{ type: 'comment_upvote_milestone', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/communityPicksFailed.ts
+++ b/src/workers/notifications/communityPicksFailed.ts
@@ -1,0 +1,21 @@
+import { messageToJson } from '../worker';
+import { Submission } from '../../entity';
+import { NotificationSubmissionContext } from '../../notifications';
+import { ChangeObject } from '../../types';
+import { NotificationWorker } from './worker';
+
+type Data = ChangeObject<Submission>;
+
+const worker: NotificationWorker = {
+  subscription: 'api.community-picks-failed-notification',
+  handler: async (message) => {
+    const data: Data = messageToJson(message);
+    const ctx: NotificationSubmissionContext = {
+      userId: data.userId,
+      submission: data,
+    };
+    return [{ type: 'community_picks_failed', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/communityPicksGranted.ts
+++ b/src/workers/notifications/communityPicksGranted.ts
@@ -1,0 +1,20 @@
+import { messageToJson } from '../worker';
+import { NotificationBaseContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+
+interface Data {
+  userId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.community-picks-granted-notification',
+  handler: async (message) => {
+    const data: Data = messageToJson(message);
+    const ctx: NotificationBaseContext = {
+      userId: data.userId,
+    };
+    return [{ type: 'community_picks_granted', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/communityPicksSucceeded.ts
+++ b/src/workers/notifications/communityPicksSucceeded.ts
@@ -1,0 +1,26 @@
+import { messageToJson } from '../worker';
+import { Post } from '../../entity';
+import { NotificationPostContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+
+interface Data {
+  postId: string;
+  scoutId: string;
+}
+
+const worker: NotificationWorker = {
+  subscription: 'api.community-picks-succeeded-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const post = await con
+      .getRepository(Post)
+      .findOne({ where: { id: data.postId } });
+    const ctx: NotificationPostContext = {
+      userId: data.scoutId,
+      post,
+    };
+    return [{ type: 'community_picks_succeeded', ctx }];
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -1,0 +1,55 @@
+import { NotificationWorker } from './worker';
+import { Worker } from '../worker';
+import {
+  generateNotification,
+  storeNotificationBundle,
+} from '../../notifications';
+import communityPicksFailed from './communityPicksFailed';
+import communityPicksSucceeded from './communityPicksSucceeded';
+import communityPicksGranted from './communityPicksGranted';
+import articlePicked from './articlePicked';
+import articleNewCommentPostCommented from './articleNewCommentPostCommented';
+import articleNewCommentCommentCommented from './articleNewCommentCommentCommented';
+import articleUpvoteMilestone from './articleUpvoteMilestone';
+import articleReportApproved from './articleReportApproved';
+import articleAnalytics from './articleAnalytics';
+import sourceRequest from './sourceRequest';
+import commentMention from './commentMention';
+import commentReply from './commentReply';
+import commentUpvoteMilestone from './commentUpvoteMilestone';
+
+function notificationWorkerToWorker(worker: NotificationWorker): Worker {
+  return {
+    ...worker,
+    handler: async (message, con, logger) => {
+      const args = await worker.handler(message, con, logger);
+      if (!args) {
+        return;
+      }
+      const bundles = args.map(({ type, ctx }) =>
+        generateNotification(type, ctx),
+      );
+      await con.transaction((entityManager) =>
+        storeNotificationBundle(entityManager, bundles),
+      );
+    },
+  };
+}
+
+const notificationWorkers: NotificationWorker[] = [
+  communityPicksFailed,
+  communityPicksSucceeded,
+  communityPicksGranted,
+  articlePicked,
+  articleNewCommentPostCommented,
+  articleNewCommentCommentCommented,
+  articleUpvoteMilestone,
+  articleReportApproved,
+  articleAnalytics,
+  sourceRequest,
+  commentMention,
+  commentReply,
+  commentUpvoteMilestone,
+];
+
+export const workers = notificationWorkers.map(notificationWorkerToWorker);

--- a/src/workers/notifications/sourceRequest.ts
+++ b/src/workers/notifications/sourceRequest.ts
@@ -1,0 +1,38 @@
+import { messageToJson } from '../worker';
+import { Source, SourceRequest } from '../../entity';
+import { NotificationSourceRequestContext } from '../../notifications';
+import { NotificationWorker } from './worker';
+import { NotificationReason } from '../../common';
+import { ChangeObject } from '../../types';
+
+type Data = {
+  reason: NotificationReason;
+  sourceRequest: ChangeObject<SourceRequest>;
+};
+
+const worker: NotificationWorker = {
+  subscription: 'api.source-request-notification',
+  handler: async (message, con) => {
+    const data: Data = messageToJson(message);
+    const ctx: NotificationSourceRequestContext = {
+      userId: data.sourceRequest.userId,
+      sourceRequest: data.sourceRequest,
+    };
+    switch (data.reason) {
+      case NotificationReason.Publish: {
+        const source = await con
+          .getRepository(Source)
+          .findOneBy({ id: data.sourceRequest.sourceId });
+        return [{ type: 'source_approved', ctx: { ...ctx, source } }];
+      }
+      case NotificationReason.Decline:
+      case NotificationReason.Exists: {
+        return [{ type: 'source_rejected', ctx }];
+      }
+      default:
+        return null;
+    }
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -1,0 +1,42 @@
+import { NotificationHandlerReturn } from './worker';
+import { Comment, Post } from '../../entity';
+import { NotificationCommenterContext } from '../../notifications';
+import { DataSource } from 'typeorm';
+
+export const uniquePostOwners = (post: Post, exclude?: string): string[] =>
+  [...new Set([post.scoutId, post.authorId])].filter(
+    (userId) => userId && userId !== exclude,
+  );
+
+export async function articleNewCommentHandler(
+  con: DataSource,
+  commentId: string,
+): Promise<NotificationHandlerReturn> {
+  const comment = await con
+    .getRepository(Comment)
+    .findOne({ where: { id: commentId }, relations: ['post', 'user'] });
+  if (!comment) {
+    return;
+  }
+  const post = await comment.post;
+  // Get unique user id which are not the author of the comment
+  const users = uniquePostOwners(post, comment.userId);
+  if (!users.length) {
+    return;
+  }
+
+  const commenter = await comment.user;
+  const ctx: Omit<NotificationCommenterContext, 'userId'> = {
+    post,
+    commenter,
+    comment,
+  };
+  return users.map((userId) => ({
+    type: 'article_new_comment',
+    ctx: { ...ctx, userId },
+  }));
+}
+
+export const UPVOTE_MILESTONES = [
+  1, 2, 3, 4, 5, 10, 20, 50, 100, 200, 500, 1000, 1250, 1500, 5000, 7500, 10000,
+];

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -38,5 +38,5 @@ export async function articleNewCommentHandler(
 }
 
 export const UPVOTE_MILESTONES = [
-  1, 2, 3, 4, 5, 10, 20, 50, 100, 200, 500, 1000, 1250, 1500, 5000, 7500, 10000,
+  1, 3, 5, 10, 20, 50, 100, 200, 500, 1000, 1250, 1500, 5000, 7500, 10000,
 ];

--- a/src/workers/notifications/worker.ts
+++ b/src/workers/notifications/worker.ts
@@ -1,0 +1,20 @@
+import { DataSource } from 'typeorm';
+import { FastifyLoggerInstance } from 'fastify';
+import { Message } from '../worker';
+import { NotificationType } from '../../entity';
+import { NotificationBaseContext } from '../../notifications';
+
+export type NotificationHandlerReturn = {
+  type: NotificationType;
+  ctx: NotificationBaseContext;
+}[];
+
+export interface NotificationWorker {
+  subscription: string;
+  handler: (
+    message: Message,
+    con: DataSource,
+    logger: FastifyLoggerInstance,
+  ) => Promise<NotificationHandlerReturn>;
+  maxMessages?: number;
+}


### PR DESCRIPTION
Generate all supported notifications using background workers.
This PR introduces new concepts:
* `NotificationWorker` - Lightweight variation of our good old `Worker` that its sole purpose is to generate notifications. It returns an array of notification types to generate along with their relevant context (parameters).
* `NotificationBuilder` - To make it easy to build new notification types, the builder has pre-built functions for common use cases, and everything is chainable to make it more readable.
* `NotificationBaseContext` - Used to store all the parameters a single notification needs in order to be generated completely. This type has inherited types that makes it flexible to provide only the needed parameters per type.

The `generateNotificationMap` object holds a map that using the `NotificationBuilder` it constructs the notification object that later on can be stored.

The storage mechanism is exactly-once, meaning that if for some reason pub/sub decided to replay the message (which can happen), we will still save it only once and there will be no notification spam. 

It's a huge PR, I suggest starting with the notifications folder as it contains all the fundamental stuff and then you can review the new workers.

WT-786 #done