### PR TITLE
feat: add members count field to source

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -291,12 +291,29 @@ query Source($id: ID!) {
     );
   });
 
-  it('should return source members for private source when the user is a member', async () => {
+  it('should return squad url', async () => {
     loggedUser = '1';
     await con.getRepository(Source).update({ id: 'a' }, { type: 'squad' });
     const res = await client.query(QUERY, { variables: { id: 'a' } });
     expect(res.errors).toBeFalsy();
     expect(res.data.source.permalink).toEqual('http://localhost:5002/squads/a');
+  });
+});
+
+describe('membersCount field', () => {
+  const QUERY = `
+query Source($id: ID!) {
+  source(id: $id) {
+    membersCount
+  }
+}
+  `;
+
+  it('should return number of members', async () => {
+    loggedUser = '1';
+    const res = await client.query(QUERY, { variables: { id: 'a' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.membersCount).toEqual(2);
   });
 });
 
@@ -451,6 +468,7 @@ describe('mutation createSquad', () => {
     expect(newSource.name).toEqual('Squad');
     expect(newSource.handle).toEqual('squad');
     expect(newSource.active).toEqual(false);
+    expect(newSource.private).toEqual(true);
     const member = await con.getRepository(SourceMember).findOneBy({
       sourceId: newId,
       userId: '1',

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -5,6 +5,7 @@ import {
   FeedSource,
   FeedTag,
   Post,
+  SourceMember,
   User,
 } from '../entity';
 import { Context } from '../Context';
@@ -157,6 +158,13 @@ const obj = new GraphORM({
           nodeToCursor: (node: GQLComment): string =>
             base64(`time:${new Date(node.createdAt).getTime()}`),
         },
+      },
+      membersCount: {
+        select: (ctx, alias, qb) =>
+          qb
+            .select('count(*)')
+            .from(SourceMember, 'sm')
+            .where(`sm."sourceId" = ${alias}.id`),
       },
     },
   },

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -112,6 +112,11 @@ export const typeDefs = /* GraphQL */ `
     URL to the source page
     """
     permalink: String!
+
+    """
+    Number of members in the source
+    """
+    membersCount: Int!
   }
 
   type SourceConnection {
@@ -533,6 +538,7 @@ export const resolvers: IResolvers<any, Context> = {
             handle,
             active: false,
             description,
+            private: true,
           });
           // Add the logged-in user as owner
           await addNewSourceMember(entityManager, {


### PR DESCRIPTION
Add new field that returns the number of members in the squad.

Also fixed an issue with creation of squad, now they are set to private by default.