### PR TITLE
fix: handle markdown injections

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2215,16 +2215,6 @@ describe('mutation createFreeformPost', () => {
     );
   });
 
-  it('should return an error if content is an empty space', async () => {
-    loggedUser = '1';
-
-    return testMutationErrorCode(
-      client,
-      { mutation: MUTATION, variables: { ...params, content: ' ' } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
-
   it('should return an error if title exceeds 80 characters', async () => {
     loggedUser = '1';
 

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -11,12 +11,14 @@ export const markdown: MarkdownIt = MarkdownIt({
   linkify: true,
   typographer: true,
   highlight: function (str, lang) {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
+    try {
+      if (lang) {
         return hljs.highlight(str, { language: lang }).value;
-      } catch (__) {}
+      }
+      return hljs.highlightAuto(str).value;
+    } catch (e) {
+      return markdown.utils.escapeHtml(str);
     }
-    return str;
   },
 });
 


### PR DESCRIPTION
When providing code snippets if lang is not provided we didn't escape the html. This PR fixes it and also tries to automatically guess the language