### PR TITLE
fix: public property now correctly calculated from private

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -378,6 +378,16 @@ query Source($id: ID!) {
     expect(res.errors).toBeFalsy();
     expect(res.data.source.id).toEqual('a');
   });
+
+  it('should return correct public property when source is private', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { handle: 'handle', private: true });
+    const res = await client.query(QUERY, { variables: { id: 'handle' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.public).toEqual(false);
+  });
 });
 
 describe('query sourceHandleExists', () => {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -170,6 +170,7 @@ const obj = new GraphORM({
     requiredColumns: ['id', 'private', 'handle', 'type'],
     fields: {
       public: {
+        select: 'private',
         transform: (value: boolean): boolean => !value,
       },
       members: {


### PR DESCRIPTION
While working on new squad create and edit pages I noticed `public` was always `true`.