### PR TITLE
fix: editing squad details should ignore unchanged handle

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1320,6 +1320,25 @@ describe('mutation editSquad', () => {
     );
   });
 
+  it('should not throw error on disallow handles if the value did not change', async () => {
+    loggedUser = '1';
+    const handle = 'existing';
+    await con.getRepository(Source).update({ id: 's1' }, { handle });
+    await con.getRepository(DisallowHandle).save({ value: handle });
+    const description = 'New description';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        handle: 'existing',
+        description,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    const edited = await con.getRepository(SquadSource).findOneBy({ handle });
+    expect(edited.description).toEqual(description);
+  });
+
   it(`should throw error if squad doesn't exist`, async () => {
     loggedUser = '1';
     return testMutationErrorCode(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1155,7 +1155,7 @@ export const resolvers: IResolvers<any, Context> = {
           async (entityManager) => {
             const current = await entityManager
               .getRepository(SquadSource)
-              .findOneByOrFail({ id: sourceId });
+              .findOneOrFail({ where: { id: sourceId }, select: ['handle'] });
             const disallowHandle =
               current.handle === handle
                 ? false

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1153,10 +1153,14 @@ export const resolvers: IResolvers<any, Context> = {
       try {
         const editedSourceId = await ctx.con.transaction(
           async (entityManager) => {
-            const disallowHandle = await checkDisallowHandle(
-              entityManager,
-              handle,
-            );
+            const current = await entityManager
+              .getRepository(SquadSource)
+              .findOneByOrFail({ id: sourceId });
+            const disallowHandle =
+              current.handle === handle
+                ? false
+                : await checkDisallowHandle(entityManager, handle);
+
             if (disallowHandle) {
               throw new ValidationError(
                 JSON.stringify({ handle: 'handle is already used' }),


### PR DESCRIPTION
When editing the Squad's details, we always check to restrict using `DisallowedHandle`, though the transaction should not necessarily want to change the handle, the FE sends the content of the form anyway, and we should check if there was really any change with it.