### PR TITLE
feat: experimentation support in digest

### DIFF
--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -46,6 +46,7 @@ Object {
         "source_name": "B",
       },
     ],
+    "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
     "email": "informer@daily.dev",
@@ -130,6 +131,7 @@ Object {
         "source_name": "B",
       },
     ],
+    "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
     "email": "informer@daily.dev",
@@ -214,6 +216,7 @@ Object {
         "source_name": "B",
       },
     ],
+    "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
     "email": "informer@daily.dev",
@@ -249,5 +252,78 @@ Object {
   "date_to": Any<String>,
   "total_posts": 5,
   "user_id": "1",
+}
+`;
+
+exports[`personalizedDigestEmail worker should set parameters based on variation 1`] = `
+Object {
+  "asm": Object {
+    "groupId": 23809,
+  },
+  "category": "Digests",
+  "dynamicTemplateData": Object {
+    "day_name": "Monday",
+    "first_name": "Ido",
+    "posts": Array [
+      Object {
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p1?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_title": "P1",
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p2?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_title": "P2",
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+      Object {
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p3?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_title": "P3",
+        "source_image": "http://image.com/c",
+        "source_name": "C",
+      },
+      Object {
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p4?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_title": "P4",
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p5?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_title": "P5",
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+    ],
+    "title": "P1",
+  },
+  "from": Object {
+    "email": "digest@daily.dev",
+    "name": "Weekly Digest",
+  },
+  "replyTo": Object {
+    "email": "hi@daily.dev",
+    "name": "daily.dev",
+  },
+  "sendAt": Any<Number>,
+  "templateId": "d-328d1104d2e04fa1ab91e410e02751cb",
+  "to": Object {
+    "email": "ido@daily.dev",
+    "name": "Ido",
+  },
+  "trackingSettings": Object {
+    "clickTracking": Object {
+      "enable": true,
+    },
+    "openTracking": Object {
+      "enable": true,
+    },
+  },
 }
 `;

--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -225,4 +225,24 @@ describe('personalizedDigestEmail worker', () => {
 
     expect(sendEmail).toHaveBeenCalledTimes(0);
   });
+
+  it('should set parameters based on variation', async () => {
+    const personalizedDigest = await con
+      .getRepository(UserPersonalizedDigest)
+      .findOneBy({
+        userId: '1',
+      });
+    personalizedDigest.variation = 2;
+
+    await expectSuccessfulBackground(worker, {
+      personalizedDigest,
+      generationTimestamp: Date.now(),
+    });
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const emailData = (sendEmail as jest.Mock).mock.calls[0][0];
+    expect(emailData).toMatchSnapshot({
+      sendAt: expect.any(Number),
+    });
+  });
 });

--- a/src/entity/UserPersonalizedDigest.ts
+++ b/src/entity/UserPersonalizedDigest.ts
@@ -17,6 +17,9 @@ export class UserPersonalizedDigest {
   @Column({ type: 'text', default: 'Etc/UTC' })
   preferredTimezone: string;
 
+  @Column({ default: 1, nullable: false })
+  variation: number;
+
   @OneToOne(() => User, {
     lazy: true,
     onDelete: 'CASCADE',

--- a/src/migration/1698317123443-DigestVariation.ts
+++ b/src/migration/1698317123443-DigestVariation.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DigestVariation1698317123443 implements MigrationInterface {
+    name = 'DigestVariation1698317123443'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_personalized_digest" ADD "variation" integer NOT NULL DEFAULT '1'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_personalized_digest" DROP COLUMN "variation"`);
+    }
+
+}


### PR DESCRIPTION
Add a variation column to the digest table.
Using the variation, we can experiment with different email settings and parameters.

It's still WIP as product hasn't concluded the exact experiment, but they are certain they want to set the title to the post title and change the sender. But it's ready for review!