### PR TITLE
feat(squad): update posting permissions

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -855,8 +855,8 @@ describe('mutation createSquad', () => {
 
 describe('mutation editSquad', () => {
   const MUTATION = `
-  mutation EditSquad($sourceId: ID!, $name: String!, $handle: String!, $description: String) {
-  editSquad(sourceId: $sourceId, name: $name, handle: $handle, description: $description) {
+  mutation EditSquad($sourceId: ID!, $name: String!, $handle: String!, $description: String, $memberPostingRole: String) {
+  editSquad(sourceId: $sourceId, name: $name, handle: $handle, description: $description, memberPostingRole: $memberPostingRole) {
     id
   }
 }`;
@@ -950,6 +950,55 @@ describe('mutation editSquad', () => {
       client,
       { mutation: MUTATION, variables },
       'FORBIDDEN',
+    );
+  });
+
+  it('should throw error when null is sent to memberPostingRole', async () => {
+    loggedUser = '1';
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...variables, memberPostingRole: null },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should edit squad memberPostingRank', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        memberPostingRole: SourceMemberRoles.Moderator,
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource?.memberPostingRank).toEqual(
+      sourceRoleRank[SourceMemberRoles.Moderator],
+    );
+  });
+
+  it('should leave squad memberPostingRank unchanged if not sent during edit', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update(
+        { id: 's1' },
+        { memberPostingRank: sourceRoleRank[SourceMemberRoles.Moderator] },
+      );
+    const res = await client.mutate(MUTATION, {
+      variables,
+    });
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource?.memberPostingRank).toEqual(
+      sourceRoleRank[SourceMemberRoles.Moderator],
     );
   });
 });

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -953,6 +953,18 @@ describe('mutation editSquad', () => {
     );
   });
 
+  it('should throw error when invalid role is provided for posting', async () => {
+    loggedUser = '1';
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...variables, memberPostingRole: 'invalidRole' },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should throw error when null is sent to memberPostingRole', async () => {
     loggedUser = '1';
     return testMutationErrorCode(
@@ -1000,6 +1012,27 @@ describe('mutation editSquad', () => {
     expect(editSource?.memberPostingRank).toEqual(
       sourceRoleRank[SourceMemberRoles.Moderator],
     );
+  });
+
+  it('should leave squad memberPostingRank unchanged when setting other fields', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update(
+        { id: 's1' },
+        { memberPostingRank: sourceRoleRank[SourceMemberRoles.Owner] },
+      );
+    const res = await client.mutate(MUTATION, {
+      variables: { ...variables, name: 'updated name' },
+    });
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource?.memberPostingRank).toEqual(
+      sourceRoleRank[SourceMemberRoles.Owner],
+    );
+    expect(editSource?.name).toEqual('updated name');
   });
 });
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -11,6 +11,7 @@ import {
 } from '../entity';
 import {
   SourceMemberRoles,
+  rankToSourceRole,
   sourceRoleRank,
   sourceRoleRankKeys,
 } from '../roles';
@@ -209,6 +210,11 @@ const obj = new GraphORM({
           },
         },
         transform: nullIfNotLoggedIn,
+      },
+      memberPostingRole: {
+        select: 'memberPostingRank',
+        transform: (value: number, ctx: Context) =>
+          nullIfNotLoggedIn(rankToSourceRole[value], ctx),
       },
     },
   },

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -17,3 +17,12 @@ export const sourceRoleRank: Record<SourceMemberRoles, number> = {
 };
 
 export const sourceRoleRankKeys = Object.keys(sourceRoleRank);
+
+export const rankToSourceRole = Object.entries(sourceRoleRank).reduce(
+  (acc, [key, value]) => {
+    acc[value] = key as SourceMemberRoles;
+
+    return acc;
+  },
+  {} as Record<number, SourceMemberRoles>,
+);

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -147,6 +147,11 @@ export const typeDefs = /* GraphQL */ `
     Privileged members
     """
     privilegedMembers: [SourceMember]
+
+    """
+    Role required for members to post
+    """
+    memberPostingRole: String
   }
 
   type SourceConnection {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -565,7 +565,10 @@ const validateSquadData = ({
   handle,
   name,
   description,
-}: Pick<SquadSource, 'handle' | 'name' | 'description'>): string => {
+  memberPostingRole,
+}: Pick<SquadSource, 'handle' | 'name' | 'description'> & {
+  memberPostingRole?: SourceMemberRoles;
+}): string => {
   handle = handle.replace('@', '').trim();
   const regexParams: ValidateRegex[] = [
     ['name', name, nameRegex, true],
@@ -574,6 +577,13 @@ const validateSquadData = ({
   ];
 
   validateRegex(regexParams);
+
+  if (
+    typeof memberPostingRole !== 'undefined' &&
+    !sourceRoleRankKeys.includes(memberPostingRole)
+  ) {
+    throw new ValidationError('Invalid member posting role');
+  }
 
   return handle;
 };
@@ -860,12 +870,9 @@ export const resolvers: IResolvers<any, Context> = {
         handle: inputHandle,
         name,
         description,
+        memberPostingRole,
       });
       try {
-        if (!sourceRoleRankKeys.includes(memberPostingRole)) {
-          throw new ValidationError('Invalid member posting role');
-        }
-
         const sourceId = await ctx.con.transaction(async (entityManager) => {
           const id = randomUUID();
           const repo = entityManager.getRepository(SquadSource);
@@ -934,16 +941,10 @@ export const resolvers: IResolvers<any, Context> = {
         handle: inputHandle,
         name,
         description,
+        memberPostingRole,
       });
 
       try {
-        if (
-          typeof memberPostingRole !== 'undefined' &&
-          !sourceRoleRankKeys.includes(memberPostingRole)
-        ) {
-          throw new ValidationError('Invalid member posting role');
-        }
-
         const editedSourceId = await ctx.con.transaction(
           async (entityManager) => {
             const repo = entityManager.getRepository(SquadSource);
@@ -954,9 +955,7 @@ export const resolvers: IResolvers<any, Context> = {
                 name,
                 handle,
                 description,
-                memberPostingRank: memberPostingRole
-                  ? sourceRoleRank[memberPostingRole]
-                  : undefined,
+                memberPostingRank: sourceRoleRank[memberPostingRole],
               },
             );
             // Upload the image (if provided)

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -938,7 +938,7 @@ export const resolvers: IResolvers<any, Context> = {
 
       try {
         if (
-          memberPostingRole &&
+          typeof memberPostingRole !== 'undefined' &&
           !sourceRoleRankKeys.includes(memberPostingRole)
         ) {
           throw new ValidationError('Invalid member posting role');


### PR DESCRIPTION
Update posting permissions during `editSquad` mutation. Also expose `memberPostingRole` field.