### PR TITLE
chore: disable temporarily cdc for changes in yggdrasil id

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -13,11 +13,14 @@ debezium.source.plugin.name=pgoutput
 debezium.source.heartbeat.interval.ms=60000
 debezium.source.topic.prefix=t
 debezium.source.tombstones.on.delete=false
-debezium.transforms=Reroute,ReadOperationFilter
+debezium.transforms=Reroute,ReadOperationFilter,YggdrasilFilter
 debezium.transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
 debezium.transforms.Reroute.topic.regex=(.*)
 debezium.transforms.Reroute.topic.replacement=%topic%
 debezium.transforms.ReadOperationFilter.type=io.debezium.transforms.Filter
 debezium.transforms.ReadOperationFilter.language=jsr223.groovy
 debezium.transforms.ReadOperationFilter.condition=!(valueSchema.field('op') && value.op == 'r')
+debezium.transforms.YggdrasilFilter.type=io.debezium.transforms.Filter
+debezium.transforms.YggdrasilFilter.language=jsr223.groovy
+debezium.transforms.YggdrasilFilter.condition=!(valueSchema.field('op') && value.op == 'u' && value.source.table == 'post' && !value.before.yggdrasilId && value.after.yggdrasilId)
 debezium.sink.type=pubsub


### PR DESCRIPTION
I'd like to backfill yggdrasil ids which is something like 50k records. I don't want to trigger CDC and flood the queue. Please make sure that my condition is correct in your review.