### PR TITLE
refactor: stop sending notifications when user is not a member anymore

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -31,6 +31,7 @@ import {
   NotificationUpvotersContext,
 } from '../../src/notifications';
 import { NotificationReason } from '../../src/common';
+import { randomUUID } from 'crypto';
 
 let con: DataSource;
 
@@ -560,6 +561,13 @@ describe('article new comment', () => {
         authorId: '1',
       },
     );
+    await con.getRepository(SourceMember).insert({
+      userId: '1',
+      sourceId: 'a',
+      role: SourceMemberRoles.Member,
+      createdAt: new Date(),
+      referralToken: randomUUID(),
+    });
     const actual = await invokeNotificationWorker(worker.default, {
       userId: '1',
       postId: 'p1',

--- a/src/workers/notifications/articleUpvoteMilestone.ts
+++ b/src/workers/notifications/articleUpvoteMilestone.ts
@@ -42,24 +42,25 @@ const worker: NotificationWorker = {
       upvoters,
       upvotes: post.upvotes,
     };
-    if (source.type !== SourceType.Squad) {
-      return users.map((userId) => ({
+
+    if (source.type === SourceType.Squad) {
+      const members = await con.getRepository(SourceMember).findBy({
+        userId: In(users),
+        sourceId: source.id,
+        role: Not(SourceMemberRoles.Blocked),
+      });
+
+      if (!members.length) {
+        return;
+      }
+
+      return members.map(({ userId }) => ({
         type: 'article_upvote_milestone',
         ctx: { ...ctx, userId },
       }));
     }
 
-    const members = await con.getRepository(SourceMember).findBy({
-      userId: In(users),
-      sourceId: source.id,
-      role: Not(SourceMemberRoles.Blocked),
-    });
-
-    if (!members.length) {
-      return;
-    }
-
-    return members.map(({ userId }) => ({
+    return users.map((userId) => ({
       type: 'article_upvote_milestone',
       ctx: { ...ctx, userId },
     }));

--- a/src/workers/notifications/articleUpvoteMilestone.ts
+++ b/src/workers/notifications/articleUpvoteMilestone.ts
@@ -1,11 +1,13 @@
 import { messageToJson } from '../worker';
-import { Upvote } from '../../entity';
+import { SourceMember, SourceType, Upvote } from '../../entity';
 import {
   NotificationPostContext,
   NotificationUpvotersContext,
 } from '../../notifications';
 import { NotificationWorker } from './worker';
 import { buildPostContext, uniquePostOwners, UPVOTE_MILESTONES } from './utils';
+import { In, Not } from 'typeorm';
+import { SourceMemberRoles } from '../../roles';
 
 interface Data {
   userId: string;
@@ -20,7 +22,7 @@ const worker: NotificationWorker = {
     if (!postCtx) {
       return;
     }
-    const { post } = postCtx;
+    const { post, source } = postCtx;
     const users = uniquePostOwners(post, [data.userId]);
     if (!users.length || !UPVOTE_MILESTONES.includes(post.upvotes.toString())) {
       return;
@@ -40,7 +42,24 @@ const worker: NotificationWorker = {
       upvoters,
       upvotes: post.upvotes,
     };
-    return users.map((userId) => ({
+    if (source.type !== SourceType.Squad) {
+      return users.map((userId) => ({
+        type: 'article_upvote_milestone',
+        ctx: { ...ctx, userId },
+      }));
+    }
+
+    const members = await con.getRepository(SourceMember).findBy({
+      userId: In(users),
+      sourceId: source.id,
+      role: Not(SourceMemberRoles.Blocked),
+    });
+
+    if (!members.length) {
+      return;
+    }
+
+    return members.map(({ userId }) => ({
       type: 'article_upvote_milestone',
       ctx: { ...ctx, userId },
     }));

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -15,6 +15,7 @@ import { NotificationHandlerReturn, NotificationWorker } from './worker';
 import { ChangeObject } from '../../types';
 import { buildPostContext } from './utils';
 import { In, Not } from 'typeorm';
+import { SourceMemberRoles } from '../../roles';
 
 interface Data {
   post: ChangeObject<Post>;
@@ -56,7 +57,11 @@ const worker: NotificationWorker = {
           .getRepository(User)
           .findOneBy({ id: post.authorId });
         const members = await con.getRepository(SourceMember).find({
-          where: { sourceId: source.id, userId: Not(In([post.authorId])) },
+          where: {
+            sourceId: source.id,
+            userId: Not(In([post.authorId])),
+            role: Not(SourceMemberRoles.Blocked),
+          },
         });
         members.forEach((member) =>
           notifs.push({

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -99,24 +99,24 @@ export async function articleNewCommentHandler(
       ? 'squad_new_comment'
       : 'article_new_comment';
 
-  if (source.type !== SourceType.Squad) {
-    return users.map((userId) => ({
+  if (source.type === SourceType.Squad) {
+    const members = await con.getRepository(SourceMember).findBy({
+      userId: In(users),
+      sourceId: source.id,
+      role: Not(SourceMemberRoles.Blocked),
+    });
+
+    if (!members.length) {
+      return;
+    }
+
+    return members.map(({ userId }) => ({
       type,
       ctx: { ...ctx, userId },
     }));
   }
 
-  const members = await con.getRepository(SourceMember).findBy({
-    userId: In(users),
-    sourceId: source.id,
-    role: Not(SourceMemberRoles.Blocked),
-  });
-
-  if (!members.length) {
-    return;
-  }
-
-  return members.map(({ userId }) => ({
+  return users.map((userId) => ({
     type,
     ctx: { ...ctx, userId },
   }));

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -1,10 +1,18 @@
 import { NotificationHandlerReturn } from './worker';
-import { Comment, Post, PostType, SharePost, SourceType } from '../../entity';
+import {
+  Comment,
+  Post,
+  PostType,
+  SharePost,
+  SourceMember,
+  SourceType,
+} from '../../entity';
 import {
   NotificationCommenterContext,
   NotificationPostContext,
 } from '../../notifications';
-import { DataSource, In } from 'typeorm';
+import { DataSource, In, Not } from 'typeorm';
+import { SourceMemberRoles } from '../../roles';
 
 export const uniquePostOwners = (
   post: Pick<Post, 'scoutId' | 'authorId'>,
@@ -53,11 +61,13 @@ export async function articleNewCommentHandler(
   if (!postCtx) {
     return;
   }
+
+  const { post, source } = postCtx;
   const excludedUsers = [comment.userId];
 
   const isReply = !!comment.parentId;
-  if (isReply && (postCtx.post.authorId || postCtx.post.scoutId)) {
-    const ids = [...new Set([postCtx.post.authorId, postCtx.post.scoutId])];
+  if (isReply && (post.authorId || post.scoutId)) {
+    const ids = [...new Set([post.authorId, post.scoutId])];
     const threadFollower = await repo
       .createQueryBuilder()
       .select('"userId"')
@@ -73,7 +83,7 @@ export async function articleNewCommentHandler(
 
   const excluded = [...new Set(excludedUsers)];
   // Get unique user id which are not the author of the comment
-  const users = uniquePostOwners(postCtx.post, excluded);
+  const users = uniquePostOwners(post, excluded);
   if (!users.length) {
     return;
   }
@@ -88,7 +98,25 @@ export async function articleNewCommentHandler(
     ctx.source.type === SourceType.Squad
       ? 'squad_new_comment'
       : 'article_new_comment';
-  return users.map((userId) => ({
+
+  if (source.type !== SourceType.Squad) {
+    return users.map((userId) => ({
+      type,
+      ctx: { ...ctx, userId },
+    }));
+  }
+
+  const members = await con.getRepository(SourceMember).findBy({
+    userId: In(users),
+    sourceId: source.id,
+    role: Not(SourceMemberRoles.Blocked),
+  });
+
+  if (!members.length) {
+    return;
+  }
+
+  return members.map(({ userId }) => ({
     type,
     ctx: { ...ctx, userId },
   }));


### PR DESCRIPTION
When a user shared a post then gets removed/blocked/left the squad. They should not receive notifications related to the Squad it came from. Removed from:
- Article new comment
- Comment new comment
- Article upvote milestone
- Comment upvote milestone.
- Post added notification

Let me know if I missed anything 🚢 