### PR TITLE
fix: showOnFeed madness

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -266,6 +266,17 @@ it('should save a new post with basic information', async () => {
   });
 });
 
+it('should set show on feed to true when order is missing', async () => {
+  await expectSuccessfulBackground(worker, {
+    title: 'Title',
+    url: 'https://post.com',
+    source_id: 'a',
+  });
+  const posts = await con.getRepository(Post).find();
+  expect(posts.length).toEqual(2);
+  expect(posts[1].showOnFeed).toEqual(true);
+});
+
 it('should save a new post with showOnFeed information', async () => {
   await expectSuccessfulBackground(worker, {
     title: 'Title',

--- a/src/cron/exportToTinybird.ts
+++ b/src/cron/exportToTinybird.ts
@@ -29,16 +29,14 @@ const cron: Cron = {
               "creatorTwitter"    AS "creator_twitter",
               "sourceId"          AS "source_id",
               "tagsStr"           AS "tags_str",
-              ("banned" or "deleted")::int AS "banned",
-              "type"              AS "post_type",
+              ("banned" or "deleted" or not "showOnFeed")::int AS "banned", "type" AS "post_type",
               "private"::int      AS "post_private"
        FROM "post"
        WHERE "metadataChangedAt" > $1
          and "sourceId" != '${UNKNOWN_SOURCE}'
          and "visible" = true
-         and "type" != '${PostType.Welcome}
-         and "showOnFeed" = true'
-     `,
+         and "type" != '${PostType.Welcome}'
+      `,
       [latest],
     );
     if (posts.length) {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -297,7 +297,7 @@ const fixData = async ({
       siteTwitter: data?.extra?.site_twitter,
       toc: data?.extra?.toc,
       contentCuration: data?.extra?.content_curation,
-      showOnFeed: data?.order === 0,
+      showOnFeed: !data?.order,
     },
   };
 };


### PR DESCRIPTION
* Set `showOnFeed` to true when order is missing
* Set `banned` to true when `showOnFeed` is false while exporting to tinybird