### PR TITLE
feat: set NODE_ENV to development for local env

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -16,6 +16,7 @@ config:
     jwtIssuer: Daily API Staging
     jwtSecret: '|r+.2!!!.Qf_-|63*%.D'
     kratosOrigin: http://heimdall-kratos-public
+    nodeEnv: development
     postScraperOrigin: http://post-scraper-one-ai-server
     pubsubEmulatorHost: pubsub:8085
     pubsubProjectId: local


### PR DESCRIPTION
`NODE_ENV` was undefined in our local environment for daily-api
Since most developers would assume it should be defined we inject it as `development` for our local setup.

This fixes some edge cases in development like send email infinite loop https://github.com/dailydotdev/daily-api/pull/1302 which was fixed but the fix did not work anymore since our `NODE_ENV` was `undefined`.