### PR TITLE
feat: squad moderator privileges

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1008,3 +1008,120 @@ describe('mutation joinSource', () => {
     );
   });
 });
+
+describe('mutation removeMember', () => {
+  const MUTATION = `
+    mutation RemoveMember($sourceId: ID!, $memberId: ID!) {
+      removeMember(sourceId: $sourceId, memberId: $memberId) {
+        _
+      }
+    }
+  `;
+
+  it('should not authorize when not logged in', () =>
+    testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { sourceId: 'a', memberId: '2' },
+      },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should restrict when not a member of the squad', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { sourceId: 'b', memberId: '2' } },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should restrict when not a moderator or an owner of the squad', async () => {
+    loggedUser = '2';
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { sourceId: 'a', memberId: '1' } },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should restrict moderator from removing the owner', async () => {
+    loggedUser = '2';
+    await con
+      .getRepository(SourceMember)
+      .update({ userId: '2' }, { role: SourceMemberRoles.Moderator });
+
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { sourceId: 'a', memberId: '1' } },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should restrict moderator from removing a moderator', async () => {
+    loggedUser = '2';
+    const repo = con.getRepository(SourceMember);
+    await repo.save({
+      userId: '3',
+      sourceId: 'a',
+      role: SourceMemberRoles.Moderator,
+      referralToken: randomUUID(),
+    });
+    await repo.update({ userId: '2' }, { role: SourceMemberRoles.Moderator });
+
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { sourceId: 'a', memberId: '3' } },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should allow owner to remove moderator from the squad', async () => {
+    loggedUser = '1';
+    const toRemoveId = '2';
+    const repo = con.getRepository(SourceMember);
+    await repo.update(
+      { userId: toRemoveId },
+      { role: SourceMemberRoles.Moderator },
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: { sourceId: 'a', memberId: toRemoveId },
+    });
+    expect(res.errors).toBeFalsy();
+    const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
+    expect(member).toBeFalsy();
+  });
+
+  it('should allow owner to remove member from the squad', async () => {
+    loggedUser = '1';
+    const toRemoveId = '2';
+    const repo = con.getRepository(SourceMember);
+    const res = await client.mutate(MUTATION, {
+      variables: { sourceId: 'a', memberId: toRemoveId },
+    });
+    expect(res.errors).toBeFalsy();
+    const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
+    expect(member).toBeFalsy();
+  });
+
+  it('should allow moderator to remove member the squad', async () => {
+    loggedUser = '3';
+    const toRemoveId = '2';
+    const repo = con.getRepository(SourceMember);
+    await repo.save({
+      userId: '3',
+      sourceId: 'a',
+      role: SourceMemberRoles.Moderator,
+      referralToken: randomUUID(),
+    });
+    const res = await client.mutate(MUTATION, {
+      variables: { sourceId: 'a', memberId: toRemoveId },
+    });
+    expect(res.errors).toBeFalsy();
+    const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
+    expect(member).toBeFalsy();
+  });
+});

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -350,10 +350,16 @@ const sourceToGQL = (source: Source): GQLSource => ({
 export enum SourcePermissions {
   View,
   Post,
+  PostDelete,
   Leave,
   Delete,
   Edit,
 }
+
+const canPostDeleteRoles = [
+  SourceMemberRoles.Owner,
+  SourceMemberRoles.Moderator,
+];
 
 export const canAccessSource = async (
   ctx: Context,
@@ -370,9 +376,18 @@ export const canAccessSource = async (
       sourceId: source.id,
     });
 
+    if (!member) {
+      return false;
+    }
+
     switch (permission) {
       case SourcePermissions.Post:
         if (source.type !== SourceType.Squad) {
+          return false;
+        }
+        break;
+      case SourcePermissions.PostDelete:
+        if (!canPostDeleteRoles.includes(member.role)) {
           return false;
         }
         break;
@@ -392,9 +407,7 @@ export const canAccessSource = async (
         break;
     }
 
-    if (member) {
-      return true;
-    }
+    return true;
   }
 
   return false;

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -63,6 +63,11 @@ export interface GQLSourceMember {
   referralToken: string;
 }
 
+interface RemoveMemberArgs {
+  sourceId: string;
+  memberId: string;
+}
+
 export const typeDefs = /* GraphQL */ `
   """
   Source to discover posts from (usually blogs)
@@ -338,6 +343,19 @@ export const typeDefs = /* GraphQL */ `
       """
       sourceId: ID!
     ): EmptyResponse! @auth
+    """
+    Removes the member from the Squad
+    """
+    removeMember(
+      """
+      Member to remove
+      """
+      memberId: ID!
+      """
+      Source to leave
+      """
+      sourceId: ID!
+    ): EmptyResponse! @auth
   }
 `;
 
@@ -351,12 +369,18 @@ export enum SourcePermissions {
   View,
   Post,
   PostDelete,
+  RemoveMember,
   Leave,
   Delete,
   Edit,
 }
 
 const canPostDeleteRoles = [
+  SourceMemberRoles.Owner,
+  SourceMemberRoles.Moderator,
+];
+
+const canRemoveMemberRoles = [
   SourceMemberRoles.Owner,
   SourceMemberRoles.Moderator,
 ];
@@ -388,6 +412,11 @@ export const canAccessSource = async (
         break;
       case SourcePermissions.PostDelete:
         if (!canPostDeleteRoles.includes(member.role)) {
+          return false;
+        }
+        break;
+      case SourcePermissions.RemoveMember:
+        if (!canRemoveMemberRoles.includes(member.role)) {
           return false;
         }
         break;
@@ -840,6 +869,37 @@ export const resolvers: IResolvers<any, Context> = {
       }
 
       return getSourceById(ctx, info, sourceId);
+    },
+    removeMember: async (
+      _,
+      { sourceId, memberId }: RemoveMemberArgs,
+      ctx,
+    ): Promise<GQLEmptyResponse> => {
+      await ensureSourcePermissions(
+        ctx,
+        sourceId,
+        SourcePermissions.RemoveMember,
+      );
+      await ctx.con.transaction(async (manager) => {
+        const repo = manager.getRepository(SourceMember);
+        const [member, loggedUser] = await Promise.all([
+          repo.findOneByOrFail({ sourceId, userId: memberId }),
+          repo.findOneByOrFail({ sourceId, userId: ctx.userId }),
+        ]);
+
+        const memberRank = roleRank[member.role];
+        const loggedUserRank = roleRank[loggedUser.role];
+
+        if (memberRank >= loggedUserRank) {
+          throw new ForbiddenError(
+            `You don't have the required permission for this action!`,
+          );
+        }
+
+        await repo.delete({ sourceId, userId: memberId });
+      });
+
+      return { _: true };
     },
   }),
   Source: {


### PR DESCRIPTION
Allow moderators and owners to delete a post.

Had one issue while running some tests so I updated the `canAccessSource` to check for members if they exist.