### PR TITLE
fix: allow newlines in description

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -692,6 +692,18 @@ describe('mutation editSquad', () => {
     expect(editSource.name).toEqual('test');
   });
 
+  it('should edit squad description with new lines', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: { ...variables, description: 'test \n something more' },
+    });
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource.description).toEqual('test \n something more');
+  });
+
   it('should throw error on duplicate handles', async () => {
     loggedUser = '1';
     await con.getRepository(SquadSource).save({

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -38,4 +38,4 @@ export const validateRegex = (params: ValidateRegex[]): void => {
 };
 export const nameRegex = new RegExp(/^(.){1,60}$/);
 export const handleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
-export const descriptionRegex = new RegExp(/^(.){1,250}$/);
+export const descriptionRegex = new RegExp(/^[\S\s]{1,250}$/);


### PR DESCRIPTION
Allowing new lines in the description of squad.
By default `.` only checks for any character excluding new lines.

Also added a test case for it.

WT-1131 #done 