### PR TITLE
fix: remove sub query to improve performance

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1123,16 +1123,10 @@ export const resolvers: IResolvers<any, Context> = {
         queryBuilder: builder.queryBuilder
           .innerJoin(
             (query) => {
-              const sub = query
-                .subQuery()
-                .select('id')
-                .from(PostQuestion, 'pq')
-                .where(`"pq"."postId" = "up"."postId"`);
               return query
                 .select('up."postId"')
                 .from(UserPost, 'up')
                 .where({ userId: ctx.userId, vote: UserPostVote.Up })
-                .andWhere(`exists(${sub.getQuery()})`)
                 .orderBy('up."votedAt"', 'DESC')
                 .limit(10);
             },


### PR DESCRIPTION
Remove sub query to improve performance. Can introduce a case where some users will not get questions.