### PR TITLE
fix: invalidating cdn cache on cloudinary

### DIFF
--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -38,7 +38,11 @@ interface UploadResult {
   id: string;
 }
 
-type UploadFn = (name: string, stream: Readable) => Promise<UploadResult>;
+type UploadFn = (
+  name: string,
+  stream: Readable,
+  options?: OptionalProps,
+) => Promise<UploadResult>;
 
 export const uploadFile = (
   name: string,
@@ -51,6 +55,7 @@ export const uploadFile = (
       {
         public_id: name,
         upload_preset: preset,
+        invalidate,
       },
       (err, callResult) => {
         if (err) {
@@ -63,7 +68,6 @@ export const uploadFile = (
             fetch_format: 'auto',
             quality: 'auto',
             sign_url: true,
-            invalidate,
           }),
           id: callResult.public_id,
         });
@@ -72,14 +76,19 @@ export const uploadFile = (
     stream.pipe(outStream);
   });
 
-export const uploadDevCardBackground: UploadFn = (name, stream) =>
-  uploadFile(name, UploadPreset.DevCard, stream);
+export const uploadDevCardBackground: UploadFn = (name, stream, options) =>
+  uploadFile(name, UploadPreset.DevCard, stream, options);
 
-export const uploadSquadImage: UploadFn = (name, stream) =>
-  uploadFile(name, UploadPreset.SquadImage, stream);
+export const uploadSquadImage: UploadFn = (name, stream, options) =>
+  uploadFile(name, UploadPreset.SquadImage, stream, options);
 
-export const uploadAvatar: UploadFn = (userId, stream) =>
-  uploadFile(`${UploadPreset.Avatar}_${userId}`, UploadPreset.Avatar, stream);
+export const uploadAvatar: UploadFn = (userId, stream, options) =>
+  uploadFile(
+    `${UploadPreset.Avatar}_${userId}`,
+    UploadPreset.Avatar,
+    stream,
+    options,
+  );
 
 type PostPreset =
   | UploadPreset.PostBannerImage

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -29,11 +29,23 @@ export enum UploadPreset {
   FreeformGif = 'freeform_gif',
 }
 
+interface OptionalProps {
+  invalidate?: boolean;
+}
+
+interface UploadResult {
+  url: string;
+  id: string;
+}
+
+type UploadFn = (name: string, stream: Readable) => Promise<UploadResult>;
+
 export const uploadFile = (
   name: string,
   preset: UploadPreset,
   stream: Readable,
-): Promise<{ url: string; id: string }> =>
+  { invalidate }: OptionalProps = {},
+): Promise<UploadResult> =>
   new Promise((resolve, reject) => {
     const outStream = cloudinary.v2.uploader.upload_stream(
       {
@@ -51,6 +63,7 @@ export const uploadFile = (
             fetch_format: 'auto',
             quality: 'auto',
             sign_url: true,
+            invalidate,
           }),
           id: callResult.public_id,
         });
@@ -59,13 +72,13 @@ export const uploadFile = (
     stream.pipe(outStream);
   });
 
-export const uploadDevCardBackground = (name: string, stream: Readable) =>
+export const uploadDevCardBackground: UploadFn = (name, stream) =>
   uploadFile(name, UploadPreset.DevCard, stream);
 
-export const uploadSquadImage = (name: string, stream: Readable) =>
+export const uploadSquadImage: UploadFn = (name, stream) =>
   uploadFile(name, UploadPreset.SquadImage, stream);
 
-export const uploadAvatar = (userId: string, stream: Readable) =>
+export const uploadAvatar: UploadFn = (userId, stream) =>
   uploadFile(`${UploadPreset.Avatar}_${userId}`, UploadPreset.Avatar, stream);
 
 type PostPreset =
@@ -77,4 +90,5 @@ export const uploadPostFile = (
   name: string,
   stream: Readable,
   preset: PostPreset,
-) => uploadFile(name, preset, stream);
+  props: OptionalProps = {},
+) => uploadFile(name, preset, stream, props);

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1177,6 +1177,7 @@ export const resolvers: IResolvers<any, Context> = {
             id,
             upload.createReadStream(),
             UploadPreset.PostBannerImage,
+            { invalidate: true },
           );
           updated.image = coverImageUrl;
         }

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1086,6 +1086,7 @@ export const resolvers: IResolvers<any, Context> = {
               const { url: imageUrl } = await uploadSquadImage(
                 sourceId,
                 stream,
+                { invalidate: true },
               );
               await repo.update({ id: sourceId }, { image: imageUrl });
             }


### PR DESCRIPTION
After further investigation, we will have to manually invalidate the cache for replacing an asset with the same name/public id.

Relevant sources:
https://support.cloudinary.com/hc/en-us/articles/202520852-I-ve-replaced-an-existing-asset-with-a-new-file-but-my-site-or-application-still-shows-the-old-asset-Why-is-that-

By default, invalidation is disabled (for good reasons), but we should invalidate in this case for replacing a thumbnail.

https://cloudinary.com/documentation/managing_assets#invalidating_cached_media_assets_on_the_cdn

Relevant API:
https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters

_Also just fixed some types while at it_