### PR TITLE
feat: feed by config query

### DIFF
--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -218,7 +218,7 @@ describe('FeedPreferencesConfigGenerator', () => {
       fresh_page_size: '1',
       offset: 3,
       page_size: 2,
-      squad_ids: ['a', 'b'],
+      squad_ids: expect.arrayContaining(['a', 'b']),
       total_pages: 20,
       user_id: '1',
     });

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -211,9 +211,9 @@ describe('FeedPreferencesConfigGenerator', () => {
 
     const actual = await generator.generate(ctx, '1', 2, 3);
     expect(actual).toEqual({
-      allowed_tags: ['javascript', 'golang'],
-      blocked_sources: ['a', 'b'],
-      blocked_tags: ['python', 'java'],
+      allowed_tags: expect.arrayContaining(['javascript', 'golang']),
+      blocked_sources: expect.arrayContaining(['a', 'b']),
+      blocked_tags: expect.arrayContaining(['python', 'java']),
       feed_config_name: FeedConfigName.Personalise,
       fresh_page_size: '1',
       offset: 3,
@@ -232,8 +232,8 @@ describe('FeedPreferencesConfigGenerator', () => {
 
     const actual = await generator.generate(ctx, '1', 2, 3);
     expect(actual).toEqual({
-      blocked_sources: ['a', 'b'],
-      blocked_tags: ['python', 'java'],
+      blocked_sources: expect.arrayContaining(['a', 'b']),
+      blocked_tags: expect.arrayContaining(['python', 'java']),
       feed_config_name: FeedConfigName.Personalise,
       fresh_page_size: '1',
       offset: 3,

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -42,8 +42,8 @@ export class FeedGenerator {
   }
 }
 
-const client = new FeedClient();
-export const cachedFeedClient = new CachedFeedClient(client, ioRedisPool);
+export const feedClient = new FeedClient();
+export const cachedFeedClient = new CachedFeedClient(feedClient, ioRedisPool);
 const opts = {
   includeBlockedTags: true,
   includeAllowedTags: true,

--- a/src/integrations/feed/index.ts
+++ b/src/integrations/feed/index.ts
@@ -9,4 +9,5 @@ export {
   feedGenerators,
   versionToFeedGenerator,
   cachedFeedClient,
+  feedClient,
 } from './generators';


### PR DESCRIPTION
New query to allow me experiment with different feed configs. This is enabled only in the private api mode so it shouldn't leak to users and cannot be abused.