### PR TITLE
fix: double notification for authors mentioned

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -541,6 +541,38 @@ it('should add comment mention notification', async () => {
   );
 });
 
+it('should not add comment mention notification when you mentioned the author', async () => {
+  const mentionedUserId = '1';
+  await con
+    .getRepository(Post)
+    .update({ id: 'p1' }, { authorId: mentionedUserId });
+  const worker = await import('../../src/workers/notifications/commentMention');
+  const actual = await invokeNotificationWorker(worker.default, {
+    commentMention: {
+      commentId: 'c1',
+      commentUserId: '2',
+      mentionedUserId,
+    },
+  });
+  expect(actual).toBeFalsy();
+});
+
+it('should not add comment mention notification when you mentioned the scout', async () => {
+  const mentionedUserId = '1';
+  await con
+    .getRepository(Post)
+    .update({ id: 'p1' }, { authorId: mentionedUserId });
+  const worker = await import('../../src/workers/notifications/commentMention');
+  const actual = await invokeNotificationWorker(worker.default, {
+    commentMention: {
+      commentId: 'c1',
+      commentUserId: '2',
+      mentionedUserId,
+    },
+  });
+  expect(actual).toBeFalsy();
+});
+
 it('should add comment reply notification', async () => {
   await con.getRepository(Comment).save([
     {

--- a/src/workers/notifications/commentMention.ts
+++ b/src/workers/notifications/commentMention.ts
@@ -24,6 +24,10 @@ const worker: NotificationWorker = {
     if (!postCtx) {
       return;
     }
+    const authors = [postCtx.post.authorId, postCtx.post.scoutId];
+    if (authors.includes(data.commentMention.mentionedUserId)) {
+      return;
+    }
     const commenter = await comment.user;
     const ctx: NotificationCommenterContext = {
       ...postCtx,

--- a/src/workers/notifications/commentMention.ts
+++ b/src/workers/notifications/commentMention.ts
@@ -24,7 +24,7 @@ const worker: NotificationWorker = {
     if (!postCtx) {
       return;
     }
-    const authors = [postCtx.post.authorId, postCtx.post.scoutId];
+    const authors = [...new Set([postCtx.post.authorId, postCtx.post.scoutId])];
     if (authors.includes(data.commentMention.mentionedUserId)) {
       return;
     }

--- a/src/workers/notifications/commentMention.ts
+++ b/src/workers/notifications/commentMention.ts
@@ -24,8 +24,8 @@ const worker: NotificationWorker = {
     if (!postCtx) {
       return;
     }
-    const authors = [...new Set([postCtx.post.authorId, postCtx.post.scoutId])];
-    if (authors.includes(data.commentMention.mentionedUserId)) {
+    const authors = new Set([postCtx.post.authorId, postCtx.post.scoutId]);
+    if (authors.has(data.commentMention.mentionedUserId)) {
       return;
     }
     const commenter = await comment.user;


### PR DESCRIPTION
When the author or scout was mentioned, they receive two notifications, one from being an author/scout of the post that is subscribed to the post's activity and one when you get mentioned.

The condition of early return should fix and not send a notification when not needed.