### PR TITLE
feat: make preview feed always fresh

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1747,6 +1747,7 @@ describe('query feedPreview', () => {
         feed_config_name: 'onboarding',
         total_pages: 1,
         page_size: 21,
+        offset: 0,
         fresh_page_size: '7',
         user_id: '1',
         allowed_tags: ['html'],

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -43,6 +43,5 @@ export class Keyword {
   occurrences: number;
 
   @Column({ type: 'jsonb', default: {} })
-  @Index('IDX_keyword_flags_onboarding', { synchronize: false })
   flags: KeywordFlags = {};
 }

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -16,6 +16,7 @@ export type KeywordFlagsPublic = never;
 
 @Entity()
 @Index('IDX_status_value', ['status', 'value'])
+@Index('IDX_keyword_flags_onboarding_value', { synchronize: false })
 export class Keyword {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_keyword_value')

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -103,7 +103,7 @@ export const feedGenerators: Record<FeedVersion, FeedGenerator> = Object.freeze(
       'popular',
     ),
     onboarding: new FeedGenerator(
-      cachedFeedClient,
+      feedClient,
       new FeedPreferencesConfigGenerator(
         {
           feed_config_name: FeedConfigName.Onboarding,

--- a/src/migration/1698230451545-OnboardingTagsIndex.ts
+++ b/src/migration/1698230451545-OnboardingTagsIndex.ts
@@ -4,11 +4,13 @@ export class OnboardingTagsIndex1698230451545 implements MigrationInterface {
     name = 'OnboardingTagsIndex1698230451545'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP INDEX "IDX_keyword_flags_onboarding"`);
       await queryRunner.query(`CREATE INDEX "IDX_keyword_flags_onboarding_value" ON keyword (((flags->'onboarding')::boolean), "value")`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
       await queryRunner.query(`DROP INDEX "IDX_keyword_flags_onboarding_value"`);
+      await queryRunner.query(`CREATE INDEX "IDX_keyword_flags_onboarding" ON post USING HASH (((flags->'onboarding')::boolean))`);
     }
 
 }

--- a/src/migration/1698230451545-OnboardingTagsIndex.ts
+++ b/src/migration/1698230451545-OnboardingTagsIndex.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class OnboardingTagsIndex1698230451545 implements MigrationInterface {
+    name = 'OnboardingTagsIndex1698230451545'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`CREATE INDEX "IDX_keyword_flags_onboarding_value" ON keyword (((flags->'onboarding')::boolean), "value")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP INDEX "IDX_keyword_flags_onboarding_value"`);
+    }
+
+}


### PR DESCRIPTION
Basically in my testing I figured that due to caching key for cached feed client is per user id and generator identifier user will always get the same feed for cache duration which we don't want.

Using regular feed client user will always get fresh feed. It should not be expensive since onboarding generator generates only one page with 20 feed items.

Also added missing index for onboardingTags because I noticed query takes on average around a 1-2 seconds, probably due to amount of rows. Index should fix it.