### PR TITLE
feat: add user post table and mutations

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3703,6 +3703,7 @@ describe('mutation dismissPostFeedback', () => {
     expect(userPost).toMatchObject({
       userId: loggedUser,
       postId: 'p1',
+      vote: UserPostVote.None,
       flags: { feedbackDismiss: true },
     });
   });
@@ -3712,6 +3713,7 @@ describe('mutation dismissPostFeedback', () => {
     await con.getRepository(UserPost).save({
       userId: loggedUser,
       postId: 'p1',
+      vote: UserPostVote.Up,
       flags: { feedbackDismiss: false },
     });
     const res = await client.mutate(MUTATION, {
@@ -3725,6 +3727,7 @@ describe('mutation dismissPostFeedback', () => {
     expect(userPost).toMatchObject({
       userId: loggedUser,
       postId: 'p1',
+      vote: UserPostVote.Up,
       flags: { feedbackDismiss: true },
     });
   });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -33,6 +33,9 @@ import {
   WelcomePost,
   Downvote,
   PostQuestion,
+  UserPost,
+  userPostDefaultData,
+  UserPostVote,
 } from '../src/entity';
 import { SourceMemberRoles, sourceRoleRank } from '../src/roles';
 import { sourcesFixture } from './fixture/source';
@@ -53,11 +56,6 @@ import { randomUUID } from 'crypto';
 import nock from 'nock';
 import { deleteKeysByPattern } from '../src/redis';
 import { checkHasMention } from '../src/common/markdown';
-import {
-  UserPost,
-  userPostDefaultData,
-  UserPostVote,
-} from '../src/entity/UserPost';
 
 jest.mock('../src/common/pubsub', () => ({
   ...(jest.requireActual('../src/common/pubsub') as Record<string, unknown>),

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3515,7 +3515,7 @@ describe('mutation votePost', () => {
       client,
       {
         mutation: MUTATION,
-        variables: { id: 'p1', vote: 'invalid' },
+        variables: { id: 'p1', vote: 3 },
       },
       'GRAPHQL_VALIDATION_FAILED',
     );

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -34,7 +34,6 @@ import {
   Downvote,
   PostQuestion,
   UserPost,
-  userPostDefaultData,
   UserPostVote,
 } from '../src/entity';
 import { SourceMemberRoles, sourceRoleRank } from '../src/roles';
@@ -3490,7 +3489,12 @@ describe('userState field', () => {
   it('should return default state if state does not exist', async () => {
     loggedUser = '1';
     const res = await client.query(QUERY);
-    expect(res.data.post.userState).toMatchObject(userPostDefaultData);
+    const { vote, hidden, flags } = con.getRepository(UserPost).create();
+    expect(res.data.post.userState).toMatchObject({
+      vote,
+      hidden,
+      flags,
+    });
   });
 
   it('should return user state', async () => {
@@ -3707,7 +3711,6 @@ describe('mutation votePost', () => {
       postId: 'p1',
       userId: loggedUser,
     });
-    console.log(userPostBefore);
     const res = await client.mutate(MUTATION, {
       variables: { id: 'p1', vote: UserPostVote.Up },
     });

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -43,6 +43,9 @@ export class UserPost {
   @UpdateDateColumn()
   updatedAt: Date;
 
+  @Column({ default: null, nullable: true })
+  votedAt: Date;
+
   @Column({ type: 'smallint', default: UserPostVote.None })
   vote: UserPostVote;
 

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -22,12 +22,6 @@ export enum UserPostVote {
   Down = -1,
 }
 
-export const userPostDefaultData = Object.freeze({
-  vote: UserPostVote.None,
-  hidden: false,
-  flags: {},
-});
-
 @Entity()
 @Index(['postId', 'userId'], { unique: true })
 export class UserPost {
@@ -47,13 +41,13 @@ export class UserPost {
   votedAt: Date;
 
   @Column({ type: 'smallint', default: UserPostVote.None })
-  vote: UserPostVote;
+  vote: UserPostVote = UserPostVote.None;
 
-  @Column({ default: false })
-  hidden: boolean;
+  @Column({ type: 'boolean', default: false })
+  hidden = false;
 
   @Column({ type: 'jsonb', default: {} })
-  flags: UserPostFlags;
+  flags: UserPostFlags = {};
 
   @ManyToOne(() => Post, {
     lazy: true,

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -11,10 +11,10 @@ import { Post } from './posts';
 import { User } from './User';
 
 export type UserPostFlags = Partial<{
-  feedbackDimiss: boolean;
+  feedbackDismiss: boolean;
 }>;
 
-export type UserPostFlagsPublic = Pick<UserPostFlags, 'feedbackDimiss'>;
+export type UserPostFlagsPublic = Pick<UserPostFlags, 'feedbackDismiss'>;
 
 export enum UserPostVote {
   Up = 1,

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -22,6 +22,12 @@ export enum UserPostVote {
   Down = -1,
 }
 
+export const userPostDefaultData = Object.freeze({
+  vote: UserPostVote.None,
+  hidden: false,
+  flags: {},
+});
+
 @Entity()
 @Index(['postId', 'userId'], { unique: true })
 export class UserPost {

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -37,7 +37,7 @@ export class UserPost {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ type: 'smallint' })
+  @Column({ type: 'smallint', default: UserPostVote.None })
   vote: UserPostVote;
 
   @Column({ default: false })

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Post } from './posts';
+import { User } from './User';
+
+export type UserPostFlags = Partial<{
+  feedbackDimiss: boolean;
+}>;
+
+export type UserPostFlagsPublic = Pick<UserPostFlags, 'feedbackDimiss'>;
+
+export enum UserPostVote {
+  Up = 1,
+  None = 0,
+  Down = -1,
+}
+
+@Entity()
+@Index(['postId', 'userId'], { unique: true })
+export class UserPost {
+  @PrimaryColumn({ type: 'text' })
+  postId: string;
+
+  @PrimaryColumn({ type: 'text' })
+  userId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ type: 'smallint' })
+  vote: UserPostVote;
+
+  @Column({ default: false })
+  hidden: boolean;
+
+  @Column({ type: 'jsonb', default: {} })
+  flags: UserPostFlags;
+
+  @ManyToOne(() => Post, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  post: Promise<Post>;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -36,3 +36,4 @@ export * from './notifications';
 export * from './Feature';
 export * from './UserAction';
 export * from './ContentImage';
+export * from './UserPost';

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -167,6 +167,16 @@ const obj = new GraphORM({
       flags: {
         jsonType: true,
       },
+      userState: {
+        relation: {
+          isMany: false,
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
+            return qb
+              .where(`${childAlias}."userId" = :userId`, { userId: ctx.userId })
+              .andWhere(`${childAlias}."postId" = "${parentAlias}".id`);
+          },
+        },
+      },
     },
   },
   Source: {
@@ -395,6 +405,13 @@ const obj = new GraphORM({
           childColumn: 'notificationId',
           parentColumn: 'id',
         },
+      },
+    },
+  },
+  UserPost: {
+    fields: {
+      flags: {
+        jsonType: true,
       },
     },
   },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -21,6 +21,8 @@ import { Context } from '../Context';
 import { GQLBookmarkList } from '../schema/bookmarks';
 import { base64 } from '../common';
 import { GQLComment } from '../schema/comments';
+import { GQLUserPost } from '../schema/posts';
+import { userPostDefaultData } from '../entity/UserPost';
 
 const existsByUserAndPost =
   (entity: string) =>
@@ -175,6 +177,17 @@ const obj = new GraphORM({
               .where(`${childAlias}."userId" = :userId`, { userId: ctx.userId })
               .andWhere(`${childAlias}."postId" = "${parentAlias}".id`);
           },
+        },
+        transform: (value: GQLUserPost, ctx: Context) => {
+          if (!ctx.userId) {
+            return null;
+          }
+
+          if (!value) {
+            return userPostDefaultData;
+          }
+
+          return value;
         },
       },
     },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -9,6 +9,7 @@ import {
   Source,
   SourceMember,
   User,
+  userPostDefaultData,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -22,7 +23,6 @@ import { GQLBookmarkList } from '../schema/bookmarks';
 import { base64 } from '../common';
 import { GQLComment } from '../schema/comments';
 import { GQLUserPost } from '../schema/posts';
-import { userPostDefaultData } from '../entity/UserPost';
 
 const existsByUserAndPost =
   (entity: string) =>

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -9,7 +9,7 @@ import {
   Source,
   SourceMember,
   User,
-  userPostDefaultData,
+  UserPost,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -184,7 +184,7 @@ const obj = new GraphORM({
           }
 
           if (!value) {
-            return userPostDefaultData;
+            return ctx.con.getRepository(UserPost).create();
           }
 
           return value;

--- a/src/migration/1691668733329-UserPost.ts
+++ b/src/migration/1691668733329-UserPost.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserPost1691668733329 implements MigrationInterface {
+    name = 'UserPost1691668733329'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "user_post" ("postId" text NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "vote" smallint NOT NULL, "hidden" boolean NOT NULL DEFAULT false, "flags" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "PK_45cdc90ca0fd4cf0f8e8026e395" PRIMARY KEY ("postId", "userId"))`);
+        await queryRunner.query(`ALTER TABLE "user_post" REPLICA IDENTITY FULL`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_45cdc90ca0fd4cf0f8e8026e39" ON "user_post" ("postId", "userId") `);
+        await queryRunner.query(`ALTER TABLE "user_post" ADD CONSTRAINT "FK_3eb8e2db42e1474c4e900b96688" FOREIGN KEY ("postId") REFERENCES "post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "user_post" ADD CONSTRAINT "FK_61c64496bf096b321869175021a" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_post" DROP CONSTRAINT "FK_61c64496bf096b321869175021a"`);
+        await queryRunner.query(`ALTER TABLE "user_post" DROP CONSTRAINT "FK_3eb8e2db42e1474c4e900b96688"`);
+        await queryRunner.query(`DROP TABLE "user_post"`);
+    }
+
+}

--- a/src/migration/1691668733329-UserPost.ts
+++ b/src/migration/1691668733329-UserPost.ts
@@ -17,16 +17,19 @@ export class UserPost1691668733329 implements MigrationInterface {
             AS
           $$
           BEGIN
-            UPDATE user_post SET "votedAt" = now();
+            NEW."votedAt" = now();
             RETURN NEW;
           END;
           $$
         `)
-        await queryRunner.query('CREATE TRIGGER voted_insert_trigger AFTER INSERT ON "user_post" FOR EACH ROW WHEN (NEW.vote != 0) EXECUTE PROCEDURE voted_at_time()')
-        await queryRunner.query('CREATE TRIGGER voted_update_trigger AFTER UPDATE ON "user_post" FOR EACH ROW WHEN (OLD.vote IS DISTINCT FROM NEW.vote) EXECUTE PROCEDURE voted_at_time()')
+        await queryRunner.query('CREATE TRIGGER voted_insert_trigger BEFORE INSERT ON "user_post" FOR EACH ROW WHEN (NEW.vote != 0) EXECUTE PROCEDURE voted_at_time()')
+        await queryRunner.query('CREATE TRIGGER voted_update_trigger BEFORE UPDATE ON "user_post" FOR EACH ROW WHEN (OLD.vote IS DISTINCT FROM NEW.vote) EXECUTE PROCEDURE voted_at_time()')
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP TRIGGER IF EXISTS voted_update_trigger ON "user_post"')
+        await queryRunner.query('DROP TRIGGER IF EXISTS voted_insert_trigger ON "user_post"')
+        await queryRunner.query('DROP FUNCTION IF EXISTS voted_at_time')
         await queryRunner.query(`ALTER TABLE "user_post" DROP CONSTRAINT "FK_61c64496bf096b321869175021a"`);
         await queryRunner.query(`ALTER TABLE "user_post" DROP CONSTRAINT "FK_3eb8e2db42e1474c4e900b96688"`);
         await queryRunner.query(`DROP TABLE "user_post"`);

--- a/src/migration/1691668733329-UserPost.ts
+++ b/src/migration/1691668733329-UserPost.ts
@@ -4,11 +4,26 @@ export class UserPost1691668733329 implements MigrationInterface {
     name = 'UserPost1691668733329'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "user_post" ("postId" text NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "vote" smallint NOT NULL DEFAULT '0', "hidden" boolean NOT NULL DEFAULT false, "flags" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "PK_45cdc90ca0fd4cf0f8e8026e395" PRIMARY KEY ("postId", "userId"))`);
+        await queryRunner.query(`CREATE TABLE "user_post" ("postId" text NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "votedAt" TIMESTAMP, "vote" smallint NOT NULL DEFAULT '0', "hidden" boolean NOT NULL DEFAULT false, "flags" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "PK_45cdc90ca0fd4cf0f8e8026e395" PRIMARY KEY ("postId", "userId"))`);
         await queryRunner.query(`ALTER TABLE "user_post" REPLICA IDENTITY FULL`);
         await queryRunner.query(`CREATE UNIQUE INDEX "IDX_45cdc90ca0fd4cf0f8e8026e39" ON "user_post" ("postId", "userId") `);
         await queryRunner.query(`ALTER TABLE "user_post" ADD CONSTRAINT "FK_3eb8e2db42e1474c4e900b96688" FOREIGN KEY ("postId") REFERENCES "post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "user_post" ADD CONSTRAINT "FK_61c64496bf096b321869175021a" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+
+        await queryRunner.query(`
+          CREATE OR REPLACE FUNCTION voted_at_time()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL
+            AS
+          $$
+          BEGIN
+            UPDATE user_post SET "votedAt" = now();
+            RETURN NEW;
+          END;
+          $$
+        `)
+        await queryRunner.query('CREATE TRIGGER voted_insert_trigger AFTER INSERT ON "user_post" FOR EACH ROW WHEN (NEW.vote != 0) EXECUTE PROCEDURE voted_at_time()')
+        await queryRunner.query('CREATE TRIGGER voted_update_trigger AFTER UPDATE ON "user_post" FOR EACH ROW WHEN (OLD.vote IS DISTINCT FROM NEW.vote) EXECUTE PROCEDURE voted_at_time()')
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/migration/1691668733329-UserPost.ts
+++ b/src/migration/1691668733329-UserPost.ts
@@ -4,7 +4,7 @@ export class UserPost1691668733329 implements MigrationInterface {
     name = 'UserPost1691668733329'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "user_post" ("postId" text NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "vote" smallint NOT NULL, "hidden" boolean NOT NULL DEFAULT false, "flags" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "PK_45cdc90ca0fd4cf0f8e8026e395" PRIMARY KEY ("postId", "userId"))`);
+        await queryRunner.query(`CREATE TABLE "user_post" ("postId" text NOT NULL, "userId" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "vote" smallint NOT NULL DEFAULT '0', "hidden" boolean NOT NULL DEFAULT false, "flags" jsonb NOT NULL DEFAULT '{}', CONSTRAINT "PK_45cdc90ca0fd4cf0f8e8026e395" PRIMARY KEY ("postId", "userId"))`);
         await queryRunner.query(`ALTER TABLE "user_post" REPLICA IDENTITY FULL`);
         await queryRunner.query(`CREATE UNIQUE INDEX "IDX_45cdc90ca0fd4cf0f8e8026e39" ON "user_post" ("postId", "userId") `);
         await queryRunner.query(`ALTER TABLE "user_post" ADD CONSTRAINT "FK_3eb8e2db42e1474c4e900b96688" FOREIGN KEY ("postId") REFERENCES "post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -459,7 +459,7 @@ export const typeDefs = /* GraphQL */ `
     """
     User state for the post
     """
-    userState: UserPost
+    userState: UserPost @auth
   }
 
   type PostConnection {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -52,6 +52,9 @@ import {
   ContentImage,
   PostQuestion,
   Downvote,
+  UserPost,
+  UserPostFlagsPublic,
+  UserPostVote,
 } from '../entity';
 import { GQLEmptyResponse } from './common';
 import {
@@ -71,11 +74,6 @@ import { markdown, saveMentions } from '../common/markdown';
 import { FileUpload } from 'graphql-upload/GraphQLUpload';
 import { insertOrIgnoreAction } from './actions';
 import { generateShortId, generateUUID } from '../ids';
-import {
-  UserPost,
-  UserPostFlagsPublic,
-  UserPostVote,
-} from '../entity/UserPost';
 
 export interface GQLPost {
   id: string;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -226,7 +226,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Whether user dismissed feedback prompt for post
     """
-    feedbackDimiss: Boolean
+    feedbackDismiss: Boolean
   }
 
   type UserPost {


### PR DESCRIPTION
- [x] add `user_post` table
- [x] update mutations to set `UserPost` entity in addition to old entities
- [x] update current tests
- [x] add new `votePost` mutation (will be used by frontend after data migration is done in other PR)
- [x] add new `userState` field
- [x] added `flags.feedbackDismiss` field and and `dismissPostFeedback` mutation (for engagement loops feature)
- [x] tests for new mutation and fields