### PR TITLE
feat: filter read messages in cdc

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -11,11 +11,16 @@ debezium.source.table.include.list=public.comment,public.comment_upvote,public.c
 debezium.source.column.exclude.list=public.post.tsv,public.post.placeholder,public.post.views,public.post.score,public.post.discussionScore,public.notification."readAt"
 debezium.source.plugin.name=pgoutput
 debezium.source.heartbeat.interval.ms=60000
-debezium.transforms=Reroute,ReadOperationFilter
+debezium.source.topic.prefix=t
+debezium.source.tombstones.on.delete=false
+debezium.transforms=Reroute,ReadOperationFilter,FlagsFilter
 debezium.transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
 debezium.transforms.Reroute.topic.regex=(.*)
 debezium.transforms.Reroute.topic.replacement=%topic%
 debezium.transforms.ReadOperationFilter.type=io.debezium.transforms.Filter
 debezium.transforms.ReadOperationFilter.language=jsr223.groovy
 debezium.transforms.ReadOperationFilter.condition=!(valueSchema.field('op') && value.op == 'r')
+debezium.transforms.FlagsFilter.type=io.debezium.transforms.Filter
+debezium.transforms.FlagsFilter.language=jsr223.groovy
+debezium.transforms.FlagsFilter.condition=!(valueSchema.field('op') && value.op == 'u' && value.source.table == 'post' && value.before.flags == '{}' && value.after.flags != '{}')
 debezium.sink.type=pubsub

--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -11,8 +11,11 @@ debezium.source.table.include.list=public.comment,public.comment_upvote,public.c
 debezium.source.column.exclude.list=public.post.tsv,public.post.placeholder,public.post.views,public.post.score,public.post.discussionScore,public.notification."readAt"
 debezium.source.plugin.name=pgoutput
 debezium.source.heartbeat.interval.ms=60000
-debezium.transforms=Reroute
+debezium.transforms=Reroute,ReadOperationFilter
 debezium.transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
 debezium.transforms.Reroute.topic.regex=(.*)
 debezium.transforms.Reroute.topic.replacement=%topic%
+debezium.transforms.ReadOperationFilter.type=io.debezium.transforms.Filter
+debezium.transforms.ReadOperationFilter.language=jsr223.groovy
+debezium.transforms.ReadOperationFilter.condition=!(valueSchema.field('op') && value.op == 'r')
 debezium.sink.type=pubsub

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -241,7 +241,7 @@ const [apps] = deployApplicationSuite(
           ],
     },
     debezium: {
-      version: isAdhocEnv ? '2.0' : '1.9',
+      version: '2.0',
       topicName: debeziumTopicName,
       propsPath: './application.properties',
       propsVars: {

--- a/.infra/package-lock.json
+++ b/.infra/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "api",
       "dependencies": {
-        "@dailydotdev/pulumi-common": "^1.22.2",
+        "@dailydotdev/pulumi-common": "^1.24.1",
         "@pulumi/gcp": "^6.30.0",
         "@pulumi/kubernetes": "^3.15.2",
         "@pulumi/pulumi": "^3.35.3"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@dailydotdev/pulumi-common": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.24.0.tgz",
-      "integrity": "sha512-IS+SYNfiKPDds72K6YVnfxh521+BOm5jaC9CQ3gKVmgG11FhuJc+6Z9l+Y0bKp7YkworX12KQmJdKxKuY24Adw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.24.1.tgz",
+      "integrity": "sha512-ZsF+FB5i5ECNg2QVrlCXODFoq5CVg1EBnIF+Af/g7pPwjOAVLhAprBEkCpOIPpFqKNBzwrH7fevFuKjxEhhi1A==",
       "dependencies": {
         "@google-cloud/pubsub": "^3.2.0",
         "@pulumi/gcp": "^6.30.0",
@@ -3719,9 +3719,9 @@
       "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q=="
     },
     "@dailydotdev/pulumi-common": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.24.0.tgz",
-      "integrity": "sha512-IS+SYNfiKPDds72K6YVnfxh521+BOm5jaC9CQ3gKVmgG11FhuJc+6Z9l+Y0bKp7YkworX12KQmJdKxKuY24Adw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.24.1.tgz",
+      "integrity": "sha512-ZsF+FB5i5ECNg2QVrlCXODFoq5CVg1EBnIF+Af/g7pPwjOAVLhAprBEkCpOIPpFqKNBzwrH7fevFuKjxEhhi1A==",
       "requires": {
         "@google-cloud/pubsub": "^3.2.0",
         "@pulumi/gcp": "^6.30.0",

--- a/.infra/package.json
+++ b/.infra/package.json
@@ -4,7 +4,7 @@
     "@types/node": "^15.14.9"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "^1.22.2",
+    "@dailydotdev/pulumi-common": "^1.24.1",
     "@pulumi/gcp": "^6.30.0",
     "@pulumi/kubernetes": "^3.15.2",
     "@pulumi/pulumi": "^3.35.3"

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -517,7 +517,10 @@ const worker: Worker = {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const data: ChangeMessage<any> = messageToJson(message);
-      if (data.schema.name === 'io.debezium.connector.common.Heartbeat') {
+      if (
+        data.schema.name === 'io.debezium.connector.common.Heartbeat' ||
+        data.payload.op === 'r'
+      ) {
         return;
       }
       switch (data.payload.source.table) {


### PR DESCRIPTION
During debezium upgrade to 2.0 we encountered a lot of snapshot messages with `op=r` property. 

This ensures those messages are ignored and not sent to pubsub and cdc worker.

Before merging this we need to test out locally that debezium 2.0 starts-up ok and that this fix really handles all the excess messages.