### PR TITLE
chore: bump rate limiter to new version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "pg": "^8.11.3",
         "pg-query-stream": "^4.5.3",
         "pino": "^8.16.0",
-        "rate-limiter-flexible": "^2.4.2",
+        "rate-limiter-flexible": "^3.0.0",
         "reflect-metadata": "^0.1.13",
         "retry": "^0.13.1",
         "rss": "^1.2.2",
@@ -8841,9 +8841,9 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/rate-limiter-flexible": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz",
-      "integrity": "sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-3.0.0.tgz",
+      "integrity": "sha512-janAJkWxWxmLka0hV+XvCTo0M8keeSeOuz8ZL33cTXrkS4ek9mQ2VJm9ri7fm03oTVth19Sfqb1ijCmo7K/vAg=="
     },
     "node_modules/raw-body": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "pg": "^8.11.3",
     "pg-query-stream": "^4.5.3",
     "pino": "^8.16.0",
-    "rate-limiter-flexible": "^2.4.2",
+    "rate-limiter-flexible": "^3.0.0",
     "reflect-metadata": "^0.1.13",
     "retry": "^0.13.1",
     "rss": "^1.2.2",


### PR DESCRIPTION
As it was a breaking change version I wanted to test it separate from the minor bumps.
Explicit tests on the rate limiter work as intended.

Note:
We actually didn't use and of the [breaking changes](https://github.com/animir/node-rate-limiter-flexible/releases/tag/v3.0.0) luckily.