### PR TITLE
refactor: post entity updated properties

### DIFF
--- a/__tests__/__snapshots__/private.ts.snap
+++ b/__tests__/__snapshots__/private.ts.snap
@@ -15,6 +15,7 @@ Object {
   "image": null,
   "lastTrending": null,
   "metadataChangedAt": Any<Date>,
+  "origin": "crawler",
   "placeholder": null,
   "private": false,
   "publishedAt": null,
@@ -37,5 +38,7 @@ Object {
   "url": "https://post.com",
   "views": 0,
   "viewsThreshold": 0,
+  "visible": true,
+  "visibleAt": null,
 }
 `;

--- a/__tests__/__snapshots__/private.ts.snap
+++ b/__tests__/__snapshots__/private.ts.snap
@@ -39,6 +39,6 @@ Object {
   "views": 0,
   "viewsThreshold": 0,
   "visible": true,
-  "visibleAt": null,
+  "visibleAt": Any<Date>,
 }
 `;

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -93,6 +93,7 @@ describe('POST /p/newPost', () => {
     expect(posts.length).toEqual(1);
     expect(body).toEqual({ status: 'ok', postId: posts[0].id });
     expect(posts[0]).toMatchSnapshot({
+      visibleAt: expect.any(Date),
       createdAt: expect.any(Date),
       metadataChangedAt: expect.any(Date),
       score: expect.any(Number),

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -671,6 +671,8 @@ describe('post', () => {
       metadataChangedAt: 0,
       publishedAt: 0,
       lastTrending: 0,
+      visible: true,
+      visibleAt: 0,
     };
     const after: ChangeObject<ObjectType> = {
       ...localBase,

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -19,7 +19,7 @@ export enum PostType {
 
 export enum PostOrigin {
   CommunityPicks = 'community_picks',
-  Ugc = 'ugc',
+  UserGenerated = 'user_generated',
   Crawler = 'crawler',
 }
 

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -1,6 +1,4 @@
 import {
-  BeforeInsert,
-  BeforeUpdate,
   Column,
   Entity,
   Index,
@@ -9,7 +7,7 @@ import {
   PrimaryColumn,
   TableInheritance,
 } from 'typeorm';
-import { COMMUNITY_PICKS_SOURCE, Source } from '../Source';
+import { Source } from '../Source';
 import { PostTag } from '../PostTag';
 import { PostKeyword } from '../PostKeyword';
 import { User } from '../User';
@@ -19,9 +17,9 @@ export enum PostType {
   Share = 'share',
 }
 
-enum PostOrigin {
+export enum PostOrigin {
   CommunityPicks = 'community_picks',
-  Squads = 'squads',
+  Ugc = 'ugc',
   Crawler = 'crawler',
 }
 
@@ -152,17 +150,5 @@ export class Post {
   visibleAt: Date;
 
   @Column({ default: null, type: 'text' })
-  private origin: PostOrigin;
-
-  @BeforeInsert()
-  @BeforeUpdate()
-  private setOrigin(): void {
-    if (this.sourceId === COMMUNITY_PICKS_SOURCE) {
-      this.origin = PostOrigin.CommunityPicks;
-    } else if (this.type === PostType.Share) {
-      this.origin = PostOrigin.Squads;
-    } else {
-      this.origin = PostOrigin.Crawler;
-    }
-  }
+  origin: PostOrigin;
 }

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -1,4 +1,6 @@
 import {
+  BeforeInsert,
+  BeforeUpdate,
   Column,
   Entity,
   Index,
@@ -7,7 +9,7 @@ import {
   PrimaryColumn,
   TableInheritance,
 } from 'typeorm';
-import { Source } from '../Source';
+import { COMMUNITY_PICKS_SOURCE, Source } from '../Source';
 import { PostTag } from '../PostTag';
 import { PostKeyword } from '../PostKeyword';
 import { User } from '../User';
@@ -15,6 +17,12 @@ import { User } from '../User';
 export enum PostType {
   Article = 'article',
   Share = 'share',
+}
+
+enum PostOrigin {
+  CommunityPicks = 'community_picks',
+  Squads = 'squads',
+  Crawler = 'crawler',
 }
 
 @Entity()
@@ -136,4 +144,25 @@ export class Post {
 
   @Column({ default: false })
   private: boolean;
+
+  @Column({ default: true })
+  visible: boolean;
+
+  @Column({ default: null })
+  visibleAt: Date;
+
+  @Column({ default: null, type: 'text' })
+  private origin: PostOrigin;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  private setOrigin(): void {
+    if (this.sourceId === COMMUNITY_PICKS_SOURCE) {
+      this.origin = PostOrigin.CommunityPicks;
+    } else if (this.type === PostType.Share) {
+      this.origin = PostOrigin.Squads;
+    } else {
+      this.origin = PostOrigin.Crawler;
+    }
+  }
 }

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -249,6 +249,8 @@ const addPostAndKeywordsToDb = async (
     origin: data.scoutId
       ? PostOrigin.CommunityPicks
       : data.origin ?? PostOrigin.Crawler,
+    visible: true,
+    visibleAt: new Date(),
   });
   await entityManager.save(post);
   if (data.tags?.length) {
@@ -372,6 +374,8 @@ export const createSharePost = async (
       sentAnalyticsReport: true,
       private: privacy,
       origin: PostOrigin.Ugc,
+      visible: true,
+      visibleAt: new Date(),
     });
   } catch (err) {
     if (err.code === TypeOrmError.FOREIGN_KEY) {

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -373,7 +373,7 @@ export const createSharePost = async (
       title: commentary,
       sentAnalyticsReport: true,
       private: privacy,
-      origin: PostOrigin.Ugc,
+      origin: PostOrigin.UserGenerated,
       visible: true,
       visibleAt: new Date(),
     });

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -9,7 +9,7 @@ import { PostTag } from '../PostTag';
 import { PostKeyword } from '../PostKeyword';
 import { validateAndApproveSubmission } from '../Submission';
 import { ArticlePost, Toc } from './ArticlePost';
-import { Post } from './Post';
+import { Post, PostOrigin } from './Post';
 import { MAX_COMMENTARY_LENGTH, SharePost } from './SharePost';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { Source } from '../Source';
@@ -75,6 +75,7 @@ export interface AddPostData {
   summary?: string;
   submissionId?: string;
   scoutId?: string;
+  origin?: PostOrigin;
 }
 
 const parseReadTime = (
@@ -245,6 +246,9 @@ const addPostAndKeywordsToDb = async (
     summary: data.summary,
     scoutId: data.scoutId,
     private: privacy,
+    origin: data.scoutId
+      ? PostOrigin.CommunityPicks
+      : data.origin ?? PostOrigin.Crawler,
   });
   await entityManager.save(post);
   if (data.tags?.length) {
@@ -367,6 +371,7 @@ export const createSharePost = async (
       title: commentary,
       sentAnalyticsReport: true,
       private: privacy,
+      origin: PostOrigin.Ugc,
     });
   } catch (err) {
     if (err.code === TypeOrmError.FOREIGN_KEY) {

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -221,7 +221,7 @@ const addPostAndKeywordsToDb = async (
   }
   const { private: privacy } = await entityManager
     .getRepository(Source)
-    .findOneById(data.publicationId);
+    .findOneBy({ id: data.publicationId });
   const post = await entityManager.getRepository(ArticlePost).create({
     id: data.id,
     shortId: data.id,
@@ -362,7 +362,7 @@ export const createSharePost = async (
   try {
     const { private: privacy } = await con
       .getRepository(Source)
-      .findOneById(sourceId);
+      .findOneBy({ id: sourceId });
     return await con.getRepository(SharePost).save({
       id,
       shortId: id,

--- a/src/migration/1677645829524-PostOrigin.ts
+++ b/src/migration/1677645829524-PostOrigin.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostOrigin1677645829524 implements MigrationInterface {
+  name = 'PostOrigin1677645829524';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "post" ADD "visible" boolean NOT NULL DEFAULT true`,
+    );
+    await queryRunner.query(`ALTER TABLE "post" ADD "visibleAt" TIMESTAMP`);
+    await queryRunner.query(`ALTER TABLE "post" ADD "origin" text`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "origin"`);
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "visibleAt"`);
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "visible"`);
+  }
+}


### PR DESCRIPTION
Introduce 3 new properties for the post entity.
  - visible: boolean
  - visibleAt: date
  - origin: text - have set this as a private property so we won't mistakenly update the value.