### PR TITLE
fix: make squads active by default

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -582,7 +582,7 @@ describe('mutation createSquad', () => {
       .findOneBy({ id: newId });
     expect(newSource.name).toEqual('Squad');
     expect(newSource.handle).toEqual('squad');
-    expect(newSource.active).toEqual(false);
+    expect(newSource.active).toEqual(true);
     expect(newSource.private).toEqual(true);
     const member = await con.getRepository(SourceMember).findOneBy({
       sourceId: newId,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -728,7 +728,7 @@ export const resolvers: IResolvers<any, Context> = {
             id,
             name,
             handle,
-            active: false,
+            active: true,
             description,
             private: true,
           });


### PR DESCRIPTION
Should only be merged once v3 is in production.
It will set squad active by default (non breaking for the frontend)

WT-1163