### PR TITLE
feat: add userState.vote for companion boot

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -25,6 +25,7 @@ import {
   SQUAD_IMAGE_PLACEHOLDER,
   SquadSource,
   User,
+  UserPostVote,
 } from '../src/entity';
 import { SourceMemberRoles, sourceRoleRank } from '../src/roles';
 import { notificationFixture } from './fixture/notifications';
@@ -889,6 +890,7 @@ describe('companion boot', () => {
     trending: null,
     upvoted: null,
     downvoted: null,
+    userState: null,
   };
 
   it('should support anonymous user', async () => {
@@ -918,6 +920,9 @@ describe('companion boot', () => {
         bookmarked: false,
         upvoted: false,
         downvoted: false,
+        userState: {
+          vote: UserPostVote.None,
+        },
       },
     });
   });

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -501,6 +501,9 @@ const COMPANION_QUERY = parse(`query Post($url: String) {
             id
           }
           downvoted
+          userState {
+            vote
+          }
         }
       }`);
 


### PR DESCRIPTION
Companion was missing `userState.vote` to be able to use new vote state. In scope of changes for engagement loop.

https://github.com/dailydotdev/apps/pull/2164