### PR TITLE
refactor: stop sending notification on welcome post to members

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -264,6 +264,26 @@ describe('source member role changed', () => {
 });
 
 describe('post added notifications', () => {
+  it('should not add any notification if post is a welcome post', async () => {
+    const worker = await import('../../src/workers/notifications/postAdded');
+    await con
+      .getRepository(Post)
+      .update({ id: 'p1' }, { authorId: '1', type: PostType.Welcome });
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { type: SourceType.Squad });
+    await con.getRepository(SourceMember).save({
+      userId: '2',
+      sourceId: 'a',
+      role: SourceMemberRoles.Member,
+      referralToken: 'random',
+    });
+    const actual = await invokeNotificationWorker(worker.default, {
+      post: postsFixture[0],
+    });
+    expect(actual).toBeFalsy();
+  });
+
   it('should add article picked notification', async () => {
     const worker = await import('../../src/workers/notifications/postAdded');
     await con.getRepository(Post).update({ id: 'p1' }, { authorId: '1' });

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -1,6 +1,7 @@
 import { messageToJson } from '../worker';
 import {
   Post,
+  PostType,
   SourceMember,
   SourceType,
   User,
@@ -31,6 +32,11 @@ const worker: NotificationWorker = {
       return;
     }
     const { post, source } = baseCtx;
+
+    if (post.type === PostType.Welcome) {
+      return;
+    }
+
     const notifs: NotificationHandlerReturn = [];
     // community_picks_succeeded notification
     if (post.scoutId) {


### PR DESCRIPTION
If the post is a welcome post, we should not send a notification to users by returning early on the postAdded worker.