### PR TITLE
fix: stop sending notification on sync posting external links

### DIFF
--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -51,6 +51,7 @@ import {
   Feed,
   Notification,
   Post,
+  PostOrigin,
   PostReport,
   Settings,
   Source,
@@ -575,6 +576,24 @@ describe('post', () => {
       worker,
       mockChangeMessage<ObjectType>({
         after: base,
+        before: null,
+        op: 'c',
+        table: 'post',
+      }),
+    );
+    expect(notifyPostVisible).toBeCalledTimes(0);
+  });
+
+  it('should not notify on post visible on creation of external link with title and visible is already true', async () => {
+    const after = {
+      ...base,
+      visible: true,
+      origin: PostOrigin.UserGenerated,
+    };
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
         before: null,
         op: 'c',
         table: 'post',

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -19,6 +19,7 @@ import {
   User,
   Feature,
   Source,
+  PostOrigin,
 } from '../entity';
 import {
   notifyCommentCommented,
@@ -263,7 +264,10 @@ const onPostChange = async (
   data: ChangeMessage<Post>,
 ): Promise<void> => {
   if (data.payload.op === 'c') {
-    if (data.payload.after.visible) {
+    if (
+      data.payload.after.visible &&
+      data.payload.after.origin !== PostOrigin.UserGenerated
+    ) {
       await notifyPostVisible(logger, data.payload.after);
     }
   } else if (data.payload.op === 'u') {


### PR DESCRIPTION
Don't send notifications when posting a link that is visible already (sync external link).