### PR TITLE
fix: add relevant index to feed tag to optimize query

### DIFF
--- a/src/entity/FeedTag.ts
+++ b/src/entity/FeedTag.ts
@@ -2,6 +2,7 @@ import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Feed } from './Feed';
 
 @Entity()
+@Index('IDX_feed_id_blocked', ['feedId', 'blocked'])
 export class FeedTag {
   @PrimaryColumn({ type: 'text' })
   @Index()
@@ -12,7 +13,6 @@ export class FeedTag {
   tag: string;
 
   @Column({ default: false })
-  @Index('IDX_feedTag_blocked')
   blocked: boolean;
 
   @ManyToOne(() => Feed, {

--- a/src/migration/1684512961790-FixFeedTagIndex.ts
+++ b/src/migration/1684512961790-FixFeedTagIndex.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixFeedTagIndex1684512961790 implements MigrationInterface {
+  name = 'FixFeedTagIndex1684512961790';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_feedTag_blocked"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_feed_id_blocked" ON "feed_tag" ("feedId", "blocked") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_feed_id_blocked"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_feedTag_blocked" ON "feed_tag" ("blocked") `,
+    );
+  }
+}


### PR DESCRIPTION
It's a low hanging fruit that ideally will optimize the feed settings query. If not we will have to optimize the query as well