### PR TITLE
fix: add the resource attributes that google expects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.17.0",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.1.0",
         "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.17.0",
+        "@google-cloud/opentelemetry-resource-util": "^2.1.0",
         "@google-cloud/pubsub": "^3.7.5",
         "@google-cloud/trace-agent": "^7.1.2",
         "@graphql-tools/schema": "^9.0.19",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.17.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.1.0",
     "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.17.0",
+    "@google-cloud/opentelemetry-resource-util": "^2.1.0",
     "@google-cloud/pubsub": "^3.7.5",
     "@google-cloud/trace-agent": "^7.1.2",
     "@graphql-tools/schema": "^9.0.19",

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -5,6 +5,7 @@ import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exp
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
+import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
 
 import { isProd } from '../common';
 
@@ -24,7 +25,7 @@ export const startMetrics = (serviceName: string): void => {
       [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
     }).merge(
       resources.detectResourcesSync({
-        detectors: [containerDetector, gcpDetector],
+        detectors: [containerDetector, gcpDetector, new GcpDetectorSync()],
       }),
     ),
   });

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -14,6 +14,7 @@ import { NodeSDK, logs, node, api, resources } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { SemanticAttributes as SemAttr } from '@opentelemetry/semantic-conventions';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
+import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
 // import { CloudPropagator } from '@google-cloud/opentelemetry-cloud-trace-propagator';
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
@@ -31,6 +32,7 @@ const resourceDetectors = [
   resources.processDetectorSync,
   containerDetector,
   gcpDetector,
+  new GcpDetectorSync(),
 ];
 
 // Try to get the app version from the header, then query param, then default to unknown


### PR DESCRIPTION
This should hopefully resolve the issue with exporting timeseries metrics