### PR TITLE
fix: flaky test due to order

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -1940,7 +1940,7 @@ Object {
       },
     ],
     "pageInfo": Object {
-      "endCursor": "c2NvcmU6MA==",
+      "endCursor": "c2NvcmU6MQ==",
       "hasNextPage": false,
     },
   },

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -510,8 +510,11 @@ describe('query feed', () => {
 
   it('should return preconfigured feed with sources filtered based on advanced settings', async () => {
     loggedUser = '1';
-    await con.getRepository(Post).delete({ id: 'p6' });
+    const repo = con.getRepository(Post);
+    await repo.delete({ id: 'p6' });
     await saveAdvancedSettingsFiltersFixtures();
+    await repo.update({ id: 'p1' }, { score: 2 });
+    await repo.update({ id: 'includedPost' }, { score: 1 });
 
     const res = await client.query(QUERY, { variables });
     expect(res.data).toMatchSnapshot();


### PR DESCRIPTION
The score value of the order by the score is the same, the query sometimes returns `p1` first over the other and vice-versa. Since they have the same score in terms of the actual issue, there should be no concern with regard to which one should come first or second.