### PR TITLE
feat: utlize async queue to wait for pending notify calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "fastify": "^4.23.2",
         "fastify-plugin": "^4.5.1",
         "fastify-raw-body": "^4.2.2",
+        "fastq": "^1.15.0",
         "form-data": "^4.0.0",
         "graphql": "^16.8.1",
         "graphql-parse-resolve-info": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "fastify": "^4.23.2",
     "fastify-plugin": "^4.5.1",
     "fastify-raw-body": "^4.2.2",
+    "fastq": "^1.15.0",
     "form-data": "^4.0.0",
     "graphql": "^16.8.1",
     "graphql-parse-resolve-info": "^4.13.0",

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -17,8 +17,8 @@ const cron: Cron = {
     const personalizedDigestStream = await personalizedDigestQuery.stream();
     const notifyQueueConcurrency = 1000;
     const notifyQueue = fastq.promise(
-      async (personalizedDigest: UserPersonalizedDigest) => {
-        await notifyGeneratePersonalizedDigest(logger, personalizedDigest);
+      (personalizedDigest: UserPersonalizedDigest) => {
+        return notifyGeneratePersonalizedDigest(logger, personalizedDigest);
       },
       notifyQueueConcurrency,
     );

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -17,8 +17,8 @@ const cron: Cron = {
     const personalizedDigestStream = await personalizedDigestQuery.stream();
     const notifyQueueConcurrency = 1000;
     const notifyQueue = fastq.promise(
-      (personalizedDigest: UserPersonalizedDigest) => {
-        return notifyGeneratePersonalizedDigest(logger, personalizedDigest);
+      async (personalizedDigest: UserPersonalizedDigest) => {
+        await notifyGeneratePersonalizedDigest(logger, personalizedDigest);
       },
       notifyQueueConcurrency,
     );


### PR DESCRIPTION
We found an issue where async method `notifyGeneratePersonalizedDigest` does not get to be resolved before the stream ends and the instance that is running a cron destroys itself. 

Utlizes async queue to manage notify tasks and awaits for queue to be drained (completed) before exiting. 