### PR TITLE
feat: copy user post data from old to new table

### DIFF
--- a/bin/copyUserPostHiddenData.ts
+++ b/bin/copyUserPostHiddenData.ts
@@ -1,0 +1,37 @@
+import '../src/config';
+import createOrGetConnection from '../src/db';
+
+(async (): Promise<void> => {
+  const limitArgument = process.argv[2];
+  const offsetArgument = process.argv[3];
+
+  if (!limitArgument || !offsetArgument) {
+    throw new Error('limit and offset arguments are required');
+  }
+
+  const limit = +limitArgument;
+
+  if (Number.isNaN(limit)) {
+    throw new Error('limit argument is invalid, it should be a number');
+  }
+
+  const offset = +offsetArgument;
+
+  if (Number.isNaN(offset)) {
+    throw new Error('offset argument is invalid, it should be a number');
+  }
+
+  const con = await createOrGetConnection();
+
+  await con.transaction(async (manager) => {
+    await manager.query(`
+      INSERT INTO user_post ("postId", "userId", hidden)
+      SELECT "postId", "userId", true AS hidden
+      FROM hidden_post
+      LIMIT ${limit} OFFSET ${offset}
+      ON CONFLICT ("postId", "userId") DO UPDATE SET hidden = true;
+    `);
+  });
+
+  process.exit();
+})();

--- a/bin/copyUserPostVoteData.ts
+++ b/bin/copyUserPostVoteData.ts
@@ -1,6 +1,6 @@
 import '../src/config';
 import createOrGetConnection from '../src/db';
-import { Downvote, HiddenPost, Upvote } from '../src/entity';
+import { Downvote, Upvote } from '../src/entity';
 
 (async (): Promise<void> => {
   const entityArgument = process.argv[2];
@@ -10,7 +10,6 @@ import { Downvote, HiddenPost, Upvote } from '../src/entity';
   const argumentToEntityMap = {
     Upvote: Upvote,
     Downvote: Downvote,
-    HiddenPost: HiddenPost,
   };
   const entity = argumentToEntityMap[entityArgument];
 
@@ -82,14 +81,6 @@ import { Downvote, HiddenPost, Upvote } from '../src/entity';
           FROM downvote
           WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
           ON CONFLICT ("postId", "userId") DO UPDATE SET "votedAt" = EXCLUDED."votedAt";
-        `);
-        break;
-      case HiddenPost:
-        await manager.query(`
-          INSERT INTO user_post ("postId", "userId", hidden)
-          SELECT "postId", "userId", true AS hidden
-          FROM hidden_post
-          ON CONFLICT ("postId", "userId") DO UPDATE SET hidden = true;
         `);
         break;
       default:

--- a/bin/syncUserPostData.ts
+++ b/bin/syncUserPostData.ts
@@ -1,0 +1,87 @@
+import '../src/config';
+import createOrGetConnection from '../src/db';
+import { Downvote, HiddenPost, Upvote } from '../src/entity';
+
+(async (): Promise<void> => {
+  const entityArgument = process.argv[2];
+  const createdFromArgument = process.argv[3];
+  const createdToArgument = process.argv[4];
+
+  const argumentToEntityMap = {
+    Upvote: Upvote,
+    Downvote: Downvote,
+    HiddenPost: HiddenPost,
+  };
+  const entity = argumentToEntityMap[entityArgument];
+
+  if (!entity) {
+    throw new Error(
+      `Invalid entity, select one from: ${Object.keys(argumentToEntityMap).join(
+        ', ',
+      )}`,
+    );
+  }
+
+  if (!createdFromArgument || !createdToArgument) {
+    throw new Error('createdFrom and createdTo arguments are required');
+  }
+
+  const createdFromDate = new Date(createdFromArgument);
+
+  if (Number.isNaN(createdFromDate.getTime())) {
+    throw new Error(
+      'createdFromDate argument is invalid, format should be ISO 6801',
+    );
+  }
+
+  const createdToDate = new Date(createdToArgument);
+
+  if (Number.isNaN(createdToDate.getTime())) {
+    throw new Error(
+      'createdToDate argument is invalid, format should be ISO 6801',
+    );
+  }
+
+  if (createdFromDate > createdToDate) {
+    throw new Error(
+      'createdFrom argument should be less than createdTo argument',
+    );
+  }
+
+  const con = await createOrGetConnection();
+
+  await con.transaction(async (manager) => {
+    switch (entity) {
+      case Upvote:
+        await manager.query(`
+          INSERT INTO user_post ("postId", "userId", "createdAt", vote)
+          SELECT "postId", "userId", "createdAt", 1 AS vote
+          FROM upvote
+          WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
+          ON CONFLICT ("postId", "userId") DO UPDATE SET vote = 1;
+        `);
+        break;
+      case Downvote:
+        await manager.query(`
+          INSERT INTO user_post ("postId", "userId", "createdAt", vote)
+          SELECT "postId", "userId", "createdAt", -1 AS vote
+          FROM downvote
+          WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
+          ON CONFLICT ("postId", "userId") DO UPDATE SET vote = -1
+        `);
+        break;
+      case HiddenPost:
+        await manager.query(`
+          INSERT INTO user_post ("postId", "userId", hidden)
+          SELECT "postId", "userId", true AS hidden
+          FROM hidden_post
+          ON CONFLICT ("postId", "userId") DO UPDATE SET hidden = true;
+        `);
+        break;
+      default:
+        throw new Error('Unhandled entity');
+    }
+  });
+
+  process.exit();
+})();

--- a/bin/syncUserPostData.ts
+++ b/bin/syncUserPostData.ts
@@ -54,20 +54,34 @@ import { Downvote, HiddenPost, Upvote } from '../src/entity';
     switch (entity) {
       case Upvote:
         await manager.query(`
-          INSERT INTO user_post ("postId", "userId", "createdAt", vote)
-          SELECT "postId", "userId", "createdAt", 1 AS vote
+          INSERT INTO user_post ("postId", "userId", vote)
+          SELECT "postId", "userId", 1 AS vote
           FROM upvote
           WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
           ON CONFLICT ("postId", "userId") DO UPDATE SET vote = 1;
         `);
+        await manager.query(`
+          INSERT INTO user_post ("postId", "userId", "votedAt")
+          SELECT "postId", "userId", "createdAt" as "votedAt"
+          FROM upvote
+          WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
+          ON CONFLICT ("postId", "userId") DO UPDATE SET "votedAt" = EXCLUDED."votedAt";
+        `);
         break;
       case Downvote:
         await manager.query(`
-          INSERT INTO user_post ("postId", "userId", "createdAt", vote)
-          SELECT "postId", "userId", "createdAt", -1 AS vote
+          INSERT INTO user_post ("postId", "userId", vote)
+          SELECT "postId", "userId", -1 AS vote
           FROM downvote
           WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
-          ON CONFLICT ("postId", "userId") DO UPDATE SET vote = -1
+          ON CONFLICT ("postId", "userId") DO UPDATE SET vote = -1;
+        `);
+        await manager.query(`
+          INSERT INTO user_post ("postId", "userId", "votedAt")
+          SELECT "postId", "userId", "createdAt" as "votedAt"
+          FROM downvote
+          WHERE "createdAt" > '${createdFromDate.toISOString()}' AND "createdAt" < '${createdToDate.toISOString()}'
+          ON CONFLICT ("postId", "userId") DO UPDATE SET "votedAt" = EXCLUDED."votedAt";
         `);
         break;
       case HiddenPost:


### PR DESCRIPTION
- [x] select and insert vote data from `upvote` and `downvote` tables to `user_post`
  - we chunk inserts per createdAt
- [x] insert hidden post data from `hidden_post` table to `user_post`
  - hidden post chunking is done with limit/offset because it does not have `createdAt`
- [x] `votedAt` is updated per old table `createdAt` to preserve vote timestamp

Migration is split into two scripts due to different chunking options as noted above. Did not want to complicate further.