### PR TITLE
refactor: mention without post

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -459,7 +459,7 @@ describe('query commentPreview', () => {
 
 describe('query recommendedMentions', () => {
   const QUERY = `
-    query RecommendedMentions($postId: String!, $query: String, $limit: Int, $sourceId: String) {
+    query RecommendedMentions($postId: String, $query: String, $limit: Int, $sourceId: String) {
       recommendedMentions(postId: $postId, query: $query, limit: $limit, sourceId: $sourceId) {
         name
         username
@@ -485,6 +485,15 @@ describe('query recommendedMentions', () => {
     expect(res.data.recommendedMentions).toMatchSnapshot(); // to easily see there's no duplicates
     expect(res.data.recommendedMentions.length).toEqual(5);
     expect(res.data.recommendedMentions[0].name).toEqual(author.name);
+  });
+
+  it('should still work without post id and return previously mentioned users if query is empty', async () => {
+    loggedUser = '1';
+    await saveCommentMentionFixtures();
+
+    const res = await client.query(QUERY, { variables: {} });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.recommendedMentions.length).toEqual(5);
   });
 
   it('should return users with user or username starting with the query prioritizing previously mentioned ones', async () => {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -84,6 +84,7 @@ export interface ReadingDaysArgs {
 interface RecentMentionsProps {
   query?: string;
   limit?: number;
+  postId?: string;
   sourceId?: string;
   excludeIds?: string[];
 }
@@ -189,9 +190,8 @@ export const recommendUsersByQuery = async (
 
 export const recommendUsersToMention = async (
   con: DataSource,
-  postId: string,
   userId: string,
-  { limit, sourceId }: RecentMentionsProps,
+  { limit, postId, sourceId }: RecentMentionsProps,
 ): Promise<string[]> => {
   const [post, commenterIds] = await Promise.all([
     con.getRepository(Post).findOneBy({ id: postId, authorId: Not(userId) }),

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -49,7 +49,7 @@ export interface GQLComment {
 }
 
 interface GQLMentionUserArgs {
-  postId: string;
+  postId?: string;
   query?: string;
   limit?: number;
   sourceId?: string;
@@ -232,7 +232,7 @@ export const typeDefs = /* GraphQL */ `
     Recommend users to mention in the comments
     """
     recommendedMentions(
-      postId: String!
+      postId: String
       query: String
       limit: Int
       sourceId: String
@@ -561,7 +561,7 @@ export const resolvers: IResolvers<any, Context> = {
       const { con, userId } = ctx;
       const ids = await (query
         ? recommendUsersByQuery(con, userId, { query, limit, sourceId })
-        : recommendUsersToMention(con, postId, userId, { limit, sourceId }));
+        : recommendUsersToMention(con, userId, { limit, postId, sourceId }));
 
       if (ids.length === 0) {
         return [];


### PR DESCRIPTION
The post requirement was just to allow fetching of the author and currently commented people.

With FreeForm post mention, we currently don't have a reference to any id which should not stop the feature itself.