### PR TITLE
fix: add full_name to squad access mail

### DIFF
--- a/__tests__/workers/newNotificationMail.ts
+++ b/__tests__/workers/newNotificationMail.ts
@@ -798,3 +798,27 @@ it('should set parameters for squad_post_viewed email', async () => {
   });
   expect(args.templateId).toEqual('d-dc0eb578886c4f84a7dcc25515c7b6a4');
 });
+
+it('should set parameters for squad_access email', async () => {
+  const ctx: NotificationBaseContext = {
+    userId: '1',
+  };
+
+  const notificationId = await saveNotificationFixture(
+    con,
+    'squad_access',
+    ctx,
+  );
+  await expectSuccessfulBackground(worker, {
+    notification: {
+      id: notificationId,
+      userId: '1',
+    },
+  });
+  expect(sendEmail).toBeCalledTimes(1);
+  const args = jest.mocked(sendEmail).mock.calls[0][0] as MailDataRequired;
+  expect(args.dynamicTemplateData).toEqual({
+    full_name: 'Ido',
+  });
+  expect(args.templateId).toEqual('d-6b3de457947b415d93d0029361edaf1d');
+});

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -429,8 +429,10 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       user_image: author.image,
     };
   },
-  squad_access: async () => {
-    return {};
+  squad_access: async (con, user) => {
+    return {
+      full_name: user.name,
+    };
   },
 };
 


### PR DESCRIPTION
Added the full_name property to the squad access mail

WT-1043 #done 