### PR TITLE
fix: add yggdrasil id to content flow

### DIFF
--- a/__tests__/workers/__snapshots__/postUpdated.ts.snap
+++ b/__tests__/workers/__snapshots__/postUpdated.ts.snap
@@ -50,5 +50,6 @@ Object {
   "viewsThreshold": 0,
   "visible": true,
   "visibleAt": Any<Date>,
+  "yggdrasilId": "f99a445f-e2fb-48e8-959c-e02a17f5e816",
 }
 `;

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -98,6 +98,7 @@ const createSharedPost = async (id = 'sp1') => {
 
 it('should not update if the database updated date is newer', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
     post_id: 'p1',
     updated_at: new Date('01-05-1990 12:00:00'),
   });
@@ -110,6 +111,7 @@ it('should not update if the post is not a squad origin', async () => {
     .getRepository(ArticlePost)
     .update({ id: 'p1' }, { origin: PostOrigin.CommunityPicks });
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
     post_id: 'p1',
     updated_at: new Date('01-05-1990 12:00:00'),
   });
@@ -122,6 +124,8 @@ it(`should not update if the post object doesn't have ID`, async () => {
     .getRepository(ArticlePost)
     .update({ id: 'p1' }, { origin: PostOrigin.CommunityPicks });
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     updated_at: new Date('01-05-1990 12:00:00'),
   });
   const post = await con.getRepository(ArticlePost).findOneBy({ id: 'p1' });
@@ -130,6 +134,7 @@ it(`should not update if the post object doesn't have ID`, async () => {
 
 it('should update the post and keep it invisible if title is missing', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
   });
@@ -141,6 +146,8 @@ it('should update the post and keep it invisible if title is missing', async () 
 
 it('should update the post and make it visible if title is available', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -157,6 +164,8 @@ it('should update all the post related shared posts to visible', async () => {
   await createSharedPost();
   await createSharedPost('sp2');
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -188,6 +197,8 @@ it('should update post and not modify keywords', async () => {
     .getRepository(Post)
     .update({ id: 'p1' }, { tagsStr: 'mongodb, alpinejs' });
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     post_id: 'p1',
     title: 'New title',
     extra: {
@@ -212,6 +223,8 @@ it('should update post and modify keywords', async () => {
     .getRepository(Post)
     .update({ id: 'p1' }, { tagsStr: 'mongodb, alpinejs' });
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     post_id: 'p1',
     title: 'New title',
     extra: {
@@ -232,6 +245,8 @@ it('should update post and modify keywords', async () => {
 it('should save a new post with the relevant content curation', async () => {
   await createDefaultKeywords();
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -250,6 +265,8 @@ it('should save a new post with the relevant content curation', async () => {
 
 it('should save a new post with basic information', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -274,6 +291,8 @@ it('should save a new post with basic information', async () => {
 
 it('should set show on feed to true when order is missing', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -285,6 +304,8 @@ it('should set show on feed to true when order is missing', async () => {
 
 it('should save a new post with showOnFeed information', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -297,6 +318,8 @@ it('should save a new post with showOnFeed information', async () => {
 
 it('should save a new post with content curation', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -311,6 +334,8 @@ it('should save a new post with content curation', async () => {
 
 it('save a post as public if source is public', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -323,6 +348,8 @@ it('save a post as public if source is public', async () => {
 
 it('save a post as private if source is private', async () => {
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'p',
@@ -345,6 +372,8 @@ it('should save a new post with the relevant scout id and update submission', as
   await createDefaultUser();
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: COMMUNITY_PICKS_SOURCE,
@@ -375,6 +404,8 @@ it('should save a new post with the relevant keywords', async () => {
   await createDefaultSubmission(uuid);
   await createDefaultKeywords();
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: `https://post.com/${uuid}`,
     source_id: COMMUNITY_PICKS_SOURCE,
@@ -403,6 +434,8 @@ it('should not accept post with same author and scout', async () => {
   await createDefaultUser();
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -424,6 +457,8 @@ it('should update submission to rejected', async () => {
   await createDefaultUser();
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -448,6 +483,8 @@ it('should not update already approved post', async () => {
     status: SubmissionStatus.Accepted,
   });
   await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -125,7 +125,6 @@ it(`should not update if the post object doesn't have ID`, async () => {
     .update({ id: 'p1' }, { origin: PostOrigin.CommunityPicks });
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     updated_at: new Date('01-05-1990 12:00:00'),
   });
   const post = await con.getRepository(ArticlePost).findOneBy({ id: 'p1' });
@@ -147,7 +146,6 @@ it('should update the post and keep it invisible if title is missing', async () 
 it('should update the post and make it visible if title is available', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -165,7 +163,6 @@ it('should update all the post related shared posts to visible', async () => {
   await createSharedPost('sp2');
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -198,7 +195,6 @@ it('should update post and not modify keywords', async () => {
     .update({ id: 'p1' }, { tagsStr: 'mongodb, alpinejs' });
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     post_id: 'p1',
     title: 'New title',
     extra: {
@@ -224,7 +220,6 @@ it('should update post and modify keywords', async () => {
     .update({ id: 'p1' }, { tagsStr: 'mongodb, alpinejs' });
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     post_id: 'p1',
     title: 'New title',
     extra: {
@@ -246,7 +241,6 @@ it('should save a new post with the relevant content curation', async () => {
   await createDefaultKeywords();
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     post_id: 'p1',
     updated_at: new Date('01-05-2023 12:00:00'),
     title: 'test',
@@ -266,7 +260,6 @@ it('should save a new post with the relevant content curation', async () => {
 it('should save a new post with basic information', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -292,7 +285,6 @@ it('should save a new post with basic information', async () => {
 it('should set show on feed to true when order is missing', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -305,7 +297,6 @@ it('should set show on feed to true when order is missing', async () => {
 it('should save a new post with showOnFeed information', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -319,7 +310,6 @@ it('should save a new post with showOnFeed information', async () => {
 it('should save a new post with content curation', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -335,7 +325,6 @@ it('should save a new post with content curation', async () => {
 it('save a post as public if source is public', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -349,7 +338,6 @@ it('save a post as public if source is public', async () => {
 it('save a post as private if source is private', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'p',
@@ -373,7 +361,6 @@ it('should save a new post with the relevant scout id and update submission', as
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: COMMUNITY_PICKS_SOURCE,
@@ -405,7 +392,6 @@ it('should save a new post with the relevant keywords', async () => {
   await createDefaultKeywords();
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: `https://post.com/${uuid}`,
     source_id: COMMUNITY_PICKS_SOURCE,
@@ -435,7 +421,6 @@ it('should not accept post with same author and scout', async () => {
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -458,7 +443,6 @@ it('should update submission to rejected', async () => {
   await createDefaultSubmission(uuid);
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',
@@ -484,7 +468,6 @@ it('should not update already approved post', async () => {
   });
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-
     title: 'Title',
     url: 'https://post.com',
     source_id: 'a',

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -192,4 +192,8 @@ export class Post {
   @Index('IDX_post_flags_deleted', { synchronize: false })
   @Index('IDX_post_flags_promoteToPublic', { synchronize: false })
   flags: PostFlags;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index('IDX_yggdrasil_id')
+  yggdrasilId: string;
 }

--- a/src/migration/1690963996461-PostYggdrasilId.ts
+++ b/src/migration/1690963996461-PostYggdrasilId.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostYggdrasilId1690963996461 implements MigrationInterface {
+  name = 'PostYggdrasilId1690963996461';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post" ADD "yggdrasilId" uuid`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_yggdrasil_id" ON "post" ("yggdrasilId") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_yggdrasil_id"`);
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "yggdrasilId"`);
+  }
+}

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -24,6 +24,7 @@ import { EntityManager } from 'typeorm';
 import { updateFlagsStatement } from '../common';
 
 interface Data {
+  id: string;
   post_id: string;
   url: string;
   image?: string;
@@ -319,6 +320,7 @@ const fixData = async ({
         showOnFeed: !data?.order,
         sentAnalyticsReport: privacy || !authorId,
       },
+      yggdrasilId: data?.id,
     },
   };
 };


### PR DESCRIPTION
We decided to add the Yggdrasil id to the post API.
For now it can simply be set, no need to expose it anywhere.