### PR TITLE
feat: update default digest time for new users and import

### DIFF
--- a/__tests__/workers/userCreatedAddPersonalizedDigest.ts
+++ b/__tests__/workers/userCreatedAddPersonalizedDigest.ts
@@ -5,6 +5,7 @@ import createOrGetConnection from '../../src/db';
 import { User } from '../../src/entity';
 import { usersFixture } from '../fixture/user';
 import { UserPersonalizedDigest } from '../../src/entity/UserPersonalizedDigest';
+import { DayOfWeek } from '../../src/types';
 
 let con: DataSource;
 
@@ -39,8 +40,8 @@ describe('userCreatedAddPersonalizedDigest worker', () => {
         userId: user?.id,
       });
     expect(personalizedDigest).toMatchObject({
-      preferredDay: 1,
-      preferredHour: 9,
+      preferredDay: DayOfWeek.Wednesday,
+      preferredHour: 8,
       preferredTimezone: 'Europe/Zagreb',
     });
   });
@@ -65,8 +66,8 @@ describe('userCreatedAddPersonalizedDigest worker', () => {
         userId: user?.id,
       });
     expect(personalizedDigest).toMatchObject({
-      preferredDay: 1,
-      preferredHour: 9,
+      preferredDay: DayOfWeek.Wednesday,
+      preferredHour: 8,
       preferredTimezone: 'Etc/UTC',
     });
   });

--- a/bin/subscribeUsersToPersonalizedDigest.ts
+++ b/bin/subscribeUsersToPersonalizedDigest.ts
@@ -41,8 +41,9 @@ import { parse } from 'csv-parse';
 
   await con.transaction(async (manager) => {
     await manager.query(`
-        INSERT INTO user_personalized_digest ("userId", "preferredTimezone")
-        SELECT id AS "userId", COALESCE(timezone, 'Etc/UTC') AS "preferredTimezone" FROM public.user WHERE id IN (${userIds
+        INSERT INTO user_personalized_digest ("userId", "preferredTimezone", "preferredHour", "preferredDay")
+        SELECT id AS "userId", COALESCE(timezone, 'Etc/UTC') AS "preferredTimezone", 8 AS "preferredHour", 3 AS "preferredDay"
+        FROM public.user WHERE id IN (${userIds
           .map((userId) => `'${userId}'`)
           .filter(Boolean)
           .join(',')}) ON CONFLICT DO NOTHING;

--- a/src/workers/userCreatedAddPersonalizedDigest.ts
+++ b/src/workers/userCreatedAddPersonalizedDigest.ts
@@ -1,5 +1,6 @@
 import { User } from '../common';
 import { UserPersonalizedDigest } from '../entity/UserPersonalizedDigest';
+import { DayOfWeek } from '../types';
 import { messageToJson, Worker } from './worker';
 
 interface Data {
@@ -14,6 +15,8 @@ const worker: Worker = {
 
     await con.getRepository(UserPersonalizedDigest).save({
       userId: user.id,
+      preferredDay: DayOfWeek.Wednesday,
+      preferredHour: 8,
       preferredTimezone: user.timezone,
     });
   },


### PR DESCRIPTION
[Request](https://dailydotdev.slack.com/archives/C05G8BHHVBR/p1696926802859009?thread_ts=1696926737.774969&cid=C05G8BHHVBR) from product to adjust default sending day and time.

Also added adjustment to frontend subscribe to send those defaults https://github.com/dailydotdev/apps/pull/2250/commits/50f9f252498eb436494d50ee1e5a34bf9f70d843

Alternative would be to adjust database defaults but I think this is the right way since we are gonna change defaults multiple times for sure and adding a migration each time is gonna be chore.