### PR TITLE
feat: set log level through LOG_LEVEL env

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -16,6 +16,7 @@ config:
     jwtIssuer: Daily API Staging
     jwtSecret: '|r+.2!!!.Qf_-|63*%.D'
     kratosOrigin: http://heimdall-kratos-public
+    logLevel: info
     nodeEnv: development
     postScraperOrigin: http://post-scraper-one-ai-server
     pubsubEmulatorHost: pubsub:8085

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,9 @@ export default async function app(
   const connection = await createOrGetConnection();
 
   const app = fastify({
-    logger: true,
+    logger: {
+      level: process.env.LOG_LEVEL || 'info',
+    },
     disableRequestLogging: true,
     trustProxy: true,
   });


### PR DESCRIPTION
Add env to control log level of the app. Useful in development when debugging events for `/e` endpoint.

Falls back to `info` if not defined per [docs](https://github.com/fastify/fastify/blob/main/docs/Reference/Logging.md#enable-logging). 