### PR TITLE
fix: enforce permissions in postByUrl query

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -620,6 +620,7 @@ describe('query post', () => {
   it('should throw error when user cannot access the post', async () => {
     loggedUser = '1';
     await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    await con.getRepository(Post).update({ id: 'p1' }, { private: true });
     return testQueryErrorCode(
       client,
       {
@@ -667,6 +668,16 @@ describe('query postByUrl', () => {
       client,
       { query: QUERY('http://p8.com') },
       'NOT_FOUND',
+    );
+  });
+
+  it('should throw error when source is private', async () => {
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    await con.getRepository(Post).update({ id: 'p1' }, { private: true });
+    return testQueryErrorCode(
+      client,
+      { query: QUERY('http://p1.com') },
+      'FORBIDDEN',
     );
   });
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -63,7 +63,14 @@ const obj = new GraphORM({
   Post: {
     from: 'ActivePost',
     metadataFrom: 'Post',
-    requiredColumns: ['id', 'shortId', 'createdAt', 'authorId', 'scoutId'],
+    requiredColumns: [
+      'id',
+      'shortId',
+      'createdAt',
+      'authorId',
+      'scoutId',
+      'private',
+    ],
     fields: {
       tags: {
         select: 'tagsStr',


### PR DESCRIPTION
* Check permissions for posts returned by `postByUrl`
* Minor perf improvement to post query for public posts