### PR TITLE
feat: filter out referral token for other users

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -581,6 +581,41 @@ query SourceMembers($id: ID!, $role: String) {
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();
   });
+
+  it('should only return referralToken for current logged user', async () => {
+    loggedUser = '1';
+    const QUERY_WITH_REFERRAL_TOKEN = `
+    query SourceMembers($id: ID!, $role: String) {
+      sourceMembers(sourceId: $id, role: $role) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            role
+            roleRank
+            user { id }
+            source { id }
+            referralToken
+          }
+        }
+      }
+    }`;
+    const res = await client.query(QUERY_WITH_REFERRAL_TOKEN, {
+      variables: {
+        id: 'a',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    res.data.sourceMembers.edges.forEach(({ node }) => {
+      if (node.user.id === loggedUser) {
+        expect(node.referralToken).toBeTruthy();
+      } else {
+        expect(node.referralToken).toBeFalsy();
+      }
+    });
+  });
 });
 
 describe('query mySourceMemberships', () => {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -35,8 +35,11 @@ const existsByUserAndPost =
 const nullIfNotLoggedIn = <T>(value: T, ctx: Context): T | null =>
   ctx.userId ? value : null;
 
-const nullIfNotSameUser = <T>(value: T, ctx: Context, parent: User): T | null =>
-  ctx.userId === parent.id ? value : null;
+const nullIfNotSameUser = <T>(
+  value: T,
+  ctx: Context,
+  parent: Pick<User, 'id'>,
+): T | null => (ctx.userId === parent.id ? value : null);
 
 const obj = new GraphORM({
   User: {
@@ -247,11 +250,7 @@ const obj = new GraphORM({
       },
       referralToken: {
         transform: (value: string, ctx: Context, member: SourceMember) => {
-          if (!ctx.userId || member.userId !== ctx.userId) {
-            return null;
-          }
-
-          return value;
+          return nullIfNotSameUser(value, ctx, { id: member.userId });
         },
       },
     },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -245,6 +245,15 @@ const obj = new GraphORM({
             ELSE 0 END)
           `,
       },
+      referralToken: {
+        transform: (value: string, ctx: Context, member: SourceMember) => {
+          if (!ctx.userId || member.userId !== ctx.userId) {
+            return null;
+          }
+
+          return value;
+        },
+      },
     },
   },
   Comment: {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -189,7 +189,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Token to be used for inviting new squad members
     """
-    referralToken: String!
+    referralToken: String
     """
     Numerical representation of the user's role
     """
@@ -1131,5 +1131,18 @@ export const resolvers: IResolvers<any, Context> = {
   }),
   Source: {
     permalink: (source: GQLSource): string => getSourceLink(source),
+  },
+  SourceMember: {
+    referralToken: (
+      sourceMember: GQLSourceMember,
+      _,
+      ctx: Context,
+    ): string | undefined => {
+      if (!ctx.userId || ctx.userId !== sourceMember.user.id) {
+        return undefined;
+      }
+
+      return sourceMember.referralToken;
+    },
   },
 };

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1132,17 +1132,4 @@ export const resolvers: IResolvers<any, Context> = {
   Source: {
     permalink: (source: GQLSource): string => getSourceLink(source),
   },
-  SourceMember: {
-    referralToken: (
-      sourceMember: GQLSourceMember,
-      _,
-      ctx: Context,
-    ): string | undefined => {
-      if (!ctx.userId || ctx.userId !== sourceMember.user.id) {
-        return undefined;
-      }
-
-      return sourceMember.referralToken;
-    },
-  },
 };


### PR DESCRIPTION
Make sure `referralToken` of other users can not be queried through relations or listings. From what I talked with Ido before this should cover all cases.