### PR TITLE
feat: unblock a squad member

### DIFF
--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -121,6 +121,8 @@ Object {
     "edges": Array [
       Object {
         "node": Object {
+          "role": "owner",
+          "roleRank": 10,
           "source": Object {
             "id": "b",
           },
@@ -144,6 +146,8 @@ Object {
     "edges": Array [
       Object {
         "node": Object {
+          "role": "member",
+          "roleRank": 0,
           "source": Object {
             "id": "a",
           },
@@ -154,6 +158,8 @@ Object {
       },
       Object {
         "node": Object {
+          "role": "owner",
+          "roleRank": 10,
           "source": Object {
             "id": "b",
           },
@@ -213,6 +219,7 @@ Object {
         "post_delete",
         "member_remove",
         "edit",
+        "member_unblock",
         "member_role_update",
         "post_limit",
         "invite_disable",
@@ -251,6 +258,31 @@ Object {
     "image": "http://a.com",
     "name": "A",
     "public": true,
+  },
+}
+`;
+
+exports[`query sourceMembers should return blocked users only 1`] = `
+Object {
+  "sourceMembers": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "role": "blocked",
+          "roleRank": -1,
+          "source": Object {
+            "id": "a",
+          },
+          "user": Object {
+            "id": "2",
+          },
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "dGltZToxNjcxNDk0NDAwMDAw",
+      "hasNextPage": false,
+    },
   },
 }
 `;

--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -220,6 +220,7 @@ Object {
         "member_remove",
         "edit",
         "member_unblock",
+        "view_blocked_members",
         "member_role_update",
         "post_limit",
         "invite_disable",
@@ -262,7 +263,32 @@ Object {
 }
 `;
 
-exports[`query sourceMembers should return blocked users only 1`] = `
+exports[`query sourceMembers should return blocked users only when user is a moderator 1`] = `
+Object {
+  "sourceMembers": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "role": "blocked",
+          "roleRank": -1,
+          "source": Object {
+            "id": "a",
+          },
+          "user": Object {
+            "id": "2",
+          },
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "dGltZToxNjcxNDk0NDAwMDAw",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query sourceMembers should return blocked users only when user is the owner 1`] = `
 Object {
   "sourceMembers": Object {
     "edges": Array [

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -446,8 +446,8 @@ query Source($id: ID!) {
 
 describe('query sourceMembers', () => {
   const QUERY = `
-query SourceMembers($id: ID!, $blockedOnly: Boolean) {
-  sourceMembers(sourceId: $id, blockedOnly: $blockedOnly) {
+query SourceMembers($id: ID!, $role: String) {
+  sourceMembers(sourceId: $id, role: $role) {
     pageInfo {
       endCursor
       hasNextPage
@@ -540,7 +540,7 @@ query SourceMembers($id: ID!, $blockedOnly: Boolean) {
       );
     loggedUser = '1';
     const res = await client.query(QUERY, {
-      variables: { blockedOnly: true, id: 'a' },
+      variables: { role: SourceMemberRoles.Blocked, id: 'a' },
     });
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1108,6 +1108,88 @@ describe('mutation updateMemberRole', () => {
   });
 });
 
+describe('mutation unblockMember', () => {
+  const MUTATION = `
+    mutation UnblockMember($sourceId: ID!, $memberId: ID!) {
+      unblockMember(sourceId: $sourceId, memberId: $memberId) {
+        _
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await con.getRepository(SourceMember).save({
+      userId: '3',
+      sourceId: 'a',
+      role: SourceMemberRoles.Blocked,
+      referralToken: randomUUID(),
+      createdAt: new Date(2022, 11, 20),
+    });
+  });
+
+  it('should not authorize when not logged in', () =>
+    testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { sourceId: 'a', memberId: '3' },
+      },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should restrict when not a member of the squad', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { sourceId: 'b', memberId: '3' },
+      },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should restrict member unblock another member', async () => {
+    loggedUser = '2';
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { sourceId: 'a', memberId: '3' },
+      },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should allow moderator to unblock a member', async () => {
+    loggedUser = '2';
+    await con
+      .getRepository(SourceMember)
+      .update({ userId: '2' }, { role: SourceMemberRoles.Moderator });
+    const res = await client.mutate(MUTATION, {
+      variables: { sourceId: 'a', memberId: '3' },
+    });
+    expect(res.errors).toBeFalsy();
+    const member = await con
+      .getRepository(SourceMember)
+      .findOneBy({ userId: '3', sourceId: 'a' });
+    expect(member).toBeFalsy();
+  });
+
+  it('should allow owner to unblock a member', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: { sourceId: 'a', memberId: '3' },
+    });
+    expect(res.errors).toBeFalsy();
+    const member = await con
+      .getRepository(SourceMember)
+      .findOneBy({ userId: '3', sourceId: 'a' });
+    expect(member).toBeFalsy();
+  });
+});
+
 describe('mutation leaveSource', () => {
   const MUTATION = `
   mutation LeaveSource($sourceId: ID!) {
@@ -1378,123 +1460,6 @@ describe('mutation joinSource', () => {
     );
   });
 });
-
-// describe('mutation removeMember', () => {
-//   const MUTATION = `
-//     mutation RemoveMember($sourceId: ID!, $memberId: ID!) {
-//       removeMember(sourceId: $sourceId, memberId: $memberId) {
-//         _
-//       }
-//     }
-//   `;
-
-//   it('should not authorize when not logged in', () =>
-//     testMutationErrorCode(
-//       client,
-//       {
-//         mutation: MUTATION,
-//         variables: { sourceId: 'a', memberId: '2' },
-//       },
-//       'UNAUTHENTICATED',
-//     ));
-
-//   it('should restrict when not a member of the squad', async () => {
-//     loggedUser = '1';
-
-//     return testMutationErrorCode(
-//       client,
-//       { mutation: MUTATION, variables: { sourceId: 'b', memberId: '2' } },
-//       'FORBIDDEN',
-//     );
-//   });
-
-//   it('should restrict when not a moderator or an owner of the squad', async () => {
-//     loggedUser = '2';
-//     return testMutationErrorCode(
-//       client,
-//       { mutation: MUTATION, variables: { sourceId: 'a', memberId: '1' } },
-//       'FORBIDDEN',
-//     );
-//   });
-
-//   it('should restrict moderator from removing the owner', async () => {
-//     loggedUser = '2';
-//     await con
-//       .getRepository(SourceMember)
-//       .update({ userId: '2' }, { role: SourceMemberRoles.Moderator });
-
-//     return testMutationErrorCode(
-//       client,
-//       { mutation: MUTATION, variables: { sourceId: 'a', memberId: '1' } },
-//       'FORBIDDEN',
-//     );
-//   });
-
-//   it('should restrict moderator from removing a moderator', async () => {
-//     loggedUser = '2';
-//     const repo = con.getRepository(SourceMember);
-//     await repo.save({
-//       userId: '3',
-//       sourceId: 'a',
-//       role: SourceMemberRoles.Moderator,
-//       referralToken: randomUUID(),
-//     });
-//     await repo.update({ userId: '2' }, { role: SourceMemberRoles.Moderator });
-
-//     return testMutationErrorCode(
-//       client,
-//       { mutation: MUTATION, variables: { sourceId: 'a', memberId: '3' } },
-//       'FORBIDDEN',
-//     );
-//   });
-
-//   it('should allow owner to remove moderator from the squad', async () => {
-//     loggedUser = '1';
-//     const toRemoveId = '2';
-//     const repo = con.getRepository(SourceMember);
-//     await repo.update(
-//       { userId: toRemoveId },
-//       { role: SourceMemberRoles.Moderator },
-//     );
-
-//     const res = await client.mutate(MUTATION, {
-//       variables: { sourceId: 'a', memberId: toRemoveId },
-//     });
-//     expect(res.errors).toBeFalsy();
-//     const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
-//     expect(member).toBeFalsy();
-//   });
-
-//   it('should allow owner to remove member from the squad', async () => {
-//     loggedUser = '1';
-//     const toRemoveId = '2';
-//     const repo = con.getRepository(SourceMember);
-//     const res = await client.mutate(MUTATION, {
-//       variables: { sourceId: 'a', memberId: toRemoveId },
-//     });
-//     expect(res.errors).toBeFalsy();
-//     const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
-//     expect(member).toBeFalsy();
-//   });
-
-//   it('should allow moderator to remove member the squad', async () => {
-//     loggedUser = '3';
-//     const toRemoveId = '2';
-//     const repo = con.getRepository(SourceMember);
-//     await repo.save({
-//       userId: '3',
-//       sourceId: 'a',
-//       role: SourceMemberRoles.Moderator,
-//       referralToken: randomUUID(),
-//     });
-//     const res = await client.mutate(MUTATION, {
-//       variables: { sourceId: 'a', memberId: toRemoveId },
-//     });
-//     expect(res.errors).toBeFalsy();
-//     const member = await repo.findOneBy({ userId: toRemoveId, sourceId: 'a' });
-//     expect(member).toBeFalsy();
-//   });
-// });
 
 describe('query source members', () => {
   const QUERY = `

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -531,14 +531,29 @@ query SourceMembers($id: ID!, $role: String) {
     );
   });
 
+  it('should not return blocked source members when user is not a moderator/owner', async () => {
+    loggedUser = '2';
+    await con
+      .getRepository(SourceMember)
+      .update(
+        { userId: '1', sourceId: 'a' },
+        { role: SourceMemberRoles.Blocked },
+      );
+    return testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { role: SourceMemberRoles.Blocked, id: 'a' } },
+      'FORBIDDEN',
+    );
+  });
+
   it('should return blocked users only', async () => {
+    loggedUser = '1';
     await con
       .getRepository(SourceMember)
       .update(
         { userId: '2', sourceId: 'a' },
         { role: SourceMemberRoles.Blocked },
       );
-    loggedUser = '1';
     const res = await client.query(QUERY, {
       variables: { role: SourceMemberRoles.Blocked, id: 'a' },
     });

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -546,13 +546,34 @@ query SourceMembers($id: ID!, $role: String) {
     );
   });
 
-  it('should return blocked users only', async () => {
+  it('should return blocked users only when user is the owner', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
       .update(
         { userId: '2', sourceId: 'a' },
         { role: SourceMemberRoles.Blocked },
+      );
+    const res = await client.query(QUERY, {
+      variables: { role: SourceMemberRoles.Blocked, id: 'a' },
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return blocked users only when user is a moderator', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SourceMember)
+      .update(
+        { userId: '2', sourceId: 'a' },
+        { role: SourceMemberRoles.Blocked },
+      );
+    await con
+      .getRepository(SourceMember)
+      .update(
+        { userId: '1', sourceId: 'a' },
+        { role: SourceMemberRoles.Moderator },
       );
     const res = await client.query(QUERY, {
       variables: { role: SourceMemberRoles.Blocked, id: 'a' },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -213,7 +213,7 @@ const obj = new GraphORM({
     },
   },
   SourceMember: {
-    requiredColumns: ['createdAt', 'userId'],
+    requiredColumns: ['createdAt', 'userId', 'role'],
     fields: {
       permissions: {
         transform: (_, ctx: Context, member: SourceMember) => {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -414,6 +414,7 @@ const sourceToGQL = (source: Source): GQLSource => ({
 export enum SourcePermissions {
   CommentDelete = 'comment_delete',
   View = 'view',
+  ViewBlockedMembers = 'view_blocked_members',
   Post = 'post',
   PostLimit = 'post_limit',
   PostDelete = 'post_delete',
@@ -680,7 +681,12 @@ export const resolvers: IResolvers<any, Context> = {
       ctx,
       info,
     ): Promise<Connection<GQLSourceMember>> => {
-      await ensureSourcePermissions(ctx, sourceId);
+      const permission =
+        role === SourceMemberRoles.Blocked
+          ? SourcePermissions.ViewBlockedMembers
+          : SourcePermissions.View;
+
+      await ensureSourcePermissions(ctx, sourceId, permission);
       const page = membershipsPageGenerator.connArgsToPage(args);
       return graphorm.queryPaginated(
         ctx,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -676,11 +676,11 @@ export const resolvers: IResolvers<any, Context> = {
     },
     sourceMembers: async (
       _,
-      { role, ...args }: SourceMemberArgs,
+      { role, sourceId, ...args }: SourceMemberArgs,
       ctx,
       info,
     ): Promise<Connection<GQLSourceMember>> => {
-      await ensureSourcePermissions(ctx, args.sourceId);
+      await ensureSourcePermissions(ctx, sourceId);
       const page = membershipsPageGenerator.connArgsToPage(args);
       return graphorm.queryPaginated(
         ctx,
@@ -692,7 +692,7 @@ export const resolvers: IResolvers<any, Context> = {
         (builder) => {
           builder.queryBuilder
             .andWhere(`${builder.alias}."sourceId" = :source`, {
-              source: args.sourceId,
+              source: sourceId,
             })
 
             .addOrderBy(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -345,6 +345,21 @@ export const typeDefs = /* GraphQL */ `
     ): EmptyResponse! @auth
 
     """
+    Unblock a removed member with blocked role
+    """
+    unblockMember(
+      """
+      Relevant source the user to update role is a member of
+      """
+      sourceId: ID!
+
+      """
+      Member to update
+      """
+      memberId: ID!
+    ): EmptyResponse! @auth
+
+    """
     Adds the logged-in user as member to the source
     """
     joinSource(
@@ -393,6 +408,7 @@ export enum SourcePermissions {
   PostLimit = 'post_limit',
   PostDelete = 'post_delete',
   MemberRemove = 'member_remove',
+  MemberUnblock = 'member_unblock',
   MemberRoleUpdate = 'member_role_update',
   InviteDisable = 'invite_disable',
   Leave = 'leave',
@@ -411,6 +427,7 @@ const moderatorPermissions = [
   SourcePermissions.PostDelete,
   SourcePermissions.MemberRemove,
   SourcePermissions.Edit,
+  SourcePermissions.MemberUnblock,
 ];
 const ownerPermissions = [
   ...moderatorPermissions,
@@ -920,6 +937,23 @@ export const resolvers: IResolvers<any, Context> = {
       await ctx.con
         .getRepository(SourceMember)
         .update({ sourceId, userId: memberId }, { role });
+
+      return { _: true };
+    },
+    unblockMember: async (
+      _,
+      { sourceId, memberId }: UpdateMemberRoleArgs,
+      ctx,
+    ): Promise<GQLEmptyResponse> => {
+      await ensureSourcePermissions(
+        ctx,
+        sourceId,
+        SourcePermissions.MemberUnblock,
+      );
+
+      await ctx.con
+        .getRepository(SourceMember)
+        .delete({ sourceId, userId: memberId });
 
       return { _: true };
     },

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -71,7 +71,7 @@ interface UpdateMemberRoleArgs {
 
 interface SourceMemberArgs extends ConnectionArguments {
   sourceId: string;
-  blockedOnly?: boolean;
+  role?: SourceMemberRoles;
 }
 
 export const typeDefs = /* GraphQL */ `
@@ -246,9 +246,9 @@ export const typeDefs = /* GraphQL */ `
       first: Int
 
       """
-      Should return users that are blocked only
+      Should return users with this specific role only
       """
-      blockedOnly: Boolean
+      role: String
     ): SourceMemberConnection!
 
     """
@@ -676,7 +676,7 @@ export const resolvers: IResolvers<any, Context> = {
     },
     sourceMembers: async (
       _,
-      { blockedOnly, ...args }: SourceMemberArgs,
+      { role, ...args }: SourceMemberArgs,
       ctx,
       info,
     ): Promise<Connection<GQLSourceMember>> => {
@@ -701,10 +701,10 @@ export const resolvers: IResolvers<any, Context> = {
             )
             .addOrderBy(`${builder.alias}."createdAt"`, 'DESC');
 
-          if (blockedOnly) {
+          if (role) {
             builder.queryBuilder = builder.queryBuilder.andWhere(
               `${builder.alias}.role = :role`,
-              { role: SourceMemberRoles.Blocked },
+              { role },
             );
           } else {
             builder.queryBuilder = builder.queryBuilder.andWhere(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -701,7 +701,6 @@ export const resolvers: IResolvers<any, Context> = {
             )
             .addOrderBy(`${builder.alias}."createdAt"`, 'DESC');
 
-          console.log('is blocked: ', blockedOnly);
           if (blockedOnly) {
             builder.queryBuilder = builder.queryBuilder.andWhere(
               `${builder.alias}.role = :role`,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -439,6 +439,7 @@ const moderatorPermissions = [
   SourcePermissions.MemberRemove,
   SourcePermissions.Edit,
   SourcePermissions.MemberUnblock,
+  SourcePermissions.ViewBlockedMembers,
 ];
 const ownerPermissions = [
   ...moderatorPermissions,


### PR DESCRIPTION
- Unblock a member by removing the row from the table which would allow the user to re-join when they want to.
- I have also deleted the commented test cases for `removing a member` as it was already reused on the role update tests.
- Update `sourceMembers` query to accept a boolean parameter to return all blocked users only.
- Also updated the queries of tests to include `role` property to easily check snapshots.