### PR TITLE
feat(squads): source members fields

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1153,8 +1153,12 @@ describe('query source members', () => {
 query Source($id: ID!) {
   source(id: $id) {
     id
-    owners,
-    moderators
+    privilegedMembers {
+      user {
+        id
+      }
+      role
+    }
   }
 }
   `;
@@ -1201,8 +1205,7 @@ query Source($id: ID!) {
     expect(res.data).toMatchObject({
       source: {
         id: 'c',
-        owners: null,
-        moderators: null,
+        privilegedMembers: null,
       },
     });
   });
@@ -1213,8 +1216,26 @@ query Source($id: ID!) {
     expect(res.data).toMatchObject({
       source: {
         id: 'c',
-        owners: ['1'],
-        moderators: ['2', '3'],
+        privilegedMembers: [
+          {
+            role: 'owner',
+            user: {
+              id: '1',
+            },
+          },
+          {
+            role: 'moderator',
+            user: {
+              id: '2',
+            },
+          },
+          {
+            role: 'moderator',
+            user: {
+              id: '3',
+            },
+          },
+        ],
       },
     });
   });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -187,6 +187,26 @@ const obj = new GraphORM({
               .andWhere(`${childAlias}."sourceId" = "${parentAlias}".id`),
         },
       },
+      owners: {
+        select: (ctx, alias, qb) => {
+          return qb
+            .select('ARRAY_AGG(sm."userId")')
+            .from(SourceMember, 'sm')
+            .where(`sm."sourceId" = "${alias}".id`)
+            .andWhere(`sm.role = 'owner'`);
+        },
+        transform: nullIfNotLoggedIn,
+      },
+      moderators: {
+        select: (ctx, alias, qb) => {
+          return qb
+            .select('ARRAY_AGG(sm."userId")')
+            .from(SourceMember, 'sm')
+            .where(`sm."sourceId" = "${alias}".id`)
+            .andWhere(`sm.role = 'moderator'`);
+        },
+        transform: nullIfNotLoggedIn,
+      },
     },
   },
   SourceMember: {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -197,9 +197,9 @@ const obj = new GraphORM({
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
               .where(`${childAlias}."sourceId" = "${parentAlias}".id`)
-              .andWhere(
-                `(${childAlias}.role = '${SourceMemberRoles.Owner}' OR ${childAlias}.role = '${SourceMemberRoles.Moderator}')`,
-              )
+              .andWhere(`${childAlias}.role IN (:...roles)`, {
+                roles: [SourceMemberRoles.Owner, SourceMemberRoles.Moderator],
+              })
               .limit(50); // limit to avoid huge arrays for members, most sources should fit into this see PR !1219 for more info
           },
         },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -193,7 +193,8 @@ const obj = new GraphORM({
             .select('ARRAY_AGG(sm."userId")')
             .from(SourceMember, 'sm')
             .where(`sm."sourceId" = "${alias}".id`)
-            .andWhere(`sm.role = 'owner'`);
+            .andWhere(`sm.role = 'owner'`)
+            .limit(50); // limit to avoid huge arrays, most squads should fit into this
         },
         transform: nullIfNotLoggedIn,
       },
@@ -203,7 +204,8 @@ const obj = new GraphORM({
             .select('ARRAY_AGG(sm."userId")')
             .from(SourceMember, 'sm')
             .where(`sm."sourceId" = "${alias}".id`)
-            .andWhere(`sm.role = 'moderator'`);
+            .andWhere(`sm.role = 'moderator'`)
+            .limit(50); // limit to avoid huge arrays, most squads should fit into this
         },
         transform: nullIfNotLoggedIn,
       },

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -130,14 +130,9 @@ export const typeDefs = /* GraphQL */ `
     currentMember: SourceMember
 
     """
-    Owner members
+    Privileged members
     """
-    owners: [String]
-
-    """
-    Moderator members
-    """
-    moderators: [String]
+    privilegedMembers: [SourceMember]
   }
 
   type SourceConnection {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -52,6 +52,8 @@ export interface GQLSource {
   public: boolean;
   members?: Connection<GQLSourceMember>;
   currentMember?: GQLSourceMember;
+  owners?: string[];
+  moderators?: string[];
 }
 
 export interface GQLSourceMember {
@@ -126,6 +128,16 @@ export const typeDefs = /* GraphQL */ `
     Logged-in member object
     """
     currentMember: SourceMember
+
+    """
+    Owner members
+    """
+    owners: [String]
+
+    """
+    Moderator members
+    """
+    moderators: [String]
   }
 
   type SourceConnection {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -52,8 +52,7 @@ export interface GQLSource {
   public: boolean;
   members?: Connection<GQLSourceMember>;
   currentMember?: GQLSourceMember;
-  owners?: string[];
-  moderators?: string[];
+  privilegedMembers?: GQLSourceMember[];
 }
 
 export interface GQLSourceMember {


### PR DESCRIPTION
We agreed on the web team sync to add member fields to the source entity to be able to show roles on the post feed and member listings for the squad members. 

We also agreed that it might not be best decision scaling wise because if squads have hundreds of moderators and other members this fields would become quite big. `50` limit was added to prevent any excess cases while in beta - this should catch most of the squads though since they don't have many privileged members.