### PR TITLE
refactor: alert entity to include state of squad tour viewed

### DIFF
--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -7,7 +7,7 @@ Object {
     "filter": false,
     "myFeed": null,
     "rankLastSeen": null,
-    "showSquadTour": true,
+    "squadTour": true,
   },
 }
 `;
@@ -19,7 +19,7 @@ Object {
     "filter": false,
     "myFeed": "created",
     "rankLastSeen": "2020-09-22T12:15:51.247Z",
-    "showSquadTour": false,
+    "squadTour": false,
   },
 }
 `;

--- a/__tests__/__snapshots__/alerts.ts.snap
+++ b/__tests__/__snapshots__/alerts.ts.snap
@@ -7,6 +7,7 @@ Object {
     "filter": false,
     "myFeed": null,
     "rankLastSeen": null,
+    "showSquadTour": true,
   },
 }
 `;
@@ -18,6 +19,7 @@ Object {
     "filter": false,
     "myFeed": "created",
     "rankLastSeen": "2020-09-22T12:15:51.247Z",
+    "showSquadTour": false,
   },
 }
 `;

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -42,6 +42,7 @@ describe('query userAlerts', () => {
       myFeed
       companionHelper
       lastChangelog
+      showSquadTour
     }
   }`;
 
@@ -82,6 +83,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen
         myFeed
         companionHelper
+        showSquadTour
       }
     }
   `;
@@ -116,6 +118,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen: rankLastSeenOld,
         myFeed: 'created',
         companionHelper: true,
+        showSquadTour: true,
       }),
     );
 
@@ -127,6 +130,7 @@ describe('mutation updateUserAlerts', () => {
           rankLastSeen: rankLastSeen.toISOString(),
           myFeed: 'created',
           companionHelper: false,
+          showSquadTour: false,
         },
       },
     });

--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -42,7 +42,7 @@ describe('query userAlerts', () => {
       myFeed
       companionHelper
       lastChangelog
-      showSquadTour
+      squadTour
     }
   }`;
 
@@ -83,7 +83,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen
         myFeed
         companionHelper
-        showSquadTour
+        squadTour
       }
     }
   `;
@@ -118,7 +118,7 @@ describe('mutation updateUserAlerts', () => {
         rankLastSeen: rankLastSeenOld,
         myFeed: 'created',
         companionHelper: true,
-        showSquadTour: true,
+        squadTour: true,
       }),
     );
 
@@ -130,7 +130,7 @@ describe('mutation updateUserAlerts', () => {
           rankLastSeen: rankLastSeen.toISOString(),
           myFeed: 'created',
           companionHelper: false,
-          showSquadTour: false,
+          squadTour: false,
         },
       },
     });

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -740,7 +740,7 @@ describe('alerts', () => {
     myFeed: 'created',
     companionHelper: true,
     lastChangelog: null,
-    showSquadTour: true,
+    squadTour: true,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -740,6 +740,7 @@ describe('alerts', () => {
     myFeed: 'created',
     companionHelper: true,
     lastChangelog: null,
+    showSquadTour: true,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -19,7 +19,7 @@ export class Alerts {
   companionHelper: boolean;
 
   @Column({ type: 'bool', default: true })
-  showSquadTour: boolean;
+  squadTour: boolean;
 
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastChangelog: Date | null;
@@ -34,5 +34,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   companionHelper: true,
   lastChangelog: new Date(),
   changelog: false,
-  showSquadTour: true,
+  squadTour: true,
 };

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -18,6 +18,9 @@ export class Alerts {
   @Column({ type: 'bool', default: true })
   companionHelper: boolean;
 
+  @Column({ type: 'bool', default: true })
+  showSquadTour: boolean;
+
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastChangelog: Date | null;
 
@@ -31,4 +34,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   companionHelper: true,
   lastChangelog: new Date(),
   changelog: false,
+  showSquadTour: true,
 };

--- a/src/migration/1677030838294-AlertViewedTour.ts
+++ b/src/migration/1677030838294-AlertViewedTour.ts
@@ -5,11 +5,11 @@ export class AlertViewedTour1677030838294 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "alerts" ADD "showSquadTour" boolean NOT NULL DEFAULT true`,
+      `ALTER TABLE "alerts" ADD "squadTour" boolean NOT NULL DEFAULT true`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "showSquadTour"`);
+    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "squadTour"`);
   }
 }

--- a/src/migration/1677030838294-AlertViewedTour.ts
+++ b/src/migration/1677030838294-AlertViewedTour.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlertViewedTour1677030838294 implements MigrationInterface {
+  name = 'AlertViewedTour1677030838294';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "showSquadTour" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "showSquadTour"`);
+  }
+}

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -10,6 +10,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         myFeed
         companionHelper
         lastChangelog
+        showSquadTour
       }
     }`;
 

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -10,7 +10,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         myFeed
         companionHelper
         lastChangelog
-        showSquadTour
+        squadTour
       }
     }`;
 

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -48,6 +48,11 @@ export const typeDefs = /* GraphQL */ `
     Date of the last changelog user saw
     """
     lastChangelog: DateTime
+
+    """
+    Whether to show the squad tour and sync across devices
+    """
+    showSquadTour: Boolean!
   }
 
   input UpdateAlertsInput {
@@ -75,6 +80,11 @@ export const typeDefs = /* GraphQL */ `
     Date of the last changelog user saw
     """
     lastChangelog: DateTime
+
+    """
+    Whether to show the squad tour and sync across devices
+    """
+    showSquadTour: Boolean
   }
 
   extend type Mutation {

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -52,7 +52,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Whether to show the squad tour and sync across devices
     """
-    showSquadTour: Boolean!
+    squadTour: Boolean!
   }
 
   input UpdateAlertsInput {
@@ -84,7 +84,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Whether to show the squad tour and sync across devices
     """
-    showSquadTour: Boolean
+    squadTour: Boolean
   }
 
   extend type Mutation {


### PR DESCRIPTION
Introduced a new alert property to identify whether to display the squad tour and be synced across devices.