### PR TITLE
fix: use the `set-cookie` header to set properly kratos cookie

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -108,7 +108,9 @@ const KRATOS_EXPIRATION = addDays(setMilliseconds(new Date(), 0), 1);
 const mockWhoami = (expected: unknown, statusCode = 200) => {
   nock(process.env.HEIMDALL_ORIGIN)
     .get('/api/whoami')
-    .reply(statusCode, JSON.stringify(expected));
+    .reply(statusCode, JSON.stringify(expected), {
+      'set-cookie': `ory_kratos_session=new_value; Path=/; Expires=${KRATOS_EXPIRATION.toUTCString()}; Max-Age=86399; HttpOnly; SameSite=Lax`,
+    });
 };
 
 const mockLoggedIn = (userId = '1') =>
@@ -174,7 +176,7 @@ describe('logged in boot', () => {
       .set('Cookie', `${kratosCookie}=value;`)
       .expect(200);
     const cookies = setCookieParser.parse(res, { map: true });
-    expect(cookies[kratosCookie].value).toEqual('value');
+    expect(cookies[kratosCookie].value).toEqual('new_value');
     expect(cookies[kratosCookie].expires).toEqual(KRATOS_EXPIRATION);
   });
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,5 +1,5 @@
-import {CookieSerializeOptions} from '@fastify/cookie';
-import {FastifyReply, FastifyRequest} from 'fastify';
+import { CookieSerializeOptions } from '@fastify/cookie';
+import { FastifyReply, FastifyRequest } from 'fastify';
 
 const env = process.env.NODE_ENV;
 

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,5 +1,5 @@
-import { CookieSerializeOptions } from '@fastify/cookie';
-import { FastifyReply, FastifyRequest } from 'fastify';
+import {CookieSerializeOptions} from '@fastify/cookie';
+import {FastifyReply, FastifyRequest} from 'fastify';
 
 const env = process.env.NODE_ENV;
 
@@ -85,11 +85,12 @@ export const setRawCookie = (
 
   if (typeof setCookie === 'string') {
     setCookie = [setCookie];
-  } else if (typeof setCookie !== 'number') {
+  }
+  if (typeof setCookie !== 'number') {
     setCookie.push(setCookieValue);
   }
   res.removeHeader('Set-Cookie');
-  res.header('Set-Cookie', setCookie);
+  return res.header('Set-Cookie', setCookie);
 };
 
 export const setCookie = (

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -73,6 +73,25 @@ const addSubdomainOpts = (
   };
 };
 
+export const setRawCookie = (
+  res: FastifyReply,
+  setCookieValue: string,
+): FastifyReply => {
+  let setCookie = res.getHeader('Set-Cookie');
+  if (!setCookie) {
+    res.header('Set-Cookie', setCookieValue);
+    return res;
+  }
+
+  if (typeof setCookie === 'string') {
+    setCookie = [setCookie];
+  } else if (typeof setCookie !== 'number') {
+    setCookie.push(setCookieValue);
+  }
+  res.removeHeader('Set-Cookie');
+  res.header('Set-Cookie', setCookie);
+};
+
 export const setCookie = (
   req: FastifyRequest,
   res: FastifyReply,

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -25,7 +25,7 @@ import { getRedisObject, setRedisObject } from '../redis';
 import { REDIS_CHANGELOG_KEY } from '../config';
 import { getSourceLink } from '../common';
 import { AccessToken, signJwt } from '../auth';
-import { cookies, setCookie } from '../cookies';
+import { cookies, setCookie, setRawCookie } from '../cookies';
 import { parse } from 'graphql/language/parser';
 import { execute } from 'graphql/execution/execute';
 import { schema } from '../graphql';
@@ -290,9 +290,9 @@ export const getBootData = async (
 ): Promise<AnonymousBoot | LoggedInBoot> => {
   const whoami = await dispatchWhoami(req);
   if (whoami.valid) {
-    setCookie(req, res, 'kratos', req.cookies[cookies.kratos.key], {
-      expires: whoami.expires,
-    });
+    if (whoami.cookie) {
+      setRawCookie(res, whoami.cookie);
+    }
     if (req.userId !== whoami.userId) {
       req.userId = whoami.userId;
       req.trackingId = req.userId;


### PR DESCRIPTION
Instead of patching the expiration of the kratos cookie, we use the returned `set-cookie` header. This will make sure there are no discrepancies.