### PR TITLE
refactor: stop using active post view

### DIFF
--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -17,7 +17,6 @@ import { MAX_COMMENTARY_LENGTH, SharePost } from './SharePost';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { Source, UNKNOWN_SOURCE } from '../Source';
 import { generateShortId } from '../../ids';
-import { ActivePost } from './ActivePost';
 
 export type PostStats = {
   numPosts: number;
@@ -40,10 +39,12 @@ export const getAuthorPostStats = async (
     .addSelect('sum(post.views)', 'numPostViews')
     .addSelect('sum(post.upvotes)', 'numPostUpvotes')
     .addSelect('sum(post.comments)', 'numPostComments')
-    .from(ActivePost, 'post')
+    .from(Post, 'post')
     .where('(post.authorId = :authorId or post.scoutId = :authorId)', {
       authorId,
     })
+    .andWhere('post.visible = true')
+    .andWhere('post.deleted = false')
     .getRawOne<StringPostStats>();
   return Object.keys(raw).reduce(
     (acc, key) => ({ ...acc, [key]: parseInt(raw[key]) || raw[key] }),

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -69,6 +69,12 @@ export interface GraphORMType {
   fields?: { [name: string]: GraphORMField };
   // Array of columns to select regardless of the resolve tree
   requiredColumns?: string[];
+  // Define a function to manipulate the query every time
+  additionalQuery?: (
+    ctx: Context,
+    alias: string,
+    qb: QueryBuilder,
+  ) => QueryBuilder;
 }
 
 // Define custom mapping to types
@@ -328,6 +334,9 @@ export class GraphORM {
         field,
       );
     });
+    if (this.mappings?.[type]?.additionalQuery) {
+      newBuilder = this.mappings[type].additionalQuery(ctx, alias, newBuilder);
+    }
     (this.mappings?.[type]?.requiredColumns ?? []).forEach((col) => {
       newBuilder = newBuilder.addSelect(`${alias}."${col}"`, col);
     });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -70,8 +70,10 @@ const obj = new GraphORM({
     requiredColumns: ['createdAt'],
   },
   Post: {
-    from: 'ActivePost',
-    metadataFrom: 'Post',
+    additionalQuery: (ctx, alias, qb) =>
+      qb
+        .andWhere(`"${alias}"."deleted" = false`)
+        .andWhere(`"${alias}"."visible" = true`),
     requiredColumns: [
       'id',
       'shortId',

--- a/src/migration/1684239736772-PinnedPost.ts
+++ b/src/migration/1684239736772-PinnedPost.ts
@@ -5,7 +5,8 @@ export class PinnedPost1684239736772 implements MigrationInterface {
   name = 'PinnedPost1684239736772';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "post" ADD "pinnedAt" TIMESTAMP`);
+    await queryRunner.query(`ALTER TABLE "post"
+      ADD "pinnedAt" TIMESTAMP`);
     await queryRunner.query(
       `CREATE INDEX "IDX_b1bed11be2023dbf95943dd4a3" ON "post" ("pinnedAt") `,
     );
@@ -14,10 +15,9 @@ export class PinnedPost1684239736772 implements MigrationInterface {
     );
 
     await queryRunner.query(
-      `UPDATE "post" SET "pinnedAt" = now() WHERE "type" = '${PostType.Welcome}'`,
-    );
-    await queryRunner.query(
-      `CREATE OR REPLACE VIEW "active_post" AS SELECT p.* FROM "public"."post" "p" WHERE "p"."deleted" = false AND "p"."visible" = true`,
+      `UPDATE "post"
+       SET "pinnedAt" = now()
+       WHERE "type" = '${PostType.Welcome}'`,
     );
   }
 

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -34,7 +34,6 @@ import {
 } from '../common/markdown';
 import { ensureSourcePermissions, SourcePermissions } from './sources';
 import { generateShortId } from '../ids';
-import { ActivePost } from '../entity/posts/ActivePost';
 
 export interface GQLComment {
   id: string;
@@ -511,9 +510,11 @@ export const resolvers: IResolvers<any, Context> = {
               .andWhere(`${builder.alias}."userId" = :userId`, {
                 userId: args.userId,
               })
-              .innerJoin(ActivePost, 'p', `"${builder.alias}"."postId" = p.id`)
+              .innerJoin(Post, 'p', `"${builder.alias}"."postId" = p.id`)
               .innerJoin(Source, 's', `"p"."sourceId" = s.id`)
-              .andWhere(`s.private = false`);
+              .andWhere(`s.private = false`)
+              .andWhere('p.visible = true')
+              .andWhere('p.deleted = false');
 
             return builder;
           },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -32,7 +32,6 @@ import graphorm from '../graphorm';
 import { GraphQLResolveInfo } from 'graphql';
 import { TypeOrmError, NotFoundError } from '../errors';
 import { deleteUser } from '../directive/user';
-import { ActivePost } from '../entity/posts/ActivePost';
 import { randomInt } from 'crypto';
 import { In } from 'typeorm';
 
@@ -491,12 +490,14 @@ const readHistoryResolver = async (
         userId: ctx.userId,
       })
       .andWhere(`"${builder.alias}"."hidden" = false`)
-      .innerJoin(ActivePost, 'p', `"${builder.alias}"."postId" = p.id`)
+      .innerJoin(Post, 'p', `"${builder.alias}"."postId" = p.id`)
       .addSelect(
         `"timestamp"::timestamptz at time zone '${user.timezone ?? 'utc'}'`,
         'timestamp',
       )
-      .addSelect('timestamp', 'timestampDb');
+      .addSelect('timestamp', 'timestampDb')
+      .andWhere('p.visible = true')
+      .andWhere('p.deleted = false');
 
     if (args?.query) {
       builder.queryBuilder.andWhere(`p.tsv @@ (${getSearchQuery(':query')})`, {
@@ -552,7 +553,9 @@ export const resolvers: IResolvers<any, Context> = {
           .addSelect('sum(comment.upvotes)', 'numCommentUpvotes')
           .from(Comment, 'comment')
           .where({ userId: id })
-          .innerJoin(ActivePost, 'p', `comment.postId = p.id`)
+          .innerJoin(Post, 'p', `comment.postId = p.id`)
+          .andWhere('p.visible = true')
+          .andWhere('p.deleted = false')
           .getRawOne(),
       ]);
       return {


### PR DESCRIPTION
Whenever we introduce a schema change to Post it required to replace the view which causes deadlocks. We introduce a new feature to GraphORM that simulates the view functionality.