### PR TITLE
fix: start metrics outside of NodeSDK

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -54,3 +54,10 @@ export const uniqueifyArray = <T>(array: T[]): T[] => {
  * @param array
  */
 export const removeEmptyValues = <T>(array: T[]): T[] => array.filter(Boolean);
+
+/**
+ * Check if the current environment is production
+ *
+ * @returns boolean
+ */
+export const isProd = process.env.NODE_ENV === 'production';

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -1,0 +1,34 @@
+import { api, resources, metrics } from '@opentelemetry/sdk-node';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
+
+import { containerDetector } from '@opentelemetry/resource-detector-container';
+import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
+
+import { isProd } from '../common';
+
+export const startMetrics = (serviceName: string): void => {
+  const metricReader = isProd
+    ? new metrics.PeriodicExportingMetricReader({
+        exportIntervalMillis: 10_000,
+        exporter: new MetricExporter(),
+      })
+    : new PrometheusExporter({}, () => {
+        const { endpoint, port } = PrometheusExporter.DEFAULT_OPTIONS;
+        console.log(`metrics endpoint: http://localhost:${port}${endpoint}`);
+      });
+
+  const meterProvider = new metrics.MeterProvider({
+    resource: new resources.Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    }).merge(
+      resources.detectResourcesSync({
+        detectors: [containerDetector, gcpDetector],
+      }),
+    ),
+  });
+
+  meterProvider.addMetricReader(metricReader);
+  api.metrics.setGlobalMeterProvider(meterProvider);
+};


### PR DESCRIPTION
Because the instrumentations can add their own metrics that we don't really want, we have to manually start the MeterProvider outside of the NodeSDK to not let them collect their metrics.

Below are the examples of a simple curl request
```console
```

<details>
<summary>Before</summary>

```metrics
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="api",telemetry_sdk_language="nodejs",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.17.1"} 1
# HELP http_server_duration Measures the duration of inbound HTTP requests.
# UNIT http_server_duration ms
# TYPE http_server_duration histogram
http_server_duration_count{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot"} 1
http_server_duration_sum{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot"} 20.366791
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="0"} 0
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="5"} 0
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="10"} 0
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="25"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="50"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="75"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="100"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="250"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="500"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="750"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="1000"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="2500"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="5000"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="7500"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="10000"} 1
http_server_duration_bucket{http_scheme="http",http_method="GET",net_host_name="api.local.com",http_flavor="1.1",http_status_code="200",net_host_port="3000",http_route="/boot",le="+Inf"} 1
# HELP http_client_duration Measures the duration of outbound HTTP requests.
# UNIT http_client_duration ms
# TYPE http_client_duration histogram
http_client_duration_count{http_method="GET",net_peer_name="metadata.google.internal."} 1
http_client_duration_sum{http_method="GET",net_peer_name="metadata.google.internal."} 40.866833
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="0"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="5"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="10"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="25"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="50"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="75"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="100"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="250"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="500"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="750"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="1000"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="2500"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="5000"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="7500"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="10000"} 1
http_client_duration_bucket{http_method="GET",net_peer_name="metadata.google.internal.",le="+Inf"} 1
http_client_duration_count{http_method="GET",net_peer_name="169.254.169.254"} 1
http_client_duration_sum{http_method="GET",net_peer_name="169.254.169.254"} 22688.727136
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="0"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="5"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="10"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="25"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="50"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="75"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="100"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="250"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="500"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="750"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="1000"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="2500"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="5000"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="7500"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="10000"} 0
http_client_duration_bucket{http_method="GET",net_peer_name="169.254.169.254",le="+Inf"} 1
# HELP requests_total How many requests have been processed
# TYPE requests_total counter
requests_total{http_method="GET",http_route="/boot",http_status_code="200",dailydev_apps_version="3.27.9"} 1
```

</details>

<details>
<summary>Details</summary>

```
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="api",telemetry_sdk_language="nodejs",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.17.1",container_id="cb03ac7659c708f4d1bf7eb2a3716f6b7abc28563bad9e1c83b617cdad13ad84"} 1
# HELP requests_total How many requests have been processed
# TYPE requests_total counter
requests_total{http_method="GET",http_route="/boot",http_status_code="200",dailydev_apps_version="3.27.9"} 1
```

</details>