### PR TITLE
feat: identify pre onboarding v2 users

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -238,7 +238,7 @@ describe('anonymous boot', () => {
       .set('Cookie', first.headers['set-cookie'])
       .expect(200);
     expect(second.body.user.id).toEqual(first.body.user.id);
-    expect(second.body.flags.onboarding_v2.value).toEqual('control');
+    expect(second.body.flags.onboarding_v2.enabled).toBeFalsy();
   });
 
   it('should not change value if user is not a pre onboarding v2 user', async () => {
@@ -247,6 +247,7 @@ describe('anonymous boot', () => {
       .get(BASE_PATH)
       .set('User-Agent', TEST_UA)
       .expect(200);
+    expect(res.body.flags.onboarding_v2.enabled).toBeTruthy();
     expect(res.body.flags.onboarding_v2.value).toEqual('v1');
   });
 });

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -91,6 +91,7 @@ const ANONYMOUS_BODY = {
   user: {
     id: expect.any(String),
     firstVisit: expect.any(String),
+    isPreOnboardingV2: false,
   },
   shouldLogout: false,
 };
@@ -157,6 +158,7 @@ describe('anonymous boot', () => {
       user: {
         id: null,
         firstVisit: null,
+        isPreOnboardingV2: false,
       },
       visit: {
         visitId: expect.any(String),
@@ -174,6 +176,7 @@ describe('anonymous boot', () => {
       user: {
         id: null,
         firstVisit: null,
+        isPreOnboardingV2: false,
         referralId: '1',
         referralOrigin: 'knightcampaign',
       },

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -87,8 +87,7 @@ const getSubmitArticleState = (flags: IFlags, user: User) => {
 
 interface UpdateParam {
   feature: string;
-  replacement: Flag['value'];
-  onCheckValidity(value: Flag['value']): boolean;
+  checkIsApplicable(value: Flag['value']): boolean;
 }
 
 export const adjustAnonymousFlags = (
@@ -97,9 +96,11 @@ export const adjustAnonymousFlags = (
 ): IFlags => {
   const updatedFlags = { ...flags };
 
-  updates.forEach(({ feature, onCheckValidity, replacement }) => {
-    if (flags?.[feature]?.enabled && onCheckValidity(flags[feature].value)) {
-      updatedFlags[feature] = { enabled: true, value: replacement };
+  updates.forEach(({ feature, checkIsApplicable }) => {
+    if (!flags?.[feature]?.enabled) return;
+
+    if (!checkIsApplicable(flags[feature].value)) {
+      updatedFlags[feature] = { enabled: false, value: '' };
     }
   });
 

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -95,14 +95,15 @@ export const adjustAnonymousFlags = (
   flags: IFlags,
   updates: UpdateParam[],
 ): IFlags => {
+  const updatedFlags = { ...flags };
+
   updates.forEach(({ feature, onCheckValidity, replacement }) => {
-    const isValid = onCheckValidity(flags[feature].value);
-    if (flags[feature].enabled && isValid) {
-      flags[feature] = { enabled: true, value: replacement };
+    if (flags?.[feature]?.enabled && onCheckValidity(flags[feature].value)) {
+      updatedFlags[feature] = { enabled: true, value: replacement };
     }
   });
 
-  return flags;
+  return updatedFlags;
 };
 
 export const adjustFlagsToUser = (flags: IFlags, user: User): IFlags => {

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -100,7 +100,7 @@ export const adjustAnonymousFlags = (
     if (!flags?.[feature]?.enabled) return;
 
     if (!checkIsApplicable(flags[feature].value)) {
-      updatedFlags[feature] = { enabled: false, value: '' };
+      updatedFlags[feature] = { enabled: false, value: null };
     }
   });
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -350,9 +350,9 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
   return finalValue;
 };
 
-// We released the firstVisit at July 10, 2023 - so to have a buffer time, the requirement is the day after.
-export const onboardingV2Requirement = new Date(2023, 6, 11);
-console.log('make changes here before releasing onboarding v2'); // just to make the fail test and avoid releasing onboarding v2
+// We released the firstVisit at July 10, 2023.
+// There should have been enough buffer time since we are releasing on July 13, 2023.
+export const onboardingV2Requirement = new Date(2023, 6, 13);
 
 const anonymousBoot = async (
   con: DataSource,

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -372,9 +372,8 @@ const anonymousBoot = async (
 
   const anonymousFlags = adjustAnonymousFlags(flags, [
     {
-      replacement: 'control',
+      checkIsApplicable: () => !isPreOnboardingV2,
       feature: 'onboarding_v2',
-      onCheckValidity: (value) => value !== 'control' && isPreOnboardingV2,
     },
   ]);
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -69,6 +69,7 @@ export type BootUserReferral = Partial<{
 interface AnonymousUser extends BootUserReferral {
   id: string;
   firstVisit: string;
+  isPreOnboardingV2: boolean;
 }
 
 export type AnonymousBoot = BaseBoot & {
@@ -346,6 +347,9 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
   return finalValue;
 };
 
+// We released the firstVisit at July 10, 2023 - so to have a buffer time, the requirement is the day after.
+export const onboardingV2Requirement = new Date(2023, 6, 11);
+
 const anonymousBoot = async (
   con: DataSource,
   req: FastifyRequest,
@@ -359,9 +363,11 @@ const anonymousBoot = async (
     middleware ? middleware(con, req, res) : {},
     getAnonymousFirstVisit(req.trackingId),
   ]);
+  const isPreOnboardingV2 = new Date(firstVisit) < onboardingV2Requirement;
   return {
     user: {
       firstVisit,
+      isPreOnboardingV2,
       id: req.trackingId,
       ...getReferralFromCookie({ req }),
     },

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -363,7 +363,9 @@ const anonymousBoot = async (
     middleware ? middleware(con, req, res) : {},
     getAnonymousFirstVisit(req.trackingId),
   ]);
-  const isPreOnboardingV2 = new Date(firstVisit) < onboardingV2Requirement;
+  const isPreOnboardingV2 = firstVisit
+    ? new Date(firstVisit) < onboardingV2Requirement
+    : false;
   return {
     user: {
       firstVisit,

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -352,6 +352,7 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
 
 // We released the firstVisit at July 10, 2023 - so to have a buffer time, the requirement is the day after.
 export const onboardingV2Requirement = new Date(2023, 6, 11);
+console.log('make changes here before releasing onboarding v2'); // just to make the fail test and avoid releasing onboarding v2
 
 const anonymousBoot = async (
   con: DataSource,


### PR DESCRIPTION
To make it easier to identify if the user is valid for v2 or not, we calculate the dates on the API instead of FE to avoid any discrepancy.