### PR TITLE
feat: add referralUrl field to source

### DIFF
--- a/__tests__/dataLoaderService.ts
+++ b/__tests__/dataLoaderService.ts
@@ -1,0 +1,95 @@
+import { MockContext, MockDataLoaderService } from './helpers';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../src/db';
+import { Context } from '../src/Context';
+
+jest.mock('../src/common', () => ({
+  ...(jest.requireActual('../src/common') as Record<string, unknown>),
+  notifyFeaturesReset: jest.fn(),
+}));
+
+let con: DataSource;
+let ctx: MockContext;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  ctx = new MockContext(con);
+  jest.resetAllMocks();
+});
+
+describe('DataLoaderService', () => {
+  it('should cache DataLoader instance', () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.test;
+    const dataLoader2 = dataLoaderService.test;
+    expect(dataLoader).toBe(dataLoader2);
+  });
+
+  it('should stringify object key', async () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.test;
+    dataLoader.prime({ foo: true }, 'test1');
+    dataLoader.prime({ foo: false }, 'test2');
+    const value1 = await dataLoader.load({ foo: true });
+    const value2 = await dataLoader.load({ foo: false });
+    expect(value1).toBe('test1');
+    expect(value2).toBe('test2');
+    expect(dataLoaderService.mockLoadFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return values when batch calling internally', async () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.test;
+    const values = await dataLoader.loadMany(['test1', 'test2', 'test3']);
+    expect(values).toEqual(['test1', 'test2', 'test3']);
+    expect(dataLoaderService.mockLoadFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return rejected errors when batch calling internally', async () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.test;
+    const values = await dataLoader.loadMany([
+      'test1',
+      new Error('error2'),
+      'test3',
+    ]);
+    expect(values).toEqual(['test1', new Error('error2'), 'test3']);
+    expect(dataLoaderService.mockLoadFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('should throw if load promise is rejected', async () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.test;
+    await expect(() => dataLoader.load(new Error('error2'))).rejects.toThrow(
+      'error2',
+    );
+  });
+
+  it('should return short url', async () => {
+    const dataLoaderService = new MockDataLoaderService({
+      ctx: ctx as Context,
+    });
+
+    const dataLoader = dataLoaderService.shortUrl;
+    const shortUrl = await dataLoader.load('https://daily.dev/test/1');
+    expect(shortUrl).toBe('https://daily.dev/test/1');
+  });
+});

--- a/__tests__/dataLoaderService.ts
+++ b/__tests__/dataLoaderService.ts
@@ -3,11 +3,6 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { Context } from '../src/Context';
 
-jest.mock('../src/common', () => ({
-  ...(jest.requireActual('../src/common') as Record<string, unknown>),
-  notifyFeaturesReset: jest.fn(),
-}));
-
 let con: DataSource;
 let ctx: MockContext;
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -37,6 +37,7 @@ import {
 } from '../src/notifications';
 import flagsmith from '../src/flagsmith';
 import { Flags } from 'flagsmith-nodejs';
+import { DataLoaderService } from '../src/dataLoaderService';
 
 export class MockContext extends Context {
   mockSpan: MockProxy<RootSpan> & RootSpan;
@@ -322,3 +323,22 @@ export const mockFeatureFlagForUser = (
 
 export const TEST_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36';
+
+export class MockDataLoaderService extends DataLoaderService {
+  public loaders: DataLoaderService['loaders'];
+  public getLoader: DataLoaderService['getLoader'];
+  public mockLoadFn = jest.fn(async (key) => {
+    if (key instanceof Error) {
+      throw key;
+    }
+
+    return key;
+  });
+
+  get test() {
+    return this.getLoader({
+      type: 'test',
+      loadFn: this.mockLoadFn,
+    });
+  }
+}

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -37,7 +37,7 @@ import {
 } from '../src/notifications';
 import flagsmith from '../src/flagsmith';
 import { Flags } from 'flagsmith-nodejs';
-import { DataLoaderService } from '../src/dataLoaderService';
+import { DataLoaderService, defaultCacheKeyFn } from '../src/dataLoaderService';
 
 export class MockContext extends Context {
   mockSpan: MockProxy<RootSpan> & RootSpan;
@@ -339,6 +339,7 @@ export class MockDataLoaderService extends DataLoaderService {
     return this.getLoader({
       type: 'test',
       loadFn: this.mockLoadFn,
+      cacheKeyFn: defaultCacheKeyFn,
     });
   }
 }

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -389,7 +389,7 @@ query Source($id: ID!) {
     expect(res.data.source.public).toEqual(false);
   });
 
-  it('should return public source referralUrl for logged source member', async () => {
+  it('should return public squad referralUrl for logged source member', async () => {
     const QUERY = `
     query Source($id: ID!) {
       source(id: $id) {
@@ -406,7 +406,10 @@ query Source($id: ID!) {
     loggedUser = '1';
     await con
       .getRepository(Source)
-      .update({ id: 'a' }, { handle: 'handle', private: false });
+      .update(
+        { id: 'a' },
+        { handle: 'handle', private: false, type: SourceType.Squad },
+      );
     await con.getRepository(SourceMember).save({
       userId: '1',
       sourceId: 'a',
@@ -420,7 +423,7 @@ query Source($id: ID!) {
     );
   });
 
-  it('should return private source referralUrl for logged source member', async () => {
+  it('should return private squad referralUrl for logged source member', async () => {
     const QUERY = `
     query Source($id: ID!) {
       source(id: $id) {
@@ -437,7 +440,10 @@ query Source($id: ID!) {
     loggedUser = '1';
     await con
       .getRepository(Source)
-      .update({ id: 'a' }, { handle: 'handle', private: true });
+      .update(
+        { id: 'a' },
+        { handle: 'handle', private: true, type: SourceType.Squad },
+      );
     await con.getRepository(SourceMember).save({
       userId: '1',
       sourceId: 'a',

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -388,6 +388,68 @@ query Source($id: ID!) {
     expect(res.errors).toBeFalsy();
     expect(res.data.source.public).toEqual(false);
   });
+
+  it('should return public source referralUrl for logged source member', async () => {
+    const QUERY = `
+    query Source($id: ID!) {
+      source(id: $id) {
+        id
+        name
+        image
+        public
+        currentMember {
+          referralToken
+        }
+        referralUrl
+      }
+    }`;
+    loggedUser = '1';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { handle: 'handle', private: false });
+    await con.getRepository(SourceMember).save({
+      userId: '1',
+      sourceId: 'a',
+      role: SourceMemberRoles.Member,
+      referralToken: 'referraltoken1',
+    });
+    const res = await client.query(QUERY, { variables: { id: 'handle' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.referralUrl).toBe(
+      `${process.env.COMMENTS_PREFIX}/squads/handle?cid=squad&userid=1`,
+    );
+  });
+
+  it('should return private source referralUrl for logged source member', async () => {
+    const QUERY = `
+    query Source($id: ID!) {
+      source(id: $id) {
+        id
+        name
+        image
+        public
+        currentMember {
+          referralToken
+        }
+        referralUrl
+      }
+    }`;
+    loggedUser = '1';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { handle: 'handle', private: true });
+    await con.getRepository(SourceMember).save({
+      userId: '1',
+      sourceId: 'a',
+      role: SourceMemberRoles.Member,
+      referralToken: 'referraltoken1',
+    });
+    const res = await client.query(QUERY, { variables: { id: 'handle' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.source.referralUrl).toBe(
+      `${process.env.COMMENTS_PREFIX}/squads/handle/referraltoken1`,
+    );
+  });
 });
 
 describe('query sourceHandleExists', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "apollo-server-types": "^3.8.0",
         "cloudinary": "^1.37.1",
         "csv-parse": "^5.4.0",
+        "dataloader": "^2.2.2",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
         "fast-json-stringify": "^5.7.0",
@@ -3872,6 +3873,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
     },
     "node_modules/date-fns": {
       "version": "2.30.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "apollo-server-types": "^3.8.0",
     "cloudinary": "^1.37.1",
     "csv-parse": "^5.4.0",
+    "dataloader": "^2.2.2",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "fast-json-stringify": "^5.7.0",

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -3,16 +3,19 @@ import { FastifyRequest, FastifyBaseLogger } from 'fastify';
 import { RootSpan } from '@google-cloud/trace-agent/build/src/plugin-types';
 import { GraphQLDatabaseLoader } from '@mando75/typeorm-graphql-loader';
 import { Roles } from './roles';
+import { DataLoaderService } from './dataLoaderService';
 
 export class Context {
   req: FastifyRequest;
   con: DataSource;
   loader: GraphQLDatabaseLoader;
+  dataLoader: DataLoaderService;
 
   constructor(req: FastifyRequest, con) {
     this.req = req;
     this.con = con;
     this.loader = new GraphQLDatabaseLoader(con);
+    this.dataLoader = new DataLoaderService({ ctx: this });
   }
 
   get service(): boolean | null {

--- a/src/dataLoaderService.ts
+++ b/src/dataLoaderService.ts
@@ -4,7 +4,7 @@ import { getShortUrl } from './common';
 import { SourceMember } from './entity';
 import { GQLSource } from './schema/sources';
 
-const defaultCacheKeyFn = <K>(key: K) => {
+export const defaultCacheKeyFn = <K>(key: K) => {
   if (typeof key === 'object') {
     return JSON.stringify(key);
   }

--- a/src/dataLoaderService.ts
+++ b/src/dataLoaderService.ts
@@ -1,0 +1,56 @@
+import DataLoader, { BatchLoadFn } from 'dataloader';
+import { Context } from './Context';
+import { getShortUrl } from './common';
+
+export class DataLoaderService {
+  protected loaders: Record<string, DataLoader<unknown, unknown>>;
+  private ctx: Context;
+
+  constructor({ ctx }: { ctx: Context }) {
+    this.loaders = {};
+    this.ctx = ctx;
+  }
+
+  protected getLoader<K, V>({
+    type,
+    loadFn,
+  }: {
+    type: string;
+    loadFn: (params: K) => Promise<V> | V;
+  }): DataLoader<K, V> {
+    if (!this.loaders[type]) {
+      const batchLoadFn: BatchLoadFn<K, V> = async (keys) => {
+        const results = await Promise.allSettled(keys.map(loadFn));
+
+        return results.map((result) => {
+          if (result.status === 'rejected') {
+            return result.reason;
+          }
+
+          return result.value;
+        });
+      };
+
+      this.loaders[type] = new DataLoader(batchLoadFn, {
+        cacheKeyFn: (key: K) => {
+          if (typeof key === 'object') {
+            return JSON.stringify(key);
+          }
+
+          return key.toString();
+        },
+        maxBatchSize: 30,
+        name: `${DataLoaderService.name}.${type}`,
+      });
+    }
+
+    return this.loaders[type] as DataLoader<K, V>;
+  }
+
+  get shortUrl() {
+    return this.getLoader<string, string>({
+      type: 'shortUrl',
+      loadFn: (url) => getShortUrl(url, this.ctx.log),
+    });
+  }
+}

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1271,39 +1271,12 @@ export const resolvers: IResolvers<any, Context> = {
         return null;
       }
 
-      const referralUrl = new URL(
-        `/squads/${source.handle}`,
-        process.env.COMMENTS_PREFIX,
-      );
+      const referralUrl = await ctx.dataLoader.referralUrl.load({
+        source,
+        userId: ctx.userId,
+      });
 
-      if (source.public) {
-        referralUrl.searchParams.append('cid', 'squad');
-        referralUrl.searchParams.append('userid', ctx.userId);
-      } else {
-        let referralToken = source.currentMember?.referralToken;
-
-        if (!referralToken) {
-          const sourceMember: Pick<SourceMember, 'referralToken'> =
-            await ctx.con.getRepository(SourceMember).findOne({
-              select: ['referralToken'],
-              where: { sourceId: source.id, userId: ctx.userId },
-            });
-
-          referralToken = sourceMember?.referralToken;
-        }
-
-        if (!referralToken) {
-          return null;
-        }
-
-        referralUrl.pathname = `/squads/${source.handle}/${referralToken}`;
-      }
-
-      const shortUrl = await ctx.dataLoader.shortUrl.load(
-        referralUrl.toString(),
-      );
-
-      return shortUrl;
+      return referralUrl;
     },
   },
 };

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1280,7 +1280,7 @@ export const resolvers: IResolvers<any, Context> = {
         referralUrl.searchParams.append('cid', 'squad');
         referralUrl.searchParams.append('userid', ctx.userId);
       } else {
-        let referralToken = null;
+        let referralToken = source.currentMember?.referralToken;
 
         if (!referralToken) {
           const sourceMember: Pick<SourceMember, 'referralToken'> =


### PR DESCRIPTION
Adding new `referralUrl` field to source to be used on frontend for invite links. Supports public and private squads.

Added in request caching with [dataloader](https://github.com/graphql/dataloader). 

Idea was to also create a generic service `DataLoaderService` that we can extend with additional loaders to provide in request caching capabilities. 

What does this enable: we can batch a lot of same database calls, 3party services calls and any promise to be batched and fetched only once in request context.

Example here is that we cache calls to our URL shortening service to avoid repeated calls while resolving multiple sources.