### PR TITLE
fix: remove broken faker version

### DIFF
--- a/__tests__/integrations.ts
+++ b/__tests__/integrations.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import { faker } from '@faker-js/faker';
 import _ from 'lodash';
 import {
   disposeGraphQLTesting,
@@ -23,15 +23,14 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  const now = new Date();
-  const randomDate = (): Date => faker.date.past(null, now);
+  const randomDate = (): Date => faker.date.past();
   integrations = Array.from(Array(5))
     .map(() =>
       con.getRepository(Integration).create({
         timestamp: randomDate(),
-        logo: faker.image.imageUrl(),
-        title: faker.random.words(1),
-        subtitle: faker.random.words(1),
+        logo: faker.image.url(),
+        title: faker.lorem.word(),
+        subtitle: faker.lorem.word(),
         url: faker.internet.url(),
       }),
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "validate.js": "^0.13.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.1.0",
         "@fastify/static": "^6.11.2",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.5",
@@ -89,7 +90,6 @@
         "eslint": "^8.49.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
-        "faker": "^5.5.3",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
         "jest-mock-extended": "^3.0.5",
@@ -987,6 +987,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.1.0.tgz",
+      "integrity": "sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@fastify/accept-negotiator": {
@@ -4909,12 +4925,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true
     },
     "node_modules/fast-content-type-parse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "faker": "^5.5.3",
+    "@faker-js/faker": "^8.1.0",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "jest-mock-extended": "^3.0.5",


### PR DESCRIPTION
We still have the legacy faker that would introduce a breaking update.
Decided to update to the successor package.