### PR TITLE
fix: add missing fields to freeform content type

### DIFF
--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -17,4 +17,13 @@ export class FreeformPost extends Post {
 
   @Column({ type: 'text', nullable: true })
   contentHtml: string;
+
+  @Column({ nullable: true })
+  readTime?: number;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ type: 'text', nullable: true })
+  summary?: string;
 }

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -170,7 +170,6 @@ const allowedFieldsMapping = {
     'readTime',
     'summary',
     'tagsStr',
-    'toc',
   ],
 };
 


### PR DESCRIPTION
The specs mention we needed to set summary as well as some other fields, which where not available on freeform post.
I added the ones we set in the specs (removed `toc` as it seemed pointless)

Also made the test a bit more concrete to what could happen, and added discussed test for welcome post.