### PR TITLE
refactor: streamline handles throughout the app

### DIFF
--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -49,10 +49,10 @@ Object {
   "infoConfirmed": false,
   "name": "Ido",
   "notificationEmail": true,
-  "permalink": "http://localhost:5002/a1",
+  "permalink": "http://localhost:5002/aaa1",
   "timezone": "Asia/Manila",
   "twitter": null,
-  "username": "a1",
+  "username": "aaa1",
 }
 `;
 

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -70,10 +70,28 @@ describe('POST /p/newUser', () => {
       .set('Content-type', 'application/json')
       .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
       .send({
-        id: usersFixture[0].id,
+        id: '100',
         name: usersFixture[0].name,
         image: usersFixture[0].image,
         username: usersFixture[0].username,
+        email: 'randomNewEmail@gmail.com',
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
+  });
+
+  it('should handle existing username with different case', async () => {
+    await createDefaultUser();
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: '100',
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: usersFixture[0].username.toUpperCase(),
         email: 'randomNewEmail@gmail.com',
       })
       .expect(200);
@@ -106,11 +124,29 @@ describe('POST /p/newUser', () => {
       .set('Content-type', 'application/json')
       .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
       .send({
-        id: usersFixture[0].id,
+        id: '100',
         name: usersFixture[0].name,
         image: usersFixture[0].image,
         username: 'randomName',
         email: usersFixture[0].email,
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
+  });
+
+  it('should handle existing email with different case', async () => {
+    await createDefaultUser();
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: '100',
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: 'randomName',
+        email: usersFixture[0].email.toUpperCase(),
       })
       .expect(200);
 
@@ -356,6 +392,17 @@ describe('POST /p/checkUsername', () => {
     await createDefaultUser();
     const { body } = await request(app.server)
       .get('/p/checkUsername?search=idoshamun')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send()
+      .expect(200);
+
+    expect(body).toEqual({ isTaken: true });
+  });
+
+  it('should normalize to lowercase and find duplicates', async () => {
+    await createDefaultUser();
+    const { body } = await request(app.server)
+      .get('/p/checkUsername?search=IdoShamun')
       .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
       .send()
       .expect(200);

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -117,6 +117,57 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
   });
 
+  it('should not allow dashes in handle', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: usersFixture[0].id,
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: 'h-ello',
+        email: 'randomNewEmail@gmail.com',
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
+  });
+
+  it('should not allow slashes in handle', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: usersFixture[0].id,
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: 'h/ello',
+        email: 'randomNewEmail@gmail.com',
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
+  });
+
+  it('should not allow short handle', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: usersFixture[0].id,
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: 'he',
+        email: 'randomNewEmail@gmail.com',
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'failed', reason: 'USERNAME_EMAIL_EXISTS' });
+  });
+
   it('should handle existing email', async () => {
     await createDefaultUser();
     const { body } = await request(app.server)
@@ -173,6 +224,23 @@ describe('POST /p/newUser', () => {
     expect(users.length).toEqual(1);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].infoConfirmed).toBeTruthy();
+  });
+
+  it('should allow underscore in username', async () => {
+    const { body } = await request(app.server)
+      .post('/p/newUser')
+      .set('Content-type', 'application/json')
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({
+        id: usersFixture[0].id,
+        name: usersFixture[0].name,
+        image: usersFixture[0].image,
+        username: 'h_ello',
+        email: usersFixture[0].email,
+      })
+      .expect(200);
+
+    expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
   });
 
   it('should add a new user with false info confirmed if data is incomplete', async () => {

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -492,20 +492,19 @@ describe('query sourceHandleExists', () => {
     }
   `;
 
-  const updateHandle = (handle = 'a') =>
+  const updateHandle = (handle = 'aaa') =>
     con.getRepository(Source).update({ id: 'a' }, { handle, private: true });
 
   it('should not authorize when user is not logged in', () =>
     testQueryErrorCode(
       client,
-      { query: QUERY, variables: { handle: 'a' } },
+      { query: QUERY, variables: { handle: 'aaa' } },
       'UNAUTHENTICATED',
     ));
 
-  it('should throw validation error when the handle did not pass our criteria', async () => {
+  it('should throw validation error when the handle did not pass our criteria', () => {
     loggedUser = '3';
-    await updateHandle();
-    testQueryErrorCode(
+    return testQueryErrorCode(
       client,
       { query: QUERY, variables: { handle: 'aa aa' } },
       'GRAPHQL_VALIDATION_FAILED',
@@ -515,14 +514,14 @@ describe('query sourceHandleExists', () => {
   it('should return false if the source handle is not taken', async () => {
     loggedUser = '3';
     await updateHandle();
-    const res = await client.query(QUERY, { variables: { handle: 'aa' } });
+    const res = await client.query(QUERY, { variables: { handle: 'aaaa' } });
     expect(res.data.sourceHandleExists).toBeFalsy();
   });
 
   it('should return true if the source handle is taken', async () => {
     loggedUser = '3';
     await updateHandle();
-    const res = await client.query(QUERY, { variables: { handle: 'a' } });
+    const res = await client.query(QUERY, { variables: { handle: 'aaa' } });
     expect(res.data.sourceHandleExists).toBeTruthy();
   });
 
@@ -547,7 +546,7 @@ describe('query sourceHandleExists', () => {
   it('should return true if the source handle is taken considering uppercase characters', async () => {
     loggedUser = '3';
     await updateHandle();
-    const res = await client.query(QUERY, { variables: { handle: 'A' } });
+    const res = await client.query(QUERY, { variables: { handle: 'AAA' } });
     expect(res.data.sourceHandleExists).toBeTruthy();
   });
 });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1658,7 +1658,7 @@ describe('mutation updateUserProfile', () => {
     const user = await repo.findOneBy({ id: loggedUser });
     const timezone = 'Asia/Manila';
     const res = await client.mutate(MUTATION, {
-      variables: { data: { timezone, username: 'a1', name: 'Ido' } },
+      variables: { data: { timezone, username: 'aaa1', name: 'Ido' } },
     });
 
     expect(res.errors?.length).toBeFalsy();
@@ -1676,7 +1676,7 @@ describe('mutation updateUserProfile', () => {
     const repo = con.getRepository(User);
     await repo.update({ id: loggedUser }, { email: 'sample@daily.dev' });
     const user = await repo.findOneBy({ id: loggedUser });
-    const username = 'a1';
+    const username = 'aaa1';
     expect(user?.infoConfirmed).toBeFalsy();
     const res = await client.mutate(MUTATION, {
       variables: { data: { username, name: user.name } },
@@ -1695,7 +1695,7 @@ describe('mutation updateUserProfile', () => {
     const email = 'sample@daily.dev';
     expect(user?.infoConfirmed).toBeFalsy();
     const res = await client.mutate(MUTATION, {
-      variables: { data: { email, username: 'u1', name: user.name } },
+      variables: { data: { email, username: 'uuu1', name: user.name } },
     });
     expect(res.errors?.length).toBeFalsy();
     const updatedUser = await repo.findOneBy({ id: loggedUser });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1589,6 +1589,16 @@ describe('mutation updateUserProfile', () => {
     );
   });
 
+  it('should not allow duplicated username with different case', async () => {
+    loggedUser = '1';
+
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { data: { username: 'Lee' } } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should not allow disallowed username', async () => {
     loggedUser = '1';
 

--- a/src/common/handles.ts
+++ b/src/common/handles.ts
@@ -1,0 +1,20 @@
+import { handleRegex, validateRegex } from './object';
+import { DataSource, EntityManager } from 'typeorm';
+import { checkDisallowHandle } from '../entity/DisallowHandle';
+import { ValidationError } from 'apollo-server-errors';
+
+export async function validateAndTransformHandle(
+  handle: string | undefined,
+  key: string,
+  entityManager: DataSource | EntityManager,
+): Promise<string> {
+  const transformed = handle?.toLowerCase().replace('@', '').trim();
+  validateRegex([[key, transformed, handleRegex, true]]);
+  const disallowHandle = await checkDisallowHandle(entityManager, transformed);
+  if (disallowHandle) {
+    throw new ValidationError(
+      JSON.stringify({ handle: 'handle is already used' }),
+    );
+  }
+  return transformed;
+}

--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -37,5 +37,6 @@ export const validateRegex = (params: ValidateRegex[]): void => {
   }
 };
 export const nameRegex = new RegExp(/^(.){1,60}$/);
-export const handleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
+export const socialHandleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
+export const handleRegex = new RegExp(/^@?[a-z0-9](\w){2,38}$/i);
 export const descriptionRegex = new RegExp(/^[\S\s]{1,250}$/);

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -22,7 +22,7 @@ import { validateAndTransformHandle } from '../common/handles';
 import { ValidationError } from 'apollo-server-errors';
 import { GQLUpdateUserInput } from '../schema/users';
 import {
-  handleRegex,
+  socialHandleRegex,
   nameRegex,
   validateRegex,
   ValidateRegex,
@@ -375,9 +375,9 @@ export const validateUserUpdate = async (
 
   const regexParams: ValidateRegex[] = [
     ['name', data.name, nameRegex, !user.name],
-    ['github', data.github, handleRegex],
+    ['github', data.github, socialHandleRegex],
     ['twitter', data.twitter, new RegExp(/^@?(\w){1,15}$/)],
-    ['hashnode', data.hashnode, handleRegex],
+    ['hashnode', data.hashnode, socialHandleRegex],
   ];
 
   validateRegex(regexParams);


### PR DESCRIPTION
Enforce the same rules on user and squad handles.

The rules:
* Transform to lowercase
* No forbidden handles
* Uses alphanumeric, underscore or dash
* No dups

The rules are enforced only when updating the handle or creating a new entity. We want to make sure users who update something else will not suddenly get an error.

WT-744 #done