### PR TITLE
fix: prevent notification for users who are part of squad

### DIFF
--- a/src/workers/notifications/featureAccessNotification.ts
+++ b/src/workers/notifications/featureAccessNotification.ts
@@ -2,7 +2,7 @@ import { messageToJson } from '../worker';
 import { ChangeObject } from '../../types';
 import { Feature } from '../../entity/Feature';
 import { NotificationWorker } from './worker';
-import { Comment, SourceMember } from '../../entity';
+import { SourceMember } from '../../entity';
 
 interface Data {
   feature: ChangeObject<Feature>;

--- a/src/workers/notifications/featureAccessNotification.ts
+++ b/src/workers/notifications/featureAccessNotification.ts
@@ -2,6 +2,7 @@ import { messageToJson } from '../worker';
 import { ChangeObject } from '../../types';
 import { Feature } from '../../entity/Feature';
 import { NotificationWorker } from './worker';
+import { Comment, SourceMember } from '../../entity';
 
 interface Data {
   feature: ChangeObject<Feature>;
@@ -9,11 +10,19 @@ interface Data {
 
 const worker: NotificationWorker = {
   subscription: 'api.feature-access-notification',
-  handler: async (message) => {
+  handler: async (message, con) => {
     const { feature: changeFeature }: Data = messageToJson(message);
 
     // We only support notifications for squad access
     if (changeFeature.feature !== 'squad') {
+      return;
+    }
+
+    // We don't need to show this if user is already part of squad
+    const sourceMember = await con
+      .getRepository(SourceMember)
+      .findOne({ where: { userId: changeFeature.userId } });
+    if (sourceMember) {
       return;
     }
 


### PR DESCRIPTION
Prevent notification for squad access for users who are already in a squad

WT-1095 #done 