### PR TITLE
fix: redirect privacy check to inline functions

### DIFF
--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -1,5 +1,4 @@
 import {
-  BeforeInsert,
   Column,
   Entity,
   Index,
@@ -12,7 +11,6 @@ import { Source } from '../Source';
 import { PostTag } from '../PostTag';
 import { PostKeyword } from '../PostKeyword';
 import { User } from '../User';
-import createOrGetConnection from '../../db';
 
 @Entity()
 @TableInheritance({
@@ -133,13 +131,4 @@ export class Post {
 
   @Column({ default: false })
   private: boolean;
-
-  @BeforeInsert()
-  async setPrivate() {
-    const con = await createOrGetConnection();
-    const sourcePrivate = await con
-      .getRepository(Source)
-      .findOneBy({ id: this.sourceId });
-    this.private = sourcePrivate.private;
-  }
 }


### PR DESCRIPTION
Moved from the beforeInsert query to inline function.
Test cases already existing for post privacy

WT-1019 #done 