### PR TITLE
feat: submitting private link and be displayed real-time

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1627,7 +1627,7 @@ describe('mutation submitExternalLink', () => {
   }
 }`;
 
-  const variables = {
+  const variables: Record<string, any> = {
     sourceId: 's1',
     url: 'https://daily.dev',
     commentary: 'My comment',
@@ -1659,20 +1659,14 @@ describe('mutation submitExternalLink', () => {
       'UNAUTHENTICATED',
     ));
 
-  it('should share to squad', async () => {
-    await con.getRepository(Source).insert({
-      id: UNKNOWN_SOURCE,
-      handle: UNKNOWN_SOURCE,
-      name: UNKNOWN_SOURCE,
-    });
-    loggedUser = '1';
+  const checkSharedPostExpectation = async (visible: boolean) => {
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const articlePost = await con
       .getRepository(ArticlePost)
       .findOneBy({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
-    expect(articlePost.visible).toEqual(false);
+    expect(articlePost.visible).toEqual(visible);
 
     expect(notifyContentRequested).toBeCalledTimes(1);
     expect(jest.mocked(notifyContentRequested).mock.calls[0].slice(1)).toEqual([
@@ -1684,7 +1678,28 @@ describe('mutation submitExternalLink', () => {
       .findOneBy({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
-    expect(sharedPost.visible).toEqual(false);
+    expect(sharedPost.visible).toEqual(visible);
+  };
+
+  it('should share to squad without title to support backwards compatibility', async () => {
+    await con.getRepository(Source).insert({
+      id: UNKNOWN_SOURCE,
+      handle: UNKNOWN_SOURCE,
+      name: UNKNOWN_SOURCE,
+    });
+    loggedUser = '1';
+    await checkSharedPostExpectation(false);
+  });
+
+  it('should share to squad and be visible automatically when title is available', async () => {
+    await con.getRepository(Source).insert({
+      id: UNKNOWN_SOURCE,
+      handle: UNKNOWN_SOURCE,
+      name: UNKNOWN_SOURCE,
+    });
+    loggedUser = '1';
+    variables.title = 'Sample external link title';
+    await checkSharedPostExpectation(true);
   });
 
   it('should share existing post to squad', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1621,8 +1621,8 @@ describe('mutation viewPost', () => {
 
 describe('mutation submitExternalLink', () => {
   const MUTATION = `
-  mutation SubmitExternalLink($sourceId: ID!, $url: String!, $commentary: String!) {
-  submitExternalLink(sourceId: $sourceId, url: $url, commentary: $commentary) {
+  mutation SubmitExternalLink($sourceId: ID!, $url: String!, $commentary: String!, $title: String!, $image: String!) {
+  submitExternalLink(sourceId: $sourceId, url: $url, commentary: $commentary, title: $title, image: $image) {
     _
   }
 }`;

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1630,6 +1630,8 @@ describe('mutation submitExternalLink', () => {
   const variables = {
     sourceId: 's1',
     url: 'https://daily.dev',
+    title: 'Sample article title',
+    image: 'https://daily.dev/sample.png',
     commentary: 'My comment',
   };
 
@@ -1672,7 +1674,7 @@ describe('mutation submitExternalLink', () => {
       .getRepository(ArticlePost)
       .findOneBy({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
-    expect(articlePost.visible).toEqual(false);
+    expect(articlePost.visible).toEqual(true);
 
     expect(notifyContentRequested).toBeCalledTimes(1);
     expect(jest.mocked(notifyContentRequested).mock.calls[0].slice(1)).toEqual([
@@ -1684,7 +1686,7 @@ describe('mutation submitExternalLink', () => {
       .findOneBy({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
-    expect(sharedPost.visible).toEqual(false);
+    expect(sharedPost.visible).toEqual(true);
   });
 
   it('should share existing post to squad', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1666,7 +1666,7 @@ describe('mutation submitExternalLink', () => {
       .getRepository(ArticlePost)
       .findOneBy({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
-    expect(articlePost.visible).toEqual(false);
+    expect(articlePost.visible).toEqual(visible);
 
     expect(notifyContentRequested).toBeCalledTimes(1);
     expect(jest.mocked(notifyContentRequested).mock.calls[0].slice(1)).toEqual([

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1621,7 +1621,7 @@ describe('mutation viewPost', () => {
 
 describe('mutation submitExternalLink', () => {
   const MUTATION = `
-  mutation SubmitExternalLink($sourceId: ID!, $url: String!, $commentary: String!, $title: String!, $image: String!) {
+  mutation SubmitExternalLink($sourceId: ID!, $url: String!, $commentary: String!, $title: String, $image: String) {
   submitExternalLink(sourceId: $sourceId, url: $url, commentary: $commentary, title: $title, image: $image) {
     _
   }
@@ -1630,8 +1630,6 @@ describe('mutation submitExternalLink', () => {
   const variables = {
     sourceId: 's1',
     url: 'https://daily.dev',
-    title: 'Sample article title',
-    image: 'https://daily.dev/sample.png',
     commentary: 'My comment',
   };
 
@@ -1674,7 +1672,7 @@ describe('mutation submitExternalLink', () => {
       .getRepository(ArticlePost)
       .findOneBy({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
-    expect(articlePost.visible).toEqual(true);
+    expect(articlePost.visible).toEqual(false);
 
     expect(notifyContentRequested).toBeCalledTimes(1);
     expect(jest.mocked(notifyContentRequested).mock.calls[0].slice(1)).toEqual([
@@ -1686,7 +1684,7 @@ describe('mutation submitExternalLink', () => {
       .findOneBy({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
-    expect(sharedPost.visible).toEqual(true);
+    expect(sharedPost.visible).toEqual(false);
   });
 
   it('should share existing post to squad', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1627,7 +1627,7 @@ describe('mutation submitExternalLink', () => {
   }
 }`;
 
-  const variables: Record<string, any> = {
+  const variables: Record<string, string> = {
     sourceId: 's1',
     url: 'https://daily.dev',
     commentary: 'My comment',

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1666,7 +1666,7 @@ describe('mutation submitExternalLink', () => {
       .getRepository(ArticlePost)
       .findOneBy({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
-    expect(articlePost.visible).toEqual(visible);
+    expect(articlePost.visible).toEqual(false);
 
     expect(notifyContentRequested).toBeCalledTimes(1);
     expect(jest.mocked(notifyContentRequested).mock.calls[0].slice(1)).toEqual([

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -390,7 +390,7 @@ export const createExternalLink = async (
       sentAnalyticsReport: true,
       private: true,
       origin: PostOrigin.Squad,
-      visible: false,
+      visible: isVisible,
     });
     await createSharePost(
       entityManager,

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -361,8 +361,8 @@ const validateCommentary = async (commentary: string) => {
 
 export interface ExternalLink {
   url: string;
-  title: string;
-  image: string;
+  title?: string;
+  image?: string;
 }
 
 export const createExternalLink = async (
@@ -389,7 +389,7 @@ export const createExternalLink = async (
       sentAnalyticsReport: true,
       private: true,
       origin: PostOrigin.Squad,
-      visible: true,
+      visible: !!title,
     });
     await createSharePost(entityManager, sourceId, userId, id, commentary);
     await notifyContentRequested(logger, {

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -375,6 +375,7 @@ export const createExternalLink = async (
 ): Promise<void> => {
   await validateCommentary(commentary);
   const id = await generateShortId();
+  const isVisible = !!title;
 
   return con.transaction(async (entityManager) => {
     await entityManager.getRepository(ArticlePost).insert({
@@ -389,9 +390,16 @@ export const createExternalLink = async (
       sentAnalyticsReport: true,
       private: true,
       origin: PostOrigin.Squad,
-      visible: !!title,
+      visible: isVisible,
     });
-    await createSharePost(entityManager, sourceId, userId, id, commentary);
+    await createSharePost(
+      entityManager,
+      sourceId,
+      userId,
+      id,
+      commentary,
+      isVisible,
+    );
     await notifyContentRequested(logger, {
       id,
       url,

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -359,12 +359,18 @@ const validateCommentary = async (commentary: string) => {
   return true;
 };
 
+export interface ExternalLink {
+  url: string;
+  title: string;
+  image: string;
+}
+
 export const createExternalLink = async (
   con: DataSource | EntityManager,
   logger: EventLogger,
   sourceId: string,
   userId: string,
-  url: string,
+  { url, title, image }: ExternalLink,
   commentary: string,
 ): Promise<void> => {
   await validateCommentary(commentary);
@@ -378,19 +384,14 @@ export const createExternalLink = async (
       sourceId: UNKNOWN_SOURCE,
       url,
       canonicalUrl: url,
+      title,
+      image,
       sentAnalyticsReport: true,
       private: true,
       origin: PostOrigin.Squad,
-      visible: false,
+      visible: true,
     });
-    await createSharePost(
-      entityManager,
-      sourceId,
-      userId,
-      id,
-      commentary,
-      false,
-    );
+    await createSharePost(entityManager, sourceId, userId, id, commentary);
     await notifyContentRequested(logger, {
       id,
       url,

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -390,7 +390,7 @@ export const createExternalLink = async (
       sentAnalyticsReport: true,
       private: true,
       origin: PostOrigin.Squad,
-      visible: isVisible,
+      visible: false,
     });
     await createSharePost(
       entityManager,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -897,9 +897,8 @@ export const resolvers: IResolvers<any, Context> = {
       { sourceId, commentary, url, title, image }: SubmitExternalLinkArgs,
       ctx,
     ): Promise<GQLEmptyResponse> => {
-      await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
-
       await ctx.con.transaction(async (manager) => {
+        await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
         const cleanUrl = standardizeURL(url);
         if (!isValidHttpUrl(cleanUrl)) {
           throw new ValidationError('URL is not valid');

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -542,11 +542,11 @@ export const typeDefs = /* GraphQL */ `
       """
       Preview image of the external link
       """
-      image: String!
+      image: String
       """
       Title of the external link
       """
-      title: String!
+      title: String
       """
       Commentary for the share
       """


### PR DESCRIPTION
We now accept parameters for the title and image to use for the external link, but to support backwards compatibility, the said parameters are kept optional.
