### PR TITLE
feat(boot): expose referralId and referralOrigin

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -157,6 +157,24 @@ describe('anonymous boot', () => {
       },
     });
   });
+
+  it('should read join_referral cookie', async () => {
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('Cookie', ['join_referral=1:knightcampaign'])
+      .expect(200);
+    expect(res.body).toEqual({
+      ...ANONYMOUS_BODY,
+      user: {
+        id: null,
+        referralId: '1',
+        referralOrigin: 'knightcampaign',
+      },
+      visit: {
+        visitId: expect.any(String),
+      },
+    });
+  });
 });
 
 describe('logged in boot', () => {


### PR DESCRIPTION
Expose referral properties from `join_referral` cookie in boot. Needed for https://github.com/dailydotdev/apps/pull/1853/commits/66ad21fb60b5c5f161d06117168d5d827429925e