### PR TITLE
fix: disable subscription for now since worker is not active

### DIFF
--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -231,10 +231,12 @@ export const workers: Worker[] = [
     topic: 'api.v1.source-created',
     subscription: 'api.source-created-squad-owner-mailing',
   },
-  {
-    topic: 'api.v1.user-created',
-    subscription: 'api.user-created-add-personalized-digest',
-  },
+  // currently we won't enroll new users to digest until we test
+  // how selected users react to emails in terms of unsubscribing
+  // {
+  //   topic: 'api.v1.user-created',
+  //   subscription: 'api.user-created-add-personalized-digest',
+  // },
   {
     topic: 'api.v1.generate-personalized-digest',
     subscription: 'api.personalized-digest-email',


### PR DESCRIPTION
Fixing [issue](https://console.cloud.google.com/monitoring/alerting/incidents/0.n32v3rv1s754?project=devkit-prod), subscription for enrolling into personalized digest was active but worker is not yet until we finish initial experiment.