### PR TITLE
refactor: streamline retryFetch and convert most usage to retry

### DIFF
--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -1,5 +1,4 @@
 import { DataSource, EntityManager } from 'typeorm';
-import fetch from 'node-fetch';
 import {
   Comment,
   ExternalLinkPreview,
@@ -16,6 +15,7 @@ import { markdown } from './markdown';
 import { generateShortId } from '../ids';
 import { GQLPost } from '../schema/posts';
 import { FileUpload } from 'graphql-upload/GraphQLUpload.js';
+import { HttpError, retryFetchParse } from '../integrations/retry';
 
 export const defaultImage = {
   urls: process.env.DEFAULT_IMAGE_URL?.split?.(',') ?? [],
@@ -75,21 +75,20 @@ export const fetchLinkPreview = async (
     throw new ValidationError('URL is not valid');
   }
 
-  const res = await fetch(`${postScraperOrigin}/preview`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ url }),
-  });
-
-  if (res.status >= 400 && res.status < 500) {
-    throw new ValidationError('Bad request!');
+  try {
+    return await retryFetchParse(`${postScraperOrigin}/preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+  } catch (err) {
+    if (err instanceof HttpError) {
+      if (err.statusCode >= 400 && err.statusCode < 500) {
+        throw new ValidationError('Bad request!');
+      }
+    }
+    throw err;
   }
-
-  if (res.status === 200) {
-    return res.json();
-  }
-
-  throw new Error('Internal server error!');
 };
 
 export const WELCOME_POST_TITLE =

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -31,6 +31,5 @@ export async function sendAnalyticsEvent<
       },
     },
     { retries: 3 },
-    false,
   );
 }

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -4,7 +4,7 @@ import { fetchOptions as globalFetchOptions } from '../../http';
 import { IORedisPool } from '@dailydotdev/ts-ioredis-pool';
 import { Context } from '../../Context';
 import { ONE_DAY_IN_SECONDS } from '../../redis';
-import { retryFetch } from '../retry';
+import { retryFetchParse } from '../retry';
 
 type RawFeedServiceResponse = {
   data: { post_id: string; metadata: Record<string, string> }[];
@@ -26,7 +26,7 @@ export class FeedClient implements IFeedClient {
   }
 
   async fetchFeed(ctx, feedId, config): Promise<FeedResponse> {
-    const res = await retryFetch<RawFeedServiceResponse>(
+    const res = await retryFetchParse<RawFeedServiceResponse>(
       this.url,
       {
         ...this.fetchOptions,
@@ -175,7 +175,7 @@ export class PersonalizedDigestFeedClient implements IFeedClient {
   }
 
   async fetchFeed(ctx, feedId, config): Promise<FeedResponse> {
-    const res = await retryFetch<{
+    const res = await retryFetchParse<{
       data: string[];
       rows: number;
     }>(

--- a/src/integrations/magni.ts
+++ b/src/integrations/magni.ts
@@ -1,5 +1,5 @@
 import { fetchOptions } from '../http';
-import { retryFetch } from './retry';
+import { retryFetch, retryFetchParse } from './retry';
 
 export const magniOrigin = process.env.MAGNI_ORIGIN;
 
@@ -47,7 +47,7 @@ export const getSessions = async (
   if (lastId) params.append('lastId', lastId);
 
   const url = `${magniOrigin}/sessions?${params.toString()}`;
-  const res = await retryFetch<SessionResponse>(url, {
+  const res = await retryFetchParse<SessionResponse>(url, {
     ...fetchOptions,
     headers: { 'X-User-Id': userId },
   });
@@ -89,7 +89,7 @@ export const getSession = async (
   sessionId: string,
 ): Promise<Search> => {
   const url = `${magniOrigin}/session?id=${sessionId}`;
-  return retryFetch(url, {
+  return retryFetchParse(url, {
     ...fetchOptions,
     headers: { 'X-User-Id': userId },
   });

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -1,6 +1,6 @@
 import retry, { OperationOptions } from 'retry';
 import isNetworkError from './networkError';
-import fetch, { RequestInit } from 'node-fetch';
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 
 export class AbortError extends Error {
   public originalError: Error;
@@ -18,6 +18,21 @@ export class AbortError extends Error {
 
     this.name = 'AbortError';
     this.message = message;
+  }
+}
+
+export class HttpError extends Error {
+  public url: string;
+  public statusCode: number;
+  public response: string;
+
+  constructor(url: string, status: number, response: string) {
+    super(`Unexpected status code: ${status}`);
+
+    this.name = 'HttpError';
+    this.url = url;
+    this.statusCode = status;
+    this.response = response;
   }
 }
 
@@ -66,23 +81,29 @@ export async function asyncRetry<T>(
   });
 }
 
-export function retryFetch<T>(
-  url: string,
+export function retryFetch(
+  url: RequestInfo,
   fetchOpts: RequestInit,
   retryOpts?: RetryOptions,
-  parseJson = true,
-): Promise<T> {
+): Promise<Response> {
   return asyncRetry(async () => {
     const res = await fetch(url, fetchOpts);
     if (res.ok) {
-      if (parseJson) {
-        return res.json();
-      }
-      return;
+      return res;
     }
+    const err = new HttpError(url.toString(), res.status, await res.text());
     if (res.status < 500) {
-      throw new AbortError(`request is invalid: ${res.status}`);
+      throw new AbortError(err);
     }
-    throw new Error(`unexpecetd response from feed service: ${res.status}`);
+    throw err;
   }, retryOpts);
+}
+
+export async function retryFetchParse<T>(
+  url: RequestInfo,
+  fetchOpts: RequestInit,
+  retryOpts?: RetryOptions,
+): Promise<T> {
+  const res = await retryFetch(url, fetchOpts, retryOpts);
+  return res.json();
 }

--- a/src/integrations/snotra/clients.ts
+++ b/src/integrations/snotra/clients.ts
@@ -1,7 +1,7 @@
 import { ISnotraClient, UserStatePayload, UserStateResponse } from './types';
 import { RequestInit } from 'node-fetch';
 import { fetchOptions as globalFetchOptions } from '../../http';
-import { retryFetch } from '../retry';
+import { retryFetchParse } from '../retry';
 
 export class SnotraClient implements ISnotraClient {
   private readonly url: string;
@@ -16,7 +16,7 @@ export class SnotraClient implements ISnotraClient {
   }
 
   fetchUserState(payload: UserStatePayload): Promise<UserStateResponse> {
-    return retryFetch(
+    return retryFetchParse(
       `${this.url}/api/v1/user/profile`,
       {
         ...this.fetchOptions,

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -43,11 +43,11 @@ const fetchKratos = async (
   } catch (err) {
     if (err instanceof HttpError) {
       const kratosError = new KratosError(err.statusCode, err.response);
-      if (err.statusCode.status >= 500) {
+      if (err.statusCode >= 500) {
         req.log.warn({ err: kratosError }, 'unexpected error from kratos');
         throw err;
       }
-      if (err.statusCode.status !== 303 && err.statusCode.status !== 401) {
+      if (err.statusCode !== 303 && err.statusCode !== 401) {
         req.log.info({ err: kratosError }, 'non-401 error from kratos');
       }
       throw new AbortError(kratosError);

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -4,7 +4,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { cookies, setCookie } from './cookies';
 import { setTrackingId } from './tracking';
 import { generateTrackingId } from './ids';
-import { AbortError, HttpError, retryFetch } from './integrations/retry';
+import { HttpError, retryFetch } from './integrations/retry';
 
 const heimdallOrigin = process.env.HEIMDALL_ORIGIN;
 const kratosOrigin = process.env.KRATOS_ORIGIN;
@@ -45,12 +45,11 @@ const fetchKratos = async (
       const kratosError = new KratosError(err.statusCode, err.response);
       if (err.statusCode >= 500) {
         req.log.warn({ err: kratosError }, 'unexpected error from kratos');
-        throw err;
       }
       if (err.statusCode !== 303 && err.statusCode !== 401) {
         req.log.info({ err: kratosError }, 'non-401 error from kratos');
       }
-      throw new AbortError(kratosError);
+      throw err;
     }
     throw err;
   }

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -1,10 +1,10 @@
-import fetch, { Headers, RequestInit } from 'node-fetch';
+import { Headers, RequestInit } from 'node-fetch';
 import { fetchOptions } from './http';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { cookies, setCookie } from './cookies';
 import { setTrackingId } from './tracking';
 import { generateTrackingId } from './ids';
-import { AbortError, asyncRetry } from './integrations/retry';
+import { AbortError, HttpError, retryFetch } from './integrations/retry';
 
 const heimdallOrigin = process.env.HEIMDALL_ORIGIN;
 const kratosOrigin = process.env.KRATOS_ORIGIN;
@@ -33,28 +33,27 @@ const fetchKratos = async (
   opts: RequestInit = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<{ res: any; headers: Headers }> => {
-  return asyncRetry(
-    async () => {
-      const res = await fetch(endpoint, {
-        ...fetchOptions,
-        ...addKratosHeaderCookies(req),
-        ...opts,
-      });
-      if (res.status < 300) {
-        return { res: await res.json(), headers: res.headers };
-      }
-      const err = new KratosError(res.status, await res.text());
-      if (res.status >= 500) {
-        req.log.warn({ err }, 'unexpected error from kratos');
+  try {
+    const res = await retryFetch(endpoint, {
+      ...fetchOptions,
+      ...addKratosHeaderCookies(req),
+      ...opts,
+    });
+    return { res: await res.json(), headers: res.headers };
+  } catch (err) {
+    if (err instanceof HttpError) {
+      const kratosError = new KratosError(err.statusCode, err.response);
+      if (err.statusCode.status >= 500) {
+        req.log.warn({ err: kratosError }, 'unexpected error from kratos');
         throw err;
       }
-      if (res.status !== 303 && res.status !== 401) {
-        req.log.info({ err }, 'non-401 error from kratos');
+      if (err.statusCode.status !== 303 && err.statusCode.status !== 401) {
+        req.log.info({ err: kratosError }, 'non-401 error from kratos');
       }
-      throw new AbortError(err);
-    },
-    { retries: 5 },
-  );
+      throw new AbortError(kratosError);
+    }
+    throw err;
+  }
 };
 
 export const clearAuthentication = async (

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -1,9 +1,9 @@
 import { FastifyInstance, FastifyReply } from 'fastify';
-import fetch from 'node-fetch';
 import { DevCard } from '../entity';
 import { generateDevCard } from '../templates/devcard';
 import { getDevCardData } from '../common/devcard';
 import createOrGetConnection from '../db';
+import { retryFetch } from '../integrations/retry';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get<{ Params: { id: string } }>(
@@ -31,7 +31,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
           backgroundImage: devCard.background,
         });
         if (format === 'png') {
-          const response = await fetch(
+          const response = await retryFetch(
             `${process.env.SCRAPER_URL}/screenshot`,
             {
               method: 'POST',


### PR DESCRIPTION
I refactor our `retryFetch` function to support more generic use cases so we'll be able to apply system-wide. It's best practice to use retries and now that we know our retry library don't introduce issues we can actually apply it :P