### PR TITLE
fix: return null is auth on scalar value

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3188,7 +3188,7 @@ describe('flags field', () => {
     }
   }`;
 
-  it('should return all the public flags', async () => {
+  it('should return all the public flags for anonymous user', async () => {
     await con.getRepository(Post).update(
       { id: 'p1' },
       {
@@ -3196,6 +3196,23 @@ describe('flags field', () => {
       },
     );
     const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+    expect(res.data.post.flags).toEqual({
+      private: true,
+      promoteToPublic: null,
+    });
+  });
+
+  it('should return all flags to logged user', async () => {
+    loggedUser = '1';
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        flags: updateFlagsStatement({ private: true, promoteToPublic: 123 }),
+      },
+    );
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
     expect(res.data.post.flags).toEqual({
       private: true,
       promoteToPublic: null,
@@ -3212,6 +3229,7 @@ describe('flags field', () => {
       },
     );
     const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
     expect(res.data.post.flags).toEqual({
       private: true,
       promoteToPublic: 123,

--- a/src/directive/auth.ts
+++ b/src/directive/auth.ts
@@ -49,6 +49,11 @@ export const transformer = (schema: GraphQLSchema): GraphQLSchema =>
               return resolve(source, args, ctx, info);
             }
             if (!ctx.userId) {
+              if (fieldConfig.type instanceof GraphQLScalarType) {
+                resolve(source, args, ctx, info);
+                return null;
+              }
+
               throw new AuthenticationError(
                 'Access denied! You need to be authorized to perform this action!',
               );

--- a/src/directive/auth.ts
+++ b/src/directive/auth.ts
@@ -1,5 +1,5 @@
 import { ForbiddenError, AuthenticationError } from 'apollo-server-errors';
-import { defaultFieldResolver } from 'graphql';
+import { defaultFieldResolver, GraphQLScalarType } from 'graphql';
 import { GraphQLSchema } from 'graphql';
 import { mapSchema, getDirective, MapperKind } from '@graphql-tools/utils';
 import { Context } from '../Context';
@@ -65,6 +65,11 @@ export const transformer = (schema: GraphQLSchema): GraphQLSchema =>
                   ) > -1;
               }
               if (!authorized) {
+                if (fieldConfig.type instanceof GraphQLScalarType) {
+                  resolve(source, args, ctx, info);
+                  return null;
+                }
+
                 throw new ForbiddenError(
                   'Access denied! You do not have permission for this action!',
                 );

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -207,7 +207,7 @@ export const typeDefs = /* GraphQL */ `
     """
     The unix timestamp (seconds) the post will be promoted to public to
     """
-    promoteToPublic: Int
+    promoteToPublic: Int @auth(requires: [MODERATOR])
   }
 
   """


### PR DESCRIPTION
Added a manual evaluation if field type is a `GraphQLScalarType` in which case we should simply return a null value.
Otherwise we can always throw forbidden error as it will be a query or mutation.

WT-1551 #done