### PR TITLE
fix: join public source

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1189,26 +1189,32 @@ export const resolvers: IResolvers<any, Context> = {
           'Access denied! You do not have permission for this action!',
         );
       }
-      if (source.private && !token) {
-        throw new ForbiddenError(
-          'Access denied! You do not have permission for this action!',
-        );
-      }
-      const member = await ctx.con
-        .getRepository(SourceMember)
-        .findOneBy({ referralToken: token });
-      if (!member) {
-        throw new ForbiddenError(
-          'Access denied! You do not have permission for this action!',
-        );
-      }
 
-      const memberRank =
-        sourceRoleRank[member.role] ?? sourceRoleRank[SourceMemberRoles.Member];
-      const squadSource = source as SquadSource;
+      if (source.private) {
+        if (!token) {
+          throw new ForbiddenError(
+            'Access denied! You do not have permission for this action!',
+          );
+        }
 
-      if (memberRank < squadSource.memberInviteRank) {
-        throw new ForbiddenError(SourcePermissionErrorKeys.InviteInvalid);
+        const member = await ctx.con
+          .getRepository(SourceMember)
+          .findOneBy({ referralToken: token });
+
+        if (!member) {
+          throw new ForbiddenError(
+            'Access denied! You do not have permission for this action!',
+          );
+        }
+
+        const memberRank =
+          sourceRoleRank[member.role] ??
+          sourceRoleRank[SourceMemberRoles.Member];
+        const squadSource = source as SquadSource;
+
+        if (memberRank < squadSource.memberInviteRank) {
+          throw new ForbiddenError(SourcePermissionErrorKeys.InviteInvalid);
+        }
       }
 
       try {


### PR DESCRIPTION
After checking, there was already a test for joining a public source and it works.

Though it seems the test was kind of a "false positive" due to the condition for fetching the member of `.findOneBy({ referralToken: token });`. Since the `token` was `undefined`, the query basically returns the very first row every time as it tells the condition to be none, hence, the `member` object always has a value.

Also, the refactor should reduce the number of queries to execute since we enclosed the condition to be checked only when it is for a private source.

The existing test:
https://github.com/dailydotdev/daily-api/blob/c2b0ac4d435295e51e431bde855f849f21a11fa8/__tests__/sources.ts#L1887-L1897