### PR TITLE
fix: extend redis cache on each visit

### DIFF
--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -368,9 +368,7 @@ const getAnonymousFirstVisit = async (trackingId: string) => {
   const firstVisit = await getRedisObject(key);
   const finalValue = firstVisit ?? new Date().toISOString();
 
-  if (!firstVisit) {
-    await setRedisObjectWithExpiry(key, finalValue, ONE_DAY_IN_SECONDS * 30);
-  }
+  await setRedisObjectWithExpiry(key, finalValue, ONE_DAY_IN_SECONDS * 30);
 
   return finalValue;
 };


### PR DESCRIPTION
Decided to simply set the value, which in turn will reset the TTL.
Also added dedicated test case to ensure TTL get's reset.

Tested locally as well by comparing TTL on redis pool.

WT-1655 #done 