### PR TITLE
feat: restrict open squad content for blocked members

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -855,6 +855,28 @@ describe('query sourceFeed', () => {
     );
     expect(freeformPost.node.image).toBeNull();
   });
+
+  it('should disallow access to feed for public source for blocked members', async () => {
+    loggedUser = '1';
+    await con.getRepository(User).save(usersFixture[0]);
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { type: SourceType.Squad, private: false });
+    await con.getRepository(SourceMember).save({
+      sourceId: 'a',
+      userId: '1',
+      referralToken: 'rt2',
+      role: SourceMemberRoles.Blocked,
+    });
+
+    return testQueryErrorCode(
+      client,
+      {
+        query: QUERY('a'),
+      },
+      'FORBIDDEN',
+    );
+  });
 });
 
 describe('query tagFeed', () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -774,6 +774,30 @@ describe('query post', () => {
     const res = await client.query(QUERY('p1'));
     expect(res.data).toMatchSnapshot();
   });
+
+  it('should disallow access to post from public source for blocked members', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { type: SourceType.Squad, private: false });
+    await con
+      .getRepository(Post)
+      .update({ id: 'p1' }, { private: false, sourceId: 'a' });
+    await con.getRepository(SourceMember).save({
+      sourceId: 'a',
+      userId: '1',
+      referralToken: 'rt2',
+      role: SourceMemberRoles.Blocked,
+    });
+
+    return testQueryErrorCode(
+      client,
+      {
+        query: QUERY('p1'),
+      },
+      'FORBIDDEN',
+    );
+  });
 });
 
 describe('query postByUrl', () => {

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -456,6 +456,28 @@ query Source($id: ID!) {
       `${process.env.COMMENTS_PREFIX}/squads/handle/referraltoken1`,
     );
   });
+
+  it('should disallow access to public source for blocked members', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { type: SourceType.Squad, private: false });
+    await con.getRepository(SourceMember).save({
+      sourceId: 'a',
+      userId: '1',
+      referralToken: 'rt2',
+      role: SourceMemberRoles.Blocked,
+    });
+
+    return testQueryErrorCode(
+      client,
+      {
+        query: QUERY,
+        variables: { id: 'a' },
+      },
+      'FORBIDDEN',
+    );
+  });
 });
 
 describe('query sourceHandleExists', () => {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -45,7 +45,6 @@ import {
   PostMention,
   PostReport,
   PostType,
-  SourceType,
   Toc,
   Upvote,
   UserActionType,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -565,6 +565,8 @@ const hasPermissionCheck = (
   return rolePermissions?.includes?.(permission);
 };
 
+export const sourceTypesWithMembers = ['squad'];
+
 export const canAccessSource = async (
   ctx: Context,
   source: Source,
@@ -573,6 +575,13 @@ export const canAccessSource = async (
   validateRankAgainstId?: string,
 ): Promise<boolean> => {
   if (permission === SourcePermissions.View && !source.private) {
+    if (sourceTypesWithMembers.includes(source.type)) {
+      const isMemberBlocked = member?.role === SourceMemberRoles.Blocked;
+      const canAccess = !isMemberBlocked;
+
+      return canAccess;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Restricting access to post and squad pages for public sources (squads).

Blocked user of open squad should not be able to:
- view squad page
- view squad posts
- comment on squad posts

Discussion [here](https://dailydotdev.slack.com/archives/C0592NL7YCU/p1689770365788359)