### PR TITLE
fix: added feature value option

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -874,7 +874,7 @@ describe('boot experimentation', () => {
       .set('User-Agent', TEST_UA)
       .set('Cookie', 'ory_kratos_session=value;')
       .expect(200);
-    expect(res.body.exp.a).toEqual({ search: true, squad: true });
+    expect(res.body.exp.a).toEqual({ search: 1, squad: 1 });
   });
 });
 

--- a/src/entity/Feature.ts
+++ b/src/entity/Feature.ts
@@ -7,8 +7,8 @@ export enum FeatureType {
 }
 
 export enum FeatureValue {
-  Up = 1,
-  Down = -1,
+  Allow = 1,
+  Block = -1,
 }
 
 @Entity()
@@ -29,6 +29,6 @@ export class Feature {
   @Column({ default: () => 'now()' })
   createdAt: Date;
 
-  @Column({ type: 'smallint', default: FeatureValue.Up })
-  value: FeatureValue = FeatureValue.Up;
+  @Column({ type: 'smallint', default: FeatureValue.Allow })
+  value: FeatureValue = FeatureValue.Allow;
 }

--- a/src/entity/Feature.ts
+++ b/src/entity/Feature.ts
@@ -6,6 +6,11 @@ export enum FeatureType {
   Search = 'search',
 }
 
+export enum FeatureValue {
+  Up = 1,
+  Down = -1,
+}
+
 @Entity()
 export class Feature {
   @PrimaryColumn({ type: 'text' })
@@ -23,4 +28,7 @@ export class Feature {
 
   @Column({ default: () => 'now()' })
   createdAt: Date;
+
+  @Column({ type: 'smallint', default: FeatureValue.Up })
+  value: FeatureValue = FeatureValue.Up;
 }

--- a/src/migration/1695795022369-FeatureValue.ts
+++ b/src/migration/1695795022369-FeatureValue.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FeatureValue1695795022369 implements MigrationInterface {
+  name = 'FeatureValue1695795022369';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "feature" ADD "value" smallint NOT NULL DEFAULT '1'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "feature" DROP COLUMN "value"`);
+  }
+}

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -323,7 +323,10 @@ const getExperimentation = async (
   return {
     f: getEncryptedFeatures(),
     e,
-    a: features.reduce((acc, { feature }) => ({ [feature]: true, ...acc }), {}),
+    a: features.reduce(
+      (acc, { feature, value }) => ({ [feature]: value, ...acc }),
+      {},
+    ),
   };
 };
 


### PR DESCRIPTION
Added option to allow values for features.
This way we can negative value people who shouldn't have access.

@idoshamun Let me know if this will work.
According to my plan we'll have to introduce a new evaluation saying if search = 1 show v1, if search = -1 show control.
But keep the `true` evaluation as well.