### PR TITLE
fix: add tags to slack report post

### DIFF
--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -892,6 +892,32 @@ describe('post report', () => {
       post,
       '💔 Link is broken',
       'Test comment',
+      undefined,
+    );
+  });
+
+  it('should notify on new post report with tags', async () => {
+    const after: ChangeObject<ObjectType> = base;
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: {
+          ...after,
+          tags: ['php', 'webdev'],
+        },
+        before: null,
+        op: 'c',
+        table: 'post_report',
+      }),
+    );
+    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+    expect(notifyPostReport).toBeCalledTimes(1);
+    expect(notifyPostReport).toBeCalledWith(
+      'u1',
+      post,
+      '💔 Link is broken',
+      'Test comment',
+      ['php', 'webdev'],
     );
   });
 });

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -39,6 +39,7 @@ export const notifyPostReport = async (
   post: Post,
   reason: string,
   comment?: string,
+  tags?: string[],
 ): Promise<void> => {
   await webhook.send({
     text: 'Post was just reported!',
@@ -58,6 +59,10 @@ export const notifyPostReport = async (
           {
             title: 'Comment',
             value: comment,
+          },
+          {
+            title: 'Tags',
+            value: tags?.join(', '),
           },
         ],
         color: '#FF1E1F',

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -346,6 +346,7 @@ const onPostReportChange = async (
         post,
         reportReasons.get(data.payload.after.reason),
         data.payload.after.comment,
+        data.payload.after.tags,
       );
     }
   }


### PR DESCRIPTION
Added the newly added tags to the slack port report worker.

WT-1450 #done