### PR TITLE
chore: measure tracking id generation

### DIFF
--- a/src/ids.ts
+++ b/src/ids.ts
@@ -1,8 +1,20 @@
 import { randomUUID } from 'crypto';
 import { customAlphabet } from 'nanoid/async';
+import { FastifyRequest } from 'fastify';
 
 const alphabet =
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-export const generateTrackingId = customAlphabet(alphabet, 21);
+export const generateLongId = customAlphabet(alphabet, 21);
 export const generateShortId = customAlphabet(alphabet, 9);
 export const generateUUID = () => randomUUID();
+
+export const generateTrackingId = (req: FastifyRequest): Promise<string> => {
+  if (req.meter) {
+    req.meter
+      .createCounter('generate_tracking_id', {
+        description: 'How many times a tracking id was generated',
+      })
+      .add(1);
+  }
+  return generateLongId();
+};

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -1,4 +1,4 @@
-import { generateTrackingId } from '../ids';
+import { generateLongId } from '../ids';
 import { retryFetch } from './retry';
 
 const generateEventId = (now) => {
@@ -12,8 +12,8 @@ export async function sendAnalyticsEvent<
 >(events: T[]): Promise<void> {
   const now = new Date();
   const [visit_id, session_id] = await Promise.all([
-    generateTrackingId(),
-    generateTrackingId(),
+    generateLongId(),
+    generateLongId(),
   ]);
   const transformed = events.map((event) => ({
     event_id: generateEventId(now),

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -72,7 +72,7 @@ export const clearAuthentication = async (
     },
     'clearing authentication',
   );
-  req.trackingId = await generateTrackingId();
+  req.trackingId = await generateTrackingId(req);
   req.userId = undefined;
   setTrackingId(req, res, req.trackingId);
   setCookie(req, res, 'auth', undefined);

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import createOrGetConnection from '../db';
 import { DataSource, EntityManager } from 'typeorm';
 import { clearAuthentication, dispatchWhoami } from '../kratos';
-import { generateTrackingId } from '../ids';
+import { generateLongId } from '../ids';
 import { generateSessionId, setTrackingId } from '../tracking';
 import { GQLUser } from '../schema/users';
 import {
@@ -108,7 +108,7 @@ const visitSection = async (
   res: FastifyReply,
 ): Promise<BaseBoot['visit']> => {
   const [visitId, sessionId] = await Promise.all([
-    generateTrackingId(),
+    generateLongId(),
     generateSessionId(req, res),
   ]);
   return {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
 import isbot from 'isbot';
 import { cookies, setCookie } from './cookies';
-import { generateTrackingId } from './ids';
+import { generateLongId, generateTrackingId } from './ids';
 
 const isBotRequest = (req: FastifyRequest): boolean =>
   !req.headers['user-agent'] || isbot(req.headers['user-agent']);
@@ -13,7 +13,7 @@ export const generateSessionId = async (
 ): Promise<string> => {
   if (!req.isBot && !req.service) {
     if (!req.sessionId?.length) {
-      req.sessionId = await generateTrackingId();
+      req.sessionId = await generateLongId();
     }
     // Refresh session cookie
     setCookie(req, res, 'session', req.sessionId);
@@ -42,7 +42,7 @@ const plugin = async (fastify: FastifyInstance): Promise<void> => {
     } else if (trackingCookie) {
       req.trackingId = trackingCookie;
     } else if (!req.isBot && !req.service) {
-      req.trackingId = await generateTrackingId();
+      req.trackingId = await generateTrackingId(req);
     }
     if (req.trackingId !== trackingCookie) {
       setTrackingId(req, res, req.trackingId);


### PR DESCRIPTION
Add metric to measure how many times we generate a tracking id. This is part of an ongoing effort to fix issues in our authentication.