### PR TITLE
fix: missing property on notification type

### DIFF
--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -100,6 +100,10 @@ export const typeDefs = /* GraphQL */ `
     """
     type: String!
     """
+    Referenced entity's id of the notification
+    """
+    referenceId: String!
+    """
     Icon type of the notification
     """
     icon: String!


### PR DESCRIPTION
In order for us to show the current preference of the user towards the said notification type, we need to fetch it first and the reference id is one of the requirements to do so.

![Screenshot 2023-07-26 at 3 07 58 PM](https://github.com/dailydotdev/daily-api/assets/13744167/dc5d76b0-3967-4fa1-bd1a-24bb95fe45e3)
