### PR TITLE
feat: add db triggers to handle upvotes count

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1433,7 +1433,7 @@ describe('mutation upvote', () => {
     });
     expect(actual).toMatchSnapshot();
     const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
-    expect(post.upvotes).toEqual(0);
+    expect(post.upvotes).toEqual(1);
   });
 });
 
@@ -1464,7 +1464,7 @@ describe('mutation cancelUpvote', () => {
     const actual = await con.getRepository(Upvote).find();
     expect(actual).toEqual([]);
     const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
-    expect(post.upvotes).toEqual(-1);
+    expect(post.upvotes).toEqual(0);
   });
 
   it('should ignore if no upvotes', async () => {

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -820,7 +820,7 @@ describe('article upvote milestone', () => {
       {
         scoutId: '1',
         authorId: '3',
-        upvotes: 5,
+        upvotes: 3,
       },
     );
     await con.getRepository(Upvote).save([

--- a/src/migration/1686749310179-UpvoteTrigger.ts
+++ b/src/migration/1686749310179-UpvoteTrigger.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpvoteTrigger1686749310179 implements MigrationInterface {
+    name = 'UpvoteTrigger1686749310179'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query(`
+        CREATE OR REPLACE FUNCTION increment_upvote()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          UPDATE post SET upvotes = upvotes + 1 WHERE id = NEW."postId";
+          RETURN NEW;
+        END;
+        $$
+      `)
+      queryRunner.query('CREATE TRIGGER upvote_create_trigger AFTER INSERT ON "upvote" FOR EACH ROW EXECUTE PROCEDURE increment_upvote()')
+      queryRunner.query(`
+        CREATE OR REPLACE FUNCTION decrement_upvote()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          UPDATE post SET upvotes = upvotes - 1 WHERE id = OLD."postId";
+          RETURN OLD;
+        END;
+        $$
+      `)
+      queryRunner.query('CREATE TRIGGER upvote_delete_trigger AFTER DELETE ON "upvote" FOR EACH ROW EXECUTE PROCEDURE decrement_upvote()')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query('DROP TRIGGER IF EXISTS upvote_create_trigger ON upvote')
+      queryRunner.query('DROP FUNCTION IF EXISTS increment_upvote')
+      queryRunner.query('DROP TRIGGER IF EXISTS upvote_delete_trigger ON upvote')
+      queryRunner.query('DROP FUNCTION IF EXISTS decrement_upvote')
+    }
+
+}

--- a/src/migration/1686835784506-DownvoteTrigger.ts
+++ b/src/migration/1686835784506-DownvoteTrigger.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DownvoteTrigger1686835784506 implements MigrationInterface {
+    name = 'DownvoteTrigger1686835784506'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query(`
+        CREATE OR REPLACE FUNCTION increment_downvote()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          UPDATE post SET downvotes = downvotes + 1 WHERE id = NEW."postId";
+          RETURN NEW;
+        END;
+        $$
+      `)
+      queryRunner.query('CREATE TRIGGER downvote_create_trigger AFTER INSERT ON "downvote" FOR EACH ROW EXECUTE PROCEDURE increment_downvote()')
+      queryRunner.query(`
+        CREATE OR REPLACE FUNCTION decrement_downvote()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          UPDATE post SET downvotes = downvotes - 1 WHERE id = OLD."postId";
+          RETURN OLD;
+        END;
+        $$
+      `)
+      queryRunner.query('CREATE TRIGGER downvote_delete_trigger AFTER DELETE ON "downvote" FOR EACH ROW EXECUTE PROCEDURE decrement_downvote()')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query('DROP TRIGGER IF EXISTS downvote_create_trigger ON downvote')
+      queryRunner.query('DROP FUNCTION IF EXISTS increment_downvote')
+      queryRunner.query('DROP TRIGGER IF EXISTS downvote_delete_trigger ON downvote')
+      queryRunner.query('DROP FUNCTION IF EXISTS decrement_downvote')
+    }
+
+}

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1183,9 +1183,6 @@ export const resolvers: IResolvers<any, Context> = {
             postId: id,
             userId: ctx.userId,
           });
-          await entityManager
-            .getRepository(Post)
-            .increment({ id }, 'upvotes', 1);
         });
       } catch (err) {
         // Foreign key violation
@@ -1214,9 +1211,6 @@ export const resolvers: IResolvers<any, Context> = {
             postId: id,
             userId: ctx.userId,
           });
-          await entityManager
-            .getRepository(Post)
-            .decrement({ id }, 'upvotes', 1);
           return true;
         }
         return false;


### PR DESCRIPTION
As per comments in the [DR](https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/544768013/Downvoting+and+reporting+posts#Other-notes) replacing inline increments with db triggers to avoid race conditions while upvoting and in the future downvoting.

Also added downvote triggers.

Also updated two tests that were right but expected wrong values due to test setup, see 4962c92f3eac11f3af9ab6e4ff06fe9f3ec5be33 commit message.

As additional note, in general we could apply this for comments too.