### PR TITLE
feat: skipping muted notifications

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -248,40 +248,6 @@ describe('generateNotification', () => {
     expect(actual.attachments.length).toEqual(0);
   });
 
-  it('should generate article_new_comment notification but ignore muted settings', () => {
-    const type = NotificationType.ArticleNewComment;
-    const ctx: NotificationCommenterContext = {
-      userId,
-      source: sourcesFixture[0] as Reference<Source>,
-      post: postsFixture[0] as Reference<Post>,
-      comment: commentFixture,
-      commenter: usersFixture[1] as Reference<User>,
-    };
-    const actual = generateNotification(type, ctx);
-    expect(actual.notification.type).toEqual(type);
-    expect(actual.notification.userId).toEqual(userId);
-    expect(actual.notification.public).toEqual(true);
-    expect(actual.notification.referenceId).toEqual('c1');
-    expect(actual.notification.referenceType).toEqual('comment');
-    expect(actual.notification.targetUrl).toEqual(
-      'http://localhost:5002/posts/p1#c-c1',
-    );
-    expect(actual.notification.description).toEqual(
-      'Complex markdown comment that needs to be simplified',
-    );
-    expect(actual.avatars).toEqual([
-      {
-        image: 'https://daily.dev/tsahi.jpg',
-        name: 'Tsahi',
-        order: 0,
-        referenceId: '2',
-        targetUrl: 'http://localhost:5002/tsahidaily',
-        type: 'user',
-      },
-    ]);
-    expect(actual.attachments.length).toEqual(0);
-  });
-
   it('should generate article_upvote_milestone notification', () => {
     const type = NotificationType.ArticleUpvoteMilestone;
     const ctx: NotificationPostContext & NotificationUpvotersContext = {

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -248,6 +248,40 @@ describe('generateNotification', () => {
     expect(actual.attachments.length).toEqual(0);
   });
 
+  it('should generate article_new_comment notification but ignore muted settings', () => {
+    const type = NotificationType.ArticleNewComment;
+    const ctx: NotificationCommenterContext = {
+      userId,
+      source: sourcesFixture[0] as Reference<Source>,
+      post: postsFixture[0] as Reference<Post>,
+      comment: commentFixture,
+      commenter: usersFixture[1] as Reference<User>,
+    };
+    const actual = generateNotification(type, ctx);
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.notification.userId).toEqual(userId);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('c1');
+    expect(actual.notification.referenceType).toEqual('comment');
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1#c-c1',
+    );
+    expect(actual.notification.description).toEqual(
+      'Complex markdown comment that needs to be simplified',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'https://daily.dev/tsahi.jpg',
+        name: 'Tsahi',
+        order: 0,
+        referenceId: '2',
+        targetUrl: 'http://localhost:5002/tsahidaily',
+        type: 'user',
+      },
+    ]);
+    expect(actual.attachments.length).toEqual(0);
+  });
+
   it('should generate article_upvote_milestone notification', () => {
     const type = NotificationType.ArticleUpvoteMilestone;
     const ctx: NotificationPostContext & NotificationUpvotersContext = {

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -56,7 +56,7 @@ export const notificationPreferenceMap: Partial<
   [NotificationType.SquadMemberJoined]: NotificationPreferenceType.Source,
 };
 
-export const commentNotificationTypes = [
+export const commentReplyNotificationTypes = [
   NotificationType.CommentReply,
   NotificationType.SquadReply,
 ];

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -51,9 +51,15 @@ export const notificationPreferenceMap: Partial<
 > = {
   [NotificationType.ArticleNewComment]: NotificationPreferenceType.Post,
   [NotificationType.CommentReply]: NotificationPreferenceType.Comment,
+  [NotificationType.SquadReply]: NotificationPreferenceType.Comment,
   [NotificationType.SquadPostAdded]: NotificationPreferenceType.Source,
   [NotificationType.SquadMemberJoined]: NotificationPreferenceType.Source,
 };
+
+export const commentNotificationTypes = [
+  NotificationType.CommentReply,
+  NotificationType.SquadReply,
+];
 
 type NotificationPreferenceUnion = NotificationPreferenceComment &
   NotificationPreferencePost &

--- a/src/workers/notifications/commentReply.ts
+++ b/src/workers/notifications/commentReply.ts
@@ -1,9 +1,17 @@
 import { messageToJson } from '../worker';
-import { Comment, SourceType } from '../../entity';
+import {
+  Comment,
+  NotificationPreferenceComment,
+  SourceType,
+} from '../../entity';
 import { NotificationCommenterContext } from '../../notifications';
-import { NotificationType } from '../../notifications/common';
+import {
+  commentNotificationTypes,
+  NotificationType,
+} from '../../notifications/common';
 import { NotificationWorker } from './worker';
 import { buildPostContext } from './utils';
+import { In } from 'typeorm';
 
 interface Data {
   userId: string;
@@ -26,8 +34,14 @@ const worker: NotificationWorker = {
     if (!postCtx) {
       return;
     }
-    const parent = await comment.parent;
-    const commenter = await comment.user;
+    const [parent, commenter, mutes] = await Promise.all([
+      comment.parent,
+      comment.user,
+      con.getRepository(NotificationPreferenceComment).findBy({
+        referenceId: comment.id,
+        notificationType: In(commentNotificationTypes),
+      }),
+    ]);
     const threadFollowers = await con
       .getRepository(Comment)
       .createQueryBuilder()
@@ -56,10 +70,12 @@ const worker: NotificationWorker = {
       ctx.source.type === SourceType.Squad
         ? NotificationType.SquadReply
         : NotificationType.CommentReply;
-    return userIds.map((userId) => ({
-      type,
-      ctx: { ...ctx, userId },
-    }));
+    return userIds
+      .filter((id) => mutes.every(({ userId }) => userId !== id))
+      .map((userId) => ({
+        type,
+        ctx: { ...ctx, userId },
+      }));
   },
 };
 

--- a/src/workers/notifications/commentReply.ts
+++ b/src/workers/notifications/commentReply.ts
@@ -6,7 +6,7 @@ import {
 } from '../../entity';
 import { NotificationCommenterContext } from '../../notifications';
 import {
-  commentNotificationTypes,
+  commentReplyNotificationTypes,
   NotificationType,
 } from '../../notifications/common';
 import { NotificationWorker } from './worker';
@@ -39,7 +39,7 @@ const worker: NotificationWorker = {
       comment.user,
       con.getRepository(NotificationPreferenceComment).findBy({
         referenceId: comment.id,
-        notificationType: In(commentNotificationTypes),
+        notificationType: In(commentReplyNotificationTypes),
       }),
     ]);
     const threadFollowers = await con

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -1,10 +1,7 @@
 import { messageToJson } from '../worker';
 import {
-  NotificationPreference,
-  NotificationPreferenceSource,
   Post,
   PostType,
-  SourceMember,
   SourceType,
   User,
   UserAction,

--- a/src/workers/notifications/squadMemberJoined.ts
+++ b/src/workers/notifications/squadMemberJoined.ts
@@ -1,12 +1,8 @@
 import { messageToJson } from '../worker';
-import {
-  NotificationPreferenceStatus,
-  NotificationType,
-} from '../../notifications/common';
+import { NotificationType } from '../../notifications/common';
 import { NotificationWorker } from './worker';
 import { ChangeObject } from '../../types';
 import {
-  NotificationPreferenceSource,
   Source,
   SourceMember,
   SourceType,

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -144,7 +144,7 @@ export async function articleNewCommentHandler(
       : NotificationType.ArticleNewComment;
 
   if (source.type === SourceType.Squad) {
-    const members = await con.getRepository(SourceMember).findBy({
+    const members = await getSubscribedMembers(con, type, post.id, {
       userId: In(users),
       sourceId: source.id,
       role: Not(SourceMemberRoles.Blocked),
@@ -163,6 +163,8 @@ export async function articleNewCommentHandler(
   const muted = await con.getRepository(NotificationPreferencePost).findBy({
     userId: In(users),
     referenceId: post.id,
+    notificationType: type,
+    type: notificationPreferenceMap[type],
     status: NotificationPreferenceStatus.Muted,
   });
 

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -138,7 +138,7 @@ export async function articleNewCommentHandler(
   });
 
   return users
-    .filter((id) => !muted.some(({ userId }) => userId === id))
+    .filter((id) => muted.every(({ userId }) => userId !== id))
     .map((userId) => ({ type, ctx: { ...ctx, userId } }));
 }
 


### PR DESCRIPTION
Skip notifications based on notification types as below:
- `comment_reply`
- `squad_reply`
- `squad_member_joined`
- `squad_post_added`
- `article_new_comment`

~~WIP: still waiting on a response from the threads below but already went ahead and fixed the assumptions but this PR should be complete already.~~

Threads:
- ~~https://dailydotdev.slack.com/archives/C02E2C3C13R/p1689776730496559~~
- ~~https://dailydotdev.slack.com/archives/C0592NL7YCU/p1689778547622899~~ (answered)

Note: will update this PRs description based on the response.