### PR TITLE
feat: more squad queries and mutations

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -249,6 +249,7 @@ describe('generateNotification', () => {
         id: 's1',
         name: 'Source',
         image: 'https://daily.dev/s1.jpg',
+        handle: 's1',
       } as Reference<Source>,
       sourceRequest: {
         id: 'sr1',

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -560,7 +560,7 @@ describe('mutation joinSource', () => {
     await con.getRepository(SourceMember).save({
       sourceId: 's1',
       userId: '2',
-      referralToken: 'rt',
+      referralToken: 'rt2',
       role: SourceMemberRoles.Member,
     });
   });
@@ -592,7 +592,7 @@ describe('mutation joinSource', () => {
     const res = await client.mutate(MUTATION, {
       variables: {
         ...variables,
-        token: 'rt',
+        token: 'rt2',
       },
     });
     expect(res.errors).toBeFalsy();
@@ -620,7 +620,7 @@ describe('mutation joinSource', () => {
         mutation: MUTATION,
         variables: {
           ...variables,
-          token: 'rt2',
+          token: 'rt3',
         },
       },
       'FORBIDDEN',

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -68,7 +68,7 @@ beforeEach(async () => {
       userId: '1',
       sourceId: 'a',
       role: SourceMemberRoles.Owner,
-      referralToken: randomUUID(),
+      referralToken: 'rt',
       createdAt: new Date(2022, 11, 19),
     },
     {
@@ -227,6 +227,14 @@ query Source($id: ID!) {
     expect(res.errors).toBeFalsy();
     expect(res.data.source.id).toEqual('a');
   });
+
+  it('should return source by handle', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { handle: 'handle' });
+    const res = await client.query(QUERY, { variables: { id: 'handle' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.id).toEqual('a');
+  });
 });
 
 describe('members field', () => {
@@ -263,6 +271,32 @@ query Source($id: ID!) {
     const res = await client.query(QUERY, { variables: { id: 'a' } });
     expect(res.errors).toBeFalsy();
     expect(res.data.source.members).toMatchSnapshot();
+  });
+});
+
+describe('permalink field', () => {
+  const QUERY = `
+query Source($id: ID!) {
+  source(id: $id) {
+    permalink
+  }
+}
+  `;
+
+  it('should return source url', async () => {
+    const res = await client.query(QUERY, { variables: { id: 'a' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.permalink).toEqual(
+      'http://localhost:5002/sources/a',
+    );
+  });
+
+  it('should return source members for private source when the user is a member', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { type: 'squad' });
+    const res = await client.query(QUERY, { variables: { id: 'a' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.permalink).toEqual('http://localhost:5002/squads/a');
   });
 });
 
@@ -342,6 +376,34 @@ query SourceMemberships {
     const res = await client.query(QUERY);
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('query sourceMemberByToken', () => {
+  const QUERY = `
+query SourceMemberByToken($token: String!) {
+  sourceMemberByToken(token: $token) {
+    user { id }
+    source { id }
+  }
+}
+  `;
+
+  it('should throw not found exception', () =>
+    testQueryErrorCode(
+      client,
+      {
+        query: QUERY,
+        variables: { token: 'notfound' },
+      },
+      'NOT_FOUND',
+    ));
+
+  it('should return source member', async () => {
+    const res = await client.query(QUERY, { variables: { token: 'rt' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.sourceMemberByToken.user.id).toEqual('1');
+    expect(res.data.sourceMemberByToken.source.id).toEqual('a');
   });
 });
 

--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -1,3 +1,5 @@
+import { Source } from '../entity';
+
 const excludeFromStandardization = [
   'youtube.com',
   'developer.apple.com',
@@ -20,8 +22,12 @@ export const getDiscussionLink = (postId: string, commentId = ''): string =>
     commentId && `#c-${commentId}`
   }`;
 
-export const getSourceLink = (sourceId: string): string =>
-  `${process.env.COMMENTS_PREFIX}/sources/${sourceId}`;
+export const getSourceLink = (
+  source: Pick<Source, 'handle' | 'type'>,
+): string =>
+  `${process.env.COMMENTS_PREFIX}/${
+    source.type === 'squad' ? 'squads' : 'sources'
+  }/${source.handle}`;
 
 export const scoutArticleLink = `${process.env.COMMENTS_PREFIX}?scout=true`;
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -34,11 +34,18 @@ const obj = new GraphORM({
     requiredColumns: ['id', 'username'],
     fields: {
       infoConfirmed: {
-        select: 'infoConfirmed',
         transform: nullIfNotSameUser,
       },
       email: {
-        select: 'email',
+        transform: nullIfNotSameUser,
+      },
+      timezone: {
+        transform: nullIfNotSameUser,
+      },
+      acceptedMarketing: {
+        transform: nullIfNotSameUser,
+      },
+      notificationEmail: {
         transform: nullIfNotSameUser,
       },
     },
@@ -130,10 +137,9 @@ const obj = new GraphORM({
     },
   },
   Source: {
-    requiredColumns: ['id', 'private'],
+    requiredColumns: ['id', 'private', 'handle', 'type'],
     fields: {
       public: {
-        select: 'private',
         transform: (value: boolean): boolean => !value,
       },
       members: {

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -121,7 +121,7 @@ export class NotificationBuilder {
 
   targetSource(source: Reference<Source>): NotificationBuilder {
     return this.enrichNotification({
-      targetUrl: getSourceLink(source.id),
+      targetUrl: getSourceLink(source),
     });
   }
 
@@ -143,7 +143,7 @@ export class NotificationBuilder {
       referenceId: source.id,
       image: source.image,
       name: source.name,
-      targetUrl: getSourceLink(source.id),
+      targetUrl: getSourceLink(source),
     });
     return this;
   }


### PR DESCRIPTION
* Add `permalink` field to `Source`
* Add `viewPost` mutation to generate view event for non-article posts
* Add `sourceMemberByToken` query for the invitation page