### PR TITLE
refactor: internal feature flags to be hard coded

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -43,7 +43,11 @@ import { addDays, setMilliseconds } from 'date-fns';
 import setCookieParser from 'set-cookie-parser';
 import { postsFixture } from './fixture/post';
 import { sourcesFixture } from './fixture/source';
-import { DEFAULT_FLAGS, submitArticleThreshold } from '../src/featureFlags';
+import {
+  DEFAULT_FLAGS,
+  DEFAULT_INTERNAL_FLAGS,
+  submitArticleThreshold,
+} from '../src/featureFlags';
 import { SourcePermissions } from '../src/schema/sources';
 import { getEncryptedFeatures } from '../src/growthbook';
 import { base64 } from 'graphql-relay/utils/base64';
@@ -71,6 +75,7 @@ const BASE_BODY = {
 
 const LOGGED_IN_BODY = {
   ...BASE_BODY,
+  flags: { ...DEFAULT_FLAGS, ...DEFAULT_INTERNAL_FLAGS },
   accessToken: {
     expiresIn: expect.any(String),
     token: expect.any(String),
@@ -828,7 +833,10 @@ describe('boot feature flags', () => {
       .get(BASE_PATH)
       .set('Cookie', 'ory_kratos_session=value;')
       .expect(200);
-    expect(res.body.flags).toEqual(DEFAULT_FLAGS);
+    expect(res.body.flags).toEqual({
+      ...DEFAULT_FLAGS,
+      ...DEFAULT_INTERNAL_FLAGS,
+    });
   });
 });
 

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,6 +1,5 @@
 import { FastifyRequest } from 'fastify';
-import { DataSource } from 'typeorm';
-import { Feature, User } from './entity';
+import { User } from './entity';
 
 type FlagValue = string | number | boolean | null;
 
@@ -26,28 +25,12 @@ export const DEFAULT_FLAGS = {
   },
 };
 
-export const getInternalFeatureFlags = async (
-  con: DataSource,
-  userId?: string,
-): Promise<FeatureFlag> => {
-  if (userId) {
-    const features = await con.getRepository(Feature).findBy({ userId });
-    return features.reduce((prev, { feature }) => {
-      prev[feature] = { enabled: true };
-      return prev;
-    }, {});
-  }
-  return {};
-};
+const DEFAULT_INTERNAL_FLAGS = { squad: { enabled: true, value: '' } };
 
-export const getUserFeatureFlags = async (
-  req: FastifyRequest,
-  con: DataSource,
-): Promise<FeatureFlag> => {
-  const [external, internal] = await Promise.all([
-    Promise.resolve(DEFAULT_FLAGS),
-    getInternalFeatureFlags(con, req.userId),
-  ]);
+export const getUserFeatureFlags = (req: FastifyRequest): FeatureFlag => {
+  const external = DEFAULT_FLAGS;
+  const internal = req.userId ? DEFAULT_INTERNAL_FLAGS : {};
+
   return { ...external, ...internal };
 };
 

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -25,7 +25,7 @@ export const DEFAULT_FLAGS = {
   },
 };
 
-const DEFAULT_INTERNAL_FLAGS = { squad: { enabled: true, value: '' } };
+export const DEFAULT_INTERNAL_FLAGS = { squad: { enabled: true, value: '' } };
 
 export const getUserFeatureFlags = (req: FastifyRequest): FeatureFlag => {
   const external = DEFAULT_FLAGS;


### PR DESCRIPTION
Since everything is going through the GB flags now, we don't have to pull internal flags anymore for better performance.