### PR TITLE
feat: check handle outside of permission

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -279,28 +279,42 @@ query Source($id: ID!) {
   });
 });
 
-describe('query sourceHandleTaken', () => {
+describe('query sourceHandleExists', () => {
   const QUERY = `
-    query SourceHandleTaken($handle: String!) {
-      sourceHandleTaken(handle: $handle) 
+    query SourceHandleExists($handle: String!) {
+      sourceHandleExists(handle: $handle) 
     }
   `;
 
   const updateHandle = (handle = 'a') =>
     con.getRepository(Source).update({ id: 'a' }, { handle, private: true });
 
+  it('should not authorize when user is not logged in', () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { handle: 'a' } },
+      'UNAUTHENTICATED',
+    ));
+
   it('should return false if the source handle is not taken', async () => {
     loggedUser = '3';
     await updateHandle();
     const res = await client.query(QUERY, { variables: { handle: 'aa' } });
-    expect(res.data.sourceHandleTaken).toBeFalsy();
+    expect(res.data.sourceHandleExists).toBeFalsy();
   });
 
   it('should return true if the source handle is taken', async () => {
     loggedUser = '3';
     await updateHandle();
     const res = await client.query(QUERY, { variables: { handle: 'a' } });
-    expect(res.data.sourceHandleTaken).toBeTruthy();
+    expect(res.data.sourceHandleExists).toBeTruthy();
+  });
+
+  it('should return true if the source handle is taken considering uppercase characters', async () => {
+    loggedUser = '3';
+    await updateHandle();
+    const res = await client.query(QUERY, { variables: { handle: 'A' } });
+    expect(res.data.sourceHandleExists).toBeTruthy();
   });
 });
 

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -279,6 +279,33 @@ query Source($id: ID!) {
   });
 });
 
+describe('query sourceHandleTaken', () => {
+  const QUERY = `
+    query SourceHandleTaken($handle: String!) {
+      sourceHandleTaken(handle: $handle) 
+    }
+  `;
+
+  const updateSource = (handle = 'a') =>
+    con.getRepository(Source).update({ id: 'a' }, { handle, private: true });
+
+  it('should return false if the source handle is not taken', async () => {
+    loggedUser = '3';
+    await updateSource();
+    const res = await client.query(QUERY, { variables: { handle: 'aa' } });
+    expect(res.data.sourceHandleTaken).toBeFalsy();
+  });
+
+  it('should return true if the source handle is taken', async () => {
+    loggedUser = '3';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { handle: 'a', private: true });
+    const res = await client.query(QUERY, { variables: { handle: 'a' } });
+    expect(res.data.sourceHandleTaken).toBeTruthy();
+  });
+});
+
 describe('members field', () => {
   const QUERY = `
 query Source($id: ID!) {

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -286,21 +286,19 @@ describe('query sourceHandleTaken', () => {
     }
   `;
 
-  const updateSource = (handle = 'a') =>
+  const updateHandle = (handle = 'a') =>
     con.getRepository(Source).update({ id: 'a' }, { handle, private: true });
 
   it('should return false if the source handle is not taken', async () => {
     loggedUser = '3';
-    await updateSource();
+    await updateHandle();
     const res = await client.query(QUERY, { variables: { handle: 'aa' } });
     expect(res.data.sourceHandleTaken).toBeFalsy();
   });
 
   it('should return true if the source handle is taken', async () => {
     loggedUser = '3';
-    await con
-      .getRepository(Source)
-      .update({ id: 'a' }, { handle: 'a', private: true });
+    await updateHandle();
     const res = await client.query(QUERY, { variables: { handle: 'a' } });
     expect(res.data.sourceHandleTaken).toBeTruthy();
   });

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -239,6 +239,11 @@ export const typeDefs = /* GraphQL */ `
     Get source member by referral token
     """
     sourceMemberByToken(token: String!): SourceMember!
+
+    """
+    Check if source handle is already taken
+    """
+    sourceHandleTaken(handle: String!): Boolean!
   }
 
   extend type Mutation {
@@ -471,6 +476,11 @@ export const resolvers: IResolvers<any, Context> = {
     ): Promise<GQLSource> => {
       await ensureSourcePermissions(ctx, id);
       return getSourceById(ctx, info, id);
+    },
+    sourceHandleTaken: async (_, { handle }: { handle: string }, ctx) => {
+      const source = await ctx.getRepository(Source).findOneBy({ handle });
+
+      return !!source;
     },
     sourceMembers: async (
       _,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -480,7 +480,7 @@ export const resolvers: IResolvers<any, Context> = {
     sourceHandleExists: async (_, { handle }: { handle: string }, ctx) => {
       const source = await ctx
         .getRepository(Source)
-        .findOneBy({ handle: handle.toLocaleLowerCase() });
+        .findOneBy({ handle: handle.toLowerCase() });
 
       return !!source;
     },

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -241,9 +241,9 @@ export const typeDefs = /* GraphQL */ `
     sourceMemberByToken(token: String!): SourceMember!
 
     """
-    Check if source handle is already taken
+    Check if source handle already exists
     """
-    sourceHandleTaken(handle: String!): Boolean!
+    sourceHandleExists(handle: String!): Boolean! @auth
   }
 
   extend type Mutation {
@@ -477,8 +477,10 @@ export const resolvers: IResolvers<any, Context> = {
       await ensureSourcePermissions(ctx, id);
       return getSourceById(ctx, info, id);
     },
-    sourceHandleTaken: async (_, { handle }: { handle: string }, ctx) => {
-      const source = await ctx.getRepository(Source).findOneBy({ handle });
+    sourceHandleExists: async (_, { handle }: { handle: string }, ctx) => {
+      const source = await ctx
+        .getRepository(Source)
+        .findOneBy({ handle: handle.toLocaleLowerCase() });
 
       return !!source;
     },


### PR DESCRIPTION
To validly check whether the `handle` is available or not, we must check it outside of the user's permission. To consider the security of the information, we will only return a boolean value instead of the whole `Source` data itself as commonly done in other queries.

Relevant discussion: https://dailydotdev.slack.com/archives/C03QZBF46JC/p1674486326108479?thread_ts=1674402848.080819&cid=C03QZBF46JC