### PR TITLE
fix: do not perform update if no post properties changed

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2390,4 +2390,31 @@ describe('mutation editPost', () => {
     expect(mention).toBeTruthy();
     expect(res.data.editPost.contentHtml).toMatchSnapshot();
   });
+
+  it('should not throw if no changes are made to post during edit mutation', async () => {
+    loggedUser = '2';
+
+    await con.getRepository(WelcomePost).save({
+      id: 'wp',
+      shortId: 'wp',
+      sourceId: 'a',
+      title: 'Welcome post',
+      content: '#Test',
+      contentHtml: '<h1>Test</h1>',
+    });
+    await con
+      .getRepository(SourceMember)
+      .update(
+        { userId: '2', sourceId: 'a' },
+        { role: SourceMemberRoles.Admin },
+      );
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        id: 'wp',
+        content: '#Test',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+  });
 });

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -981,7 +981,9 @@ export const resolvers: IResolvers<any, Context> = {
           );
         }
 
-        await repo.update({ id }, updated);
+        if (Object.keys(updated).length) {
+          await repo.update({ id }, updated);
+        }
       });
 
       return graphorm.queryOneOrFail<GQLPost>(ctx, info, (builder) => ({


### PR DESCRIPTION
Without this mutation throws unexpected error when you just press save in the UI with the same post content since updated object is empty on the API side and typeorm does not like that.