### PR TITLE
fix: nullable post title usages

### DIFF
--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -142,6 +142,8 @@ export const saveMentions = (
 };
 
 export const checkHasMention = (content: string, username: string) => {
+  if (!content?.length) return false;
+
   const lines = content.split('\n');
 
   return lines.some((line) => {

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -25,7 +25,7 @@ export const notifyNewComment = async (
           },
           {
             title: 'Post title',
-            value: post.title,
+            value: post.title ?? '',
           },
         ],
         color: '#1DDC6F',
@@ -44,7 +44,7 @@ export const notifyPostReport = async (
     text: 'Post was just reported!',
     attachments: [
       {
-        title: post.title,
+        title: post.title ?? '',
         title_link: getDiscussionLink(post.id),
         fields: [
           {

--- a/src/common/twitter.ts
+++ b/src/common/twitter.ts
@@ -1,4 +1,9 @@
 import { Post } from '../entity';
 
-export const truncatePostToTweet = (post: Pick<Post, 'title'>): string =>
-  post.title.length <= 130 ? post.title : `${post.title.substring(0, 127)}...`;
+export const truncatePostToTweet = (post: Pick<Post, 'title'>): string => {
+  if (!post.title?.length) return '';
+
+  return post.title.length <= 130
+    ? post.title
+    : `${post.title.substring(0, 127)}...`;
+};

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -166,7 +166,7 @@ export class NotificationBuilder {
       order: this.attachments.length,
       type: 'post',
       image: (post as ArticlePost)?.image || pickImageUrl(post),
-      title: post.title,
+      title: post.title ?? '',
       referenceId: post.id,
     });
     return this;

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -157,7 +157,7 @@ export const generateNotificationMap: Record<
       .referencePost(ctx.post)
       .icon(NotificationIcon.Comment)
       .description(
-        checkHasMention(ctx.post.title, ctx.doneTo.username)
+        checkHasMention(ctx.post.title ?? '', ctx.doneTo.username)
           ? ctx.post.title
           : ctx.post.content,
         true,

--- a/src/workers/postScoutMatchedSlack.ts
+++ b/src/workers/postScoutMatchedSlack.ts
@@ -20,7 +20,7 @@ const worker: Worker = {
         text: 'New community link!',
         attachments: [
           {
-            title: post.title,
+            title: post.title ?? '',
             title_link: getDiscussionLink(post.id),
             fields: [
               {


### PR DESCRIPTION
Searched through the codebase for any usage of the post title and applied a default value.