### PR TITLE
feat: notification email preference

### DIFF
--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -48,6 +48,7 @@ Object {
   "image": "https://daily.dev/ido.jpg",
   "infoConfirmed": false,
   "name": "Ido",
+  "notificationEmail": true,
   "permalink": "http://localhost:5002/a1",
   "timezone": "Asia/Manila",
   "twitter": null,

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1502,6 +1502,7 @@ describe('mutation updateUserProfile', () => {
         hashnode
         createdAt
         infoConfirmed
+        notificationEmail
         timezone
       }
     }
@@ -1643,6 +1644,23 @@ describe('mutation updateUserProfile', () => {
     expect(res.errors?.length).toBeFalsy();
     const updatedUser = await repo.findOneBy({ id: loggedUser });
     expect(updatedUser?.email).toEqual(email);
+  });
+
+  it('should update notification email preference', async () => {
+    loggedUser = '1';
+
+    const repo = con.getRepository(User);
+    const user = await repo.findOneBy({ id: loggedUser });
+    expect(user?.notificationEmail).toBeTruthy();
+    const notificationEmail = false;
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        data: { username: 'sample', name: 'test', notificationEmail },
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const updatedUser = await repo.findOneBy({ id: loggedUser });
+    expect(updatedUser?.notificationEmail).toEqual(notificationEmail);
   });
 
   it('should not update if username is empty', async () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -114,6 +114,7 @@ const defaultUser: ChangeObject<User> = {
   username: 'idoshamun',
   infoConfirmed: true,
   acceptedMarketing: true,
+  notificationEmail: true,
 };
 
 describe('source request', () => {

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -40,6 +40,9 @@ export class User {
   @Column({ default: false })
   acceptedMarketing: boolean;
 
+  @Column({ default: true })
+  notificationEmail: boolean;
+
   @Column({ default: 10 })
   reputation: number;
 

--- a/src/migration/1671161744023-EmailNotificationPreference.ts
+++ b/src/migration/1671161744023-EmailNotificationPreference.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EmailNotificationPreference1671161744023
+  implements MigrationInterface
+{
+  name = 'EmailNotificationPreference1671161744023';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "notificationEmail" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP COLUMN "notificationEmail"`,
+    );
+  }
+}

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -48,6 +48,7 @@ export interface GQLUpdateUserInput {
   hashnode?: string;
   portfolio?: string;
   acceptedMarketing?: boolean;
+  notificationEmail?: boolean;
   infoConfirmed?: boolean;
 }
 
@@ -69,6 +70,7 @@ export interface GQLUser {
   hashnode?: string;
   portfolio?: string;
   reputation?: number;
+  notificationEmail?: boolean;
   timezone?: string;
 }
 
@@ -187,6 +189,10 @@ export const typeDefs = /* GraphQL */ `
     If the user has accepted marketing
     """
     acceptedMarketing: Boolean
+    """
+    If the user should receive email for notifications
+    """
+    notificationEmail: Boolean
   }
 
   """
@@ -245,6 +251,10 @@ export const typeDefs = /* GraphQL */ `
     If the user has accepted marketing
     """
     acceptedMarketing: Boolean
+    """
+    If the user should receive email for notifications
+    """
+    notificationEmail: Boolean
     """
     If the user's info is confirmed
     """

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -268,7 +268,7 @@ const worker: Worker = {
       getNotificationAndChildren(con, id),
       con.getRepository(User).findOneBy({ id: userId }),
     ]);
-    if (!user?.email || !notification) {
+    if (!user?.email || !user?.notificationEmail || !notification) {
       return;
     }
     const templateData = await notificationToTemplateData[notification.type](


### PR DESCRIPTION
As discussed, to keep things simple, we will include the notification email preference in the user's table than creating a new one.

We will then create a separate table once we decide to implement a more granular control of the notification preference.