### PR TITLE
fix: validate handle based on regex before checking availability

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -287,6 +287,16 @@ describe('query sourceHandleExists', () => {
       'UNAUTHENTICATED',
     ));
 
+  it('should throw validation error when the handle did not pass our criteria', async () => {
+    loggedUser = '3';
+    await updateHandle();
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { handle: 'aa aa' } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should return false if the source handle is not taken', async () => {
     loggedUser = '3';
     await updateHandle();

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -22,10 +22,8 @@ type Value = string;
 type IsRequired = boolean;
 export type ValidateRegex = [Key, Value, RegExp, IsRequired?];
 
-export const validateRegex = (
-  params: ValidateRegex[],
-): Record<string, string> =>
-  params.reduce((result, [key, value, regex, isRequired]) => {
+export const validateRegex = (params: ValidateRegex[]): void => {
+  const result = params.reduce((result, [key, value, regex, isRequired]) => {
     if (isNullOrUndefined(value)) {
       return isRequired ? { ...result, [key]: `${key} is required!` } : result;
     }
@@ -34,14 +32,10 @@ export const validateRegex = (
     return isValid ? result : { ...result, [key]: `${key} is invalid!` };
   }, {});
 
+  if (Object.keys(result).length) {
+    throw new ValidationError(JSON.stringify(result));
+  }
+};
 export const nameRegex = new RegExp(/^(.){1,60}$/);
 export const handleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
 export const descriptionRegex = new RegExp(/^(.){1,250}$/);
-
-export const validateRegexOrFail = (params: ValidateRegex[]): void => {
-  const regexResult = validateRegex(params);
-
-  if (Object.keys(regexResult).length) {
-    throw new ValidationError(JSON.stringify(regexResult));
-  }
-};

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from 'apollo-server-errors';
 import { ObjectLiteral } from 'typeorm';
 
 export const mapArrayToOjbect = <T extends ObjectLiteral>(
@@ -36,3 +37,11 @@ export const validateRegex = (
 export const nameRegex = new RegExp(/^(.){1,60}$/);
 export const handleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
 export const descriptionRegex = new RegExp(/^(.){1,250}$/);
+
+export const validateRegexOrFail = (params: ValidateRegex[]): void => {
+  const regexResult = validateRegex(params);
+
+  if (Object.keys(regexResult).length) {
+    throw new ValidationError(JSON.stringify(regexResult));
+  }
+};

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -40,7 +40,6 @@ import {
   nameRegex,
   validateRegex,
   ValidateRegex,
-  validateRegexOrFail,
 } from '../common/object';
 
 export interface GQLSource {
@@ -411,10 +410,8 @@ const validateSquadData = ({
     ['handle', handle, handleRegex, true],
     ['description', description, descriptionRegex, false],
   ];
-  const regexResult = validateRegex(regexParams);
-  if (Object.keys(regexResult).length) {
-    throw new ValidationError(JSON.stringify(regexResult));
-  }
+
+  validateRegex(regexParams);
 
   return handle;
 };
@@ -535,7 +532,7 @@ export const resolvers: IResolvers<any, Context> = {
       return getSourceById(ctx, info, id);
     },
     sourceHandleExists: async (_, { handle }: { handle: string }, ctx) => {
-      validateRegexOrFail([['handle', handle, handleRegex, true]]);
+      validateRegex([['handle', handle, handleRegex, true]]);
 
       const source = await ctx
         .getRepository(Source)

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -40,6 +40,7 @@ import {
   nameRegex,
   validateRegex,
   ValidateRegex,
+  validateRegexOrFail,
 } from '../common/object';
 
 export interface GQLSource {
@@ -534,6 +535,8 @@ export const resolvers: IResolvers<any, Context> = {
       return getSourceById(ctx, info, id);
     },
     sourceHandleExists: async (_, { handle }: { handle: string }, ctx) => {
+      validateRegexOrFail([['handle', handle, handleRegex, true]]);
+
       const source = await ctx
         .getRepository(Source)
         .findOneBy({ handle: handle.toLowerCase() });

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -766,10 +766,8 @@ export const resolvers: IResolvers<any, Context> = {
         ['twitter', data.twitter, new RegExp(/^@?(\w){1,15}$/)],
         ['hashnode', data.hashnode, handleRegex],
       ];
-      const regexResult = validateRegex(regexParams);
-      if (Object.keys(regexResult).length) {
-        throw new ValidationError(JSON.stringify(regexResult));
-      }
+
+      validateRegex(regexParams);
 
       const avatar =
         upload && process.env.CLOUDINARY_URL


### PR DESCRIPTION
When we check for the availability of the handle, we must also check if the given parameter is actually valid based on our rules.

This would also allow us to keep the form validations in the same step rather than doing it when the user is finishing the Squad they are trying to create.