### PR TITLE
feat: query user's membership

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -639,12 +639,12 @@ describe('query checkUserMembership', () => {
   it('should not authorize when source does not exist', () =>
     testQueryErrorCode(
       client,
-      { query: QUERY, variables: { memberId: '2', sourceId: 'a' } },
+      { query: QUERY, variables: { userId: '2', sourceId: 'a' } },
       'UNAUTHENTICATED',
     ));
 
   it('should return forbidden when user is not a member', async () => {
-    loggedUser = '1';
+    loggedUser = '3';
     const params = { userId: '2', sourceId: 'a' };
     await con.getRepository(SourceMember).delete(params);
     await con.getRepository(Source).update({ id: 'a' }, { private: true });
@@ -656,23 +656,12 @@ describe('query checkUserMembership', () => {
     );
   });
 
-  it('should return forbidden when user is blocked', async () => {
+  it('should return member', async () => {
     loggedUser = '1';
     const params = { userId: '2', sourceId: 'a' };
-    await con.getRepository(Source).update({ id: 'a' }, { private: true });
     await con
       .getRepository(SourceMember)
       .update(params, { role: SourceMemberRoles.Blocked });
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: params },
-      'FORBIDDEN',
-    );
-  });
-
-  it('should return member when user is not a blocked member', async () => {
-    loggedUser = '1';
-    const params = { userId: '2', sourceId: 'a' };
     await con.getRepository(Source).update({ id: 'a' }, { private: true });
     const res = await client.query(QUERY, {
       variables: params,

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -627,6 +627,61 @@ describe('query mySourceMemberships', () => {
   });
 });
 
+describe('query checkUserMembership', () => {
+  const QUERY = `
+    query CheckUserMembership($userId: ID!, $sourceId: ID!) {
+      member: checkUserMembership(memberId: $userId, sourceId: $sourceId) {
+        role
+      }
+    }
+  `;
+
+  it('should not authorize when source does not exist', () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { memberId: '2', sourceId: 'a' } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should return forbidden when user is not a member', async () => {
+    loggedUser = '1';
+    const params = { userId: '2', sourceId: 'a' };
+    await con.getRepository(SourceMember).delete(params);
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+
+    return testQueryErrorCode(
+      client,
+      { query: QUERY, variables: params },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should return forbidden when user is blocked', async () => {
+    loggedUser = '1';
+    const params = { userId: '2', sourceId: 'a' };
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    await con
+      .getRepository(SourceMember)
+      .update(params, { role: SourceMemberRoles.Blocked });
+    return testQueryErrorCode(
+      client,
+      { query: QUERY, variables: params },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should return member when user is not a blocked member', async () => {
+    loggedUser = '1';
+    const params = { userId: '2', sourceId: 'a' };
+    await con.getRepository(Source).update({ id: 'a' }, { private: true });
+    const res = await client.query(QUERY, {
+      variables: params,
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.member).toBeTruthy();
+  });
+});
+
 describe('query sourceMemberByToken', () => {
   const QUERY = `
 query SourceMemberByToken($token: String!) {

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -547,7 +547,7 @@ export class GraphORM {
     throw new Error('Resolve info is empty');
   }
 
-  async queryOne<T>(
+  async queryOneOrFail<T>(
     ctx: Context,
     resolveInfo: GraphQLResolveInfo,
     beforeQuery?: (builder: GraphORMBuilder) => GraphORMBuilder,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -285,7 +285,7 @@ export const typeDefs = /* GraphQL */ `
       sourceId: ID!
 
       """
-      Username or the user id to check
+      User id of the member to check
       """
       memberId: ID!
     ): SourceMember @auth


### PR DESCRIPTION
We display an indicator to let the our users know whether the author of the comment they are replying to won't be able to have access on their response by showing some alert. We display that alert after checking whether the user is blocked or not a member of the squad.

Changes:
- Seeing the graphorm used for fetching single-row items on numerous areas, I've decided to abstract the throwing of error when none is found.
- Introduced a query to check the user's membership.