### PR TITLE
fix: name can not be null

### DIFF
--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -168,7 +168,7 @@ const worker: Worker = {
       ...baseNotificationEmailData,
       to: {
         email: user.email,
-        name: user.name,
+        name: userName,
       },
       sendAt: Math.floor(emailSendDate.getTime() / 1000),
       templateId: emailTemplateId,


### PR DESCRIPTION
name can not be null, so defaulting to use the set `userName` object.

![Screenshot 2023-10-24 at 07 41 23](https://github.com/dailydotdev/daily-api/assets/554874/f0d8cad6-8792-4bd6-937c-d1aa075c632b)
