### PR TITLE
fix: issue with empty email notification callback

### DIFF
--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -212,7 +212,10 @@ export const generateNotificationMap: Record<
       .icon(NotificationIcon.Bell)
       .objectPost(ctx.post, ctx.source, ctx.sharedPost),
   squad_blocked: (builder, ctx: NotificationSourceContext) =>
-    builder.icon(NotificationIcon.Block).referenceSource(ctx.source),
+    builder
+      .targetUrl('system')
+      .icon(NotificationIcon.Block)
+      .referenceSource(ctx.source),
   promoted_to_owner: (builder, ctx: NotificationSourceContext) =>
     builder
       .icon(NotificationIcon.Star)

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -481,7 +481,9 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       user_reputation: user.reputation,
     };
   },
-  squad_blocked: null,
+  squad_blocked: async () => {
+    return null;
+  },
   promoted_to_owner: async (con, user, notification) => {
     const source = await con
       .getRepository(Source)
@@ -498,7 +500,9 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       ),
     };
   },
-  demoted_to_member: null,
+  demoted_to_member: async () => {
+    return null;
+  },
   promoted_to_moderator: async (con, user, notification) => {
     const source = await con
       .getRepository(Source)


### PR DESCRIPTION
Changed the empty email callback to not fail.
Also added reference for system on the squad blocked notification.
And added test cases to ensure there is no error thrown.

WT-1229 #done