### PR TITLE
fix: always return search recs when possible

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -55,7 +55,6 @@ import {
   UserPost,
   UserPostFlagsPublic,
   UserPostVote,
-  NotificationPreference,
 } from '../entity';
 import { GQLEmptyResponse } from './common';
 import {


### PR DESCRIPTION
Previous query took 5 recent upvotes without checking whether there are any questions related to these posts. I added a check to make sure we always return search recs when possible.