### PR TITLE
feat: we should auto populate the usernames for auth onboarding

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1893,7 +1893,7 @@ describe('query generateUniqueUsername', () => {
     query GenerateUniqueUsername($name: String!) {
       generateUniqueUsername(name: $name)
   }`;
-  
+
   it('should return ', async () => {
     const res = await client.query(QUERY, { variables: { name: 'John Doe' } });
     expect(res.errors).toBeFalsy();

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1887,3 +1887,16 @@ describe('DELETE /v1/users/me', () => {
     expect(cookies['da3'].value).toBeFalsy();
   });
 });
+
+describe('query generateUniqueUsername', () => {
+  const QUERY = `
+    query GenerateUniqueUsername($name: String!) {
+      generateUniqueUsername(name: $name)
+  }`;
+  
+  it('should return ', async () => {
+    const res = await client.query(QUERY, { variables: { name: 'John Doe' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.generateUniqueUsername).toEqual('johndoe');
+  });
+});

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1894,9 +1894,17 @@ describe('query generateUniqueUsername', () => {
       generateUniqueUsername(name: $name)
   }`;
 
-  it('should return ', async () => {
+  it('should return a unique username', async () => {
     const res = await client.query(QUERY, { variables: { name: 'John Doe' } });
     expect(res.errors).toBeFalsy();
     expect(res.data.generateUniqueUsername).toEqual('johndoe');
+  });
+
+  it('should return a unique username with a random string', async () => {
+    await con.getRepository(User).update({ id: '1' }, { username: 'johndoe' });
+
+    const res = await client.query(QUERY, { variables: { name: 'John Doe' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.generateUniqueUsername).not.toEqual('johndoe');
   });
 });

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -720,21 +720,16 @@ export const resolvers: IResolvers<any, Context> = {
       const username = name.substring(0, 39);
       let generatedUsernames = [username];
 
-      const generateRandomUsernames = (count: number) => {
-        for (let i = 0; i < count; i++) {
-          const random = randomInt(100);
-          const randomUsername = `${username.substring(0, 37)}${random}`;
-          generatedUsernames.push(randomUsername);
-        }
-      };
+      for (let i = 0; i < 4; i++) {
+        const random = randomInt(100);
+        const randomUsername = `${username.substring(0, 37)}${random}`;
+        generatedUsernames.push(randomUsername);
+      }
 
-      generateRandomUsernames(4);
-
-      const usernameChecks = await (async () => {
-        return ctx
-          .getRepository(User)
-          .findBy({ username: In(generatedUsernames) });
-      })();
+      const usernameChecks = await ctx.getRepository(User).find({
+        where: { username: In(generatedUsernames) },
+        select: ['username'],
+      });
 
       for (const usernameCheck in usernameChecks) {
         generatedUsernames = generatedUsernames.filter(
@@ -743,6 +738,7 @@ export const resolvers: IResolvers<any, Context> = {
       }
 
       if (generatedUsernames.length === 0) {
+        ctx.log.info('usernameChecks', usernameChecks);
         return '';
       }
 


### PR DESCRIPTION
Created a new query `generateUniqueUsername `, that takes the users name on signup and attempts to generate a username for them. It has 3 attempts to do so or it will exit without a suggestion. If the name of the user is already a username in the system, it will attempted 3 times to add a random string of numbers at the end to generate a unique username

WT-804 #done 