### PR TITLE
chore: prevent unnecessary logs on development

### DIFF
--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -22,6 +22,8 @@ export async function sendPushNotification(
   }: Notification | ChangeObject<Notification>,
   avatar?: NotificationAvatar,
 ): Promise<void> {
+  if (!appId || !apiKey) return;
+
   const push = new OneSignal.Notification();
   push.app_id = appId;
   push.include_external_user_ids = [userId];

--- a/src/workers/addToMailingList.ts
+++ b/src/workers/addToMailingList.ts
@@ -8,6 +8,8 @@ interface Data {
 const worker: Worker = {
   subscription: 'api.add-to-mailing-list',
   handler: async (message, con, log) => {
+    if (process.env.NODE_ENV === 'development') return;
+
     const data = messageToJson<Data>(message);
     const { user } = data;
     if (user.infoConfirmed && user.email) {


### PR DESCRIPTION
When in development mode, some of the workers endless throw errors which throw logs that make it difficult to catch the right you are waiting for.

After further investigation, it was from integrations when you lack some API keys or secrets.