### PR TITLE
refactor: post report entity tags column

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1315,6 +1315,7 @@ describe('mutation reportPost', () => {
       userId: '1',
       createdAt: expect.anything(),
       reason: 'BROKEN',
+      tags: null,
       comment: 'Test comment',
     });
   });
@@ -1336,6 +1337,7 @@ describe('mutation reportPost', () => {
       userId: '1',
       createdAt: expect.anything(),
       reason: 'BROKEN',
+      tags: null,
       comment: null,
     });
   });

--- a/src/entity/PostReport.ts
+++ b/src/entity/PostReport.ts
@@ -17,6 +17,9 @@ export class PostReport {
   @Column({ length: 12 })
   reason: string;
 
+  @Column({ type: 'text', array: true, default: null })
+  tags?: string[];
+
   @Column({ type: 'text', nullable: true })
   comment: string;
 

--- a/src/migration/1687171948216-PostReportTags.ts
+++ b/src/migration/1687171948216-PostReportTags.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostReportTags1687171948216 implements MigrationInterface {
+  name = 'PostReportTags1687171948216';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post_report" ADD "tags" text array`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post_report" DROP COLUMN "tags"`);
+  }
+}


### PR DESCRIPTION
The array of strings for the `tags` column when reporting irrelevant tags.

The updates on the mutation will be included in a different PR.