### PR TITLE
feat: introducing changelog flag for boot

### DIFF
--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -167,4 +167,8 @@ export const workers: Worker[] = [
     topic: 'api.v1.user-created',
     subscription: 'api.add-to-mailing-list',
   },
+  {
+    topic: 'api.v1.post-added',
+    subscription: 'api.post-changelog-added',
+  },
 ];

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -41,13 +41,17 @@ describe('query userAlerts', () => {
       rankLastSeen
       myFeed
       companionHelper
+      lastChangelog
     }
   }`;
 
   it('should return alerts default values if anonymous', async () => {
     const res = await client.query(QUERY);
-
-    expect(res.data.userAlerts).toEqual(ALERTS_DEFAULT);
+    res.data.userAlerts.changelog = false;
+    expect(res.data.userAlerts).toEqual({
+      ...ALERTS_DEFAULT,
+      lastChangelog: res.data.userAlerts.lastChangelog,
+    });
   });
 
   it('should return user alerts', async () => {
@@ -63,7 +67,10 @@ describe('query userAlerts', () => {
 
     delete expected.userId;
 
-    expect(res.data.userAlerts).toEqual(expected);
+    expect(res.data.userAlerts).toEqual({
+      ...expected,
+      lastChangelog: expected.lastChangelog.toISOString(),
+    });
   });
 });
 
@@ -144,7 +151,10 @@ describe('dedicated api routes', () => {
       const res = await authorizeRequest(
         request(app.server).get('/alerts'),
       ).expect(200);
-      expect(res.body).toEqual(expected);
+      expect(res.body).toEqual({
+        ...expected,
+        lastChangelog: expected['lastChangelog'].toISOString(),
+      });
     });
   });
 });

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -39,7 +39,6 @@ const DEFAULT_BODY = {
   notifications: { unreadNotificationsCount: 0 },
   squads: [],
   features: {},
-  changelog: false,
 };
 
 beforeAll(async () => {
@@ -75,6 +74,7 @@ it('should return user alerts', async () => {
     myFeed: 'created',
   });
   const alerts = new Object(data);
+  alerts['changelog'] = false;
   delete alerts['userId'];
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
@@ -95,6 +95,7 @@ it('should return changelog as true', async () => {
   });
   const alerts = new Object(data);
   alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
+  alerts['changelog'] = true;
   delete alerts['userId'];
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
@@ -102,7 +103,6 @@ it('should return changelog as true', async () => {
   expect(res.body).toEqual({
     ...DEFAULT_BODY,
     alerts,
-    changelog: true,
   });
 });
 
@@ -115,6 +115,7 @@ it('should return changelog as false', async () => {
   });
   const alerts = new Object(data);
   alerts['lastChangelog'] = '2023-02-06T12:00:00.000Z';
+  alerts['changelog'] = false;
   delete alerts['userId'];
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -24,17 +24,21 @@ import {
 } from '../src/entity';
 import { notificationFixture } from './fixture/notifications';
 import { usersFixture } from './fixture/user';
+import { setRedisObject } from '../src/redis';
+import { REDIS_CHANGELOG_KEY } from '../src/config';
 
 let app: FastifyInstance;
 let con: DataSource;
 let state: GraphQLTestingState;
 
+const { lastChangelog, ...alerts } = ALERTS_DEFAULT;
 const DEFAULT_BODY = {
-  alerts: ALERTS_DEFAULT,
+  alerts: alerts,
   settings: { ...SETTINGS_DEFAULT, companionExpanded: null },
   notifications: { unreadNotificationsCount: 0 },
   squads: [],
   features: {},
+  changelog: false,
 };
 
 beforeAll(async () => {
@@ -49,6 +53,7 @@ beforeEach(async () => {
 
 it('should return defaults for anonymous', async () => {
   const res = await request(app.server).get('/boot').expect(200);
+  delete res.body.alerts.lastChangelog;
   expect(res.body).toEqual({
     ...DEFAULT_BODY,
     settings: SETTINGS_DEFAULT,
@@ -59,6 +64,7 @@ it('should return defaults for user when not set', async () => {
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
   );
+  delete res.body.alerts.lastChangelog;
   expect(res.body).toEqual(DEFAULT_BODY);
 });
 
@@ -68,6 +74,46 @@ it('should return user alerts', async () => {
     myFeed: 'created',
   });
   const alerts = new Object(data);
+  delete alerts['userId'];
+  const res = await authorizeRequest(request(app.server).get('/boot')).expect(
+    200,
+  );
+  alerts['lastChangelog'] = res.body.alerts.lastChangelog;
+  expect(res.body).toEqual({
+    ...DEFAULT_BODY,
+    alerts,
+  });
+});
+
+it('should return changelog as true', async () => {
+  await setRedisObject(REDIS_CHANGELOG_KEY, '2023-02-06 12:00:00');
+  const data = await con.getRepository(Alerts).save({
+    userId: '1',
+    myFeed: 'created',
+    lastChangelog: new Date('2023-02-05 12:00:00'),
+  });
+  const alerts = new Object(data);
+  alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
+  delete alerts['userId'];
+  const res = await authorizeRequest(request(app.server).get('/boot')).expect(
+    200,
+  );
+  expect(res.body).toEqual({
+    ...DEFAULT_BODY,
+    alerts,
+    changelog: true,
+  });
+});
+
+it('should return changelog as false', async () => {
+  await setRedisObject(REDIS_CHANGELOG_KEY, '2023-02-05 12:00:00');
+  const data = await con.getRepository(Alerts).save({
+    userId: '1',
+    myFeed: 'created',
+    lastChangelog: new Date('2023-02-06 12:00:00'),
+  });
+  const alerts = new Object(data);
+  alerts['lastChangelog'] = '2023-02-06T12:00:00.000Z';
   delete alerts['userId'];
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
@@ -91,6 +137,7 @@ it('should return user settings', async () => {
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
   );
+  delete res.body.alerts.lastChangelog;
   expect(res.body).toEqual({
     ...DEFAULT_BODY,
     settings,
@@ -108,6 +155,7 @@ it('should return unread notifications count', async () => {
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
   );
+  delete res.body.alerts.lastChangelog;
   expect(res.body).toEqual({
     ...DEFAULT_BODY,
     notifications: { unreadNotificationsCount: 2 },
@@ -170,6 +218,7 @@ it('should return the user squads', async () => {
   const res = await authorizeRequest(request(app.server).get('/boot')).expect(
     200,
   );
+  delete res.body.alerts.lastChangelog;
   expect(res.body).toEqual({
     ...DEFAULT_BODY,
     squads: [

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -31,6 +31,7 @@ let app: FastifyInstance;
 let con: DataSource;
 let state: GraphQLTestingState;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { lastChangelog, ...alerts } = ALERTS_DEFAULT;
 const DEFAULT_BODY = {
   alerts: alerts,

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -739,6 +739,7 @@ describe('alerts', () => {
     rankLastSeen: rankLastSeen.getTime(),
     myFeed: 'created',
     companionHelper: true,
+    lastChangelog: null,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/__tests__/workers/postChangelogAdded.ts
+++ b/__tests__/workers/postChangelogAdded.ts
@@ -1,0 +1,20 @@
+import { expectSuccessfulBackground } from '../helpers';
+import worker from '../../src/workers/postChangelogAdded';
+import { getRedisObject } from '../../src/redis';
+import { REDIS_CHANGELOG_KEY } from '../../src/config';
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+});
+
+it('should update redis cache', async () => {
+  const postDate = '2023-02-06 12:43:21';
+  await expectSuccessfulBackground(worker, {
+    post: {
+      id: 'p1',
+      sourceId: 'daily_updates',
+      createdAt: postDate,
+    },
+  });
+  expect(await getRedisObject(REDIS_CHANGELOG_KEY)).toEqual(postDate);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,3 +9,5 @@ export const fallbackImages = {
   avatar:
     'https://daily-now-res.cloudinary.com/image/upload/f_auto/v1664367305/placeholders/placeholder3',
 };
+
+export const REDIS_CHANGELOG_KEY = 'boot:latest_changelog';

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -20,6 +20,8 @@ export class Alerts {
 
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastChangelog: Date | null;
+
+  changelog: boolean;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
@@ -28,4 +30,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   myFeed: null,
   companionHelper: true,
   lastChangelog: new Date(),
+  changelog: false,
 };

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -21,7 +21,7 @@ export class Alerts {
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastChangelog: Date | null;
 
-  changelog: boolean;
+  changelog?: boolean;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -17,6 +17,9 @@ export class Alerts {
 
   @Column({ type: 'bool', default: true })
   companionHelper: boolean;
+
+  @Column({ type: 'timestamp without time zone', default: () => 'now()' })
+  lastChangelog: Date | null;
 }
 
 export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
@@ -24,4 +27,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   rankLastSeen: null,
   myFeed: null,
   companionHelper: true,
+  lastChangelog: new Date(),
 };

--- a/src/migration/1675936666556-AlertsChangelog.ts
+++ b/src/migration/1675936666556-AlertsChangelog.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlertsChangelog1675936666556 implements MigrationInterface {
+  name = 'AlertsChangelog1675936666556';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "lastChangelog" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "lastChangelog"`);
+  }
+}

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -11,6 +11,20 @@ export const redisPubSub = new RedisPubSub({
   connection: redisOptions,
 });
 
+const ioRedisPoolOpts = IORedisPoolOptions.fromHostAndPort(
+  redisOptions.host,
+  redisOptions.port,
+)
+  .withIORedisOptions(redisOptions)
+  .withPoolOptions({
+    min: 10,
+    max: 50,
+    evictionRunIntervalMillis: 60000,
+    idleTimeoutMillis: 30000,
+  });
+
+export const ioRedisPool = new IORedisPool(ioRedisPoolOpts);
+
 export function deleteKeysByPattern(pattern: string): Promise<void> {
   return ioRedisPool.execute(
     (client) =>
@@ -27,16 +41,8 @@ export function deleteKeysByPattern(pattern: string): Promise<void> {
   );
 }
 
-const ioRedisPoolOpts = IORedisPoolOptions.fromHostAndPort(
-  redisOptions.host,
-  redisOptions.port,
-)
-  .withIORedisOptions(redisOptions)
-  .withPoolOptions({
-    min: 10,
-    max: 50,
-    evictionRunIntervalMillis: 60000,
-    idleTimeoutMillis: 30000,
-  });
+export const setRedisObject = (key, value) =>
+  ioRedisPool.execute((client) => client.set(key, value));
 
-export const ioRedisPool = new IORedisPool(ioRedisPoolOpts);
+export const getRedisObject = (key) =>
+  ioRedisPool.execute((client) => client.get(key));

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -9,6 +9,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         rankLastSeen
         myFeed
         companionHelper
+        lastChangelog
       }
     }`;
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -89,7 +89,10 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         getRedisObject(REDIS_CHANGELOG_KEY),
       ]);
       return res.send({
-        alerts: excludeProperties(alerts, ['userId']),
+        alerts: {
+          ...excludeProperties(alerts, ['userId']),
+          changelog: alerts.lastChangelog < new Date(lastChangelog),
+        },
         settings: excludeProperties(settings, [
           'userId',
           'updatedAt',
@@ -98,16 +101,14 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         notifications: { unreadNotificationsCount },
         squads,
         features,
-        changelog: alerts.lastChangelog < new Date(lastChangelog),
       });
     }
     return res.send({
-      alerts: ALERTS_DEFAULT,
+      alerts: { ...ALERTS_DEFAULT, lastChangelog: false },
       settings: SETTINGS_DEFAULT,
       notifications: { unreadNotificationsCount: 0 },
       squads: [],
       features: {},
-      changelog: false,
     });
   });
 }

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -104,7 +104,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       });
     }
     return res.send({
-      alerts: { ...ALERTS_DEFAULT, lastChangelog: false },
+      alerts: { ...ALERTS_DEFAULT, changelog: false },
       settings: SETTINGS_DEFAULT,
       notifications: { unreadNotificationsCount: 0 },
       squads: [],

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -43,6 +43,11 @@ export const typeDefs = /* GraphQL */ `
     Once the user has seen it once, we set this value to false
     """
     companionHelper: Boolean!
+
+    """
+    Date of the last changelog user saw
+    """
+    lastChangelog: DateTime
   }
 
   input UpdateAlertsInput {
@@ -65,6 +70,11 @@ export const typeDefs = /* GraphQL */ `
     Status to display for companion helper
     """
     companionHelper: Boolean
+
+    """
+    Date of the last changelog user saw
+    """
+    lastChangelog: DateTime
   }
 
   extend type Mutation {

--- a/src/workers/postChangelogAdded.ts
+++ b/src/workers/postChangelogAdded.ts
@@ -1,0 +1,32 @@
+import { messageToJson, Worker } from './worker';
+import { Post } from '../entity';
+import { ChangeObject } from '../types';
+import { setRedisObject } from '../redis';
+import { REDIS_CHANGELOG_KEY } from '../config';
+
+interface Data {
+  post: ChangeObject<Post>;
+}
+
+const CHANGELOG_SOURCE_ID = 'daily_updates';
+
+const worker: Worker = {
+  subscription: 'api.post-changelog-added',
+  handler: async (message, con, logger): Promise<void> => {
+    const data: Data = messageToJson(message);
+    const { post } = data;
+    if (post?.sourceId !== CHANGELOG_SOURCE_ID) {
+      return;
+    }
+    try {
+      await setRedisObject(REDIS_CHANGELOG_KEY, post.createdAt);
+    } catch (err) {
+      logger.error(
+        { data, messageId: message.messageId, err },
+        'failed to set redis cache for post changelog',
+      );
+    }
+  },
+};
+
+export default worker;


### PR DESCRIPTION
Added a new alert flag for lastChangelog, FE will be responsible for updating it through existing channels.
Added a new worker to set a redis cached value of our last changelog date.
Boot can then check wether this date is more up to date, and set Changelog to true.

WT-1054 #done 