### PR TITLE
fix: add notification deletion

### DIFF
--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -124,6 +124,14 @@ export const workers: Worker[] = [
   },
   // Notifications
   {
+    topic: 'api.v1.comment-deleted',
+    subscription: 'api.comment-deleted-notification-cleanup',
+  },
+  {
+    topic: 'post-banned-or-removed',
+    subscription: 'api.post-deleted-notification-cleanup',
+  },
+  {
     topic: 'community-link-rejected',
     subscription: 'api.community-picks-failed-notification',
   },

--- a/__tests__/workers/notifications/commentDeleted.ts
+++ b/__tests__/workers/notifications/commentDeleted.ts
@@ -1,0 +1,122 @@
+import { expectSuccessfulBackground, saveFixtures } from '../../helpers';
+import worker from '../../../src/workers/notifications/commentDeleted';
+import {
+  ArticlePost,
+  Comment,
+  Notification,
+  NotificationAttachment,
+  NotificationAvatar,
+  Post,
+  PostOrigin,
+  PostType,
+  SharePost,
+  Source,
+  User,
+} from '../../../src/entity';
+import { sourcesFixture } from '../../fixture/source';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../../src/db';
+import { usersFixture } from '../../fixture/user';
+import { NotificationType } from '../../../src/notifications/common';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+const createSharedPost = async (id = 'sp1') => {
+  const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+  await con.getRepository(SharePost).save({
+    ...post,
+    id,
+    shortId: `short-${id}`,
+    sharedPostId: 'p1',
+    type: PostType.Share,
+    visible: false,
+  });
+};
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, ArticlePost, [
+    {
+      id: 'p1',
+      shortId: 'p1',
+      url: 'http://p1.com',
+      score: 0,
+      metadataChangedAt: new Date('01-05-2020 12:00:00'),
+      sourceId: 'a',
+      visible: true,
+      createdAt: new Date('01-05-2020 12:00:00'),
+      origin: PostOrigin.Squad,
+      title: 'testing',
+    },
+  ]);
+  await createSharedPost();
+  await con.getRepository(Comment).save({
+    id: 'c1',
+    postId: 'sp1',
+    userId: '1',
+    content: 'test',
+    contentHtml: '<p>test</t>',
+  });
+  await con.getRepository(Notification).save({
+    id: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    userId: '1',
+    type: NotificationType.SquadNewComment,
+    title: 'title',
+    referenceId: 'c1',
+    referenceType: 'comment',
+    icon: 'bell',
+    targetUrl: 'http://target.com',
+  });
+  await con.getRepository(NotificationAttachment).save({
+    notificationId: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    order: 0,
+    type: 'post',
+    image: 'http://image.com',
+    title: 'title',
+    referenceId: 'referenceId',
+  });
+  await con.getRepository(NotificationAvatar).save({
+    notificationId: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    order: 0,
+    type: 'source',
+    image: 'http://image.com',
+    targetUrl: 'http://target.com',
+    name: 'test',
+    referenceId: 'referenceId',
+  });
+});
+
+it('should not delete notification objects if post not found', async () => {
+  await expectSuccessfulBackground(worker, {
+    comment: {
+      id: 'c2',
+    },
+  });
+
+  const notifications = await con.getRepository(Notification).find();
+  expect(notifications.length).toEqual(1);
+  const attachments = await con.getRepository(NotificationAttachment).find();
+  expect(attachments.length).toEqual(1);
+  const avatars = await con.getRepository(NotificationAvatar).find();
+  expect(avatars.length).toEqual(1);
+});
+it('should delete all notification objects related to a deleted post', async () => {
+  await expectSuccessfulBackground(worker, {
+    comment: {
+      id: 'c1',
+    },
+  });
+
+  const notifications = await con.getRepository(Notification).find();
+  expect(notifications.length).toEqual(0);
+  const attachments = await con.getRepository(NotificationAttachment).find();
+  expect(attachments.length).toEqual(0);
+  const avatars = await con.getRepository(NotificationAvatar).find();
+  expect(avatars.length).toEqual(0);
+});

--- a/__tests__/workers/notifications/postDeleted.ts
+++ b/__tests__/workers/notifications/postDeleted.ts
@@ -1,0 +1,114 @@
+import { expectSuccessfulBackground, saveFixtures } from '../../helpers';
+import worker from '../../../src/workers/notifications/postDeleted';
+import {
+  ArticlePost,
+  Notification,
+  NotificationAttachment,
+  NotificationAvatar,
+  Post,
+  PostOrigin,
+  PostType,
+  SharePost,
+  Source,
+  User,
+} from '../../../src/entity';
+import { sourcesFixture } from '../../fixture/source';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../../src/db';
+import { usersFixture } from '../../fixture/user';
+import { NotificationType } from '../../../src/notifications/common';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+const createSharedPost = async (id = 'sp1') => {
+  const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+  await con.getRepository(SharePost).save({
+    ...post,
+    id,
+    shortId: `short-${id}`,
+    sharedPostId: 'p1',
+    type: PostType.Share,
+    visible: false,
+  });
+};
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, ArticlePost, [
+    {
+      id: 'p1',
+      shortId: 'p1',
+      url: 'http://p1.com',
+      score: 0,
+      metadataChangedAt: new Date('01-05-2020 12:00:00'),
+      sourceId: 'a',
+      visible: true,
+      createdAt: new Date('01-05-2020 12:00:00'),
+      origin: PostOrigin.Squad,
+      title: 'testing',
+    },
+  ]);
+  await createSharedPost();
+  await con.getRepository(Notification).save({
+    id: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    userId: '1',
+    type: NotificationType.SquadPostAdded,
+    title: 'title',
+    referenceId: 'sp1',
+    referenceType: 'post',
+    icon: 'bell',
+    targetUrl: 'http://target.com',
+  });
+  await con.getRepository(NotificationAttachment).save({
+    notificationId: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    order: 0,
+    type: 'post',
+    image: 'http://image.com',
+    title: 'title',
+    referenceId: 'referenceId',
+  });
+  await con.getRepository(NotificationAvatar).save({
+    notificationId: '60e66c38-84a3-46cc-a97e-23080a31d410',
+    order: 0,
+    type: 'source',
+    image: 'http://image.com',
+    targetUrl: 'http://target.com',
+    name: 'test',
+    referenceId: 'referenceId',
+  });
+});
+
+it('should not delete notification objects if post not found', async () => {
+  await expectSuccessfulBackground(worker, {
+    post: {
+      id: 'sp2',
+    },
+  });
+
+  const notifications = await con.getRepository(Notification).find();
+  expect(notifications.length).toEqual(1);
+  const attachments = await con.getRepository(NotificationAttachment).find();
+  expect(attachments.length).toEqual(1);
+  const avatars = await con.getRepository(NotificationAvatar).find();
+  expect(avatars.length).toEqual(1);
+});
+it('should delete all notification objects related to a deleted post', async () => {
+  await expectSuccessfulBackground(worker, {
+    post: {
+      id: 'sp1',
+    },
+  });
+
+  const notifications = await con.getRepository(Notification).find();
+  expect(notifications.length).toEqual(0);
+  const attachments = await con.getRepository(NotificationAttachment).find();
+  expect(attachments.length).toEqual(0);
+  const avatars = await con.getRepository(NotificationAvatar).find();
+  expect(avatars.length).toEqual(0);
+});

--- a/src/workers/notifications/commentDeleted.ts
+++ b/src/workers/notifications/commentDeleted.ts
@@ -1,0 +1,45 @@
+import { messageToJson, Worker } from '../worker';
+import { Notification, Comment } from '../../entity';
+import { ChangeObject } from '../../types';
+
+interface Data {
+  comment: ChangeObject<Comment>;
+}
+
+const worker: Worker = {
+  subscription: 'api.comment-deleted-notification-cleanup',
+  handler: async (message, con, logger) => {
+    const data: Data = messageToJson(message);
+    const { comment } = data;
+
+    try {
+      await con
+        .getRepository(Notification)
+        .createQueryBuilder()
+        .delete()
+        .where({
+          referenceType: 'comment',
+          referenceId: comment?.id,
+        })
+        .execute();
+      logger.info(
+        {
+          data,
+          messageId: message.messageId,
+        },
+        'deleted notifications due to comment deletion',
+      );
+    } catch (err) {
+      logger.error(
+        {
+          data,
+          messageId: message.messageId,
+          err,
+        },
+        'failed to delete notifications due to comment deletion',
+      );
+    }
+  },
+};
+
+export default worker;

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -20,6 +20,8 @@ import memberJoinedSource from './squadMemberJoined';
 import sourceMemberRoleChanged from './sourceMemberRoleChanged';
 import { TypeOrmError } from '../../errors';
 import postMention from './postMention';
+import commentDeleted from './commentDeleted';
+import postDeleted from './postDeleted';
 
 function notificationWorkerToWorker(worker: NotificationWorker): Worker {
   return {
@@ -68,4 +70,9 @@ const notificationWorkers: NotificationWorker[] = [
   sourceMemberRoleChanged,
 ];
 
-export const workers = notificationWorkers.map(notificationWorkerToWorker);
+export const workers = [
+  ...notificationWorkers.map(notificationWorkerToWorker),
+  // Regular workers under notification scope
+  commentDeleted,
+  postDeleted,
+];


### PR DESCRIPTION
Added workers on existing topics to handle deletion of posts and comment to remove notifications.
Decided to split them in case we eventually wanted to add more logic.

WT-1805 #done 