### PR TITLE
Wt 1281 first post notification

### DIFF
--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -31,6 +31,7 @@ export const getSourceLink = (
 
 export const scoutArticleLink = `${process.env.COMMENTS_PREFIX}?scout=true`;
 export const squadCreateLink = `${process.env.COMMENTS_PREFIX}?squad=true`;
+export const subscribeNotificationsLink = `${process.env.COMMENTS_PREFIX}/notifications?subscribe=true`;
 
 export const standardizeURL = (url: string): string => {
   const domain = subtractDomain(url);

--- a/src/entity/Notification.ts
+++ b/src/entity/Notification.ts
@@ -32,6 +32,7 @@ export type NotificationType =
   | 'squad_new_comment'
   | 'squad_reply'
   | 'squad_post_viewed'
+  | 'squad_subscribe_to_notification'
   | 'squad_blocked'
   | 'promoted_to_admin'
   | 'demoted_to_member'

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -1,7 +1,11 @@
 import { NotificationType } from '../entity';
 import { NotificationBuilder } from './builder';
 import { NotificationIcon } from './icons';
-import { scoutArticleLink, squadCreateLink } from '../common';
+import {
+  scoutArticleLink,
+  squadCreateLink,
+  subscribeNotificationsLink,
+} from '../common';
 import {
   NotificationBaseContext,
   NotificationCommentContext,
@@ -72,6 +76,8 @@ export const notificationTitleMap: Record<
     `<b>${ctx.doneBy.name}</b> <span class="text-theme-color-cabbage">viewed</span> your post on <b>${ctx.source.name}</b>.`,
   squad_blocked: (ctx: NotificationSourceContext) =>
     `You are no longer part of <b>${ctx.source.name}</b>`,
+  squad_subscribe_to_notification: (ctx: NotificationSourceContext) =>
+    `Congrats on your first post on <b>${ctx.source.name}</b>. Subscribe to get updates about activity in your squad.  Subscribe for updates.`,
   promoted_to_admin: (ctx: NotificationSourceContext) =>
     `Congratulations! You are now an <span class="text-theme-color-cabbage">admin</span> of <b>${ctx.source.name}</b>`,
   demoted_to_member: (ctx: NotificationSourceMemberRoleContext) =>
@@ -210,6 +216,12 @@ export const generateNotificationMap: Record<
       .targetUrl(process.env.COMMENTS_PREFIX)
       .avatarSource(ctx.source)
       .icon(NotificationIcon.Block)
+      .referenceSource(ctx.source),
+  squad_subscribe_to_notification: (builder, ctx: NotificationSourceContext) =>
+    builder
+      .targetUrl(subscribeNotificationsLink)
+      .avatarSource(ctx.source)
+      .icon(NotificationIcon.Bell)
       .referenceSource(ctx.source),
   promoted_to_admin: (builder, ctx: NotificationSourceContext) =>
     builder

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -1,5 +1,5 @@
 import { messageToJson } from '../worker';
-import { Post, SourceMember, SourceType, User } from '../../entity';
+import { Post, SharePost, SourceMember, SourceType, User } from '../../entity';
 import {
   NotificationDoneByContext,
   NotificationPostContext,
@@ -66,6 +66,16 @@ const worker: NotificationWorker = {
             } as NotificationPostContext & Partial<NotificationDoneByContext>,
           }),
         );
+
+        const posts = await con.getRepository(SharePost).findBy({
+          authorId: post.authorId,
+        });
+        if (posts.length === 1) {
+          notifs.push({
+            type: 'squad_subscribe_to_notification',
+            ctx: { ...baseCtx, userId: post.authorId },
+          });
+        }
       }
     }
     return notifs;


### PR DESCRIPTION
Introduced a new type of notification `squad_subscribe_to_notification`. Have added the prefix `squad` to the type since the content has a context of the squad and most likely we will have another `subscribe_to_notification` type.

I was planning to use the OneSignal API/SDK to check whether the user has any subscribed devices, but after checking, the said feature is not yet available. So now, it would depend on the FE whether we will render this notification item based on their subscription.