### PR TITLE
fix: don't add article picked notification for private posts

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -145,6 +145,21 @@ describe('post added notifications', () => {
     expect(ctx.sharedPost).toBeFalsy();
   });
 
+  it('should not add article picked notification for private post', async () => {
+    const worker = await import('../../src/workers/notifications/postAdded');
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: '1',
+        private: true,
+      },
+    );
+    const actual = await invokeNotificationWorker(worker.default, {
+      post: postsFixture[0],
+    });
+    expect(actual.length).toEqual(0);
+  });
+
   it('should add community picks succeeded notification', async () => {
     const worker = await import('../../src/workers/notifications/postAdded');
     await con.getRepository(Post).update({ id: 'p1' }, { scoutId: '1' });

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -35,7 +35,7 @@ const worker: NotificationWorker = {
     if (source) {
       // article_picked notification
       if (source.type === SourceType.Machine) {
-        if (post.authorId) {
+        if (post.authorId && !post.private) {
           const ctx: NotificationPostContext = {
             ...baseCtx,
             userId: post.authorId,


### PR DESCRIPTION
With external links we need to be careful not to send notifications for authors that can't access the post. So if the post belongs to a machine source we will not send a notification for private posts