### PR TITLE
refactor: send whoami calls only when jwt is about to expire or not available

### DIFF
--- a/.env
+++ b/.env
@@ -39,3 +39,6 @@ ANALYTICS_URL=http://localhost:5000
 
 EXPERIMENTATION_KEY=6FA4C8D3DD2400B9D614BB7A229FD69B
 #GROWTHBOOK_CLIENT_KEY=override_me_in_env.development
+
+JWT_PUBLIC_KEY_PATH=../apps/.cert/public.pem
+JWT_PRIVATE_KEY_PATH=../apps/.cert/key.pem

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -285,6 +285,25 @@ describe('anonymous boot', () => {
     expect(res.body.flags.onboarding_v2.enabled).toBeTruthy();
     expect(res.body.flags.onboarding_v2.value).toEqual('v1');
   });
+
+  it('should return anonymous boot if jwt is expired', async () => {
+    const accessToken = await signJwt(
+      {
+        userId: '1',
+        roles: [],
+      },
+      -15 * 60 * 1000,
+    );
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set(
+        'Cookie',
+        `${cookies.auth.key}=${app.signCookie(accessToken.token)};`,
+      )
+      .expect(200);
+    expect(res.body).toEqual(ANONYMOUS_BODY);
+  });
 });
 
 describe('logged in boot', () => {


### PR DESCRIPTION
To reduce the load on heimdall side, we'll call the whoami only when we actually must. This should also optimize subsequent calls to boot in the same session.