### PR TITLE
feat: add generationTimestamp for digest worker

### DIFF
--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -52,6 +52,7 @@ describe('personalizedDigest cron', () => {
       expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledWith(
         expect.anything(),
         personalizedDigest,
+        expect.any(Number),
       );
     });
   });
@@ -81,6 +82,7 @@ describe('personalizedDigest cron', () => {
       expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledWith(
         expect.anything(),
         personalizedDigest,
+        expect.any(Number),
       );
     });
   });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -18,7 +18,7 @@ import { Roles } from '../src/roles';
 import { Cron } from '../src/cron/cron';
 import { ChangeMessage, ChangeObject } from '../src/types';
 import { PubSub } from '@google-cloud/pubsub';
-import pino from 'pino';
+import pino, { Logger } from 'pino';
 import { createMercuriusTestClient } from 'mercurius-integration-testing';
 import appFunc from '../src';
 import createOrGetConnection from '../src/db';
@@ -212,15 +212,16 @@ export const invokeNotificationWorker = async (
   return worker.handler(mockMessage(data).message, con, logger);
 };
 
-export const invokeCron = async (cron: Cron): Promise<void> => {
+export const invokeCron = async (cron: Cron, logger: Logger): Promise<void> => {
   const con = await createOrGetConnection();
   const pubsub = new PubSub();
-  const logger = pino();
   await cron.handler(con, logger, pubsub);
 };
 
-export const expectSuccessfulCron = (cron: Cron): Promise<void> =>
-  invokeCron(cron);
+export const expectSuccessfulCron = (
+  cron: Cron,
+  logger: Logger = pino(),
+): Promise<void> => invokeCron(cron, logger);
 
 export const mockChangeMessage = <T>({
   before,

--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -61,6 +61,7 @@ describe('personalizedDigestEmail worker', () => {
 
     await expectSuccessfulBackground(worker, {
       personalizedDigest,
+      generationTimestamp: Date.now(),
     });
 
     expect(sendEmail).toHaveBeenCalledTimes(1);
@@ -99,6 +100,7 @@ describe('personalizedDigestEmail worker', () => {
 
     await expectSuccessfulBackground(worker, {
       personalizedDigest,
+      generationTimestamp: Date.now(),
     });
 
     expect(sendEmail).toHaveBeenCalledTimes(1);
@@ -141,6 +143,7 @@ describe('personalizedDigestEmail worker', () => {
 
     await expectSuccessfulBackground(worker, {
       personalizedDigest,
+      generationTimestamp: Date.now(),
     });
 
     expect(sendEmail).toHaveBeenCalledTimes(1);
@@ -187,6 +190,7 @@ describe('personalizedDigestEmail worker', () => {
 
     await expectSuccessfulBackground(worker, {
       personalizedDigest,
+      generationTimestamp: Date.now(),
     });
 
     expect(sendEmail).toHaveBeenCalledTimes(0);

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -426,5 +426,9 @@ export const notifySourceCreated = async (
 export const notifyGeneratePersonalizedDigest = async (
   log: EventLogger,
   personalizedDigest: ChangeObject<UserPersonalizedDigest>,
+  generationTimestamp: number,
 ): Promise<void> =>
-  publishEvent(log, generatePersonalizedDigestTopic, { personalizedDigest });
+  publishEvent(log, generatePersonalizedDigestTopic, {
+    personalizedDigest,
+    generationTimestamp,
+  });

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -14,6 +14,7 @@ const cron: Cron = {
         nextPreferredDay,
       });
     const timestamp = Date.now();
+    let digestCount = 0;
 
     const personalizedDigestStream = await personalizedDigestQuery.stream();
     const notifyQueueConcurrency = 1000;
@@ -24,6 +25,8 @@ const cron: Cron = {
           personalizedDigest,
           timestamp,
         );
+
+        digestCount += 1;
       },
       notifyQueueConcurrency,
     );
@@ -47,6 +50,8 @@ const cron: Cron = {
       personalizedDigestStream.on('end', resolve);
     });
     await notifyQueue.drained();
+
+    logger.info({ digestCount }, 'personalized digest sent');
   },
 };
 

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -13,12 +13,17 @@ const cron: Cron = {
       .where('upd."preferredDay" = :nextPreferredDay', {
         nextPreferredDay,
       });
+    const timestamp = Date.now();
 
     const personalizedDigestStream = await personalizedDigestQuery.stream();
     const notifyQueueConcurrency = 1000;
     const notifyQueue = fastq.promise(
       async (personalizedDigest: UserPersonalizedDigest) => {
-        await notifyGeneratePersonalizedDigest(logger, personalizedDigest);
+        await notifyGeneratePersonalizedDigest(
+          logger,
+          personalizedDigest,
+          timestamp,
+        );
       },
       notifyQueueConcurrency,
     );


### PR DESCRIPTION
Based on the thread [here](https://dailydotdev.slack.com/archives/C05G8BHHVBR/p1696840091899069?thread_ts=1696581507.796259&cid=C05G8BHHVBR) I added `generationTimestamp`. 

That timestamp can be used to set timestamp for time of generation of digest message and allow us to forward/backward between actual sending days without a need to wait for cron. 

It can also be useful if for any reason digest fails to send we can just provide `generationTimestamp` for previous day and digest will process like it's that day. We would still need to watch out for people timezones but at least it gives us flexibility to do it.

It will also help us with initial testing.