### PR TITLE
fix: proper permissions enforcement

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -167,6 +167,19 @@ describe('query postComments', () => {
     ]);
   });
 
+  it('should throw error when user cannot access the post', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    return testQueryErrorCode(
+      client,
+      {
+        query: QUERY,
+        variables: { postId: 'p1' },
+      },
+      'FORBIDDEN',
+    );
+  });
+
   it('should fetch comments and sub-comments of a post', async () => {
     const res = await client.query(QUERY, { variables: { postId: 'p1' } });
     expect(res.errors).toBeFalsy();
@@ -216,6 +229,19 @@ describe('query commentUpvotes', () => {
     }
   }
   `;
+
+  it('should throw error when user cannot access the post', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    return testQueryErrorCode(
+      client,
+      {
+        query: QUERY,
+        variables: { id: 'c1' },
+      },
+      'FORBIDDEN',
+    );
+  });
 
   it('should return users that upvoted the comment by id in descending order', async () => {
     const commentUpvoteRepo = con.getRepository(CommentUpvote);
@@ -435,6 +461,19 @@ describe('mutation commentOnPost', () => {
   }
 }`;
 
+  it('should throw error when user cannot access the post', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { postId: 'p1', content: 'comment' },
+      },
+      'FORBIDDEN',
+    );
+  });
+
   it('should not allow comment if content is empty string', () => {
     loggedUser = '1';
 
@@ -631,6 +670,22 @@ describe('mutation commentOnComment', () => {
     );
   });
 
+  it('should throw error when user cannot access the post', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          content: '# my comment http://daily.dev',
+          commentId: 'c1',
+        },
+      },
+      'FORBIDDEN',
+    );
+  });
+
   it('should comment on a comment', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, {
@@ -756,6 +811,19 @@ describe('mutation upvoteComment', () => {
         variables: { id: 'c1' },
       },
       'NOT_FOUND',
+    );
+  });
+
+  it('should throw error when user cannot access the post', async () => {
+    loggedUser = '1';
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { id: 'c1' },
+      },
+      'FORBIDDEN',
     );
   });
 

--- a/__tests__/compatibility.ts
+++ b/__tests__/compatibility.ts
@@ -6,7 +6,13 @@ import {
   MockContext,
   saveFixtures,
 } from './helpers';
-import { ArticlePost, Bookmark, PostKeyword, Source } from '../src/entity';
+import {
+  ArticlePost,
+  Bookmark,
+  Post,
+  PostKeyword,
+  Source,
+} from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { postKeywordsFixture, postsFixture } from './fixture/post';
 import { DataSource } from 'typeorm';
@@ -76,6 +82,7 @@ describe('query latest', () => {
   }`;
 
   it('should return anonymous feed with no filters ordered by popularity', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     const latest = new Date().toISOString();
     const res = await client.query(QUERY, {
       variables: { params: { latest } },
@@ -84,6 +91,7 @@ describe('query latest', () => {
   });
 
   it('should return anonymous feed with no filters ordered by time', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     const latest = new Date().toISOString();
     const res = await client.query(QUERY, {
       variables: { params: { latest, sortBy: 'creation' } },

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -282,11 +282,13 @@ describe('query anonymousFeed', () => {
 `;
 
   it('should return anonymous feed with no filters ordered by popularity', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     const res = await client.query(QUERY, { variables });
     expect(res.data).toMatchSnapshot();
   });
 
   it('should return anonymous feed with no filters ordered by time', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     const res = await client.query(QUERY, {
       variables: { ...variables, ranking: Ranking.TIME },
     });
@@ -309,6 +311,7 @@ describe('query anonymousFeed', () => {
   });
 
   it('should return anonymous feed while excluding sources', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     const res = await client.query(QUERY, {
       variables: { ...variables, filters: { excludeSources: ['a'] } },
     });
@@ -316,6 +319,7 @@ describe('query anonymousFeed', () => {
   });
 
   it('should return feed while excluding sources based on advanced settings', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveAdvancedSettingsFiltersFixtures();
     mockFeatures();
     const filters = await feedToFilters(con, '1', '1');
@@ -339,6 +343,7 @@ describe('query anonymousFeed', () => {
   });
 
   it('should remove banned posts from the feed', async () => {
+    await con.getRepository(Post).delete({ id: 'p6' });
     await con.getRepository(Post).update({ id: 'p5' }, { banned: true });
     mockFeatures();
     const res = await client.query(QUERY, { variables });
@@ -438,6 +443,7 @@ describe('query feed', () => {
 
   it('should return preconfigured feed with blocked tags filters only', async () => {
     loggedUser = '1';
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
     await saveFixtures(con, FeedTag, [
       { feedId: '1', tag: 'html', blocked: true },
@@ -461,6 +467,7 @@ describe('query feed', () => {
 
   it('should return preconfigured feed with sources filters only', async () => {
     loggedUser = '1';
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
     await saveFixtures(con, FeedSource, [{ feedId: '1', sourceId: 'a' }]);
     mockFeatures();
@@ -470,6 +477,7 @@ describe('query feed', () => {
 
   it('should return preconfigured feed with sources filtered based on advanced settings', async () => {
     loggedUser = '1';
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveAdvancedSettingsFiltersFixtures();
     mockFeatures();
     const res = await client.query(QUERY, { variables });
@@ -478,6 +486,7 @@ describe('query feed', () => {
 
   it('should return preconfigured feed with no filters', async () => {
     loggedUser = '1';
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
     mockFeatures();
     const res = await client.query(QUERY, { variables });
@@ -486,6 +495,7 @@ describe('query feed', () => {
 
   it('should return unread posts from preconfigured feed', async () => {
     loggedUser = '1';
+    await con.getRepository(Post).delete({ id: 'p6' });
     await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
     await con.getRepository(View).save([{ userId: '1', postId: 'p1' }]);
     mockFeatures();
@@ -1302,6 +1312,7 @@ describe('mutation removeFiltersFromFeed', () => {
 describe('compatibility routes', () => {
   describe('GET /posts/latest', () => {
     it('should return anonymous feed with no filters ordered by popularity', async () => {
+      await con.getRepository(Post).delete({ id: 'p6' });
       const res = await request(app.server)
         .get('/v1/posts/latest')
         .query({ latest: new Date(), pageSize: 2, page: 0 })

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -313,14 +313,16 @@ export const canAccessSource = async (
 
 export const ensureSourcePermissions = async (
   ctx: Context,
-  sourceId: string,
+  sourceId: string | undefined,
   permission = SourcePermissions.View,
 ): Promise<Source> => {
-  const source = await ctx.con
-    .getRepository(Source)
-    .findOneByOrFail([{ id: sourceId }, { handle: sourceId }]);
-  if (await canAccessSource(ctx, source, permission)) {
-    return source;
+  if (sourceId) {
+    const source = await ctx.con
+      .getRepository(Source)
+      .findOneByOrFail([{ id: sourceId }, { handle: sourceId }]);
+    if (await canAccessSource(ctx, source, permission)) {
+      return source;
+    }
   }
   throw new ForbiddenError('Access denied!');
 };


### PR DESCRIPTION
Limit the ability of users to comment/upvote/fetch data of posts that they cannot access. 
This might impact the performance of some pages, so we should keep it in mind.