### PR TITLE
fix: move feed endpoint call from get to post

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ ENABLE_SETTINGS_EXPERIMENT=
 FLAGSMITH_KEY=key
 FLAGSMITH_WEBHOOK_SECRET=webhook
 
-INTERNAL_FEED=http://localhost:6000/feed.json?token=token
+INTERNAL_FEED=http://localhost:6000/feed.json
 
 POST_SCRAPER_ORIGIN=http://localhost:8000
 HEIMDALL_ORIGIN=http://localhost:7000

--- a/__tests__/personalizedFeed.ts
+++ b/__tests__/personalizedFeed.ts
@@ -55,9 +55,12 @@ const setCache = (
 
 it('should fetch anonymous feed and serve consequent pages from cache', async () => {
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&feed_id=global',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      feed_id: 'global',
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -85,9 +88,12 @@ it('should fetch anonymous feed and serve consequent pages from cache', async ()
 
 it('should fetch anonymous feed and serve consequent calls from cache', async () => {
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&feed_id=global',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      feed_id: 'global',
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -122,9 +128,12 @@ it('should fetch anonymous feed even when cache is old', async () => {
   await setCache(key, ['7', '8']);
 
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&feed_id=global',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      feed_id: 'global',
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -150,7 +159,11 @@ it('should not fetch anonymous feed even when cache is still fresh', async () =>
   ]);
 
   nock('http://localhost:6000')
-    .get('/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5')
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -182,9 +195,12 @@ it('should fetch anonymous feed when last updated time is greater than last gene
   await setCache(key, ['7', '8']);
 
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&feed_id=global',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      feed_id: 'global',
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -212,9 +228,16 @@ it('should set the correct query parameters', async () => {
     { feedId: '1', sourceId: 'b' },
   ]);
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&user_id=u1&feed_id=1&allowed_tags=javascript,golang&blocked_tags=python,java&blocked_sources=a,b',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      user_id: 'u1',
+      feed_id: '1',
+      allowed_tags: ['javascript', 'golang'],
+      blocked_tags: ['python', 'java'],
+      blocked_sources: ['a', 'b'],
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -235,9 +258,14 @@ it('should encode query parameters', async () => {
   await con.getRepository(Feed).save({ id: '1', userId: 'u1' });
   await con.getRepository(FeedTag).save([{ feedId: '1', tag: 'c#' }]);
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&user_id=u1&feed_id=1&allowed_tags=c%23',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      user_id: 'u1',
+      feed_id: '1',
+      allowed_tags: ['c#'],
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -271,9 +299,14 @@ it('should send source memberships as parameter', async () => {
     },
   ]);
   nock('http://localhost:6000')
-    .get(
-      '/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5&user_id=1&feed_id=1&squad_ids=a,b',
-    )
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+      user_id: '1',
+      feed_id: '1',
+      squad_ids: ['a', 'b'],
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,
@@ -298,7 +331,11 @@ it('should support legacy cache format', async () => {
   await setCache(key, ['7', '8']);
 
   nock('http://localhost:6000')
-    .get('/feed.json?token=token&page_size=2&fresh_page_size=1&feed_version=5')
+    .post('/feed.json', {
+      page_size: 2,
+      fresh_page_size: '1',
+      feed_version: 5,
+    })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
     con,


### PR DESCRIPTION
We where running out of space for the GET request with amount of params we sending.
So decided to switch to POST instead.

Note this is only verified locally on test simulations.
Needs to be tested against the actually feed to verify it doesn't break anything.

WT-1302 #done 