### PR TITLE
feat: exclude post permission for squad based on memberPostingRank

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -37,6 +37,8 @@ import flagsmith from '../src/flagsmith';
 import { postsFixture } from './fixture/post';
 import { sourcesFixture } from './fixture/source';
 import { DEFAULT_FLAGS } from '../src/featureFlags';
+import { SourcePermissions } from '../src/schema/sources';
+import { sourceRoleRank } from '../src/roles';
 
 jest.mock('../src/flagsmith', () => ({
   getIdentityFlags: jest.fn(),
@@ -424,6 +426,14 @@ describe('boot misc', () => {
         private: true,
         active: true,
       },
+      {
+        id: 's5',
+        handle: 's5',
+        name: 'Squad 5',
+        private: true,
+        active: true,
+        memberPostingRank: sourceRoleRank[SourceMemberRoles.Moderator],
+      },
     ]);
     await con.getRepository(MachineSource).save([
       {
@@ -453,6 +463,12 @@ describe('boot misc', () => {
         referralToken: 'rt3',
         role: SourceMemberRoles.Member,
       },
+      {
+        sourceId: 's5',
+        userId: '1',
+        referralToken: 'rt5',
+        role: SourceMemberRoles.Member,
+      },
     ]);
     const res = await request(app.server)
       .get(BASE_PATH)
@@ -468,6 +484,9 @@ describe('boot misc', () => {
         permalink: 'http://localhost:5002/squads/s1',
         public: true,
         type: SourceType.Squad,
+        currentMember: {
+          permissions: [SourcePermissions.Post],
+        },
       },
       {
         active: true,
@@ -478,6 +497,22 @@ describe('boot misc', () => {
         permalink: 'http://localhost:5002/squads/s2',
         public: false,
         type: SourceType.Squad,
+        currentMember: {
+          permissions: [SourcePermissions.Post],
+        },
+      },
+      {
+        active: true,
+        handle: 's5',
+        id: 's5',
+        image: SQUAD_IMAGE_PLACEHOLDER,
+        name: 'Squad 5',
+        permalink: 'http://localhost:5002/squads/s5',
+        public: false,
+        type: SourceType.Squad,
+        currentMember: {
+          permissions: [],
+        },
       },
     ]);
   });
@@ -537,6 +572,9 @@ describe('boot misc', () => {
         permalink: 'http://localhost:5002/squads/s1',
         public: true,
         type: SourceType.Squad,
+        currentMember: {
+          permissions: [SourcePermissions.Post],
+        },
       },
     ]);
   });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1,4 +1,4 @@
-import { SourcePermissions, roleSourcePermissions } from './../schema/sources';
+import { getPermissionsForMember } from './../schema/sources';
 import { GraphORM, QueryBuilder } from './graphorm';
 import {
   Bookmark,
@@ -239,19 +239,7 @@ const obj = new GraphORM({
             return null;
           }
 
-          const permissions =
-            roleSourcePermissions[member.role] ?? roleSourcePermissions.member;
-          const memberRank =
-            sourceRoleRank[member.role] ??
-            sourceRoleRank[SourceMemberRoles.Member];
-
-          if (memberRank < memberPostingRank) {
-            return permissions.filter(
-              (item) => item !== SourcePermissions.Post,
-            );
-          }
-
-          return permissions;
+          return getPermissionsForMember(member, { memberPostingRank });
         },
       },
       roleRank: {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -226,8 +226,8 @@ const obj = new GraphORM({
         select: (ctx: Context, alias: string, qb: QueryBuilder): string => {
           const query = qb
             .select('"memberPostingRank"')
-            .from(Source, 'ps')
-            .where(`ps.id = ${alias}."sourceId"`);
+            .from(Source, 'postingSquad')
+            .where(`postingSquad.id = ${alias}."sourceId"`);
           return `${query.getQuery()}`;
         },
         transform: (

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -17,7 +17,11 @@ import {
   SquadSource,
   User,
 } from '../entity';
-import { GQLSource } from '../schema/sources';
+import {
+  GQLSource,
+  SourcePermissions,
+  getPermissionsForMember,
+} from '../schema/sources';
 import { adjustFlagsToUser, getUserFeatureFlags } from '../featureFlags';
 import { getAlerts } from '../schema/alerts';
 import { getSettings } from '../schema/settings';
@@ -32,13 +36,20 @@ import { schema } from '../graphql';
 import { Context } from '../Context';
 import { SourceMemberRoles } from '../roles';
 
+export type BootSquadSource = Omit<GQLSource, 'currentMember'> & {
+  permalink: string;
+  currentMember: {
+    permissions: SourcePermissions[];
+  };
+};
+
 export type BaseBoot = {
   visit: { visitId: string; sessionId: string };
   flags: IFlags;
   alerts: Omit<Alerts, 'userId'>;
   settings: Omit<Settings, 'userId' | 'updatedAt'>;
   notifications: { unreadNotificationsCount: number };
-  squads: (GQLSource & { permalink: string })[];
+  squads: BootSquadSource[];
 };
 
 export type AnonymousBoot = BaseBoot & {
@@ -90,7 +101,7 @@ const excludeProperties = <T, K extends keyof T>(
 const getSquads = async (
   con: DataSource,
   userId: string,
-): Promise<(GQLSource & { permalink: string })[]> => {
+): Promise<BootSquadSource[]> => {
   const sources = await con
     .createQueryBuilder()
     .select('id')
@@ -100,6 +111,8 @@ const getSquads = async (
     .addSelect('image')
     .addSelect('NOT private', 'public')
     .addSelect('active')
+    .addSelect('role')
+    .addSelect('"memberPostingRank"')
     .from(SourceMember, 'sm')
     .innerJoin(
       SquadSource,
@@ -109,11 +122,34 @@ const getSquads = async (
     .where('sm."userId" = :userId', { userId })
     .andWhere('sm."role" != :role', { role: SourceMemberRoles.Blocked })
     .orderBy('LOWER(s.name)', 'ASC')
-    .getRawMany<GQLSource>();
-  return sources.map((source) => ({
-    ...source,
-    permalink: getSourceLink(source),
-  }));
+    .getRawMany<
+      GQLSource & { role: SourceMemberRoles; memberPostingRank: number }
+    >();
+
+  return sources.map((source) => {
+    const { role, memberPostingRank, ...restSource } = source;
+
+    const permissions = getPermissionsForMember(
+      {
+        role,
+      },
+      {
+        memberPostingRank,
+      },
+    );
+    // we only send posting permissions from boot to keep the payload small
+    const postingPermissions = permissions.filter(
+      (item) => item === SourcePermissions.Post,
+    );
+
+    return {
+      ...restSource,
+      permalink: getSourceLink(source),
+      currentMember: {
+        permissions: postingPermissions,
+      },
+    };
+  });
 };
 
 const moderators = [

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -130,12 +130,8 @@ const getSquads = async (
     const { role, memberPostingRank, ...restSource } = source;
 
     const permissions = getPermissionsForMember(
-      {
-        role,
-      },
-      {
-        memberPostingRank,
-      },
+      { role },
+      { memberPostingRank },
     );
     // we only send posting permissions from boot to keep the payload small
     const postingPermissions = permissions.filter(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -702,6 +702,22 @@ const addNewSourceMember = async (
   });
 };
 
+export const getPermissionsForMember = (
+  member: Pick<SourceMember, 'role'>,
+  source: Pick<SquadSource, 'memberPostingRank'>,
+): SourcePermissions[] => {
+  const permissions =
+    roleSourcePermissions[member.role] ?? roleSourcePermissions.member;
+  const memberRank =
+    sourceRoleRank[member.role] ?? sourceRoleRank[SourceMemberRoles.Member];
+
+  if (memberRank < source.memberPostingRank) {
+    return permissions.filter((item) => item !== SourcePermissions.Post);
+  }
+
+  return permissions;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const resolvers: IResolvers<any, Context> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Since `permissions` are used on the frontend to check if user should see any action/ui element we wanted to automatically exclude `SourcePermissions.Post` permissions array based on `memberPostingRank` setting for squad. 

Also adds `currentMember.permissions` to `boot.squads` (only `SourcePermissions.Post` to keep boot size lean).

Initial discussion and alternatives can be found here https://github.com/dailydotdev/apps/pull/1723#discussion_r1159470225

Note to @idoshamun I am not sure if this kind of `select` is performant or is there a better way to do it - considering everything `graphorm` does under the hood. 