### PR TITLE
feat: add downvoted property to gql post

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -648,6 +648,7 @@ describe('companion boot', () => {
     title: 'P1',
     trending: null,
     upvoted: null,
+    downvoted: null,
   };
 
   it('should support anonymous user', async () => {
@@ -676,6 +677,7 @@ describe('companion boot', () => {
         ...POST_DATA,
         bookmarked: false,
         upvoted: false,
+        downvoted: false,
       },
     });
   });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -160,6 +160,10 @@ const obj = new GraphORM({
           parentColumn: 'sharedPostId',
         },
       },
+      downvoted: {
+        select: existsByUserAndPost('Downvote'),
+        transform: nullIfNotLoggedIn,
+      },
     },
   },
   Source: {

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -394,6 +394,7 @@ const COMPANION_QUERY = parse(`query Post($url: String) {
           author {
             id
           }
+          downvoted
         }
       }`);
 

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -108,6 +108,7 @@ export interface GQLPost {
   feedMeta?: string;
   content?: string;
   contentHtml?: string;
+  downvoted?: boolean;
 }
 
 interface PinPostArgs {
@@ -383,6 +384,11 @@ export const typeDefs = /* GraphQL */ `
     HTML Parsed content of the comment
     """
     contentHtml: String
+
+    """
+    Whether the user downvoted this post
+    """
+    downvoted: Boolean
   }
 
   type PostConnection {


### PR DESCRIPTION
Add `downvoted` property to gql post and boot to be used in companion.