### PR TITLE
feat: check permission when joining squad

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -5,6 +5,7 @@ import {
   initializeGraphQLTesting,
   MockContext,
   saveFixtures,
+  testMutationError,
   testMutationErrorCode,
   testQueryErrorCode,
 } from './helpers';
@@ -28,6 +29,7 @@ import { usersFixture } from './fixture/user';
 import { postsFixture } from './fixture/post';
 import { createSource } from './fixture/source';
 import { SourcePermissions } from '../src/schema/sources';
+import { SourcePermissionErrorKeys } from '../src/errors';
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -1955,7 +1957,7 @@ describe('mutation joinSource', () => {
     });
 
     loggedUser = '1';
-    return testMutationErrorCode(
+    await testMutationError(
       client,
       {
         mutation: MUTATION,
@@ -1964,7 +1966,13 @@ describe('mutation joinSource', () => {
           token: 'rt2',
         },
       },
-      'FORBIDDEN',
+      (errors) => {
+        expect(errors.length).toEqual(1);
+        expect(errors[0].extensions?.code).toEqual('FORBIDDEN');
+        expect(errors[0].message).toEqual(
+          SourcePermissionErrorKeys.InviteInvalid,
+        );
+      },
     );
   });
 });

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1938,6 +1938,35 @@ describe('mutation joinSource', () => {
       'NOT_FOUND',
     );
   });
+
+  it('should throw error when joining with invite link of a member without invite permission', async () => {
+    await con.getRepository(SquadSource).save({
+      id: 's1',
+      handle: 's1',
+      name: 'Squad',
+      private: true,
+      memberInviteRank: sourceRoleRank[SourceMemberRoles.Moderator],
+    });
+    await con.getRepository(SourceMember).save({
+      sourceId: 's1',
+      userId: '2',
+      referralToken: 'rt2',
+      role: SourceMemberRoles.Member,
+    });
+
+    loggedUser = '1';
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          sourceId: 's1',
+          token: 'rt2',
+        },
+      },
+      'FORBIDDEN',
+    );
+  });
 });
 
 describe('query source members', () => {

--- a/src/entity/Submission.ts
+++ b/src/entity/Submission.ts
@@ -64,7 +64,7 @@ export const validateAndApproveSubmission = async (
       { id: data.submissionId },
       {
         status: SubmissionStatus.Rejected,
-        reason: 'SCOUT_IS_AUTHOR',
+        reason: SubmissionFailErrorKeys.ScoutIsAuthor,
       },
     );
     return { rejected: true };

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -194,7 +194,7 @@ export const updateUserEmail = async (
   logger: FastifyLoggerInstance,
 ): Promise<UpdateUserEmailResult> => {
   if (!data.email || !data.id) {
-    return { status: 'failed', reason: 'MISSING_FIELDS' };
+    return { status: 'failed', reason: UpdateUserFailErrorKeys.MissingFields };
   }
 
   return con.transaction(async (entityManager) => {
@@ -206,7 +206,10 @@ export const updateUserEmail = async (
         logger.info(
           `Failed to update email user not found with ID: ${data.id}`,
         );
-        return { status: 'failed', reason: 'USER_DOESNT_EXIST' };
+        return {
+          status: 'failed',
+          reason: UpdateUserFailErrorKeys.UserDoesntExist,
+        };
       }
 
       logger.info(`Updated email for user with ID: ${data.id}`);
@@ -236,13 +239,16 @@ export const addNewUser = async (
 ): Promise<AddNewUserResult> => {
   if (!checkRequiredFields(data)) {
     logger.info({ data }, 'missing fields when adding new user');
-    return { status: 'failed', reason: 'MISSING_FIELDS' };
+    return { status: 'failed', reason: UserFailErrorKeys.MissingFields };
   }
 
   return con.transaction(async (entityManager) => {
     const isUniqueUser = await checkUsernameAndEmail(entityManager, data);
     if (!isUniqueUser) {
-      return { status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' };
+      return {
+        status: 'failed',
+        reason: UserFailErrorKeys.UsernameEmailExists,
+      };
     }
 
     // Clear GitHub handle in case it already exists
@@ -297,7 +303,7 @@ export const addNewUser = async (
 
       // Unique
       if (error?.code === TypeOrmError.DUPLICATE_ENTRY) {
-        return { status: 'failed', reason: 'USER_EXISTS' };
+        return { status: 'failed', reason: UserFailErrorKeys.UserExists };
       }
 
       throw error;

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -123,14 +123,14 @@ const shouldAddNewPost = async (
     )
     .getRawOne();
   if (p) {
-    return 'POST_EXISTS';
+    return SubmissionFailErrorKeys.PostExists;
   }
   if (bannedAuthors.indexOf(data.creatorTwitter) > -1) {
-    return 'AUTHOR_BANNED';
+    return SubmissionFailErrorKeys.AuthorBanned;
   }
 
   if (!data.title) {
-    return 'MISSING_FIELDS';
+    return SubmissionFailErrorKeys.MissingFields;
   }
 };
 
@@ -291,7 +291,7 @@ export const addNewPost = async (
   logger: FastifyLoggerInstance,
 ): Promise<AddNewPostResult> => {
   if (!checkRequiredFields(data)) {
-    return { status: 'failed', reason: 'MISSING_FIELDS' };
+    return { status: 'failed', reason: SubmissionFailErrorKeys.MissingFields };
   }
 
   const creatorTwitter =
@@ -318,7 +318,10 @@ export const addNewPost = async (
     )) || { scoutId: null, rejected: false };
 
     if (rejected) {
-      return { status: 'failed', reason: 'SCOUT_IS_AUTHOR' };
+      return {
+        status: 'failed',
+        reason: SubmissionFailErrorKeys.ScoutIsAuthor,
+      };
     }
 
     const combinedData = {
@@ -337,11 +340,19 @@ export const addNewPost = async (
     } catch (error) {
       // Unique
       if (error?.code === TypeOrmError.DUPLICATE_ENTRY) {
-        return { status: 'failed', reason: 'POST_EXISTS', error };
+        return {
+          status: 'failed',
+          reason: SubmissionFailErrorKeys.PostExists,
+          error,
+        };
       }
       // Null violation
       if (error?.code === TypeOrmError.NULL_VIOLATION) {
-        return { status: 'failed', reason: 'MISSING_FIELDS', error };
+        return {
+          status: 'failed',
+          reason: SubmissionFailErrorKeys.MissingFields,
+          error,
+        };
       }
       throw error;
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,27 +1,32 @@
 import { ApolloError } from 'apollo-server-errors';
 
-export type UserFailErrorKeys =
-  | 'GENERIC_ERROR'
-  | 'MISSING_FIELDS'
-  | 'USER_EXISTS'
-  | 'USERNAME_EMAIL_EXISTS';
+export enum UserFailErrorKeys {
+  GenericError = 'GENERIC_ERROR',
+  MissingFields = 'MISSING_FIELDS',
+  UserExists = 'USER_EXISTS',
+  UsernameEmailExists = 'USERNAME_EMAIL_EXISTS',
+}
 
-export type UpdateUserFailErrorKeys = 'MISSING_FIELDS' | 'USER_DOESNT_EXIST';
+export enum UpdateUserFailErrorKeys {
+  MissingFields = 'MISSING_FIELDS',
+  UserDoesntExist = 'USER_DOESNT_EXIST',
+}
 
-export type SubmissionFailErrorKeys =
-  | 'GENERIC_ERROR'
-  | 'PAYWALL'
-  | 'MISSING_FIELDS'
-  | 'SCOUT_IS_AUTHOR'
-  | 'POST_EXISTS'
-  | 'AUTHOR_BANNED'
-  | 'ACCESS_DENIED'
-  | 'LIMIT_REACHED'
-  | 'INVALID_URL'
-  | 'POST_DELETED'
-  | 'EXISTS_STARTED'
-  | 'EXISTS_ACCEPTED'
-  | 'EXISTS_REJECTED';
+export enum SubmissionFailErrorKeys {
+  GenericError = 'GENERIC_ERROR',
+  Paywall = 'PAYWALL',
+  MissingFields = 'MISSING_FIELDS',
+  ScoutIsAuthor = 'SCOUT_IS_AUTHOR',
+  PostExists = 'POST_EXISTS',
+  AuthorBanned = 'AUTHOR_BANNED',
+  AccessDenied = 'ACCESS_DENIED',
+  LimitReached = 'LIMIT_REACHED',
+  InvalidUrl = 'INVALID_URL',
+  PostDeleted = 'POST_DELETED',
+  ExistsStarted = 'EXISTS_STARTED',
+  ExistsAccepted = 'EXISTS_ACCEPTED',
+  ExistsRejected = 'EXISTS_REJECTED',
+}
 
 export const SubmissionFailErrorMessage: Record<
   SubmissionFailErrorKeys,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,3 +72,7 @@ export enum TypeOrmError {
   FOREIGN_KEY = '23503',
   DUPLICATE_ENTRY = '23505',
 }
+
+export enum SourcePermissionErrorKeys {
+  InviteInvalid = 'SOURCE_PERMISSION_INVITE_INVALID',
+}

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -50,7 +50,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
           reason:
             data?.reason in SubmissionFailErrorMessage
               ? <SubmissionFailErrorKeys>data?.reason
-              : 'GENERIC_ERROR',
+              : SubmissionFailErrorKeys.GenericError,
         });
       }
       return res

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1166,6 +1166,17 @@ export const resolvers: IResolvers<any, Context> = {
           'Access denied! You do not have permission for this action!',
         );
       }
+
+      const memberRank =
+        sourceRoleRank[member.role] ?? sourceRoleRank[SourceMemberRoles.Member];
+      const squadSource = source as SquadSource;
+
+      if (memberRank < squadSource.memberInviteRank) {
+        throw new ForbiddenError(
+          'Access denied! You do not have permission for this action!',
+        );
+      }
+
       try {
         await ctx.con.transaction(async (entityManager) => {
           await addNewSourceMember(entityManager, {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1172,9 +1172,7 @@ export const resolvers: IResolvers<any, Context> = {
       const squadSource = source as SquadSource;
 
       if (memberRank < squadSource.memberInviteRank) {
-        throw new ForbiddenError(
-          'Access denied! You do not have permission for this action!',
-        );
+        throw new ForbiddenError('Access denied! Invite is no longer valid!');
       }
 
       try {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -37,7 +37,7 @@ import { FileUpload } from 'graphql-upload/GraphQLUpload';
 import { randomUUID } from 'crypto';
 import { getSourceLink, uploadSquadImage } from '../common';
 import { GraphQLResolveInfo } from 'graphql';
-import { TypeOrmError } from '../errors';
+import { SourcePermissionErrorKeys, TypeOrmError } from '../errors';
 import {
   descriptionRegex,
   handleRegex,
@@ -1172,7 +1172,7 @@ export const resolvers: IResolvers<any, Context> = {
       const squadSource = source as SquadSource;
 
       if (memberRank < squadSource.memberInviteRank) {
-        throw new ForbiddenError('Access denied! Invite is no longer valid!');
+        throw new ForbiddenError(SourcePermissionErrorKeys.InviteInvalid);
       }
 
       try {


### PR DESCRIPTION
With invite permission on squad there is a chance now that member shared a link on twitter or something and then after that admin restricted squad invites to moderators and above.

In that case since the link is out and we block the actual join request when it happens on our API.

Per comments here I refactored `errors.ts` to be `enum` instead of types https://github.com/dailydotdev/apps/pull/1761#discussion_r1173722616 