### PR TITLE
feat: action table

### DIFF
--- a/__tests__/actions.ts
+++ b/__tests__/actions.ts
@@ -1,0 +1,101 @@
+import { DataSource } from 'typeorm';
+import { Action, ActionType } from '../src/entity';
+import createOrGetConnection from '../src/db';
+import {
+  disposeGraphQLTesting,
+  GraphQLTestClient,
+  GraphQLTestingState,
+  initializeGraphQLTesting,
+  MockContext,
+  testMutationErrorCode,
+  testQueryErrorCode,
+} from './helpers';
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+let loggedUser: string = null;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(
+    () => new MockContext(con, loggedUser),
+  );
+  client = state.client;
+});
+
+afterAll(() => disposeGraphQLTesting(state));
+
+beforeEach(async () => {
+  loggedUser = null;
+});
+
+describe('query actions', () => {
+  const QUERY = `{
+    actions {
+      type
+      completedAt
+    }
+  }`;
+
+  it('should return alerts default values if anonymous', () =>
+    testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED'));
+
+  it('should return user alerts', async () => {
+    loggedUser = '1';
+
+    const completedAt = new Date('2020-09-21T07:15:51.247Z');
+    const repo = con.getRepository(Action);
+    const alerts = repo.create({
+      userId: loggedUser,
+      completedAt,
+      type: ActionType.Notification,
+    });
+    const expected = await repo.save(alerts);
+    const res = await client.query(QUERY);
+    const [action] = res.data.actions;
+
+    expect(expected.userId).toEqual(action.userId);
+    expect(expected.type).toEqual(action.type);
+    expect(expected.completedAt).toEqual(action.completedAt);
+  });
+});
+
+describe('mutation completeAction', () => {
+  const MUTATION = `
+    mutation CompleteAction($type: String!) {
+      completeAction(type: $type) {
+        _
+      }
+    }
+  `;
+
+  it('should not authorize when not logged in', () =>
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { type: ActionType.Notification } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should record when the action is completed', async () => {
+    loggedUser = '1';
+    const type = ActionType.Notification;
+    await client.mutate(MUTATION, { variables: { type } });
+    const action = await con
+      .getRepository(Action)
+      .findOneBy({ userId: loggedUser, type });
+    expect(action.type).toEqual(type);
+  });
+
+  it('should ignore when record is already completed', async () => {
+    loggedUser = '1';
+    const type = ActionType.Notification;
+    await client.mutate(MUTATION, { variables: { type } });
+    const action = await con
+      .getRepository(Action)
+      .findOneBy({ userId: loggedUser, type });
+    expect(action.type).toEqual(type);
+    const res = await client.mutate(MUTATION, { variables: { type } });
+    expect(res.errors).toBeFalsy();
+  });
+});

--- a/src/entity/Action.ts
+++ b/src/entity/Action.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+export enum ActionType {
+  Notification = 'notification',
+}
+
+@Entity()
+export class Action {
+  @Index()
+  @PrimaryColumn({ type: 'text' })
+  userId: string;
+
+  @Index()
+  @PrimaryColumn({ type: 'text' })
+  type: ActionType;
+
+  @Column({ type: 'timestamp without time zone', default: () => 'now()' })
+  completedAt: Date;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -35,3 +35,4 @@ export * from './NotificationAvatar';
 export * from './NotificationAttachment';
 export * from './Notification';
 export * from './Feature';
+export * from './Action';

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -15,6 +15,7 @@ import * as sources from './schema/sources';
 import * as tags from './schema/tags';
 import * as users from './schema/users';
 import * as alerts from './schema/alerts';
+import * as actions from './schema/actions';
 import * as keywords from './schema/keywords';
 import * as authDirective from './directive/auth';
 import * as urlDirective from './directive/url';
@@ -48,6 +49,7 @@ export const schema = urlDirective.transformer(
           keywords.typeDefs,
           alerts.typeDefs,
           submissions.typeDefs,
+          actions.typeDefs,
         ],
         resolvers: merge(
           common.resolvers,
@@ -66,6 +68,7 @@ export const schema = urlDirective.transformer(
           keywords.resolvers,
           alerts.resolvers,
           submissions.resolvers,
+          actions.resolvers,
         ),
       }),
     ),

--- a/src/migration/1682673635953-ActionEntity.ts
+++ b/src/migration/1682673635953-ActionEntity.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ActionEntity1682673635953 implements MigrationInterface {
+  name = 'ActionEntity1682673635953';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "action" ("userId" text NOT NULL, "type" text NOT NULL, "completedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_d2be31969535c36966ac5b76410" PRIMARY KEY ("userId", "type"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b2e3f7568dafa9e86ae0391011" ON "action" ("userId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_11db75ea5697b4c806aedc0739" ON "action" ("type") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_11db75ea5697b4c806aedc0739"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b2e3f7568dafa9e86ae0391011"`,
+    );
+    await queryRunner.query(`DROP TABLE "action"`);
+  }
+}

--- a/src/schema/actions.ts
+++ b/src/schema/actions.ts
@@ -1,0 +1,73 @@
+import { Action, ActionType } from '../entity';
+
+import { IResolvers } from '@graphql-tools/utils';
+import { traceResolvers } from './trace';
+import { Context } from '../Context';
+import { EmptyResponse } from '@google-cloud/pubsub';
+
+type GQLAction = Pick<Action, 'userId' | 'type' | 'completedAt'>;
+
+interface CompleteActionParams {
+  type: ActionType;
+}
+
+export const typeDefs = /* GraphQL */ `
+  """
+  Action that the user has completed
+  """
+  type Action {
+    """
+    The relevant user that made the action
+    """
+    userId: ID!
+
+    """
+    The type of action the user performed
+    """
+    type: String!
+
+    """
+    The date when the user completed the type of action
+    """
+    completedAt: DateTime!
+  }
+
+  extend type Mutation {
+    """
+    Complete action by the logged in user
+    """
+    completeAction(type: String!): EmptyResponse @auth
+  }
+
+  extend type Query {
+    """
+    Get the actions for user
+    """
+    actions: [Action]! @auth
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const resolvers: IResolvers<any, Context> = traceResolvers({
+  Mutation: {
+    completeAction: async (
+      _,
+      { type }: CompleteActionParams,
+      { con, userId },
+    ): Promise<EmptyResponse> => {
+      await con
+        .getRepository(Action)
+        .createQueryBuilder()
+        .insert()
+        .values({ userId, type })
+        .orIgnore()
+        .execute();
+
+      return;
+    },
+  },
+  Query: {
+    actions: (_, __, { con, userId }): Promise<GQLAction[]> =>
+      con.getRepository(Action).findBy({ userId }),
+  },
+});


### PR DESCRIPTION
Introduction of `action` table. The workers and the retro checks will be worked in a different PR so we can move forward with the tasks that require this information.

Thoughts: the whole schema for action is pretty small, would you rather have it in the `users` schema or continue with having its own?