### PR TITLE
refactor: link preview to return default title when null or empty

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2018,10 +2018,27 @@ describe('mutation checkLinkPreview', () => {
     expect(res.data.checkLinkPreview.id).toBeFalsy();
   });
 
-  it('should return link preview image and default title when null or empty', async () => {
+  it('should return link preview image and default title when null', async () => {
     loggedUser = '1';
 
     const sampleResponse = { title: null };
+
+    nock(postScraperOrigin)
+      .post('/preview', { url: variables.url })
+      .reply(200, sampleResponse);
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.checkLinkPreview.title).toEqual(DEFAULT_POST_TITLE);
+    expect(res.data.checkLinkPreview.image).toEqual(defaultImage.placeholder);
+    expect(res.data.checkLinkPreview.id).toBeFalsy();
+  });
+
+  it('should return link preview image and default title when empty', async () => {
+    loggedUser = '1';
+
+    const sampleResponse = { title: '' };
 
     nock(postScraperOrigin)
       .post('/preview', { url: variables.url })

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -43,6 +43,7 @@ import {
   postScraperOrigin,
   notifyContentRequested,
   notifyView,
+  DEFAULT_POST_TITLE,
 } from '../src/common';
 import { randomUUID } from 'crypto';
 import nock from 'nock';
@@ -2013,6 +2014,23 @@ describe('mutation checkLinkPreview', () => {
 
     expect(res.errors).toBeFalsy();
     expect(res.data.checkLinkPreview.title).toEqual(sampleResponse.title);
+    expect(res.data.checkLinkPreview.image).toEqual(defaultImage.placeholder);
+    expect(res.data.checkLinkPreview.id).toBeFalsy();
+  });
+
+  it('should return link preview image and default title when null or empty', async () => {
+    loggedUser = '1';
+
+    const sampleResponse = { title: null };
+
+    nock(postScraperOrigin)
+      .post('/preview', { url: variables.url })
+      .reply(200, sampleResponse);
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.checkLinkPreview.title).toEqual(DEFAULT_POST_TITLE);
     expect(res.data.checkLinkPreview.image).toEqual(defaultImage.placeholder);
     expect(res.data.checkLinkPreview.id).toBeFalsy();
   });

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -53,6 +53,8 @@ export const getPostCommenterIds = async (
 export const hasAuthorScout = (post: Post): boolean =>
   !!post?.authorId || !!post?.scoutId;
 
+export const DEFAULT_POST_TITLE = 'No title';
+
 export const postScraperOrigin = process.env.POST_SCRAPER_ORIGIN;
 
 export const fetchLinkPreview = async (

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -13,6 +13,7 @@ import {
 import { Context } from '../Context';
 import { traceResolverObject } from './trace';
 import {
+  DEFAULT_POST_TITLE,
   defaultImage,
   fetchLinkPreview,
   getDiscussionLink,
@@ -924,11 +925,13 @@ export const resolvers: IResolvers<any, Context> = {
         .andWhere({ deleted: false })
         .getRawOne();
 
-      if (!post) {
-        return fetchLinkPreview(standardizedUrl);
+      if (post) {
+        return post;
       }
 
-      return post;
+      const { title, image } = await fetchLinkPreview(standardizedUrl);
+
+      return { image, title: title ?? DEFAULT_POST_TITLE };
     },
     submitExternalLink: async (
       _,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -925,13 +925,11 @@ export const resolvers: IResolvers<any, Context> = {
         .andWhere({ deleted: false })
         .getRawOne();
 
-      if (post) {
-        return post;
+      if (!post) {
+        return fetchLinkPreview(standardizedUrl);
       }
 
-      const { title, image } = await fetchLinkPreview(standardizedUrl);
-
-      return { image, title: title ?? DEFAULT_POST_TITLE };
+      return post;
     },
     submitExternalLink: async (
       _,
@@ -1054,5 +1052,7 @@ export const resolvers: IResolvers<any, Context> = {
   LinkPreview: {
     image: (preview: ExternalLinkPreview) =>
       preview.image ?? defaultImage.placeholder,
+    title: (preview: ExternalLinkPreview) =>
+      preview.title?.length ? preview.title : DEFAULT_POST_TITLE,
   },
 };


### PR DESCRIPTION
After discussing the list of links we have that produces no title or null values, it was mentioned that there is nothing that can be applied to fix it at the moment, so after checking with Product, we should continue returning our default title of `No title`.

Link to discussion: https://dailydotdev.slack.com/archives/C04UQUBDWKD/p1682418073810469

When the title is empty, we now return the default title we use since the scraper can return either `null` or an empty string.

Though when it returns an error, our mutation should still continue to return the proper error.