### PR TITLE
fix: do not send notification to author/scout from comment following a thread

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -281,6 +281,42 @@ describe('article new comment', () => {
     expect(actual).toBeFalsy();
   });
 
+  it('should not add notification for scout and author when they are following a thread as they will receive one from reply', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/articleNewCommentCommentCommented'
+    );
+    const repo = con.getRepository(Comment);
+    await repo.save([
+      {
+        id: 'c2',
+        postId: 'p1',
+        parentId: 'c1',
+        userId: '3',
+        content: 'a',
+      },
+      {
+        id: 'c3',
+        postId: 'p1',
+        parentId: 'c1',
+        userId: '1',
+        content: 'a',
+      },
+    ]);
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        scoutId: '1',
+        authorId: '3',
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: '1',
+      postId: 'p1',
+      childCommentId: 'c3',
+    });
+    expect(actual).toBeFalsy();
+  });
+
   it('should add notification for scout and author on new reply', async () => {
     const worker = await import(
       '../../src/workers/notifications/articleNewCommentCommentCommented'

--- a/src/workers/notifications/articleUpvoteMilestone.ts
+++ b/src/workers/notifications/articleUpvoteMilestone.ts
@@ -21,7 +21,7 @@ const worker: NotificationWorker = {
       return;
     }
     const { post } = postCtx;
-    const users = uniquePostOwners(post, data.userId);
+    const users = uniquePostOwners(post, [data.userId]);
     if (!users.length || !UPVOTE_MILESTONES.includes(post.upvotes.toString())) {
       return;
     }

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -65,7 +65,7 @@ export async function articleNewCommentHandler(
         id: comment.parentId,
         userId: postCtx.post.authorId,
       })
-      .where(`(id == :id OR "parentId" == id)`, { id: comment.parentId })
+      .where(`(id == :id OR "parentId" == :id)`, { id: comment.parentId })
       .andWhere({ userId: In(ids) })
       .groupBy('"userId"')
       .getRawMany();

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -8,10 +8,10 @@ import { DataSource } from 'typeorm';
 
 export const uniquePostOwners = (
   post: Pick<Post, 'scoutId' | 'authorId'>,
-  exclude?: string,
+  ignoreIds: string[] = [],
 ): string[] =>
   [...new Set([post.scoutId, post.authorId])].filter(
-    (userId) => userId && userId !== exclude,
+    (userId) => userId && !ignoreIds.includes(userId),
   );
 
 export const buildPostContext = async (
@@ -41,9 +41,11 @@ export async function articleNewCommentHandler(
   con: DataSource,
   commentId: string,
 ): Promise<NotificationHandlerReturn> {
-  const comment = await con
-    .getRepository(Comment)
-    .findOne({ where: { id: commentId }, relations: ['user'] });
+  const repo = con.getRepository(Comment);
+  const comment = await repo.findOne({
+    where: { id: commentId },
+    relations: ['user'],
+  });
   if (!comment) {
     return;
   }
@@ -51,8 +53,38 @@ export async function articleNewCommentHandler(
   if (!postCtx) {
     return;
   }
+  const excludedUsers = [comment.userId];
+
+  const isReply = !!comment.parentId;
+  if (isReply && (postCtx.post.authorId || postCtx.post.scoutId)) {
+    const threadFollower = await repo
+      .createQueryBuilder()
+      .select('"userId"')
+      .where({
+        id: comment.parentId,
+        userId: postCtx.post.authorId,
+      })
+      .orWhere({
+        parentId: comment.parentId,
+        userId: postCtx.post.authorId,
+      })
+      .orWhere({
+        id: comment.parentId,
+        userId: postCtx.post.scoutId,
+      })
+      .orWhere({
+        parentId: comment.parentId,
+        userId: postCtx.post.scoutId,
+      })
+      .getRawMany();
+    if (threadFollower.length) {
+      threadFollower.forEach(({ userId }) => excludedUsers.push(userId));
+    }
+  }
+
+  const excluded = [...new Set(excludedUsers)];
   // Get unique user id which are not the author of the comment
-  const users = uniquePostOwners(postCtx.post, comment.userId);
+  const users = uniquePostOwners(postCtx.post, excluded);
   if (!users.length) {
     return;
   }

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -61,10 +61,6 @@ export async function articleNewCommentHandler(
     const threadFollower = await repo
       .createQueryBuilder()
       .select('"userId"')
-      .where({
-        id: comment.parentId,
-        userId: postCtx.post.authorId,
-      })
       .where(`(id = :id OR "parentId" = :id)`, { id: comment.parentId })
       .andWhere({ userId: In(ids) })
       .groupBy('"userId"')

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -65,7 +65,7 @@ export async function articleNewCommentHandler(
         id: comment.parentId,
         userId: postCtx.post.authorId,
       })
-      .where(`(id == :id OR "parentId" == :id)`, { id: comment.parentId })
+      .where(`(id = :id OR "parentId" = :id)`, { id: comment.parentId })
       .andWhere({ userId: In(ids) })
       .groupBy('"userId"')
       .getRawMany();


### PR DESCRIPTION
A comment notification is duplicated when the author/scout is following a thread where they will receive a "reply notificaion" when there is a new comment.

After the discussion, Sab has decided to prioritize the "reply notification" and forego the author/scout post new comment notification for these cases.

https://dailydotdev.slack.com/archives/C03QZBF46JC/p1676885204557179?thread_ts=1676878287.868739&cid=C03QZBF46JC