### PR TITLE
chore: add coverage directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ prod.sh
 schema.graphql
 debezium/conf/key.json
 debezium/data
+coverage


### PR DESCRIPTION
Just noticed that `coverage` is not in our `.gitignore` so if running tests locally with `--coverage` you get a bunch of files in your git changes.