### PR TITLE
refactor: temporarily disable subscribe to notification

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -433,26 +433,26 @@ describe('post added notifications', () => {
       .update({ id: postId }, { authorId: '1', type: PostType.Share });
   };
 
-  it('should add squad subscribe to notification', async () => {
-    await prepareSubscribeTests();
-    await con
-      .getRepository(UserAction)
-      .delete({ userId: '1', type: UserActionType.SquadFirstPost });
-    const worker = await import('../../src/workers/notifications/postAdded');
-    const actual = await invokeNotificationWorker(worker.default, {
-      post: postsFixture[0],
-    });
-    expect(actual.length).toBeTruthy();
-    const subscribe = actual.find(
-      ({ type }) => type === 'squad_subscribe_to_notification',
-    );
-
-    const ctx = subscribe.ctx as NotificationPostContext;
-    expect(subscribe).toBeTruthy();
-    expect(ctx.post.id).toEqual('p1');
-    expect(ctx.source.id).toEqual('a');
-    expect(subscribe.ctx.userId).toEqual('1');
-  });
+  // it('should add squad subscribe to notification', async () => {
+  //   await prepareSubscribeTests();
+  //   await con
+  //     .getRepository(UserAction)
+  //     .delete({ userId: '1', type: UserActionType.SquadFirstPost });
+  //   const worker = await import('../../src/workers/notifications/postAdded');
+  //   const actual = await invokeNotificationWorker(worker.default, {
+  //     post: postsFixture[0],
+  //   });
+  //   expect(actual.length).toBeTruthy();
+  //   const subscribe = actual.find(
+  //     ({ type }) => type === 'squad_subscribe_to_notification',
+  //   );
+  //
+  //   const ctx = subscribe.ctx as NotificationPostContext;
+  //   expect(subscribe).toBeTruthy();
+  //   expect(ctx.post.id).toEqual('p1');
+  //   expect(ctx.source.id).toEqual('a');
+  //   expect(subscribe.ctx.userId).toEqual('1');
+  // });
 
   it('should not add squad subscribe to notification when user has made many posts already', async () => {
     await prepareSubscribeTests();

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -85,17 +85,17 @@ const worker: NotificationWorker = {
             post.authorId,
             UserActionType.SquadFirstPost,
           );
-          const subscribed = await con.getRepository(UserAction).findOneBy({
-            userId: post.authorId,
-            type: UserActionType.EnableNotification,
-          });
-
-          if (!subscribed) {
-            notifs.push({
-              type: 'squad_subscribe_to_notification',
-              ctx: { ...baseCtx, userId: post.authorId },
-            });
-          }
+          //   const subscribed = await con.getRepository(UserAction).findOneBy({
+          //     userId: post.authorId,
+          //     type: UserActionType.EnableNotification,
+          //   });
+          //
+          //   if (!subscribed) {
+          //     notifs.push({
+          //       type: 'squad_subscribe_to_notification',
+          //       ctx: { ...baseCtx, userId: post.authorId },
+          //     });
+          //   }
         }
       }
     }


### PR DESCRIPTION
Until we do the retro check for those who have already subscribed, we don't want to show it to those who have existing subscriptions.

This also got me thinking after we do the retro checks for completed actions specifically the first post, should we also send a notification for those unsubscribed for PN yet?