### PR TITLE
fix: change owner to admin naming

### DIFF
--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -25,7 +25,7 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
-            "role": "owner",
+            "role": "admin",
             "source": Object {
               "id": "a",
             },
@@ -63,7 +63,7 @@ Object {
         },
         Object {
           "node": Object {
-            "role": "owner",
+            "role": "admin",
             "source": Object {
               "id": "a",
             },
@@ -177,6 +177,33 @@ Object {
 }
 `;
 
+exports[`query source current member should return current member as admin 1`] = `
+Object {
+  "source": Object {
+    "currentMember": Object {
+      "permissions": Array [
+        "view",
+        "post",
+        "leave",
+        "comment_delete",
+        "post_delete",
+        "member_remove",
+        "edit",
+        "member_unblock",
+        "view_blocked_members",
+        "member_role_update",
+        "post_limit",
+        "invite_disable",
+        "delete",
+      ],
+      "role": "admin",
+      "roleRank": 10,
+    },
+    "id": "a",
+  },
+}
+`;
+
 exports[`query source current member should return current member as blocked 1`] = `
 Object {
   "source": Object {
@@ -201,33 +228,6 @@ Object {
       ],
       "role": "member",
       "roleRank": 0,
-    },
-    "id": "a",
-  },
-}
-`;
-
-exports[`query source current member should return current member as owner 1`] = `
-Object {
-  "source": Object {
-    "currentMember": Object {
-      "permissions": Array [
-        "view",
-        "post",
-        "leave",
-        "comment_delete",
-        "post_delete",
-        "member_remove",
-        "edit",
-        "member_unblock",
-        "view_blocked_members",
-        "member_role_update",
-        "post_limit",
-        "invite_disable",
-        "delete",
-      ],
-      "role": "owner",
-      "roleRank": 10,
     },
     "id": "a",
   },
@@ -288,7 +288,7 @@ Object {
 }
 `;
 
-exports[`query sourceMembers should return blocked users only when user is the owner 1`] = `
+exports[`query sourceMembers should return blocked users only when user is the admin 1`] = `
 Object {
   "sourceMembers": Object {
     "edges": Array [

--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -175,7 +175,7 @@ const saveSquadFixture = async (sourceId: string) => {
     {
       userId: '1',
       sourceId,
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       referralToken: 'rt1',
       createdAt: new Date(2022, 11, 19),
     },
@@ -910,12 +910,12 @@ describe('mutation deleteComment', () => {
     );
   });
 
-  it('should delete a comment if source owner has permissions', async () => {
+  it('should delete a comment if source admin has permissions', async () => {
     loggedUser = '1';
     await con.getRepository(SourceMember).insert({
       userId: '1',
       sourceId: 'squad',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       referralToken: 's1',
     });
     const res = await client.mutate(MUTATION, { variables: { id: 'c8' } });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -674,7 +674,7 @@ describe('query sourceFeed', () => {
       {
         userId: '1',
         sourceId: 'b',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
         referralToken: randomUUID(),
         createdAt: new Date(2022, 11, 19),
       },
@@ -1535,7 +1535,7 @@ describe('function feedToFilters', () => {
       {
         userId: '1',
         sourceId: 'b',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
         referralToken: 'rt2',
       },
     ]);

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -685,15 +685,15 @@ describe('generateNotification', () => {
     );
   });
 
-  it('should generate promoted_to_owner notification', () => {
-    const type = 'promoted_to_owner';
+  it('should generate promoted_to_admin notification', () => {
+    const type = 'promoted_to_admin';
     const ctx: NotificationSourceMemberRoleContext = {
       userId,
       source: {
         ...sourcesFixture[0],
         type: SourceType.Squad,
       } as Reference<Source>,
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
     };
     const actual = generateNotification(type, ctx);
     expect(actual.notification.type).toEqual(type);
@@ -703,7 +703,7 @@ describe('generateNotification', () => {
     expect(actual.notification.referenceType).toEqual('source');
     expect(actual.notification.icon).toEqual('Star');
     expect(actual.notification.title).toEqual(
-      `Congratulations! You are now an <span class="text-theme-color-cabbage">${SourceMemberRoles.Owner}</span> of <b>${sourcesFixture[0].name}</b>`,
+      `Congratulations! You are now an <span class="text-theme-color-cabbage">${SourceMemberRoles.Admin}</span> of <b>${sourcesFixture[0].name}</b>`,
     );
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/squads/a',
@@ -718,7 +718,7 @@ describe('generateNotification', () => {
         ...sourcesFixture[0],
         type: SourceType.Squad,
       } as Reference<Source>,
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
     };
     const actual = generateNotification(type, ctx);
     expect(actual.notification.type).toEqual(type);
@@ -728,7 +728,7 @@ describe('generateNotification', () => {
     expect(actual.notification.referenceType).toEqual('source');
     expect(actual.notification.icon).toEqual('Star');
     expect(actual.notification.title).toEqual(
-      `You are no longer a <span class="text-theme-color-cabbage">${SourceMemberRoles.Owner}</span> in <b>${sourcesFixture[0].name}</b>`,
+      `You are no longer a <span class="text-theme-color-cabbage">${SourceMemberRoles.Admin}</span> in <b>${sourcesFixture[0].name}</b>`,
     );
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/squads/a',

--- a/__tests__/personalizedFeed.ts
+++ b/__tests__/personalizedFeed.ts
@@ -266,7 +266,7 @@ it('should send source memberships as parameter', async () => {
     {
       userId: '1',
       sourceId: 'b',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       referralToken: 'rt2',
     },
   ]);

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -971,10 +971,10 @@ describe('mutation deletePost', () => {
     );
   });
 
-  it('should restrict member deleting a post from the owner', async () => {
+  it('should restrict member deleting a post from the admin', async () => {
     loggedUser = '1';
     const id = 'sp1';
-    await createSharedPost(id, { role: SourceMemberRoles.Owner });
+    await createSharedPost(id, { role: SourceMemberRoles.Admin });
 
     return testMutationErrorCode(
       client,
@@ -1029,10 +1029,10 @@ describe('mutation deletePost', () => {
     expect(actual?.deleted).toBeTruthy();
   });
 
-  it('should allow moderator deleting a post from the owner', async () => {
+  it('should allow moderator deleting a post from the admin', async () => {
     loggedUser = '1';
     const id = 'sp1';
-    await createSharedPost(id, { role: SourceMemberRoles.Owner });
+    await createSharedPost(id, { role: SourceMemberRoles.Admin });
     await con
       .getRepository(SourceMember)
       .update({ userId: '1' }, { role: SourceMemberRoles.Moderator });
@@ -1043,10 +1043,10 @@ describe('mutation deletePost', () => {
     expect(actual?.deleted).toBeTruthy();
   });
 
-  it('should delete the shared post as an owner of the squad', async () => {
+  it('should delete the shared post as an admin of the squad', async () => {
     loggedUser = '2';
     const id = 'sp1';
-    await createSharedPost(id, { role: SourceMemberRoles.Owner }, '1');
+    await createSharedPost(id, { role: SourceMemberRoles.Admin }, '1');
     const res = await client.mutate(MUTATION, { variables: { id: 'sp1' } });
     expect(res.errors).toBeFalsy();
     const actual = await con.getRepository(SharePost).findOneBy({ id: 'sp1' });
@@ -1514,7 +1514,7 @@ describe('mutation sharePost', () => {
     expect(post.title).toEqual('My comment');
   });
 
-  it('should allow owners to post when posting to squad is not allowed', async () => {
+  it('should allow admins to post when posting to squad is not allowed', async () => {
     loggedUser = '1';
     await con.getRepository(SquadSource).update('s1', {
       memberPostingRank: sourceRoleRank[SourceMemberRoles.Moderator],
@@ -1522,7 +1522,7 @@ describe('mutation sharePost', () => {
     await con.getRepository(SourceMember).update(
       { sourceId: 's1', userId: '1' },
       {
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     );
 
@@ -1797,7 +1797,7 @@ describe('mutation submitExternalLink', () => {
     expect(sharedPost.visible).toEqual(true);
   });
 
-  it('should allow owners to share when posting to squad is not allowed', async () => {
+  it('should allow admins to share when posting to squad is not allowed', async () => {
     loggedUser = '1';
     await con.getRepository(SquadSource).update('s1', {
       memberPostingRank: sourceRoleRank[SourceMemberRoles.Moderator],
@@ -1805,7 +1805,7 @@ describe('mutation submitExternalLink', () => {
     await con.getRepository(SourceMember).update(
       { sourceId: 's1', userId: '1' },
       {
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     );
 

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -59,7 +59,7 @@ beforeEach(async () => {
     {
       userId: '1',
       sourceId: 'a',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       referralToken: 'rt',
       createdAt: new Date(2022, 11, 19),
     },
@@ -73,7 +73,7 @@ beforeEach(async () => {
     {
       userId: '2',
       sourceId: 'b',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       referralToken: randomUUID(),
       createdAt: new Date(2022, 11, 19),
     },
@@ -203,11 +203,11 @@ query Source($id: ID!) {
     expect(res.data).toMatchSnapshot();
   });
 
-  it('should return current member as owner', async () => {
+  it('should return current member as admin', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
-      .update({ userId: '1' }, { role: SourceMemberRoles.Owner });
+      .update({ userId: '1' }, { role: SourceMemberRoles.Admin });
     const res = await client.query(QUERY, { variables: { id: 'a' } });
     expect(res.data).toMatchSnapshot();
   });
@@ -522,7 +522,7 @@ query SourceMembers($id: ID!, $role: String) {
     expect(noModRes.errors).toBeFalsy();
     const [noModFirst, noModSecond, noModThird] =
       noModRes.data.sourceMembers.edges;
-    expect(noModFirst.node.role).toEqual(SourceMemberRoles.Owner);
+    expect(noModFirst.node.role).toEqual(SourceMemberRoles.Admin);
     expect(noModSecond.node.role).toEqual(SourceMemberRoles.Member);
     expect(noModThird.node.role).toEqual(SourceMemberRoles.Member);
 
@@ -534,7 +534,7 @@ query SourceMembers($id: ID!, $role: String) {
     const res = await client.query(QUERY, { variables: { id: 'a' } });
     expect(res.errors).toBeFalsy();
     const [first, second, third] = res.data.sourceMembers.edges;
-    expect(first.node.role).toEqual(SourceMemberRoles.Owner);
+    expect(first.node.role).toEqual(SourceMemberRoles.Admin);
     expect(second.node.role).toEqual(SourceMemberRoles.Moderator);
     expect(third.node.role).toEqual(SourceMemberRoles.Member);
   });
@@ -557,7 +557,7 @@ query SourceMembers($id: ID!, $role: String) {
     );
   });
 
-  it('should not return blocked source members when user is not a moderator/owner', async () => {
+  it('should not return blocked source members when user is not a moderator/admin', async () => {
     loggedUser = '2';
     await con
       .getRepository(SourceMember)
@@ -572,7 +572,7 @@ query SourceMembers($id: ID!, $role: String) {
     );
   });
 
-  it('should return blocked users only when user is the owner', async () => {
+  it('should return blocked users only when user is the admin', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
@@ -812,7 +812,7 @@ describe('mutation createSquad', () => {
       sourceId: newId,
       userId: '1',
     });
-    expect(member.role).toEqual(SourceMemberRoles.Owner);
+    expect(member.role).toEqual(SourceMemberRoles.Admin);
     const post = await con
       .getRepository(SharePost)
       .findOneBy({ sourceId: newId });
@@ -948,7 +948,7 @@ describe('mutation createSquad', () => {
       sourceId: newId,
       userId: '1',
     });
-    expect(member.role).toEqual(SourceMemberRoles.Owner);
+    expect(member.role).toEqual(SourceMemberRoles.Admin);
     const post = await con
       .getRepository(SharePost)
       .findOneBy({ sourceId: newId });
@@ -984,7 +984,7 @@ describe('mutation editSquad', () => {
       sourceId: 's1',
       userId: '1',
       referralToken: 'rt2',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
     });
   });
 
@@ -1046,7 +1046,7 @@ describe('mutation editSquad', () => {
     );
   });
 
-  it(`should throw error if user is not the squad owner`, async () => {
+  it(`should throw error if user is not the squad admin`, async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
@@ -1125,7 +1125,7 @@ describe('mutation editSquad', () => {
       .getRepository(SquadSource)
       .update(
         { id: 's1' },
-        { memberPostingRank: sourceRoleRank[SourceMemberRoles.Owner] },
+        { memberPostingRank: sourceRoleRank[SourceMemberRoles.Admin] },
       );
     const res = await client.mutate(MUTATION, {
       variables: { ...variables, name: 'updated name' },
@@ -1135,7 +1135,7 @@ describe('mutation editSquad', () => {
       .getRepository(SquadSource)
       .findOneBy({ id: variables.sourceId });
     expect(editSource?.memberPostingRank).toEqual(
-      sourceRoleRank[SourceMemberRoles.Owner],
+      sourceRoleRank[SourceMemberRoles.Admin],
     );
     expect(editSource?.name).toEqual('updated name');
   });
@@ -1226,7 +1226,7 @@ describe('mutation updateMemberRole', () => {
     );
   });
 
-  it('should allow owner to promote a member to moderator', async () => {
+  it('should allow admin to promote a member to moderator', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, {
       variables: {
@@ -1242,7 +1242,7 @@ describe('mutation updateMemberRole', () => {
     expect(member.role).toEqual(SourceMemberRoles.Moderator);
   });
 
-  it('should allow owner to promote a moderator to an owner', async () => {
+  it('should allow admin to promote a moderator to an admin', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
@@ -1251,21 +1251,21 @@ describe('mutation updateMemberRole', () => {
       variables: {
         sourceId: 'a',
         memberId: '2',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     });
     expect(res.errors).toBeFalsy();
     const member = await con
       .getRepository(SourceMember)
       .findOneBy({ userId: '2', sourceId: 'a' });
-    expect(member.role).toEqual(SourceMemberRoles.Owner);
+    expect(member.role).toEqual(SourceMemberRoles.Admin);
   });
 
-  it('should allow owner to demote an owner to a moderator', async () => {
+  it('should allow admin to demote an admin to a moderator', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
-      .update({ userId: '2' }, { role: SourceMemberRoles.Owner });
+      .update({ userId: '2' }, { role: SourceMemberRoles.Admin });
     const res = await client.mutate(MUTATION, {
       variables: {
         sourceId: 'a',
@@ -1280,7 +1280,7 @@ describe('mutation updateMemberRole', () => {
     expect(member.role).toEqual(SourceMemberRoles.Moderator);
   });
 
-  it('should allow owner to demote a moderator to a member', async () => {
+  it('should allow admin to demote a moderator to a member', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
@@ -1299,11 +1299,11 @@ describe('mutation updateMemberRole', () => {
     expect(member.role).toEqual(SourceMemberRoles.Member);
   });
 
-  it('should allow owner to remove and block an owner', async () => {
+  it('should allow admin to remove and block an admin', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
-      .update({ userId: '2' }, { role: SourceMemberRoles.Owner });
+      .update({ userId: '2' }, { role: SourceMemberRoles.Admin });
     const res = await client.mutate(MUTATION, {
       variables: {
         sourceId: 'a',
@@ -1318,7 +1318,7 @@ describe('mutation updateMemberRole', () => {
     expect(member.role).toEqual(SourceMemberRoles.Blocked);
   });
 
-  it('should allow owner to remove and block a moderator', async () => {
+  it('should allow admin to remove and block a moderator', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
@@ -1337,7 +1337,7 @@ describe('mutation updateMemberRole', () => {
     expect(member.role).toEqual(SourceMemberRoles.Blocked);
   });
 
-  it('should allow owner to remove and block a member', async () => {
+  it('should allow admin to remove and block a member', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, {
       variables: {
@@ -1375,7 +1375,7 @@ describe('mutation updateMemberRole', () => {
     );
   });
 
-  it('should restrict moderator to remove and block an owner', async () => {
+  it('should restrict moderator to remove and block an admin', async () => {
     loggedUser = '2';
     await con
       .getRepository(SourceMember)
@@ -1483,7 +1483,7 @@ describe('mutation unblockMember', () => {
     expect(member).toBeFalsy();
   });
 
-  it('should allow owner to unblock a member', async () => {
+  it('should allow admin to unblock a member', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, {
       variables: { sourceId: 'a', memberId: '3' },
@@ -1543,11 +1543,11 @@ describe('mutation leaveSource', () => {
     expect(sourceMembers).toEqual(0);
   });
 
-  it('should leave squad even if the user is the owner', async () => {
+  it('should leave squad even if the user is the admin', async () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
-      .update({ userId: '1' }, { role: SourceMemberRoles.Owner });
+      .update({ userId: '1' }, { role: SourceMemberRoles.Admin });
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const sourceMembers = await con
@@ -1595,7 +1595,7 @@ describe('mutation deleteSource', () => {
       'UNAUTHENTICATED',
     ));
 
-  it('should not delete source if user is not the owner', async () => {
+  it('should not delete source if user is not the admin', async () => {
     loggedUser = '1';
     return testMutationErrorCode(
       client,
@@ -1608,7 +1608,7 @@ describe('mutation deleteSource', () => {
     loggedUser = '1';
     await con
       .getRepository(SourceMember)
-      .update({ userId: '1' }, { role: SourceMemberRoles.Owner });
+      .update({ userId: '1' }, { role: SourceMemberRoles.Admin });
 
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
@@ -1644,7 +1644,7 @@ describe('mutation joinSource', () => {
       sourceId: 's1',
       userId: '2',
       referralToken: 'rt2',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
     });
   });
 
@@ -1699,7 +1699,7 @@ describe('mutation joinSource', () => {
       sourceId: 's1',
       userId: '2',
     });
-    expect(member.role).toEqual(SourceMemberRoles.Owner);
+    expect(member.role).toEqual(SourceMemberRoles.Admin);
   });
 
   it('should throw error when joining private squad without token', async () => {
@@ -1791,7 +1791,7 @@ query Source($id: ID!) {
       {
         userId: '1',
         sourceId: 'c',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
         referralToken: randomUUID(),
         createdAt: new Date(2022, 11, 19),
       },
@@ -1837,7 +1837,7 @@ query Source($id: ID!) {
         id: 'c',
         privilegedMembers: [
           {
-            role: 'owner',
+            role: 'admin',
             user: {
               id: '1',
             },

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -1207,7 +1207,7 @@ describe('source member', () => {
   it('should notify when role changed', async () => {
     const after: ChangeObject<ObjectType> = {
       ...base,
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
     };
     await saveFixtures(con, User, [defaultUser]);
     await expectSuccessfulBackground(

--- a/__tests__/workers/newNotificationMail.ts
+++ b/__tests__/workers/newNotificationMail.ts
@@ -939,7 +939,7 @@ it('should set parameters for squad_post_live email', async () => {
   expect(args.templateId).toEqual('d-343845599453499d9fa5d3ffafc91514');
 });
 
-it('should set parameters for promoted_to_owner email', async () => {
+it('should set parameters for promoted_to_admin email', async () => {
   await con
     .getRepository(Source)
     .update({ id: 'a' }, { type: SourceType.Squad });
@@ -951,7 +951,7 @@ it('should set parameters for promoted_to_owner email', async () => {
 
   const notificationId = await saveNotificationFixture(
     con,
-    'promoted_to_owner',
+    'promoted_to_admin',
     ctx,
   );
   await expectSuccessfulBackground(worker, {
@@ -965,7 +965,7 @@ it('should set parameters for promoted_to_owner email', async () => {
   expect(args.dynamicTemplateData).toEqual({
     first_name: 'Ido',
     squad_link:
-      'http://localhost:5002/squads/a?utm_source=notification&utm_medium=email&utm_campaign=promoted_to_owner',
+      'http://localhost:5002/squads/a?utm_source=notification&utm_medium=email&utm_campaign=promoted_to_admin',
     squad_name: 'A',
   });
   expect(args.templateId).toEqual('d-397a5e4a394a4b7f91ea33c29efb8d01');
@@ -1011,7 +1011,7 @@ it('should not invoke demoted_to_member email', async () => {
   const ctx: NotificationSourceMemberRoleContext = {
     userId: '1',
     source,
-    role: SourceMemberRoles.Owner,
+    role: SourceMemberRoles.Admin,
   };
 
   const notificationId = await saveNotificationFixture(

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -100,7 +100,7 @@ it('should not send squad access notification if user is part of squad', async (
   await con.getRepository(SourceMember).save({
     sourceId: 'a',
     userId: '1',
-    role: SourceMemberRoles.Owner,
+    role: SourceMemberRoles.Admin,
     referralToken: 'a',
   });
   const worker = await import(
@@ -169,18 +169,18 @@ describe('source member role changed', () => {
     expect(actual[0].type).toEqual('promoted_to_moderator');
     expect(actual[0].ctx).toEqual({ userId: '1', source });
   });
-  it('should add member to owner notification', async () => {
+  it('should add member to admin notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
     const actual = await invokeNotificationWorker(worker.default, {
       previousRole: SourceMemberRoles.Member,
-      sourceMember: { ...baseMember, role: SourceMemberRoles.Owner },
+      sourceMember: { ...baseMember, role: SourceMemberRoles.Admin },
     });
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
 
     expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('promoted_to_owner');
+    expect(actual[0].type).toEqual('promoted_to_admin');
     expect(actual[0].ctx).toEqual({
       userId: '1',
       source,
@@ -204,28 +204,28 @@ describe('source member role changed', () => {
       source,
     });
   });
-  it('should add moderator to owner notification', async () => {
+  it('should add moderator to admin notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
     const actual = await invokeNotificationWorker(worker.default, {
       previousRole: SourceMemberRoles.Moderator,
-      sourceMember: { ...baseMember, role: SourceMemberRoles.Owner },
+      sourceMember: { ...baseMember, role: SourceMemberRoles.Admin },
     });
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
     expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('promoted_to_owner');
+    expect(actual[0].type).toEqual('promoted_to_admin');
     expect(actual[0].ctx).toEqual({
       userId: '1',
       source,
     });
   });
-  it('should add owner to member notification', async () => {
+  it('should add admin to member notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
     const actual = await invokeNotificationWorker(worker.default, {
-      previousRole: SourceMemberRoles.Owner,
+      previousRole: SourceMemberRoles.Admin,
       sourceMember: { ...baseMember, role: SourceMemberRoles.Member },
     });
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
@@ -234,16 +234,16 @@ describe('source member role changed', () => {
     expect(actual[0].type).toEqual('demoted_to_member');
     expect(actual[0].ctx).toEqual({
       userId: '1',
-      role: SourceMemberRoles.Owner,
+      role: SourceMemberRoles.Admin,
       source,
     });
   });
-  it('should add owner to moderator notification', async () => {
+  it('should add admin to moderator notification', async () => {
     const worker = await import(
       '../../src/workers/notifications/sourceMemberRoleChanged'
     );
     const actual = await invokeNotificationWorker(worker.default, {
-      previousRole: SourceMemberRoles.Owner,
+      previousRole: SourceMemberRoles.Admin,
       sourceMember: { ...baseMember, role: SourceMemberRoles.Moderator },
     });
     const source = await con.getRepository(Source).findOneBy({ id: 'squad' });
@@ -1008,7 +1008,7 @@ describe('comment upvote milestone', () => {
 });
 
 describe('squad member joined', () => {
-  it('should add notification to squad owner', async () => {
+  it('should add notification to squad admin', async () => {
     const worker = await import(
       '../../src/workers/notifications/squadMemberJoined'
     );
@@ -1020,7 +1020,7 @@ describe('squad member joined', () => {
         sourceId: 'a',
         userId: '2',
         referralToken: 'rt1',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     ]);
     const actual = await invokeNotificationWorker(worker.default, {
@@ -1038,7 +1038,7 @@ describe('squad member joined', () => {
     expect(ctx.doneBy.id).toEqual('1');
   });
 
-  it('should not add notification when owner joins', async () => {
+  it('should not add notification when admin joins', async () => {
     const worker = await import(
       '../../src/workers/notifications/squadMemberJoined'
     );
@@ -1047,7 +1047,7 @@ describe('squad member joined', () => {
         sourceId: 'a',
         userId: '2',
         referralToken: 'rt1',
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     ]);
     const actual = await invokeNotificationWorker(worker.default, {

--- a/src/entity/Notification.ts
+++ b/src/entity/Notification.ts
@@ -34,7 +34,7 @@ export type NotificationType =
   | 'squad_post_viewed'
   | 'squad_post_live'
   | 'squad_blocked'
-  | 'promoted_to_owner'
+  | 'promoted_to_admin'
   | 'demoted_to_member'
   | 'promoted_to_moderator';
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -208,7 +208,7 @@ const obj = new GraphORM({
             return qb
               .where(`${childAlias}."sourceId" = "${parentAlias}".id`)
               .andWhere(`${childAlias}.role IN (:...roles)`, {
-                roles: [SourceMemberRoles.Owner, SourceMemberRoles.Moderator],
+                roles: [SourceMemberRoles.Admin, SourceMemberRoles.Moderator],
               })
               .limit(50); // limit to avoid huge arrays for members, most sources should fit into this see PR !1219 for more info
           },

--- a/src/migration/1681297594048-OwnerToAdmin.ts
+++ b/src/migration/1681297594048-OwnerToAdmin.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class OwnerToAdmin1681297594048 implements MigrationInterface {
+  name = 'OwnerToAdmin1681297594048';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "public"."source_member" SET "role" = 'admin' WHERE "role" = 'owner'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "public"."source_member" SET "role" = 'owner' WHERE "role" = 'admin'`,
+    );
+  }
+}

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -34,7 +34,7 @@ const roleToIcon: Record<SourceMemberRoles, NotificationIcon> = {
   [SourceMemberRoles.Blocked]: NotificationIcon.Block,
   [SourceMemberRoles.Member]: NotificationIcon.Bell,
   [SourceMemberRoles.Moderator]: NotificationIcon.User,
-  [SourceMemberRoles.Owner]: NotificationIcon.Star,
+  [SourceMemberRoles.Admin]: NotificationIcon.Star,
 };
 
 export class NotificationBuilder {

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -74,8 +74,8 @@ export const notificationTitleMap: Record<
     `<b>Your post</b> is now <span class="text-theme-color-cabbage">live</span> on <b>${ctx.source.name}</b>.`,
   squad_blocked: (ctx: NotificationSourceContext) =>
     `You are no longer part of <b>${ctx.source.name}</b>`,
-  promoted_to_owner: (ctx: NotificationSourceContext) =>
-    `Congratulations! You are now an <span class="text-theme-color-cabbage">owner</span> of <b>${ctx.source.name}</b>`,
+  promoted_to_admin: (ctx: NotificationSourceContext) =>
+    `Congratulations! You are now an <span class="text-theme-color-cabbage">admin</span> of <b>${ctx.source.name}</b>`,
   demoted_to_member: (ctx: NotificationSourceMemberRoleContext) =>
     `You are no longer a <span class="text-theme-color-cabbage">${ctx.role}</span> in <b>${ctx.source.name}</b>`,
   promoted_to_moderator: (ctx: NotificationSourceContext) =>
@@ -217,7 +217,7 @@ export const generateNotificationMap: Record<
       .avatarSource(ctx.source)
       .icon(NotificationIcon.Block)
       .referenceSource(ctx.source),
-  promoted_to_owner: (builder, ctx: NotificationSourceContext) =>
+  promoted_to_admin: (builder, ctx: NotificationSourceContext) =>
     builder
       .avatarSource(ctx.source)
       .icon(NotificationIcon.Star)

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -3,14 +3,14 @@ export enum Roles {
 }
 
 export enum SourceMemberRoles {
-  Owner = 'owner',
+  Admin = 'admin',
   Moderator = 'moderator',
   Member = 'member',
   Blocked = 'blocked',
 }
 
 export const sourceRoleRank: Record<SourceMemberRoles, number> = {
-  owner: 10,
+  admin: 10,
   moderator: 5,
   member: 0,
   blocked: -1,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -478,7 +478,7 @@ const moderatorPermissions = [
   SourcePermissions.MemberUnblock,
   SourcePermissions.ViewBlockedMembers,
 ];
-const ownerPermissions = [
+const adminPermissions = [
   ...moderatorPermissions,
   SourcePermissions.MemberRoleUpdate,
   SourcePermissions.PostLimit,
@@ -490,7 +490,7 @@ export const roleSourcePermissions: Record<
   SourceMemberRoles,
   SourcePermissions[]
 > = {
-  owner: ownerPermissions,
+  admin: adminPermissions,
   moderator: moderatorPermissions,
   member: memberPermissions,
   blocked: [],
@@ -508,7 +508,7 @@ export const hasGreaterAccessCheck = (
   loggedUser: BaseSourceMember,
   member: BaseSourceMember,
 ) => {
-  if (loggedUser.role === SourceMemberRoles.Owner) {
+  if (loggedUser.role === SourceMemberRoles.Admin) {
     return;
   }
 
@@ -934,11 +934,11 @@ export const resolvers: IResolvers<any, Context> = {
             private: true,
             memberPostingRank: sourceRoleRank[memberPostingRole],
           });
-          // Add the logged-in user as owner
+          // Add the logged-in user as admin
           await addNewSourceMember(entityManager, {
             sourceId: id,
             userId: ctx.userId,
-            role: SourceMemberRoles.Owner,
+            role: SourceMemberRoles.Admin,
           });
           if (postId) {
             // Create the first post of the squad

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -56,7 +56,7 @@ const notificationToTemplateId: Record<NotificationType, string> = {
   squad_access: 'd-6b3de457947b415d93d0029361edaf1d',
   squad_post_live: 'd-343845599453499d9fa5d3ffafc91514',
   squad_blocked: '',
-  promoted_to_owner: 'd-397a5e4a394a4b7f91ea33c29efb8d01',
+  promoted_to_admin: 'd-397a5e4a394a4b7f91ea33c29efb8d01',
   demoted_to_member: '',
   promoted_to_moderator: 'd-b1dbd1e86ee14bf094f7616f7469fee8',
 };
@@ -484,7 +484,7 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
   squad_blocked: async () => {
     return null;
   },
-  promoted_to_owner: async (con, user, notification) => {
+  promoted_to_admin: async (con, user, notification) => {
     const source = await con
       .getRepository(Source)
       .findOneBy({ id: notification.referenceId });

--- a/src/workers/notifications/sourceMemberRoleChanged.ts
+++ b/src/workers/notifications/sourceMemberRoleChanged.ts
@@ -18,15 +18,15 @@ const previousRoleToNewRole: Partial<
 > = {
   [SourceMemberRoles.Member]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
-    [SourceMemberRoles.Owner]: 'promoted_to_owner',
+    [SourceMemberRoles.Admin]: 'promoted_to_admin',
     [SourceMemberRoles.Moderator]: 'promoted_to_moderator',
   },
   [SourceMemberRoles.Moderator]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
-    [SourceMemberRoles.Owner]: 'promoted_to_owner',
+    [SourceMemberRoles.Admin]: 'promoted_to_admin',
     [SourceMemberRoles.Member]: 'demoted_to_member',
   },
-  [SourceMemberRoles.Owner]: {
+  [SourceMemberRoles.Admin]: {
     [SourceMemberRoles.Blocked]: 'squad_blocked',
     [SourceMemberRoles.Moderator]: 'promoted_to_moderator',
     [SourceMemberRoles.Member]: 'demoted_to_member',
@@ -61,7 +61,7 @@ const worker: NotificationWorker = {
           },
         ];
         break;
-      case 'promoted_to_owner':
+      case 'promoted_to_admin':
       case 'promoted_to_moderator':
       case 'squad_blocked':
         return [{ type: roleToNotificationMap, ctx: baseCtx }];

--- a/src/workers/notifications/squadMemberJoined.ts
+++ b/src/workers/notifications/squadMemberJoined.ts
@@ -17,14 +17,14 @@ const worker: NotificationWorker = {
   subscription: 'api.member-joined-source-notification',
   handler: async (message, con) => {
     const { sourceMember: member }: Data = messageToJson(message);
-    const owner = await con.getRepository(SourceMember).findOne({
+    const admin = await con.getRepository(SourceMember).findOne({
       where: {
         sourceId: member.sourceId,
         userId: Not(In([member.userId])),
-        role: SourceMemberRoles.Owner,
+        role: SourceMemberRoles.Admin,
       },
     });
-    if (!owner) {
+    if (!admin) {
       return;
     }
     const [doneBy, source] = await Promise.all([
@@ -35,7 +35,7 @@ const worker: NotificationWorker = {
       return;
     }
     const ctx: NotificationSourceContext & NotificationDoneByContext = {
-      userId: owner.userId,
+      userId: admin.userId,
       source,
       doneBy,
     };


### PR DESCRIPTION
Decided to rather fully rename everything to keep things clean.
Starting with API with a retro db update to ensure it keeps working.

All new squads will auto be `admin` role now.
We just need to update frontend to reflect it, opening PR soon.

Since we use roles and permissions it should not break existing frontend to much besides V4.

WT-1236