### PR TITLE
feat: first visit in cache

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -87,6 +87,7 @@ const ANONYMOUS_BODY = {
   settings: SETTINGS_DEFAULT,
   user: {
     id: expect.any(String),
+    firstVisit: expect.any(String),
   },
   shouldLogout: false,
 };
@@ -151,6 +152,7 @@ describe('anonymous boot', () => {
       ...ANONYMOUS_BODY,
       user: {
         id: null,
+        firstVisit: null,
       },
       visit: {
         visitId: expect.any(String),
@@ -167,6 +169,7 @@ describe('anonymous boot', () => {
       ...ANONYMOUS_BODY,
       user: {
         id: null,
+        firstVisit: null,
         referralId: '1',
         referralOrigin: 'knightcampaign',
       },

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -12,24 +12,28 @@ import { DataSource } from 'typeorm';
 import {
   Alerts,
   ALERTS_DEFAULT,
+  ArticlePost,
+  MachineSource,
+  Notification,
+  Post,
   Settings,
   SETTINGS_DEFAULT,
-  Notification,
-  User,
-  SquadSource,
   Source,
   SourceMember,
-  MachineSource,
-  SQUAD_IMAGE_PLACEHOLDER,
   SourceType,
-  Post,
-  ArticlePost,
+  SQUAD_IMAGE_PLACEHOLDER,
+  SquadSource,
+  User,
 } from '../src/entity';
-import { SourceMemberRoles } from '../src/roles';
+import { SourceMemberRoles, sourceRoleRank } from '../src/roles';
 import { notificationFixture } from './fixture/notifications';
 import { usersFixture } from './fixture/user';
-import { getRedisObject, setRedisObject } from '../src/redis';
-import { REDIS_CHANGELOG_KEY } from '../src/config';
+import { getRedisObject, ioRedisPool, setRedisObject } from '../src/redis';
+import {
+  generateStorageKey,
+  REDIS_CHANGELOG_KEY,
+  StorageTopic,
+} from '../src/config';
 import nock from 'nock';
 import { addDays, setMilliseconds } from 'date-fns';
 import setCookieParser from 'set-cookie-parser';
@@ -38,7 +42,6 @@ import { postsFixture } from './fixture/post';
 import { sourcesFixture } from './fixture/source';
 import { DEFAULT_FLAGS } from '../src/featureFlags';
 import { SourcePermissions } from '../src/schema/sources';
-import { sourceRoleRank } from '../src/roles';
 
 jest.mock('../src/flagsmith', () => ({
   getIdentityFlags: jest.fn(),
@@ -104,6 +107,7 @@ beforeEach(async () => {
   await con.getRepository(Source).save(sourcesFixture);
   await con.getRepository(Post).save(postsFixture);
   mockFeatureFlagForUser();
+  await ioRedisPool.execute((client) => client.flushall());
 });
 
 const BASE_PATH = '/boot';
@@ -177,6 +181,39 @@ describe('anonymous boot', () => {
         visitId: expect.any(String),
       },
     });
+  });
+
+  it('should set first visit value if null', async () => {
+    const first = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .expect(200);
+    expect(first.body.user.firstVisit).toBeTruthy();
+    await ioRedisPool.execute((client) => client.flushall());
+    const second = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('Cookie', first.headers['set-cookie'])
+      .expect(200);
+    expect(second.body.user.id).toEqual(first.body.user.id);
+    expect(second.body.user.firstVisit).toBeTruthy();
+    expect(second.body.user.firstVisit).not.toEqual(first.body.user.firstVisit);
+  });
+
+  it('should retain first visit value if not null', async () => {
+    const first = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .expect(200);
+    expect(first.body.user.firstVisit).toBeTruthy();
+    const second = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('Cookie', first.headers['set-cookie'])
+      .expect(200);
+    expect(second.body.user.id).toEqual(first.body.user.id);
+    expect(second.body.user.firstVisit).toBeTruthy();
+    expect(second.body.user.firstVisit).toEqual(first.body.user.firstVisit);
   });
 });
 

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -29,11 +29,7 @@ import { SourceMemberRoles, sourceRoleRank } from '../src/roles';
 import { notificationFixture } from './fixture/notifications';
 import { usersFixture } from './fixture/user';
 import { getRedisObject, ioRedisPool, setRedisObject } from '../src/redis';
-import {
-  generateStorageKey,
-  REDIS_CHANGELOG_KEY,
-  StorageTopic,
-} from '../src/config';
+import { REDIS_CHANGELOG_KEY } from '../src/config';
 import nock from 'nock';
 import { addDays, setMilliseconds } from 'date-fns';
 import setCookieParser from 'set-cookie-parser';

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,3 +11,13 @@ export const fallbackImages = {
 };
 
 export const REDIS_CHANGELOG_KEY = 'boot:latest_changelog';
+
+export enum StorageTopic {
+  Boot = 'boot',
+}
+
+export const generateStorageKey = (
+  topic: StorageTopic,
+  key: string,
+  identifier = 'global',
+): string => `${topic}:${key}:${identifier}`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,5 +19,5 @@ export enum StorageTopic {
 export const generateStorageKey = (
   topic: StorageTopic,
   key: string,
-  identifier = 'global',
+  identifier: string, // mostly used for user id - "global" for global keys
 ): string => `${topic}:${key}:${identifier}`;

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -44,8 +44,16 @@ export function deleteKeysByPattern(pattern: string): Promise<void> {
   );
 }
 
-export const setRedisObject = (key, value) =>
+export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+
+export const setRedisObject = (key: string, value: string | Buffer | number) =>
   ioRedisPool.execute((client) => client.set(key, value));
+
+export const setTimedRedisObject = (
+  key: string,
+  value: string | Buffer | number,
+  seconds: number,
+) => ioRedisPool.execute((client) => client.set(key, value, 'EX', seconds));
 
 export const getRedisObject = (key) =>
   ioRedisPool.execute((client) => client.get(key));

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -46,12 +46,14 @@ export function deleteKeysByPattern(pattern: string): Promise<void> {
 
 export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 
-export const setRedisObject = (key: string, value: string | Buffer | number) =>
+type RedisObject = string | Buffer | number;
+
+export const setRedisObject = (key: string, value: RedisObject) =>
   ioRedisPool.execute((client) => client.set(key, value));
 
-export const setTimedRedisObject = (
+export const setRedisObjectWithExpiry = (
   key: string,
-  value: string | Buffer | number,
+  value: RedisObject,
   seconds: number,
 ) => ioRedisPool.execute((client) => client.set(key, value, 'EX', seconds));
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -29,7 +29,7 @@ import {
   getRedisObject,
   ONE_DAY_IN_SECONDS,
   setRedisObject,
-  setTimedRedisObject,
+  setRedisObjectWithExpiry,
 } from '../redis';
 import {
   generateStorageKey,
@@ -338,7 +338,7 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
 
   if (!firstVisit) {
     const now = new Date();
-    await setTimedRedisObject(key, now.getTime(), ONE_DAY_IN_SECONDS * 30);
+    await setRedisObjectWithExpiry(key, now.getTime(), ONE_DAY_IN_SECONDS * 30);
   }
 
   return parseInt(firstVisit);

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -333,19 +333,17 @@ const loggedInBoot = async (
 };
 
 const getAnonymousFirstVisit = async (trackingId: string) => {
+  if (!trackingId) return null;
+
   const key = generateStorageKey(StorageTopic.Boot, 'first_visit', trackingId);
   const firstVisit = await getRedisObject(key);
+  const finalValue = firstVisit ?? new Date().toISOString();
 
   if (!firstVisit) {
-    const now = new Date();
-    await setRedisObjectWithExpiry(
-      key,
-      now.toISOString(),
-      ONE_DAY_IN_SECONDS * 30,
-    );
+    await setRedisObjectWithExpiry(key, finalValue, ONE_DAY_IN_SECONDS * 30);
   }
 
-  return firstVisit;
+  return finalValue;
 };
 
 const anonymousBoot = async (

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -68,7 +68,7 @@ export type BootUserReferral = Partial<{
 
 interface AnonymousUser extends BootUserReferral {
   id: string;
-  firstVisit: number;
+  firstVisit: string;
 }
 
 export type AnonymousBoot = BaseBoot & {
@@ -338,10 +338,14 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
 
   if (!firstVisit) {
     const now = new Date();
-    await setRedisObjectWithExpiry(key, now.getTime(), ONE_DAY_IN_SECONDS * 30);
+    await setRedisObjectWithExpiry(
+      key,
+      now.toISOString(),
+      ONE_DAY_IN_SECONDS * 30,
+    );
   }
 
-  return parseInt(firstVisit);
+  return firstVisit;
 };
 
 const anonymousBoot = async (


### PR DESCRIPTION
We now generate the `firstVisit` and turned it into a number to make it easier to consume at the frontend.

Note: we might need another value in the cache in the future relating to the user, should we probably store an object instead (with `firstVisit` as its property) so that we will only have to fetch once whenever we introduce new properties instead of touching the cache twice? Thoughts?