### PR TITLE
fix: new role evaluation

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -685,8 +685,8 @@ describe('generateNotification', () => {
     );
   });
 
-  it('should generate promoted_to_role owner notification', () => {
-    const type = 'promoted_to_role';
+  it('should generate promoted_to_owner notification', () => {
+    const type = 'promoted_to_owner';
     const ctx: NotificationSourceMemberRoleContext = {
       userId,
       source: {
@@ -703,32 +703,7 @@ describe('generateNotification', () => {
     expect(actual.notification.referenceType).toEqual('source');
     expect(actual.notification.icon).toEqual('Star');
     expect(actual.notification.title).toEqual(
-      `You are now a <span class="text-theme-color-cabbage">${SourceMemberRoles.Owner}</span> in <b>${sourcesFixture[0].name}</b>`,
-    );
-    expect(actual.notification.targetUrl).toEqual(
-      'http://localhost:5002/squads/a',
-    );
-  });
-
-  it('should generate promoted_to_role moderator notification', () => {
-    const type = 'promoted_to_role';
-    const ctx: NotificationSourceMemberRoleContext = {
-      userId,
-      source: {
-        ...sourcesFixture[0],
-        type: SourceType.Squad,
-      } as Reference<Source>,
-      role: SourceMemberRoles.Moderator,
-    };
-    const actual = generateNotification(type, ctx);
-    expect(actual.notification.type).toEqual(type);
-    expect(actual.notification.userId).toEqual(userId);
-    expect(actual.notification.public).toEqual(true);
-    expect(actual.notification.referenceId).toEqual('a');
-    expect(actual.notification.referenceType).toEqual('source');
-    expect(actual.notification.icon).toEqual('User');
-    expect(actual.notification.title).toEqual(
-      `You are now a <span class="text-theme-color-cabbage">${SourceMemberRoles.Moderator}</span> in <b>${sourcesFixture[0].name}</b>`,
+      `Congratulations! You are now an <span class="text-theme-color-cabbage">${SourceMemberRoles.Owner}</span> of <b>${sourcesFixture[0].name}</b>`,
     );
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/squads/a',
@@ -777,7 +752,7 @@ describe('generateNotification', () => {
     expect(actual.notification.referenceType).toEqual('source');
     expect(actual.notification.icon).toEqual('User');
     expect(actual.notification.title).toEqual(
-      `Congratulations! You got promoted to a <span class="text-theme-color-cabbage">moderator</span> role in <b>${sourcesFixture[0].name}</b>`,
+      `You are now a <span class="text-theme-color-cabbage">moderator</span> in <b>${sourcesFixture[0].name}</b>`,
     );
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/squads/a',

--- a/__tests__/workers/newNotificationMail.ts
+++ b/__tests__/workers/newNotificationMail.ts
@@ -936,3 +936,67 @@ it('should set parameters for squad_post_live email', async () => {
   });
   expect(args.templateId).toEqual('d-343845599453499d9fa5d3ffafc91514');
 });
+
+it('should set parameters for promoted_to_owner email', async () => {
+  await con
+    .getRepository(Source)
+    .update({ id: 'a' }, { type: SourceType.Squad });
+  const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+  const ctx: NotificationSourceContext = {
+    userId: '1',
+    source,
+  };
+
+  const notificationId = await saveNotificationFixture(
+    con,
+    'promoted_to_owner',
+    ctx,
+  );
+  await expectSuccessfulBackground(worker, {
+    notification: {
+      id: notificationId,
+      userId: '1',
+    },
+  });
+  expect(sendEmail).toBeCalledTimes(1);
+  const args = jest.mocked(sendEmail).mock.calls[0][0] as MailDataRequired;
+  expect(args.dynamicTemplateData).toEqual({
+    first_name: 'Ido',
+    squad_link:
+      'http://localhost:5002/squads/a?utm_source=notification&utm_medium=email&utm_campaign=promoted_to_owner',
+    squad_name: 'A',
+  });
+  expect(args.templateId).toEqual('d-397a5e4a394a4b7f91ea33c29efb8d01');
+});
+
+it('should set parameters for promoted_to_moderator email', async () => {
+  await con
+    .getRepository(Source)
+    .update({ id: 'a' }, { type: SourceType.Squad });
+  const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+  const ctx: NotificationSourceContext = {
+    userId: '1',
+    source,
+  };
+
+  const notificationId = await saveNotificationFixture(
+    con,
+    'promoted_to_moderator',
+    ctx,
+  );
+  await expectSuccessfulBackground(worker, {
+    notification: {
+      id: notificationId,
+      userId: '1',
+    },
+  });
+  expect(sendEmail).toBeCalledTimes(1);
+  const args = jest.mocked(sendEmail).mock.calls[0][0] as MailDataRequired;
+  expect(args.dynamicTemplateData).toEqual({
+    first_name: 'Ido',
+    squad_link:
+      'http://localhost:5002/squads/a?utm_source=notification&utm_medium=email&utm_campaign=promoted_to_moderator',
+    squad_name: 'A',
+  });
+  expect(args.templateId).toEqual('d-b1dbd1e86ee14bf094f7616f7469fee8');
+});

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -169,7 +169,7 @@ describe('source member role changed', () => {
     expect(actual[0].type).toEqual('promoted_to_moderator');
     expect(actual[0].ctx).toEqual({ userId: '1', source });
   });
-  it('should add member to admin notification', async () => {
+  it('should add member to owner notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
@@ -180,10 +180,9 @@ describe('source member role changed', () => {
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
 
     expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('promoted_to_role');
+    expect(actual[0].type).toEqual('promoted_to_owner');
     expect(actual[0].ctx).toEqual({
       userId: '1',
-      role: SourceMemberRoles.Owner,
       source,
     });
   });
@@ -205,7 +204,7 @@ describe('source member role changed', () => {
       source,
     });
   });
-  it('should add moderator to admin notification', async () => {
+  it('should add moderator to owner notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
@@ -215,10 +214,9 @@ describe('source member role changed', () => {
     });
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
     expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('promoted_to_role');
+    expect(actual[0].type).toEqual('promoted_to_owner');
     expect(actual[0].ctx).toEqual({
       userId: '1',
-      role: SourceMemberRoles.Owner,
       source,
     });
   });
@@ -251,10 +249,9 @@ describe('source member role changed', () => {
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
 
     expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('promoted_to_role');
+    expect(actual[0].type).toEqual('promoted_to_moderator');
     expect(actual[0].ctx).toEqual({
       userId: '1',
-      role: SourceMemberRoles.Moderator,
       source,
     });
   });

--- a/src/entity/Notification.ts
+++ b/src/entity/Notification.ts
@@ -34,7 +34,7 @@ export type NotificationType =
   | 'squad_post_viewed'
   | 'squad_post_live'
   | 'squad_blocked'
-  | 'promoted_to_role'
+  | 'promoted_to_owner'
   | 'demoted_to_member'
   | 'promoted_to_moderator';
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -8,8 +8,8 @@ import {
   NotificationCommenterContext,
   NotificationDoneByContext,
   NotificationPostContext,
-  NotificationSourceMemberRoleContext,
   NotificationSourceContext,
+  NotificationSourceMemberRoleContext,
   NotificationSourceRequestContext,
   NotificationSubmissionContext,
   NotificationUpvotersContext,
@@ -74,12 +74,12 @@ export const notificationTitleMap: Record<
     `<b>Your post</b> is now <span class="text-theme-color-cabbage">live</span> on <b>${ctx.source.name}</b>.`,
   squad_blocked: (ctx: NotificationSourceContext) =>
     `You are no longer part of <b>${ctx.source.name}</b>`,
-  promoted_to_role: (ctx: NotificationSourceMemberRoleContext) =>
-    `You are now a <span class="text-theme-color-cabbage">${ctx.role}</span> in <b>${ctx.source.name}</b>`,
+  promoted_to_owner: (ctx: NotificationSourceContext) =>
+    `Congratulations! You are now an <span class="text-theme-color-cabbage">owner</span> of <b>${ctx.source.name}</b>`,
   demoted_to_member: (ctx: NotificationSourceMemberRoleContext) =>
     `You are no longer a <span class="text-theme-color-cabbage">${ctx.role}</span> in <b>${ctx.source.name}</b>`,
   promoted_to_moderator: (ctx: NotificationSourceContext) =>
-    `Congratulations! You got promoted to a <span class="text-theme-color-cabbage">moderator</span> role in <b>${ctx.source.name}</b>`,
+    `You are now a <span class="text-theme-color-cabbage">moderator</span> in <b>${ctx.source.name}</b>`,
 };
 
 export const generateNotificationMap: Record<
@@ -213,9 +213,9 @@ export const generateNotificationMap: Record<
       .objectPost(ctx.post, ctx.source, ctx.sharedPost),
   squad_blocked: (builder, ctx: NotificationSourceContext) =>
     builder.icon(NotificationIcon.Block).referenceSource(ctx.source),
-  promoted_to_role: (builder, ctx: NotificationSourceMemberRoleContext) =>
+  promoted_to_owner: (builder, ctx: NotificationSourceContext) =>
     builder
-      .sourceMemberRole(ctx.role)
+      .icon(NotificationIcon.Star)
       .referenceSource(ctx.source)
       .targetSource(ctx.source),
   demoted_to_member: (builder, ctx: NotificationSourceMemberRoleContext) =>

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -56,9 +56,9 @@ const notificationToTemplateId: Record<NotificationType, string> = {
   squad_access: 'd-6b3de457947b415d93d0029361edaf1d',
   squad_post_live: 'd-343845599453499d9fa5d3ffafc91514',
   squad_blocked: '',
-  promoted_to_role: '',
+  promoted_to_owner: 'd-397a5e4a394a4b7f91ea33c29efb8d01',
   demoted_to_member: '',
-  promoted_to_moderator: '',
+  promoted_to_moderator: 'd-b1dbd1e86ee14bf094f7616f7469fee8',
 };
 
 type TemplateDataFunc = (
@@ -482,9 +482,39 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     };
   },
   squad_blocked: null,
-  promoted_to_role: null,
+  promoted_to_owner: async (con, user, notification) => {
+    const source = await con
+      .getRepository(Source)
+      .findOneBy({ id: notification.referenceId });
+    if (!source) {
+      return;
+    }
+    return {
+      first_name: getFirstName(user.name),
+      squad_name: source.name,
+      squad_link: addNotificationEmailUtm(
+        notification.targetUrl,
+        notification.type,
+      ),
+    };
+  },
   demoted_to_member: null,
-  promoted_to_moderator: null,
+  promoted_to_moderator: async (con, user, notification) => {
+    const source = await con
+      .getRepository(Source)
+      .findOneBy({ id: notification.referenceId });
+    if (!source) {
+      return;
+    }
+    return {
+      first_name: getFirstName(user.name),
+      squad_name: source.name,
+      squad_link: addNotificationEmailUtm(
+        notification.targetUrl,
+        notification.type,
+      ),
+    };
+  },
 };
 
 const formatTemplateDate = <T extends Record<string, unknown>>(data: T): T => {

--- a/src/workers/notifications/sourceMemberRoleChanged.ts
+++ b/src/workers/notifications/sourceMemberRoleChanged.ts
@@ -18,17 +18,17 @@ const previousRoleToNewRole: Partial<
 > = {
   [SourceMemberRoles.Member]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
-    [SourceMemberRoles.Owner]: 'promoted_to_role',
+    [SourceMemberRoles.Owner]: 'promoted_to_owner',
     [SourceMemberRoles.Moderator]: 'promoted_to_moderator',
   },
   [SourceMemberRoles.Moderator]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
-    [SourceMemberRoles.Owner]: 'promoted_to_role',
+    [SourceMemberRoles.Owner]: 'promoted_to_owner',
     [SourceMemberRoles.Member]: 'demoted_to_member',
   },
   [SourceMemberRoles.Owner]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
-    [SourceMemberRoles.Moderator]: 'promoted_to_role',
+    [SourceMemberRoles.Moderator]: 'promoted_to_moderator',
     [SourceMemberRoles.Member]: 'demoted_to_member',
   },
 };
@@ -53,14 +53,6 @@ const worker: NotificationWorker = {
       previousRoleToNewRole[previousRole]?.[member.role];
 
     switch (roleToNotificationMap) {
-      case 'promoted_to_role':
-        return [
-          {
-            type: roleToNotificationMap,
-            ctx: { ...baseCtx, role: member.role },
-          },
-        ];
-        break;
       case 'demoted_to_member':
         return [
           {
@@ -69,6 +61,7 @@ const worker: NotificationWorker = {
           },
         ];
         break;
+      case 'promoted_to_owner':
       case 'promoted_to_moderator':
       case 'squad_blocked':
         return [{ type: roleToNotificationMap, ctx: baseCtx }];


### PR DESCRIPTION
We changed the copy to be uniform to role (owner and moderator) these promotions now also get a email.
Added test cases and modified existing ones.

WT-1220 #done 