### PR TITLE
fix: test case and update type based on content type

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -3,6 +3,7 @@ import worker from '../../src/workers/postUpdated';
 import {
   ArticlePost,
   COMMUNITY_PICKS_SOURCE,
+  FreeformPost,
   Keyword,
   Post,
   PostKeyword,
@@ -43,7 +44,7 @@ beforeEach(async () => {
       origin: PostOrigin.Squad,
     },
   ]);
-  await saveFixtures(con, ArticlePost, [
+  await saveFixtures(con, FreeformPost, [
     {
       id: 'p2',
       shortId: 'p2',
@@ -259,24 +260,21 @@ it('should update freeform post and only modify allowed fields', async () => {
     title: 'test',
     url: 'https://test.com',
     extra: {
+      // Sending this, as it should avoid it for freeform
       site_twitter: 'text',
       canonical_url: 'https://test.com/canon',
       content_curation: ['news', 'story', 'release'],
     },
     content_type: PostType.Freeform,
   });
-  const post = await con.getRepository(ArticlePost).findOneBy({ id: 'p2' });
+  const post = await con.getRepository(FreeformPost).findOneBy({ id: 'p2' });
   expect(post.metadataChangedAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
   expect(post.visible).toEqual(true);
   expect(post.flags.visible).toEqual(true);
   expect(post.visibleAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
   expect(post.contentCuration).toEqual(['news', 'story', 'release']);
-  expect(post.siteTwitter).toEqual('text');
   expect(post.yggdrasilId).toEqual('f99a445f-e2fb-48e8-959c-e02a17f5e816');
-
   expect(post.title).toEqual('freeform post');
-  expect(post.canonicalUrl).toBeNull();
-  expect(post.url).toBeNull();
 });
 
 it('should save keywords without special characters', async () => {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -193,7 +193,7 @@ const updatePost = async ({
   data,
   id,
   mergedKeywords,
-  content_type,
+  content_type = PostType.Article,
 }: UpdatePostProps) => {
   const postType = contentTypeFromPostType[content_type];
   const databasePost = await entityManager

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -5,6 +5,7 @@ import {
   ArticlePost,
   bannedAuthors,
   findAuthor,
+  FreeformPost,
   mergeKeywords,
   parseReadTime,
   Post,
@@ -17,6 +18,7 @@ import {
   SubmissionStatus,
   Toc,
   UNKNOWN_SOURCE,
+  WelcomePost,
 } from '../entity';
 import { SubmissionFailErrorKeys, SubmissionFailErrorMessage } from '../errors';
 import { generateShortId } from '../ids';
@@ -166,11 +168,17 @@ const allowedFieldsMapping = {
     'description',
     'metadataChangedAt',
     'readTime',
-    'siteTwitter',
     'summary',
     'tagsStr',
     'toc',
   ],
+};
+
+const contentTypeFromPostType: Record<PostType, typeof Post> = {
+  [PostType.Article]: ArticlePost,
+  [PostType.Freeform]: FreeformPost,
+  [PostType.Share]: SharePost,
+  [PostType.Welcome]: WelcomePost,
 };
 
 type UpdatePostProps = {
@@ -187,8 +195,9 @@ const updatePost = async ({
   mergedKeywords,
   content_type,
 }: UpdatePostProps) => {
+  const postType = contentTypeFromPostType[content_type];
   const databasePost = await entityManager
-    .getRepository(ArticlePost)
+    .getRepository(postType)
     .findOneBy({ id });
 
   if (data?.origin === PostOrigin.Squad) {
@@ -234,7 +243,7 @@ const updatePost = async ({
     });
   }
 
-  await entityManager.getRepository(ArticlePost).update(
+  await entityManager.getRepository(postType).update(
     { id: databasePost.id },
     {
       ...data,


### PR DESCRIPTION
We needed to distinguish between content_type => post_type mapping.
Basically the old flow was only working for ArticlePost.

Also modified test cases to ensure non existing fields don't throw errors.

Note:
Currently only works for ArticlePost and FreeformPost (expected, but good to note)