### PR TITLE
feat: use text instead of boolean cast index

### DIFF
--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -46,7 +46,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -132,7 +132,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -218,7 +218,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -304,7 +304,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "P1",
   },
   "from": Object {

--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -46,7 +46,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -132,7 +132,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -218,7 +218,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
   },
   "from": Object {
@@ -304,7 +304,7 @@ Object {
         "source_name": "B",
       },
     ],
-    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based topics you love reading about. Let's get to it!",
     "title": "P1",
   },
   "from": Object {

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -16,7 +16,7 @@ export type KeywordFlagsPublic = never;
 
 @Entity()
 @Index('IDX_status_value', ['status', 'value'])
-@Index('IDX_keyword_flags_onboarding_value', { synchronize: false })
+@Index('IDX_keyword_flags_onboarding_value_text', { synchronize: false })
 export class Keyword {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_keyword_value')

--- a/src/migration/1698323453474-OnboardingTagsTextIndex.ts
+++ b/src/migration/1698323453474-OnboardingTagsTextIndex.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class OnboardingTagsTextIndex1698323453474 implements MigrationInterface {
+    name = 'OnboardingTagsTextIndex1698323453474'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP INDEX "IDX_keyword_flags_onboarding_value"`);
+      await queryRunner.query(`CREATE INDEX "IDX_keyword_flags_onboarding_value_text" ON keyword ((flags->'onboarding'), "value")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP INDEX "IDX_keyword_flags_onboarding_value_text"`);
+      await queryRunner.query(`CREATE INDEX "IDX_keyword_flags_onboarding_value" ON keyword (((flags->'onboarding')::boolean), "value")`);
+    }
+
+}

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -112,15 +112,13 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       };
     },
     onboardingTags: async (source, args, ctx): Promise<GQLTagResults> => {
-      const hits = await ctx.getRepository(Keyword).find({
-        select: ['value'],
-        where: {
-          flags: {
-            onboarding: true,
-          },
-        },
-        order: { value: 'ASC' },
-      });
+      const hits = await ctx
+        .getRepository(Keyword)
+        .createQueryBuilder()
+        .select('value')
+        .where(`(flags->'onboarding') = 'true'`)
+        .orderBy('value', 'ASC')
+        .execute();
 
       return {
         hits: hits.map((hit) => ({ name: hit.value })),


### PR DESCRIPTION
After deployment of https://github.com/dailydotdev/daily-api/pull/1504 I noticed that onboarding tags were still slow. 

After further debugging I found out why the query is slow. It was not due to index (I mean they help) but the main culprit is how typeorm assembles the query when you use json fields, I logged it under the hood and the query is something like:
```sql
SELECT value FROM keyword WHERE flags = '{ "onboarding": true }' ORDER BY value ASC
```
With the above query we don't actually hit the index since query queries the whole flags field. Optimal query (and what I was expecting `typeorm` was doing) would be:

```sql
SELECT value FROM keyword WHERE (flags->'onboarding') = 'true' ORDER BY value ASC
```

After replacing inefficient query from `typeorm` with the raw one it actually worked and query was much faster.

After adjusting the query I tried the actual query on psql version that was same as production and noticed that index was not used and query was slow again, `EXPLAIN` was saying that it did not use the index:
<img width="529" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/90d5504c-0962-47dd-b028-be7e949a619c">

Locally on psql v15 it used it:
<img width="571" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/f7d75af4-79a2-4ed1-b5d6-56e845e6b2a3">

After some additional debugging with Ido we noticed that on our prod version (psql v11) the index was working only if we used plain text index for json field instead of boolean. So in this PR we add migration to add the plain index.

On general note until we upgrade our psql version we have to make sure we use raw queries when querying per `flags` json columns.