### PR TITLE
feat: do not send push notif to connected users

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -227,7 +227,7 @@ const [apps] = deployApplicationSuite(
           ],
     },
     debezium: {
-      version: '1.9',
+      version: isAdhocEnv ? '2.0' : '1.9',
       topicName: debeziumTopicName,
       propsPath: './application.properties',
       propsVars: {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -135,7 +135,7 @@ export const testMutationErrorCode = async (
 ): Promise<void> =>
   testMutationError(client, mutation, (errors) => {
     expect(errors.length).toEqual(1);
-    expect(errors[0].extensions.code).toEqual(code);
+    expect(errors[0].extensions?.code).toEqual(code);
   });
 
 export type Query = {

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1268,7 +1268,7 @@ describe('mutation generateDevCard', () => {
 
   it('should not validate passed url', () => {
     loggedUser = '1';
-    testMutationErrorCode(
+    return testMutationErrorCode(
       client,
       {
         mutation: MUTATION,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import fastify, { FastifyRequest, FastifyInstance } from 'fastify';
 import helmet from '@fastify/helmet';
 import cors from '@fastify/cors';
-import mercurius, { MercuriusCommonOptions, MercuriusError } from 'mercurius';
+import mercurius, { MercuriusError } from 'mercurius';
 import MercuriusGQLUpload from 'mercurius-upload';
 import MercuriusCache from 'mercurius-cache';
 import { NoSchemaIntrospectionCustomRule } from 'graphql';
@@ -11,16 +11,16 @@ import { NoSchemaIntrospectionCustomRule } from 'graphql';
 import './config';
 
 import trace from './trace';
-import auth, { verifyJwt } from './auth';
+import auth from './auth';
 import compatibility from './compatibility';
 import routes from './routes';
-import { Context, SubscriptionContext } from './Context';
+import { Context } from './Context';
 import { schema } from './graphql';
 import createOrGetConnection from './db';
 import { stringifyHealthCheck } from './common';
 import { GraphQLError } from 'graphql';
 import cookie, { FastifyCookieOptions } from '@fastify/cookie';
-import { DataSource } from 'typeorm';
+import { getSubscriptionSettings } from './subscription';
 
 type Mutable<Type> = {
   -readonly [Key in keyof Type]: Type[Key];
@@ -38,32 +38,6 @@ const trackingExtendKey = (
   ctx: Context,
 ): string | undefined =>
   ctx.trackingId ? `tracking:${ctx.trackingId}` : undefined;
-
-const getSubscriptionSettings = (
-  connection: DataSource,
-): MercuriusCommonOptions['subscription'] | undefined => {
-  if (process.env.ENABLE_SUBSCRIPTIONS) {
-    return {
-      context: (wsConnection, request): Omit<SubscriptionContext, 'userId'> => {
-        return { req: request, con: connection, log: request.log };
-      },
-      onConnect: async ({
-        payload,
-      }): Promise<Pick<SubscriptionContext, 'userId'> | boolean> => {
-        try {
-          if (payload?.token) {
-            const jwtPayload = await verifyJwt(payload?.token);
-            return { userId: jwtPayload.userId };
-          }
-        } catch (err) {
-          // JWT is invalid
-        }
-        return true;
-      },
-    };
-  }
-  return undefined;
-};
 
 export default async function app(
   contextFn?: (request: FastifyRequest) => Context,

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -1,0 +1,62 @@
+import { DataSource } from 'typeorm';
+import { MercuriusCommonOptions } from 'mercurius';
+import { SubscriptionContext } from './Context';
+import { verifyJwt } from './auth';
+import { ioRedisPool } from './redis';
+
+const getKey = (userId: string) => `connected:${userId}`;
+
+const ONE_HOUR_SECONDS = 60 * 60;
+const DEFAULT_VALUE = '1';
+
+export const cacheConnectedUser = async (userId: string): Promise<void> => {
+  await ioRedisPool.execute((client) =>
+    client.set(getKey(userId), DEFAULT_VALUE, 'EX', ONE_HOUR_SECONDS),
+  );
+};
+
+export const clearCacheForConnectedUser = async (
+  userId: string,
+): Promise<void> => {
+  await ioRedisPool.execute((client) => client.del(getKey(userId)));
+};
+
+export const isUserConnected = async (userId: string): Promise<boolean> => {
+  const val = await ioRedisPool.execute((client) => client.get(getKey(userId)));
+  return val === DEFAULT_VALUE;
+};
+
+export const getSubscriptionSettings = (
+  connection: DataSource,
+): MercuriusCommonOptions['subscription'] | undefined => {
+  if (process.env.ENABLE_SUBSCRIPTIONS) {
+    return {
+      context: (wsConnection, request): Omit<SubscriptionContext, 'userId'> => {
+        return { req: request, con: connection, log: request.log };
+      },
+      onConnect: async ({
+        payload,
+      }): Promise<Pick<SubscriptionContext, 'userId'> | boolean> => {
+        try {
+          if (payload?.token) {
+            const jwtPayload = await verifyJwt(payload?.token);
+            const userId = jwtPayload.userId;
+            // Don't block connection for caching
+            cacheConnectedUser(userId);
+            return { userId };
+          }
+        } catch (err) {
+          // JWT is invalid
+        }
+        return true;
+      },
+      onDisconnect: async (mercuriusCtx) => {
+        const ctx = mercuriusCtx as unknown as SubscriptionContext;
+        if (ctx.userId) {
+          await clearCacheForConnectedUser(ctx.userId);
+        }
+      },
+    };
+  }
+  return undefined;
+};

--- a/src/workers/newNotificationPush.ts
+++ b/src/workers/newNotificationPush.ts
@@ -2,6 +2,7 @@ import { messageToJson, Worker } from './worker';
 import { ChangeObject } from '../types';
 import { Notification } from '../entity';
 import { sendPushNotification } from '../onesignal';
+import { isUserConnected } from '../subscription';
 
 interface Data {
   notification: ChangeObject<Notification>;
@@ -12,7 +13,11 @@ const worker: Worker = {
   handler: async (message): Promise<void> => {
     const { notification }: Data = messageToJson(message);
     if (notification.public) {
-      await sendPushNotification(notification);
+      const isConnected = isUserConnected(notification.userId);
+      // Don't send push when user is connected
+      if (!isConnected) {
+        await sendPushNotification(notification);
+      }
     }
   },
 };


### PR DESCRIPTION
Use Redis to keep a list of connected users to our gql subscription. Using this list we decide whether to send a push notif or not.