### PR TITLE
chore: remove `sourceId` as a required argument on `editSharePost`

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2017,8 +2017,8 @@ describe('mutation sharePost', () => {
 
 describe('mutation editSharePost', () => {
   const MUTATION = `
-  mutation editSharePost($id: ID!, $sourceId: ID!, $commentary: String) {
-    editSharePost(sourceId: $sourceId, id: $id, commentary: $commentary) {
+  mutation editSharePost($id: ID!, $commentary: String) {
+    editSharePost(id: $id, commentary: $commentary) {
       id
     }
   }`;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -849,10 +849,6 @@ export const typeDefs = /* GraphQL */ `
       """
       id: ID!
       """
-      Source to share the post to
-      """
-      sourceId: ID!
-      """
       Commentary for the share
       """
       commentary: String
@@ -1674,24 +1670,20 @@ export const resolvers: IResolvers<any, Context> = {
     },
     editSharePost: async (
       _,
-      {
-        id,
-        sourceId,
-        commentary,
-      }: { id: string; sourceId: string; commentary: string },
+      { id, commentary }: { id: string; commentary: string },
       ctx,
       info,
     ): Promise<GQLPost> => {
       const post = await ctx.con.getRepository(Post).findOneByOrFail({ id });
       validateEditAllowed(post.authorId, ctx.userId);
 
-      await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
+      await ensureSourcePermissions(ctx, post.sourceId, SourcePermissions.Post);
 
       const { postId } = await updateSharePost(
         ctx.con,
         ctx.userId,
         id,
-        sourceId,
+        post.sourceId,
         commentary,
       );
       return getPostById(ctx, info, postId);


### PR DESCRIPTION
leftover item from the original PR for editing posts: https://github.com/dailydotdev/apps/pull/2259#discussion_r1360551010