### PR TITLE
fix: failsafe as we use for the upvote comment itself already

### DIFF
--- a/src/workers/commentUpvoteCanceledRep.ts
+++ b/src/workers/commentUpvoteCanceledRep.ts
@@ -15,10 +15,18 @@ const worker: Worker = {
   subscription: 'comment-upvote-canceled-rep',
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
+    const logDetails = { data, messageId: message.messageId };
+
     try {
       const comment = await con
         .getRepository(Comment)
         .findOneBy({ id: data.commentId });
+
+      if (!comment) {
+        logger.info(logDetails, 'comment does not exist');
+        return;
+      }
+
       if (comment.userId !== data.userId) {
         await con
           .getRepository(ReputationEvent)


### PR DESCRIPTION
We have this failsafe in the upvote, but not upvote cancel.
This just makes it inline and avoid a [error](https://console.cloud.google.com/errors/detail/CLHxl67d54W9_wE;service=api-bg?project=devkit-prod).