### PR TITLE
fix: add check for deletion of comments by relevant role

### DIFF
--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -209,6 +209,7 @@ Object {
         "view",
         "post",
         "leave",
+        "comment_delete",
         "post_delete",
         "member_remove",
         "edit",

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -23,6 +23,7 @@ import {
   SQUAD_IMAGE_PLACEHOLDER,
   SourceType,
   Post,
+  ArticlePost,
 } from '../src/entity';
 import { SourceMemberRoles } from '../src/roles';
 import { notificationFixture } from './fixture/notifications';
@@ -537,7 +538,7 @@ describe('companion boot', () => {
   it('should support anonymous user', async () => {
     const res = await request(app.server)
       .get(`${BASE_PATH}/companion`)
-      .query({ url: postsFixture[0].url })
+      .query({ url: (postsFixture[0] as ArticlePost).url })
       .set('User-Agent', TEST_UA)
       .expect(200);
     expect(res.body).toEqual({
@@ -550,7 +551,7 @@ describe('companion boot', () => {
     mockLoggedIn();
     const res = await request(app.server)
       .get(`${BASE_PATH}/companion`)
-      .query({ url: postsFixture[0].url })
+      .query({ url: (postsFixture[0] as ArticlePost).url })
       .set('User-Agent', TEST_UA)
       .set('Cookie', 'ory_kratos_session=value;')
       .expect(200);

--- a/__tests__/cron/__snapshots__/updateTagsStr.ts.snap
+++ b/__tests__/cron/__snapshots__/updateTagsStr.ts.snap
@@ -30,5 +30,9 @@ Array [
     "id": "p7",
     "tagsStr": null,
   },
+  Post {
+    "id": "squadP1",
+    "tagsStr": null,
+  },
 ]
 `;

--- a/__tests__/cron/__snapshots__/updateTrending.ts.snap
+++ b/__tests__/cron/__snapshots__/updateTrending.ts.snap
@@ -30,5 +30,9 @@ Array [
     "id": "p7",
     "trending": null,
   },
+  Post {
+    "id": "squadP1",
+    "trending": null,
+  },
 ]
 `;

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -99,11 +99,13 @@ export const postsFixture: DeepPartial<ArticlePost | SharePost>[] = [
     title: 'Squad 1',
     url: 'http://squad1.com',
     image: 'http://image/sp1',
+    score: 10,
     sourceId: 'squad',
     createdAt: new Date(now.getTime() - 5000),
     type: PostType.Share,
     visible: true,
     sharedPostId: 'p1',
+    private: true,
   },
 ];
 

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -1,9 +1,15 @@
 import { DeepPartial } from 'typeorm';
-import { ArticlePost, PostKeyword, PostTag, PostType } from '../../src/entity';
+import {
+  ArticlePost,
+  PostKeyword,
+  PostTag,
+  PostType,
+  SharePost,
+} from '../../src/entity';
 
 const now = new Date();
 
-export const postsFixture: DeepPartial<ArticlePost>[] = [
+export const postsFixture: DeepPartial<ArticlePost | SharePost>[] = [
   {
     id: 'p1',
     shortId: 'sp1',
@@ -86,6 +92,18 @@ export const postsFixture: DeepPartial<ArticlePost>[] = [
     createdAt: new Date(now.getTime() - 5000),
     type: PostType.Article,
     visible: false,
+  },
+  {
+    id: 'squadP1',
+    shortId: 'squadP1',
+    title: 'Squad 1',
+    url: 'http://squad1.com',
+    image: 'http://image/sp1',
+    sourceId: 'squad',
+    createdAt: new Date(now.getTime() - 5000),
+    type: PostType.Share,
+    visible: true,
+    sharedPostId: 'p1',
   },
 ];
 

--- a/__tests__/fixture/source.ts
+++ b/__tests__/fixture/source.ts
@@ -43,4 +43,13 @@ export const sourcesFixture: DeepPartial<MachineSource>[] = [
     image: 'http://image.com/c',
     handle: 'community',
   },
+  {
+    id: 'squad',
+    name: 'Squad',
+    image: 'http//image.com/s',
+    handle: 'squad',
+    type: SourceType.Squad,
+    active: true,
+    private: true,
+  },
 ];

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -730,7 +730,10 @@ export const resolvers: IResolvers<any, Context> = {
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
         const repo = entityManager.getRepository(Comment);
-        const comment = await repo.findOneByOrFail({ id });
+        const comment = await ctx.con.getRepository(Comment).findOneOrFail({
+          where: { id },
+          relations: ['post'],
+        });
         const post = await comment.post;
         if (
           comment.userId !== ctx.userId &&
@@ -738,7 +741,7 @@ export const resolvers: IResolvers<any, Context> = {
           !(await ensureSourcePermissions(
             ctx,
             post.sourceId,
-            SourcePermissions.PostDelete,
+            SourcePermissions.CommentDelete,
           ))
         ) {
           throw new ForbiddenError("Cannot delete someone else's comment");

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -355,6 +355,7 @@ const sourceToGQL = (source: Source): GQLSource => ({
 });
 
 export enum SourcePermissions {
+  CommentDelete = 'comment_delete',
   View = 'view',
   Post = 'post',
   PostLimit = 'post_limit',
@@ -375,6 +376,7 @@ const memberPermissions = [
 ];
 const moderatorPermissions = [
   ...memberPermissions,
+  SourcePermissions.CommentDelete,
   SourcePermissions.PostDelete,
   SourcePermissions.MemberRemove,
   SourcePermissions.Edit,


### PR DESCRIPTION
Allow deletion of comments by relevant roles.
Let me know if you guys think postDelete scope is ok, or we want a seperate scope?

WT-1183 #done 