### PR TITLE
refactor: unnecessary live post notification

### DIFF
--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -584,24 +584,6 @@ describe('post', () => {
     expect(notifyPostVisible).toBeCalledTimes(0);
   });
 
-  it('should not notify on post visible on creation of external link with title and visible is already true', async () => {
-    const after = {
-      ...base,
-      visible: true,
-      origin: PostOrigin.UserGenerated,
-    };
-    await expectSuccessfulBackground(
-      worker,
-      mockChangeMessage<ObjectType>({
-        after,
-        before: null,
-        op: 'c',
-        table: 'post',
-      }),
-    );
-    expect(notifyPostVisible).toBeCalledTimes(0);
-  });
-
   it('should notify on post visible on creation', async () => {
     const after = {
       ...base,

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -3,7 +3,7 @@ import {
   ReputationEvent,
   ReputationReason,
   ReputationType,
-} from './../../src/entity/ReputationEvent';
+} from '../../src/entity';
 import {
   notifyAlertsUpdated,
   notifyCommentCommented,
@@ -51,7 +51,6 @@ import {
   Feed,
   Notification,
   Post,
-  PostOrigin,
   PostReport,
   Settings,
   Source,

--- a/__tests__/workers/newNotificationMail.ts
+++ b/__tests__/workers/newNotificationMail.ts
@@ -890,55 +890,6 @@ it('should set parameters for squad_access email', async () => {
   expect(args.templateId).toEqual('d-6b3de457947b415d93d0029361edaf1d');
 });
 
-it('should set parameters for squad_post_live email', async () => {
-  const sharedPost = await con.getRepository(ArticlePost).save(postsFixture[0]);
-  await con
-    .getRepository(Source)
-    .update({ id: 'a' }, { type: SourceType.Squad });
-  const source = await con.getRepository(Source).findOneBy({ id: 'a' });
-  const post = await con.getRepository(SharePost).save({
-    id: 'ps',
-    shortId: 'ps',
-    sourceId: 'a',
-    title: 'Shared post',
-    sharedPostId: 'p1',
-    authorId: '2',
-  });
-  const ctx: NotificationPostContext = {
-    userId: '2',
-    post,
-    sharedPost,
-    source,
-  };
-
-  const notificationId = await saveNotificationFixture(
-    con,
-    'squad_post_live',
-    ctx,
-  );
-  await expectSuccessfulBackground(worker, {
-    notification: {
-      id: notificationId,
-      userId: '2',
-    },
-  });
-  expect(sendEmail).toBeCalledTimes(1);
-  const args = jest.mocked(sendEmail).mock.calls[0][0] as MailDataRequired;
-  expect(args.dynamicTemplateData).toEqual({
-    commentary: 'Shared post',
-    full_name: 'Tsahi',
-    post_image: 'https://daily.dev/image.jpg',
-    post_link:
-      'http://localhost:5002/posts/ps?utm_source=notification&utm_medium=email&utm_campaign=squad_post_live',
-    post_title: 'P1',
-    profile_image: 'https://daily.dev/tsahi.jpg',
-    squad_image: 'http://image.com/a',
-    squad_name: 'A',
-    user_reputation: '10',
-  });
-  expect(args.templateId).toEqual('d-343845599453499d9fa5d3ffafc91514');
-});
-
 it('should set parameters for promoted_to_admin email', async () => {
   await con
     .getRepository(Source)

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -5,9 +5,7 @@ import {
   FeatureType,
   MachineSource,
   Post,
-  PostOrigin,
   PostReport,
-  PostType,
   Source,
   SourceMember,
   SourceType,
@@ -16,7 +14,7 @@ import {
   User,
 } from '../../src/entity';
 import { SourceMemberRoles } from '../../src/roles';
-import { DataSource, DeepPartial } from 'typeorm';
+import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { usersFixture } from '../fixture/user';
 import { postsFixture } from '../fixture/post';

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -367,29 +367,6 @@ describe('post added notifications', () => {
     expect(actual[0].ctx.userId).toEqual('2');
     expect(actual[1].ctx.userId).toEqual('3');
   });
-
-  it('should add post live notification to author when it is an external link post', async () => {
-    const worker = await import('../../src/workers/notifications/postAdded');
-    await con
-      .getRepository(Source)
-      .update({ id: 'a' }, { type: SourceType.Squad });
-    await con.getRepository(Post).update({ id: 'p1' }, {
-      authorId: '1',
-      type: PostType.Share,
-      sharedPostId: 'p2',
-    } as DeepPartial<Post>);
-    await con
-      .getRepository(Post)
-      .update({ id: 'p2' }, { origin: PostOrigin.Squad });
-    const actual = await invokeNotificationWorker(worker.default, {
-      post: postsFixture[0],
-    });
-    expect(actual.length).toEqual(1);
-    expect(actual[0].type).toEqual('squad_post_live');
-    expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
-    expect((actual[0].ctx as NotificationPostContext).source.id).toEqual('a');
-    expect(actual[0].ctx.userId).toEqual('1');
-  });
 });
 
 describe('article new comment', () => {

--- a/src/entity/Notification.ts
+++ b/src/entity/Notification.ts
@@ -32,7 +32,6 @@ export type NotificationType =
   | 'squad_new_comment'
   | 'squad_reply'
   | 'squad_post_viewed'
-  | 'squad_post_live'
   | 'squad_blocked'
   | 'promoted_to_admin'
   | 'demoted_to_member'

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -70,8 +70,6 @@ export const notificationTitleMap: Record<
     ctx: NotificationPostContext & NotificationDoneByContext,
   ) =>
     `<b>${ctx.doneBy.name}</b> <span class="text-theme-color-cabbage">viewed</span> your post on <b>${ctx.source.name}</b>.`,
-  squad_post_live: (ctx: NotificationPostContext) =>
-    `<b>Your post</b> is now <span class="text-theme-color-cabbage">live</span> on <b>${ctx.source.name}</b>.`,
   squad_blocked: (ctx: NotificationSourceContext) =>
     `You are no longer part of <b>${ctx.source.name}</b>`,
   promoted_to_admin: (ctx: NotificationSourceContext) =>
@@ -207,10 +205,6 @@ export const generateNotificationMap: Record<
       .objectPost(ctx.post, ctx.source, ctx.sharedPost)
       .avatarManyUsers([ctx.doneBy])
       .uniqueKey(ctx.doneBy.id),
-  squad_post_live: (builder, ctx: NotificationPostContext) =>
-    builder
-      .icon(NotificationIcon.Bell)
-      .objectPost(ctx.post, ctx.source, ctx.sharedPost),
   squad_blocked: (builder, ctx: NotificationSourceContext) =>
     builder
       .targetUrl(process.env.COMMENTS_PREFIX)

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -264,10 +264,7 @@ const onPostChange = async (
   data: ChangeMessage<Post>,
 ): Promise<void> => {
   if (data.payload.op === 'c') {
-    if (
-      data.payload.after.visible &&
-      data.payload.after.origin !== PostOrigin.UserGenerated
-    ) {
+    if (data.payload.after.visible) {
       await notifyPostVisible(logger, data.payload.after);
     }
   } else if (data.payload.op === 'u') {

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -19,7 +19,6 @@ import {
   User,
   Feature,
   Source,
-  PostOrigin,
 } from '../entity';
 import {
   notifyCommentCommented,

--- a/src/workers/newNotificationMail.ts
+++ b/src/workers/newNotificationMail.ts
@@ -54,7 +54,6 @@ const notificationToTemplateId: Record<NotificationType, string> = {
   squad_reply: 'd-cbb2de40b61840c38d3aa21028af0c68',
   squad_post_viewed: 'd-dc0eb578886c4f84a7dcc25515c7b6a4',
   squad_access: 'd-6b3de457947b415d93d0029361edaf1d',
-  squad_post_live: 'd-343845599453499d9fa5d3ffafc91514',
   squad_blocked: '',
   promoted_to_admin: 'd-397a5e4a394a4b7f91ea33c29efb8d01',
   demoted_to_member: '',
@@ -449,36 +448,6 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
   squad_access: async (con, user) => {
     return {
       full_name: user.name,
-    };
-  },
-  squad_post_live: async (con, user, notification) => {
-    const post = await con.getRepository(SharePost).findOne({
-      where: { id: notification.referenceId },
-      relations: ['source'],
-    });
-    if (!post || !post?.sharedPostId) {
-      return;
-    }
-    const [source, sharedPost] = await Promise.all([
-      post.source,
-      con.getRepository(Post).findOneBy({ id: post.sharedPostId }),
-    ]);
-    if (!source || !sharedPost) {
-      return;
-    }
-    return {
-      full_name: user.name,
-      profile_image: user.image,
-      squad_name: source.name,
-      squad_image: source.image,
-      commentary: truncatePostToTweet(post),
-      post_link: addNotificationEmailUtm(
-        notification.targetUrl,
-        notification.type,
-      ),
-      post_image: (sharedPost as ArticlePost).image || pickImageUrl(sharedPost),
-      post_title: truncatePostToTweet(sharedPost),
-      user_reputation: user.reputation,
     };
   },
   squad_blocked: async () => {

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -73,19 +73,6 @@ const worker: NotificationWorker = {
             } as NotificationPostContext & Partial<NotificationDoneByContext>,
           }),
         );
-
-        if (post.type === PostType.Share) {
-          // squad_post_live notification
-          if (baseCtx.sharedPost?.origin === PostOrigin.Squad) {
-            notifs.push({
-              type: 'squad_post_live',
-              ctx: {
-                ...baseCtx,
-                userId: post.authorId,
-              } as NotificationPostContext,
-            });
-          }
-        }
       }
     }
     return notifs;

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -1,12 +1,5 @@
 import { messageToJson } from '../worker';
-import {
-  Post,
-  PostOrigin,
-  PostType,
-  SourceMember,
-  SourceType,
-  User,
-} from '../../entity';
+import { Post, SourceMember, SourceType, User } from '../../entity';
 import {
   NotificationDoneByContext,
   NotificationPostContext,


### PR DESCRIPTION
**Blocked**: until [preview PR in FE](https://github.com/dailydotdev/apps/pull/1744) is merged.

Sync external link submission post-release removal of the post_live notification.