### PR TITLE
refactor: freeform and welcome post nullable image

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -50,7 +50,7 @@ import {
   getPersonalizedFeedKey,
   getPersonalizedFeedKeyPrefix,
 } from '../src/personalizedFeed';
-import { DataSource, In } from 'typeorm';
+import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { randomUUID } from 'crypto';
 import { usersFixture } from './fixture/user';

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -7,6 +7,7 @@ import {
   FeedAdvancedSettings,
   FeedSource,
   FeedTag,
+  FreeformPost,
   Keyword,
   MachineSource,
   Post,
@@ -19,6 +20,7 @@ import {
   SourceType,
   User,
   View,
+  WelcomePost,
 } from '../src/entity';
 import { SourceMemberRoles } from '../src/roles';
 import { Category } from '../src/entity/Category';
@@ -48,7 +50,7 @@ import {
   getPersonalizedFeedKey,
   getPersonalizedFeedKeyPrefix,
 } from '../src/personalizedFeed';
-import { DataSource } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { randomUUID } from 'crypto';
 import { usersFixture } from './fixture/user';
@@ -651,6 +653,7 @@ describe('query feed', () => {
 });
 
 describe('query sourceFeed', () => {
+  let additionalProps = '';
   const QUERY = (
     source: string,
     ranking: Ranking = Ranking.POPULARITY,
@@ -658,10 +661,14 @@ describe('query sourceFeed', () => {
     first = 10,
     after = '',
   ): string => `{
-    sourceFeed(source: "${source}", ranking: ${ranking}, now: "${now.toISOString()}", first: ${first}, supportedTypes: ["article", "share", "welcome"], after: "${after}") {
-      ${feedFields('pinnedAt')}
+    sourceFeed(source: "${source}", ranking: ${ranking}, now: "${now.toISOString()}", first: ${first}, supportedTypes: ["article", "share", "welcome", "freeform"], after: "${after}") {
+      ${feedFields(`pinnedAt ${additionalProps}`)}
     }
   }`;
+
+  beforeEach(() => {
+    additionalProps = '';
+  });
 
   it('should return a single source feed', async () => {
     const res = await client.query(QUERY('b'));
@@ -790,6 +797,47 @@ describe('query sourceFeed', () => {
     res.data.sourceFeed.edges.forEach(({ node }) =>
       expect(node.source.id).toEqual('b'),
     );
+  });
+
+  it('should return a freeform or welcome post without image', async () => {
+    loggedUser = '1';
+    additionalProps = 'type image';
+    await con.getRepository(User).save(usersFixture[0]);
+    const repo = con.getRepository(Source);
+    await repo.update({ id: 'b' }, { private: true });
+    const source = await repo.findOneBy({ id: 'b' });
+    const welcome = await createSquadWelcomePost(con, source, '1');
+    const freeform = await createSquadWelcomePost(con, source, '1');
+    await con
+      .getRepository(Post)
+      .update({ id: freeform.id }, { type: PostType.Freeform });
+    await con
+      .getRepository(FreeformPost)
+      .update({ id: freeform.id }, { image: null });
+    await con
+      .getRepository(WelcomePost)
+      .update({ id: welcome.id }, { image: null });
+    await con.getRepository(SourceMember).save([
+      {
+        userId: '1',
+        sourceId: 'b',
+        role: SourceMemberRoles.Admin,
+        referralToken: randomUUID(),
+        createdAt: new Date(2022, 11, 19),
+      },
+    ]);
+
+    const res = await client.query(QUERY('b'));
+    const edges = res.data?.sourceFeed?.edges;
+    edges.forEach(({ node }) => expect(node.source.id).toEqual('b'));
+    const welcomePost = edges.find(
+      ({ node }) => node.type === PostType.Welcome,
+    );
+    expect(welcomePost.node.image).toBeNull();
+    const freeformPost = edges.find(
+      ({ node }) => node.type === PostType.Freeform,
+    );
+    expect(freeformPost.node.image).toBeNull();
   });
 });
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -82,6 +82,7 @@ const obj = new GraphORM({
       'authorId',
       'scoutId',
       'private',
+      'type',
     ],
     fields: {
       tags: {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -13,7 +13,6 @@ import {
 import { Context } from '../Context';
 import { traceResolverObject } from './trace';
 import {
-  saveFreeformPost,
   CreatePost,
   CreatePostArgs,
   DEFAULT_POST_TITLE,
@@ -25,6 +24,7 @@ import {
   isValidHttpUrl,
   notifyView,
   pickImageUrl,
+  saveFreeformPost,
   standardizeURL,
   uploadPostFile,
   UploadPreset,
@@ -39,13 +39,13 @@ import {
   FreeformPost,
   HiddenPost,
   Post,
+  PostMention,
   PostReport,
   PostType,
   Toc,
   Upvote,
-  WelcomePost,
-  PostMention,
   UserActionType,
+  WelcomePost,
 } from '../entity';
 import { GQLEmptyResponse } from './common';
 import {
@@ -69,7 +69,7 @@ import { ContentImage } from '../entity/ContentImage';
 
 export interface GQLPost {
   id: string;
-  type: string;
+  type: PostType;
   shortId: string;
   publishedAt?: Date;
   pinnedAt?: Date;
@@ -721,6 +721,8 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
+const nullableImageType = [PostType.Freeform, PostType.Welcome];
+
 const saveHiddenPost = async (
   con: DataSource,
   hiddenPost: DeepPartial<HiddenPost>,
@@ -1347,7 +1349,11 @@ export const resolvers: IResolvers<any, Context> = {
     },
   },
   Post: {
-    image: (post: GQLPost): string => post.image || pickImageUrl(post),
+    image: (post: GQLPost): string => {
+      if (nullableImageType.includes(post.type)) return post.image;
+
+      return post.image || pickImageUrl(post);
+    },
     placeholder: (post: GQLPost): string =>
       post.image ? post.placeholder : defaultImage.placeholder,
     ratio: (post: GQLPost): number =>


### PR DESCRIPTION
From the guideline, Freeform and Welcome posts should be allowed to return a null value as we should handle it in the FE rather than returning our placeholder images.

![Screenshot 2023-05-29 at 7 12 45 PM](https://github.com/dailydotdev/daily-api/assets/13744167/4dfc4ef6-fb6c-47bb-9ccd-afad1062c901)
