### PR TITLE
fix: allow partial user profile update when profile is confirmed

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1675,12 +1675,26 @@ describe('mutation updateUserProfile', () => {
 
   it('should not update if name is empty', async () => {
     loggedUser = '1';
+    await con.getRepository(User).update({ id: loggedUser }, { name: null });
 
     await testMutationErrorCode(
       client,
       { mutation: MUTATION, variables: { data: { username: 'u1' } } },
       'GRAPHQL_VALIDATION_FAILED',
     );
+  });
+
+  it('should update if name is already set but not provided', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(User)
+      .update({ id: loggedUser }, { username: 'handle' });
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        data: { acceptedMarketing: true },
+      },
+    });
+    expect(res.errors).toBeFalsy();
   });
 
   it('should not update user profile if email exists', async () => {

--- a/__tests__/workers/newNotificationRealTime.ts
+++ b/__tests__/workers/newNotificationRealTime.ts
@@ -129,6 +129,7 @@ it('should publish an event to redis', async () => {
     await expectSuccessfulBackground(worker, {
       notification: {
         id,
+        public: true,
       },
     });
   });

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -762,8 +762,13 @@ export const resolvers: IResolvers<any, Context> = {
       });
 
       const regexParams: ValidateRegex[] = [
-        ['name', data.name, new RegExp(/^(.*){1,60}$/), true],
-        ['username', data.username, new RegExp(/^@?(\w){1,39}$/), true],
+        ['name', data.name, new RegExp(/^(.*){1,60}$/), !user.name],
+        [
+          'username',
+          data.username,
+          new RegExp(/^@?(\w){1,39}$/),
+          !user.username,
+        ],
         ['github', data.github, new RegExp(/^@?([\w-]){1,39}$/i)],
         ['twitter', data.twitter, new RegExp(/^@?(\w){1,15}$/)],
         ['hashnode', data.hashnode, new RegExp(/^@?([\w-]){1,39}$/i)],


### PR DESCRIPTION
Users are not able to update their community newsletter setting because the mutation is too strict. I loosen it a bit to allow partial update if the profile is already confirmed.