### PR TITLE
fix: notification preference query on post related types

### DIFF
--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -331,7 +331,7 @@ const prepareNotificationPreferences = async () => {
       userId: '1',
       sourceId: sourcesFixture[0].id,
       referenceId: sourcesFixture[0].id,
-      notificationType: NotificationType.SourceApproved,
+      notificationType: NotificationType.SquadPostAdded,
       status: NotificationPreferenceStatus.Muted,
     },
   ]);
@@ -377,7 +377,6 @@ describe('query notificationPreferences', () => {
       variables: {
         data: [
           {
-            type: NotificationPreferenceType.Post,
             referenceId: postsFixture[0].id,
             notificationType: NotificationType.ArticleNewComment,
           },
@@ -398,14 +397,12 @@ describe('query notificationPreferences', () => {
     await prepareNotificationPreferences();
 
     const postParam = {
-      type: NotificationPreferenceType.Post,
       referenceId: postsFixture[0].id,
       notificationType: NotificationType.ArticleNewComment,
     };
     const sourceParam = {
-      type: NotificationPreferenceType.Source,
       referenceId: sourcesFixture[0].id,
-      notificationType: NotificationType.SourceApproved,
+      notificationType: NotificationType.SquadPostAdded,
     };
     const res = await client.query(QUERY, {
       variables: { data: [postParam, sourceParam] },
@@ -413,14 +410,16 @@ describe('query notificationPreferences', () => {
     expect(res.data.notificationPreferences.length).toEqual(2);
 
     const hasPost = res.data.notificationPreferences.some(
-      ({ type, referenceId }) =>
-        type === postParam.type && referenceId === postParam.referenceId,
+      ({ notificationType, referenceId }) =>
+        notificationType === postParam.notificationType &&
+        referenceId === postParam.referenceId,
     );
     expect(hasPost).toBeTruthy();
 
     const hasSource = res.data.notificationPreferences.some(
-      ({ type, referenceId }) =>
-        type === sourceParam.type && referenceId === sourceParam.referenceId,
+      ({ notificationType, referenceId }) =>
+        notificationType === sourceParam.notificationType &&
+        referenceId === sourceParam.referenceId,
     );
     expect(hasSource).toBeTruthy();
 

--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -672,8 +672,8 @@ describe('mutation clearNotificationPreference', () => {
 
     const params = {
       userId: loggedUser,
-      referenceId: postsFixture[0].id,
-      notificationType: NotificationType.ArticleNewComment,
+      referenceId: sourcesFixture[0].id,
+      notificationType: NotificationType.SquadPostAdded,
     };
 
     const preference = await con

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -6,9 +6,10 @@ import {
   getUnreadNotificationsCount,
   Notification,
   NotificationPreference,
+  Comment,
 } from '../entity';
 import { ConnectionArguments } from 'graphql-relay';
-import { IsNull } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { Connection as ConnectionRelay } from 'graphql-relay/connection/connection';
 import graphorm from '../graphorm';
 import { createDatePageGenerator } from '../common/datePageGenerator';
@@ -20,6 +21,7 @@ import {
   NotificationType,
   saveNotificationPreference,
   NotificationPreferenceType,
+  postNewCommentNotificationTypes,
 } from '../notifications/common';
 import { ValidationError } from 'apollo-server-errors';
 
@@ -40,6 +42,7 @@ type GQLNotificationPreference = Pick<
 interface NotificationPreferenceArgs {
   referenceId: string;
   type: NotificationPreferenceType;
+  notificationType: NotificationType;
 }
 
 interface NotificationPreferenceMutationArgs {
@@ -223,9 +226,14 @@ export const typeDefs = /* GraphQL */ `
     referenceId: ID!
 
     """
-    Type of the notification preference
+    Type of the notification preference whether it is "post", "source", "comment"
     """
     type: String!
+
+    """
+    Notification type for which kind of notification you want to mute
+    """
+    notificationType: String!
   }
 
   extend type Query {
@@ -361,7 +369,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         },
       );
     },
-    notificationPreferences: (
+    notificationPreferences: async (
       _,
       { data }: NotificationPreferenceInput,
       ctx,
@@ -374,6 +382,21 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       const params = data.reduce((args, value) => {
         return [...args, { ...value, userId: ctx.userId }];
       }, []);
+
+      const newComments = data.filter(({ notificationType }) =>
+        postNewCommentNotificationTypes.includes(notificationType),
+      );
+
+      if (newComments.length) {
+        const ids = newComments.map(({ referenceId }) => referenceId);
+        const comments = await ctx
+          .getRepository(Comment)
+          .find({ select: ['id', 'postId'], where: { id: In(ids) } });
+        comments.forEach(({ id, postId }) => {
+          const param = params.find(({ referenceId }) => referenceId === id);
+          param.referenceId = postId;
+        });
+      }
 
       return graphorm.query(ctx, info, (builder) => {
         builder.queryBuilder = builder.queryBuilder.where(params);
@@ -420,6 +443,19 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       { type, referenceId }: NotificationPreferenceMutationArgs,
       { con, userId },
     ): Promise<GQLEmptyResponse> => {
+      if (postNewCommentNotificationTypes.includes(type)) {
+        const comment = await con.getRepository(Comment).findOne({
+          where: { id: referenceId },
+          select: ['postId'],
+        });
+
+        if (!comment) {
+          throw new ValidationError('Comment not found');
+        }
+
+        referenceId = comment.postId;
+      }
+
       await con
         .getRepository(NotificationPreference)
         .delete({ userId, notificationType: type, referenceId });

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -20,8 +20,8 @@ import {
   NotificationPreferenceStatus,
   NotificationType,
   saveNotificationPreference,
-  NotificationPreferenceType,
   postNewCommentNotificationTypes,
+  notificationPreferenceMap,
 } from '../notifications/common';
 import { ValidationError } from 'apollo-server-errors';
 
@@ -41,7 +41,6 @@ type GQLNotificationPreference = Pick<
 
 interface NotificationPreferenceArgs {
   referenceId: string;
-  type: NotificationPreferenceType;
   notificationType: NotificationType;
 }
 
@@ -226,11 +225,6 @@ export const typeDefs = /* GraphQL */ `
     referenceId: ID!
 
     """
-    Type of the notification preference whether it is "post", "source", "comment"
-    """
-    type: String!
-
-    """
     Notification type for which kind of notification you want to mute
     """
     notificationType: String!
@@ -380,7 +374,8 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       }
 
       const params = data.reduce((args, value) => {
-        return [...args, { ...value, userId: ctx.userId }];
+        const type = notificationPreferenceMap[value.notificationType];
+        return [...args, { ...value, type, userId: ctx.userId }];
       }, []);
 
       const newComments = data.filter(({ notificationType }) =>

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -387,6 +387,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         const comments = await ctx
           .getRepository(Comment)
           .find({ select: ['id', 'postId'], where: { id: In(ids) } });
+
         comments.forEach(({ id, postId }) => {
           const param = params.find(({ referenceId }) => referenceId === id);
           param.referenceId = postId;


### PR DESCRIPTION
Similar to the PR for muting notification types relating to `article_new_comment` (https://github.com/dailydotdev/daily-api/pull/1374) - we should also update the query counterpart and the clearing of notifications.

Note: I will also raise a PR to make the FE work with the new requirements.