### PR TITLE
fix: only allow public posts in ws

### DIFF
--- a/__tests__/workers/postCommentedRedis.ts
+++ b/__tests__/workers/postCommentedRedis.ts
@@ -1,11 +1,12 @@
 import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/postCommentedRedis';
-import { ArticlePost, Source } from '../../src/entity';
+import { ArticlePost, Post, Source } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { redisPubSub } from '../../src/redis';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { getPostNotification } from '../../src/schema/posts';
 
 let con: DataSource;
 
@@ -38,5 +39,36 @@ it('should publish an event to redis', async () => {
       userId: '1',
       commentId: 'c1',
     });
+  });
+});
+
+it('should not publish an event to redis if post is private', async () => {
+  await con.getRepository(Post).update('p1', { private: true });
+  return new Promise<void>(async (resolve) => {
+    const subId = await redisPubSub.subscribe(
+      'events.posts.commented',
+      (value) => {
+        expect(value).toEqual(null);
+        redisPubSub.unsubscribe(subId);
+        resolve();
+      },
+    );
+    await expectSuccessfulBackground(worker, {
+      postId: 'p1',
+      userId: '1',
+      commentId: 'c1',
+    });
+  });
+});
+
+it('should not publish an event to redis if post is private', async () => {
+  await con.getRepository(Post).update('p1', { private: true });
+
+  expect(await getPostNotification(con, 'p1')).toEqual(null);
+
+  expect(await getPostNotification(con, 'p2')).toEqual({
+    id: 'p2',
+    numComments: 0,
+    numUpvotes: 0,
   });
 });

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -94,10 +94,11 @@ export const getPostNotification = async (
   con: DataSource,
   postId: string,
 ): Promise<GQLPostNotification> => {
-  const post = await con
-    .getRepository(Post)
-    .findOne({ where: { id: postId }, select: ['id', 'upvotes', 'comments'] });
-  if (!post) {
+  const post = await con.getRepository(Post).findOne({
+    where: { id: postId },
+    select: ['id', 'upvotes', 'comments', 'private'],
+  });
+  if (!post || post.private) {
     return null;
   }
   return { id: post.id, numUpvotes: post.upvotes, numComments: post.comments };


### PR DESCRIPTION
Modified the shared post retrieval to evaluate wether to even publish to `ws` stream.
The one test case is generic as it won't even get to that part, the newly introduced test is to simply ensure the functions behaviour over time.

WT-983 #done 