### PR TITLE
fix: await post content upload id

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -950,7 +950,7 @@ export const resolvers: IResolvers<any, Context> = {
         extension === 'gif'
           ? UploadPreset.FreeformGif
           : UploadPreset.FreeformImage;
-      const id = generateShortId();
+      const id = await generateShortId();
       const filename = `post_content_${id}`;
 
       return uploadPostFile(filename, upload.createReadStream(), preset);


### PR DESCRIPTION
Names are always the same since the promise was not awaited.