### PR TITLE
fix: reporting hidden post not correctly writes report to database

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1398,6 +1398,29 @@ describe('mutation reportPost', () => {
       'GRAPHQL_VALIDATION_FAILED',
     );
   });
+
+  it('should save report if post is hidden already', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(HiddenPost)
+      .save(
+        con
+          .getRepository(HiddenPost)
+          .create({ postId: 'p1', userId: loggedUser }),
+      );
+    const res = await client.mutate(MUTATION, {
+      variables: { id: 'p1', reason: 'BROKEN', comment: 'Test comment' },
+    });
+    expect(res.errors).toBeFalsy();
+    const actual = await con.getRepository(PostReport).findOne({
+      where: { userId: loggedUser },
+      select: ['postId', 'userId'],
+    });
+    expect(actual).toEqual({
+      postId: 'p1',
+      userId: '1',
+    });
+  });
 });
 
 describe('mutation upvote', () => {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -782,10 +782,11 @@ const saveHiddenPost = async (
       throw new NotFoundError('Post not found');
     }
     // Unique violation
-    if (err?.code !== TypeOrmError.DUPLICATE_ENTRY) {
-      throw err;
+    if (err?.code === TypeOrmError.DUPLICATE_ENTRY) {
+      return true;
     }
-    return false;
+
+    throw err;
   }
   return true;
 };

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -782,11 +782,9 @@ const saveHiddenPost = async (
       throw new NotFoundError('Post not found');
     }
     // Unique violation
-    if (err?.code === TypeOrmError.DUPLICATE_ENTRY) {
-      return true;
+    if (err?.code !== TypeOrmError.DUPLICATE_ENTRY) {
+      throw err;
     }
-
-    throw err;
   }
   return true;
 };


### PR DESCRIPTION
This surfaced now that we added downvote option.

If you already downvoted since downvote also calls `saveHiddenPost` the report after that would always silently fail since `saveHiddenPost` would return `false` as the `hidden_post` row existed.

FIx here returns `true` if post is already hidden and throws error in all other cases as it should be to notify frontend of any API errors.