### PR TITLE
refactor: throwing of error when unable to save to db

### DIFF
--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -832,7 +832,7 @@ export const resolvers: IResolvers<any, Context> = {
         });
       } catch (err) {
         if (err?.code !== TypeOrmError.DUPLICATE_ENTRY) {
-          ctx.log.error({ err }, 'failed to save report to database');
+          throw new Error('Failed to save report to database');
         }
       }
 

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -988,12 +988,7 @@ export const resolvers: IResolvers<any, Context> = {
             });
           } catch (err) {
             if (err?.code !== TypeOrmError.DUPLICATE_ENTRY) {
-              ctx.log.error(
-                {
-                  err,
-                },
-                'failed to save report to database',
-              );
+              throw new Error('Failed to save report to database');
             }
           }
         }


### PR DESCRIPTION
When the error is not about duplicated entries, we should throw an error.