### PR TITLE
fix: migrated to reply thread notifications

### DIFF
--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -238,8 +238,14 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     if (!commenter || !parent || !post) {
       return;
     }
+
+    const parentUser = await parent.user;
+    if (!parentUser) {
+      return;
+    }
+
     return {
-      user_profile_image: user.image,
+      user_profile_image: parentUser.image,
       full_name: commenter.name,
       main_comment: simplifyComment(parent.content),
       new_comment: notification.description,
@@ -248,10 +254,10 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
         notification.targetUrl,
         notification.type,
       ),
-      user_reputation: user.reputation,
+      user_reputation: parentUser.reputation,
       commenter_reputation: commenter.reputation,
       commenter_profile_image: commenter.image,
-      user_name: user.name,
+      user_name: parentUser.name,
     };
   },
   comment_upvote_milestone: async (con, user, notification) => {


### PR DESCRIPTION
Our previous `comment_reply` email was heavily focussed on people always responding to the receiving user.
The reality is that our comment system supports "thread" like notifications.

The email template has been adjusted to reflect this content wise, [see here](https://dailydotdev.slack.com/archives/C02AA18RD1D/p1677663574970499?thread_ts=1677572131.388829&cid=C02AA18RD1D).
This means from a API side we should always fetch the active user from the parent comment.

WT-1111 #done 