### PR TITLE
fix: allow cors from vercel previews

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export default async function app(
 
   app.register(helmet);
   app.register(cors, {
-    origin: isProd ? /daily\.dev$/ : true,
+    origin: isProd ? [/daily\.dev$/, /dailydotdev\.vercel\.app$/] : true,
     credentials: true,
   });
   app.register(cookie, {


### PR DESCRIPTION
Proposal to allow cors from the vercel previews.
It's still narrowed down to only our domains there.