### PR TITLE
feat: provide user attributes as part of boot

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -14,6 +14,8 @@ import {
   ALERTS_DEFAULT,
   ArticlePost,
   Banner,
+  Feature,
+  FeatureType,
   MachineSource,
   Notification,
   Post,
@@ -70,7 +72,7 @@ const BASE_BODY = {
     sessionId: expect.any(String),
     visitId: expect.any(String),
   },
-  exp: { f: 'enc', e: [] },
+  exp: { f: 'enc', e: [], a: {} },
 };
 
 const LOGGED_IN_BODY = {
@@ -864,6 +866,20 @@ describe('boot experimentation', () => {
       .set('Cookie', 'ory_kratos_session=value;')
       .expect(200);
     expect(res.body.exp.e).toEqual([base64('e1:v1'), base64('e2:v2')]);
+  });
+
+  it('should return features as attributes', async () => {
+    mockLoggedIn();
+    await con.getRepository(Feature).save({
+      userId: '1',
+      feature: FeatureType.Search,
+    });
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('Cookie', 'ory_kratos_session=value;')
+      .expect(200);
+    expect(res.body.exp.a).toEqual({ search: true });
   });
 });
 

--- a/src/entity/Feature.ts
+++ b/src/entity/Feature.ts
@@ -3,6 +3,7 @@ import { User } from './User';
 
 export enum FeatureType {
   Squad = 'squad',
+  Search = 'search',
 }
 
 @Entity()

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import createOrGetConnection from '../db';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import { clearAuthentication, dispatchWhoami } from '../kratos';
 import { generateTrackingId } from '../ids';
 import { generateSessionId, setTrackingId } from '../tracking';
@@ -10,6 +10,7 @@ import {
   Alerts,
   ALERTS_DEFAULT,
   Banner,
+  Feature,
   getUnreadNotificationsCount,
   Post,
   Settings,
@@ -63,6 +64,7 @@ export type BootSquadSource = Omit<GQLSource, 'currentMember'> & {
 export type Experimentation = {
   f: string;
   e: string[];
+  a: Record<string, unknown>;
 };
 
 export type BaseBoot = {
@@ -304,10 +306,14 @@ export function getReferralFromCookie({
   };
 }
 
-const getExperimentation = async (userId: string): Promise<Experimentation> => {
-  const hash = await ioRedisPool.execute((client) =>
-    client.hgetall(`exp:${userId}`),
-  );
+const getExperimentation = async (
+  userId: string,
+  con: DataSource | EntityManager,
+): Promise<Experimentation> => {
+  const [hash, features] = await Promise.all([
+    ioRedisPool.execute((client) => client.hgetall(`exp:${userId}`)),
+    con.getRepository(Feature).findBy({ userId }),
+  ]);
   const e = Object.keys(hash || {}).map((key) => {
     const [variation] = hash[key].split(':');
     return base64(`${key}:${variation}`);
@@ -315,6 +321,7 @@ const getExperimentation = async (userId: string): Promise<Experimentation> => {
   return {
     f: getEncryptedFeatures(),
     e,
+    a: features.reduce((acc, { feature }) => ({ [feature]: true }), {}),
   };
 };
 
@@ -349,7 +356,7 @@ const loggedInBoot = async (
     getSquads(con, userId),
     getAndUpdateLastChangelogRedis(con),
     getAndUpdateLastBannerRedis(con),
-    getExperimentation(userId),
+    getExperimentation(userId, con),
     middleware ? middleware(con, req, res) : {},
   ]);
   if (!user) {
@@ -421,7 +428,7 @@ const anonymousBoot = async (
     getUserFeatureFlags(req, con),
     middleware ? middleware(con, req, res) : {},
     getAnonymousFirstVisit(req.trackingId),
-    getExperimentation(req.trackingId),
+    getExperimentation(req.trackingId, con),
   ]);
   const isPreOnboardingV2 = firstVisit
     ? new Date(firstVisit) < onboardingV2Requirement


### PR DESCRIPTION
To reduce growthbook payload size we have to use user attributes. This will allow us to move from defining hard coded user ids on GB to having them on our database. Hence, it will reduce significantly the payload.

NOTE: Requires apps changes but not blocking this PR