### PR TITLE
fix: squad shared post visibility condition

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1829,4 +1829,43 @@ describe('mutation submitExternalLink', () => {
     expect(sharedPost.title).toEqual('My comment');
     expect(sharedPost.visible).toEqual(true);
   });
+
+  it('should not make squad post visible if shared post is not yet ready and visible', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        url: 'http://p7.com',
+        commentary: 'Share 1',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const articlePost = await con
+      .getRepository(ArticlePost)
+      .findOneBy({ url: 'http://p7.com' });
+    expect(articlePost?.url).toEqual('http://p7.com');
+    expect(articlePost?.visible).toEqual(false);
+    const sharedPost = await con
+      .getRepository(SharePost)
+      .findOneBy({ sharedPostId: articlePost?.id });
+    expect(sharedPost?.visible).toEqual(false);
+
+    const res2 = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        url: 'http://p7.com',
+        commentary: 'Share 2',
+      },
+    });
+    expect(res2.errors).toBeFalsy();
+    const articlePost2 = await con
+      .getRepository(ArticlePost)
+      .findOneBy({ url: 'http://p7.com' });
+    expect(articlePost2?.url).toEqual('http://p7.com');
+    expect(articlePost2?.visible).toEqual(false);
+    const sharedPost2 = await con
+      .getRepository(SharePost)
+      .findOneBy({ sharedPostId: articlePost2?.id });
+    expect(sharedPost2?.visible).toEqual(false);
+  });
 });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1847,7 +1847,7 @@ describe('mutation submitExternalLink', () => {
     expect(articlePost?.visible).toEqual(false);
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost?.id });
+      .findOneBy({ sharedPostId: articlePost?.id, title: 'Share 1' });
     expect(sharedPost?.visible).toEqual(false);
 
     const res2 = await client.mutate(MUTATION, {
@@ -1858,14 +1858,9 @@ describe('mutation submitExternalLink', () => {
       },
     });
     expect(res2.errors).toBeFalsy();
-    const articlePost2 = await con
-      .getRepository(ArticlePost)
-      .findOneBy({ url: 'http://p7.com' });
-    expect(articlePost2?.url).toEqual('http://p7.com');
-    expect(articlePost2?.visible).toEqual(false);
     const sharedPost2 = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost2?.id });
+      .findOneBy({ sharedPostId: articlePost?.id, title: 'Share 2' });
     expect(sharedPost2?.visible).toEqual(false);
   });
 });

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -130,8 +130,9 @@ it('should update the post and make it visible if title is available', async () 
   expect(post.title).toEqual('test');
 });
 
-it('should update the post related shared post to visible', async () => {
+it('should update all the post related shared posts to visible', async () => {
   await createSharedPost();
+  await createSharedPost('sp2');
   await expectSuccessfulBackground(worker, {
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
@@ -147,6 +148,11 @@ it('should update the post related shared post to visible', async () => {
     .findOneBy({ id: 'sp1' });
   expect(sharedPost.visible).toEqual(true);
   expect(sharedPost.visibleAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
+  const sharedPost2 = await con
+    .getRepository(SharePost)
+    .findOneBy({ id: 'sp2' });
+  expect(sharedPost2?.visible).toEqual(true);
+  expect(sharedPost2?.visibleAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
 });
 
 it('should save a new post with the relevant keywords', async () => {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -895,10 +895,11 @@ export const resolvers: IResolvers<any, Context> = {
           throw new ValidationError('URL is not valid');
         }
 
-        const existingPost = await manager.getRepository(ArticlePost).findOne({
-          select: ['id', 'deleted'],
-          where: [{ url: cleanUrl }, { canonicalUrl: cleanUrl }],
-        });
+        const existingPost: Pick<ArticlePost, 'id' | 'deleted' | 'visible'> =
+          await manager.getRepository(ArticlePost).findOne({
+            select: ['id', 'deleted', 'visible'],
+            where: [{ url: cleanUrl }, { canonicalUrl: cleanUrl }],
+          });
         if (existingPost) {
           if (existingPost.deleted) {
             throw new ValidationError(SubmissionFailErrorMessage.POST_DELETED);
@@ -909,6 +910,7 @@ export const resolvers: IResolvers<any, Context> = {
             ctx.userId,
             existingPost.id,
             commentary,
+            existingPost.visible,
           );
           return { _: true };
         }


### PR DESCRIPTION
Re-submitting a not yet finished private link would result in making the shared post immediately visible in squad (also breaking UI since `post.sharedPost` was `undefined`).

During private link creation `visible` property of the original post is now checked and shared post visibility is set to the same value. 

Also updated `postUpdated` test to make sure all the pending squad posts are made visible once the content requirements are met through scraping (was already the case but just to be more specific).