### PR TITLE
feat: update redis cache inline during changelog computation

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -313,7 +313,7 @@ describe('boot alerts', () => {
       .expect(200);
     expect(res.body.alerts).toEqual(alerts);
     expect(await getRedisObject(REDIS_CHANGELOG_KEY)).toEqual(
-      post?.createdAt.toISOString(),
+      post.createdAt.toISOString(),
     );
   });
 
@@ -347,7 +347,7 @@ describe('boot alerts', () => {
       .expect(200);
     expect(res.body.alerts).toEqual(alerts);
     expect(await getRedisObject(REDIS_CHANGELOG_KEY)).toEqual(
-      post?.createdAt.toISOString(),
+      post.createdAt.toISOString(),
     );
   });
 });

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -166,8 +166,6 @@ const getAndUpdateLastChangelogRedis = async (
 ): Promise<string> => {
   let lastChangelogFromRedis = await getRedisObject(REDIS_CHANGELOG_KEY);
 
-  console.log({ lastChangelogFromRedis });
-
   if (!lastChangelogFromRedis) {
     const post: Pick<Post, 'createdAt'> = await con
       .getRepository(Post)

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -181,10 +181,10 @@ const getAndUpdateLastChangelogRedis = async (
 
     if (post) {
       lastChangelogFromRedis = post.createdAt.toISOString();
+
+      await setRedisObject(REDIS_CHANGELOG_KEY, lastChangelogFromRedis);
     }
   }
-
-  await setRedisObject(REDIS_CHANGELOG_KEY, lastChangelogFromRedis);
 
   return lastChangelogFromRedis;
 };

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -10,6 +10,7 @@ import {
   Alerts,
   ALERTS_DEFAULT,
   getUnreadNotificationsCount,
+  Post,
   Settings,
   SETTINGS_DEFAULT,
   SourceMember,
@@ -20,7 +21,7 @@ import { GQLSource } from '../schema/sources';
 import { adjustFlagsToUser, getUserFeatureFlags } from '../featureFlags';
 import { getAlerts } from '../schema/alerts';
 import { getSettings } from '../schema/settings';
-import { getRedisObject } from '../redis';
+import { getRedisObject, setRedisObject } from '../redis';
 import { REDIS_CHANGELOG_KEY } from '../config';
 import { getSourceLink } from '../common';
 import { AccessToken, signJwt } from '../auth';
@@ -160,6 +161,36 @@ const setAuthCookie = async (
   return accessToken;
 };
 
+const getAndUpdateLastChangelogRedis = async (
+  con: DataSource,
+): Promise<string> => {
+  let lastChangelogFromRedis = await getRedisObject(REDIS_CHANGELOG_KEY);
+
+  console.log({ lastChangelogFromRedis });
+
+  if (!lastChangelogFromRedis) {
+    const post: Pick<Post, 'createdAt'> = await con
+      .getRepository(Post)
+      .findOne({
+        select: ['createdAt'],
+        where: [{ sourceId: 'daily_updates' }],
+        order: {
+          createdAt: {
+            direction: 'DESC',
+          },
+        },
+      });
+
+    if (post) {
+      lastChangelogFromRedis = post.createdAt.toISOString();
+    }
+  }
+
+  await setRedisObject(REDIS_CHANGELOG_KEY, lastChangelogFromRedis);
+
+  return lastChangelogFromRedis;
+};
+
 const loggedInBoot = async (
   con: DataSource,
   req: FastifyRequest,
@@ -187,7 +218,7 @@ const loggedInBoot = async (
     getSettings(con, userId),
     getUnreadNotificationsCount(con, userId),
     getSquads(con, userId),
-    getRedisObject(REDIS_CHANGELOG_KEY),
+    getAndUpdateLastChangelogRedis(con),
     middleware ? middleware(con, req, res) : {},
   ]);
   if (!user) {


### PR DESCRIPTION
Fix edge case where if redis value is empty boot `changelog` will always be `false`.