### PR TITLE
fix: add feed config names

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -871,6 +871,56 @@ Object {
 }
 `;
 
+exports[`query anonymousFeed should return anonymous feed vector type 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
 exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
 Object {
   "anonymousFeed": Object {
@@ -1368,6 +1418,56 @@ Object {
 `;
 
 exports[`query feed should respect the supportedTypes argument 1`] = `
+Object {
+  "feed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "url": "http://p4.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "url": "http://p1.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "c2NvcmU6MQ==",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
+
+exports[`query feed should respect the supportedTypes argument 2`] = `
 Object {
   "feed": Object {
     "edges": Array [
@@ -2537,6 +2637,8 @@ Object {
   },
 }
 `;
+
+exports[`query randomDiscussedPosts should filter out the given post 1`] = `null`;
 
 exports[`query searchPostSuggestions should return search suggestions 1`] = `
 Object {

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -1467,56 +1467,6 @@ Object {
 }
 `;
 
-exports[`query feed should respect the supportedTypes argument 2`] = `
-Object {
-  "feed": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "id": "p4",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "backend",
-            "data",
-            "javascript",
-          ],
-          "title": "P4",
-          "url": "http://p4.com",
-        },
-      },
-      Object {
-        "node": Object {
-          "id": "p1",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "javascript",
-            "webdev",
-          ],
-          "title": "P1",
-          "url": "http://p1.com",
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "c2NvcmU6MQ==",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
-
 exports[`query feed should return feed v2 1`] = `
 Object {
   "feed": Object {
@@ -2637,8 +2587,6 @@ Object {
   },
 }
 `;
-
-exports[`query randomDiscussedPosts should filter out the given post 1`] = `null`;
 
 exports[`query searchPostSuggestions should return search suggestions 1`] = `
 Object {

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1152,7 +1152,7 @@ describe('query mostDiscussedFeed', () => {
       .getRepository(Source)
       .update({ id: 'squad' }, { type: SourceType.Squad });
     const repo = con.getRepository(Post);
-    await repo.update({ id: 'p1' }, { comments: 5 });
+    await repo.update({ id: 'p1' }, { comments: 6 });
     await repo.update({ id: 'p3' }, { comments: 5 });
     await repo.update({ id: 'p2' }, { comments: 5, sourceId: 'squad' });
 
@@ -1166,7 +1166,7 @@ describe('query mostDiscussedFeed', () => {
       .getRepository(Source)
       .update({ id: 'squad' }, { type: SourceType.Squad, private: false });
     const repo = con.getRepository(Post);
-    await repo.update({ id: 'p1' }, { comments: 5 });
+    await repo.update({ id: 'p1' }, { comments: 6 });
     await repo.update({ id: 'p3' }, { comments: 5 });
     await repo.update({ id: 'p2' }, { comments: 5, sourceId: 'squad' });
 

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -361,7 +361,7 @@ describe('query anonymousFeed', () => {
         total_pages: 40,
         page_size: 11,
         fresh_page_size: '4',
-        feed_version: 2,
+        feed_config_name: 'personalise',
         feed_id: 'global',
       })
       .reply(200, {
@@ -373,13 +373,31 @@ describe('query anonymousFeed', () => {
     expect(res.data).toMatchSnapshot();
   });
 
+  it('should return anonymous feed vector type', async () => {
+    nock('http://localhost:6000')
+      .post('/feed.json', {
+        total_pages: 40,
+        page_size: 11,
+        fresh_page_size: '4',
+        feed_config_name: 'vector',
+        feed_id: 'global',
+      })
+      .reply(200, {
+        data: [{ post_id: 'p1' }, { post_id: 'p4' }],
+      });
+    const res = await client.query(QUERY, {
+      variables: { ...variables, version: 14 },
+    });
+    expect(res.data).toMatchSnapshot();
+  });
+
   it('should safetly handle a case where the feed is empty', async () => {
     nock('http://localhost:6000')
       .post('/feed.json', {
         total_pages: 40,
         page_size: 11,
         fresh_page_size: '4',
-        feed_version: 2,
+        feed_config_name: 'personalise',
         feed_id: 'global',
       })
       .reply(200, {
@@ -411,7 +429,7 @@ describe('query anonymousFeed', () => {
         total_pages: 40,
         page_size: 11,
         fresh_page_size: '4',
-        feed_version: 2,
+        feed_config_name: 'personalise',
         user_id: '1',
         feed_id: 'global',
       })
@@ -587,7 +605,7 @@ describe('query feed', () => {
         total_pages: 40,
         page_size: 11,
         fresh_page_size: '4',
-        feed_version: 2,
+        feed_config_name: 'personalise',
         user_id: '1',
         feed_id: '1',
         allowed_tags: ['javascript', 'golang'],
@@ -610,7 +628,7 @@ describe('query feed', () => {
         total_pages: 40,
         page_size: 11,
         fresh_page_size: '4',
-        feed_version: 2,
+        feed_config_name: 'personalise',
         user_id: '1',
         feed_id: '1',
       })

--- a/__tests__/personalizedFeed.ts
+++ b/__tests__/personalizedFeed.ts
@@ -59,7 +59,7 @@ it('should fetch anonymous feed and serve consequent pages from cache', async ()
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       feed_id: 'global',
     })
     .reply(200, feedResponse);
@@ -93,7 +93,7 @@ it('should fetch anonymous feed and serve consequent calls from cache', async ()
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       feed_id: 'global',
     })
     .reply(200, feedResponse);
@@ -134,7 +134,7 @@ it('should fetch anonymous feed even when cache is old', async () => {
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       feed_id: 'global',
     })
     .reply(200, feedResponse);
@@ -166,7 +166,7 @@ it('should not fetch anonymous feed even when cache is still fresh', async () =>
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
     })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({
@@ -203,7 +203,7 @@ it('should fetch anonymous feed when last updated time is greater than last gene
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       feed_id: 'global',
     })
     .reply(200, feedResponse);
@@ -237,7 +237,7 @@ it('should set the correct query parameters', async () => {
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       user_id: 'u1',
       feed_id: '1',
       allowed_tags: ['javascript', 'golang'],
@@ -268,7 +268,7 @@ it('should encode query parameters', async () => {
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       user_id: 'u1',
       feed_id: '1',
       allowed_tags: ['c#'],
@@ -310,7 +310,7 @@ it('should send source memberships as parameter', async () => {
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
       user_id: '1',
       feed_id: '1',
       squad_ids: ['a', 'b'],
@@ -343,7 +343,7 @@ it('should support legacy cache format', async () => {
       total_pages: 40,
       page_size: 2,
       fresh_page_size: '1',
-      feed_version: 5,
+      feed_config_name: 'personalise',
     })
     .reply(200, feedResponse);
   const page0 = await generatePersonalizedFeed({

--- a/src/personalizedFeed.ts
+++ b/src/personalizedFeed.ts
@@ -198,7 +198,6 @@ async function fetchAndCacheFeed(
 const shouldServeFromCache = async (
   offset: number,
   key: string,
-  feedVersion: number,
   feedId?: string,
 ): Promise<boolean> => {
   if (offset) {
@@ -210,13 +209,12 @@ const shouldServeFromCache = async (
       return client.mget(`${key}:time`, updateKey);
     },
   );
-  const ttl = feedVersion != 8 ? 3 * 60 * 1000 : 60 * 1000;
+  const ttl = 3 * 60 * 1000;
   return !(
     !lastGenerated ||
     (lastUpdated && lastUpdated > lastGenerated) ||
     new Date().getTime() - new Date(lastGenerated).getTime() > ttl
   );
-  // return !key;
 };
 
 export async function generatePersonalizedFeed({
@@ -245,7 +243,7 @@ export async function generatePersonalizedFeed({
       await runInSpan(
         ctx?.span,
         'Feed_v2.shouldServeFromCache',
-        () => shouldServeFromCache(offset, key, feedVersion, feedId),
+        () => shouldServeFromCache(offset, key, feedId),
         {
           offset,
           key,


### PR DESCRIPTION
Changed the final feed version to be mapped to feed_config_name.
Supporting only the two names at the moment.

I decided to keep the internal based on version, not sure that was intended behaviour?

WT-1661 #done 