### PR TITLE
fix: correct notification preference type

### DIFF
--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -29,6 +29,7 @@ import { subDays } from 'date-fns';
 import request from 'supertest';
 import { FastifyInstance } from 'fastify';
 import {
+  notificationPreferenceMap,
   NotificationPreferenceStatus,
   NotificationPreferenceType,
   NotificationType,
@@ -551,6 +552,9 @@ describe('mutation muteNotificationPreference', () => {
       .findOneBy(params);
 
     expect(muted).toBeTruthy();
+    expect(muted.type).toEqual(
+      notificationPreferenceMap[params.notificationType],
+    );
   });
 
   it('should ignore when preference is already muted', async () => {

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -1,5 +1,4 @@
 import {
-  NotificationPreference,
   NotificationPreferenceComment,
   NotificationPreferencePost,
   NotificationPreferenceSource,
@@ -79,6 +78,22 @@ const notificationPreferenceProp: Record<
   source: 'sourceId',
 };
 
+const getRepository = (
+  con: DataSource | EntityManager,
+  type: NotificationPreferenceType,
+) => {
+  switch (type) {
+    case NotificationPreferenceType.Post:
+      return con.getRepository(NotificationPreferencePost);
+    case NotificationPreferenceType.Comment:
+      return con.getRepository(NotificationPreferenceComment);
+    case NotificationPreferenceType.Source:
+      return con.getRepository(NotificationPreferenceSource);
+    default:
+      throw new ValidationError('Notification type not supported');
+  }
+};
+
 export const saveNotificationPreference = async (
   con: DataSource | EntityManager,
   userId: string,
@@ -103,8 +118,7 @@ export const saveNotificationPreference = async (
   };
 
   try {
-    await con
-      .getRepository(NotificationPreference)
+    await getRepository(con, type)
       .createQueryBuilder()
       .insert()
       .values(params)


### PR DESCRIPTION
after further development, I noticed that even though we strictly set the proper `type` of the `NotificationPreference`, it is getting overridden by what was defined in the class. Using the base class results in always setting it to `NotificationPreference` string as shown below. I have pushed a commit to fix this and ended up with a switch case, I tried doing a map of the class but wasn't working.

![Screenshot 2023-07-26 at 7 24 51 PM](https://github.com/dailydotdev/daily-api/assets/13744167/0e5c3c1d-1893-41cf-87ea-59c85b83d10d)