### PR TITLE
feat: limit search results to 100 and min query to 2 chars

### DIFF
--- a/__tests__/tags.ts
+++ b/__tests__/tags.ts
@@ -72,6 +72,31 @@ describe('query searchTags', () => {
     const res = await client.query(QUERY('web-dev'));
     expect(res.data).toMatchSnapshot();
   });
+
+  it('should return no results if query length is less then 2', async () => {
+    const res = await client.query(QUERY('d'));
+    expect(res.data).toMatchObject({
+      searchTags: {
+        query: 'd',
+        hits: [],
+      },
+    });
+  });
+
+  it('should return no more then 100 results', async () => {
+    await con.getRepository(Keyword).save(
+      new Array(110).fill('tag').map((item, index) => ({
+        value: item + index,
+        occurances: 0,
+        status: 'allow',
+      })),
+    );
+
+    const res = await client.query(QUERY('tag'));
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.searchTags.hits.length).toBe(100);
+  });
 });
 
 describe('query onboardingTags', () => {

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -20,6 +20,10 @@ type GQLTagResults = Pick<GQLTagSearchResults, 'hits'>;
 
 export const RECOMMENDED_TAGS_LIMIT = 5;
 
+export const MIN_SEARCH_QUERY_LENGTH = 2;
+
+export const SEARCH_TAGS_LIMIT = 100;
+
 export const typeDefs = /* GraphQL */ `
   """
   Post tag
@@ -98,6 +102,13 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       { query }: { query: string },
       ctx,
     ): Promise<GQLTagSearchResults> => {
+      if (query.length < MIN_SEARCH_QUERY_LENGTH) {
+        return {
+          query,
+          hits: [],
+        };
+      }
+
       const hits = await ctx
         .getRepository(Keyword)
         .createQueryBuilder()
@@ -105,6 +116,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         .where(`status = 'allow'`)
         .andWhere(`value ilike :query`, { query: `%${query}%` })
         .orderBy('value', 'ASC')
+        .limit(SEARCH_TAGS_LIMIT)
         .getRawMany();
       return {
         query,


### PR DESCRIPTION
To prevent many search results being returned with too general of a query.