### PR TITLE
fix: add new alerts columns

### DIFF
--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -87,24 +87,6 @@ describe('query userAlerts', () => {
   });
 });
 
-it('should populate database', async () => {
-  const start = new Date('02/05/2020');
-  let loop = new Date(start);
-  for (let i = 0; i < 100000; i++) {
-    const newDate = loop.setDate(loop.getDate() + i);
-    loop = new Date(newDate);
-    const repo = con.getRepository(Alerts);
-    const alerts = repo.create({
-      userId: `${i}`,
-      filter: true,
-      flags: { lastReferralReminder: loop },
-    });
-    await repo.save(alerts);
-    console.log('done');
-  }
-  expect('something').toEqual('false');
-});
-
 describe('mutation updateUserAlerts', () => {
   const MUTATION = `
     mutation UpdateUserAlerts($data: UpdateAlertsInput!) {

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -49,6 +49,7 @@ import { base64 } from 'graphql-relay/utils/base64';
 import { cookies } from '../src/cookies';
 import { signJwt } from '../src/auth';
 import { submitArticleThreshold } from '../src/common';
+import { saveReturnAlerts } from '../src/schema/alerts';
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -378,7 +379,8 @@ describe('boot alerts', () => {
       userId: '1',
       myFeed: 'created',
     });
-    const alerts = new Object(data);
+
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['changelog'] = false;
     alerts['banner'] = false;
     delete alerts['userId'];
@@ -402,7 +404,7 @@ describe('boot alerts', () => {
       lastChangelog: new Date('2023-02-05 12:00:00'),
       lastBanner: new Date('2023-02-05 12:00:00'),
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
     alerts['changelog'] = true;
     alerts['banner'] = false;
@@ -425,7 +427,7 @@ describe('boot alerts', () => {
       lastChangelog: new Date('2023-02-06 12:00:00'),
       lastBanner: new Date('2023-02-06 12:00:00'),
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-06T12:00:00.000Z';
     alerts['lastBanner'] = '2023-02-06T12:00:00.000Z';
     alerts['changelog'] = false;
@@ -459,7 +461,7 @@ describe('boot alerts', () => {
       createdAt: new Date('2023-02-06 12:00:00'),
       sourceId: 'daily_updates',
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
     alerts['lastBanner'] = '2023-02-05T12:00:00.000Z';
     alerts['changelog'] = true;
@@ -496,7 +498,7 @@ describe('boot alerts', () => {
       createdAt: new Date('2023-02-05 12:00:00'),
       sourceId: 'daily_updates',
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-06T12:00:00.000Z';
     alerts['lastBanner'] = '2023-02-06T12:00:00.000Z';
     alerts['changelog'] = false;
@@ -521,7 +523,7 @@ describe('boot alerts', () => {
       lastBanner: new Date('2023-02-05 12:00:00'),
       lastChangelog: new Date('2023-02-05 12:00:00'),
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastBanner'] = '2023-02-05T12:00:00.000Z';
     alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
     alerts['changelog'] = false;
@@ -543,7 +545,7 @@ describe('boot alerts', () => {
       lastBanner: new Date('2023-02-06 12:00:00'),
       lastChangelog: new Date('2023-02-06 12:00:00'),
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-06T12:00:00.000Z';
     alerts['lastBanner'] = '2023-02-06T12:00:00.000Z';
     alerts['banner'] = false;
@@ -565,7 +567,7 @@ describe('boot alerts', () => {
       lastChangelog: new Date('2023-02-05 12:00:00'),
       lastBanner: new Date('2023-02-05 12:00:00'),
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
     alerts['changelog'] = false;
     alerts['lastBanner'] = '2023-02-05T12:00:00.000Z';
@@ -594,7 +596,7 @@ describe('boot alerts', () => {
       url: 'test',
       theme: 'cabbage',
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastBanner'] = '2023-02-06T12:00:00.000Z';
     alerts['banner'] = true;
     alerts['changelog'] = false;
@@ -621,7 +623,7 @@ describe('boot alerts', () => {
       changelog: false,
       showGenericReferral: true,
     });
-    const alerts = new Object(data);
+    const alerts = new Object(saveReturnAlerts(data));
     alerts['lastBanner'] = '2023-02-05T12:00:00.000Z';
     alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
     delete alerts['userId'];

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -609,6 +609,28 @@ describe('boot alerts', () => {
       banner.timestamp.toISOString(),
     );
   });
+
+  it('should return showGenericReferral as true', async () => {
+    mockLoggedIn();
+    const data = await con.getRepository(Alerts).save({
+      userId: '1',
+      myFeed: 'created',
+      lastChangelog: new Date('2023-02-05 12:00:00'),
+      lastBanner: new Date('2023-02-05 12:00:00'),
+      banner: false,
+      changelog: false,
+      showGenericReferral: true,
+    });
+    const alerts = new Object(data);
+    alerts['lastBanner'] = '2023-02-05T12:00:00.000Z';
+    alerts['lastChangelog'] = '2023-02-05T12:00:00.000Z';
+    delete alerts['userId'];
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('Cookie', 'ory_kratos_session=value;')
+      .expect(200);
+    expect(res.body.alerts).toEqual(alerts);
+  });
 });
 
 describe('boot misc', () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -1227,7 +1227,7 @@ describe('post report', () => {
 });
 
 describe('alerts', () => {
-  type ObjectType = Alerts;
+  type ObjectType = Omit<Alerts, 'flags'>;
   const rankLastSeen = new Date('2020-09-21T07:15:51.247Z');
   const rankLastSeenNew = new Date('2020-09-22T07:15:51.247Z');
   const base: ChangeObject<ObjectType> = {
@@ -1239,6 +1239,7 @@ describe('alerts', () => {
     lastChangelog: null,
     lastBanner: null,
     squadTour: true,
+    showGenericReferral: false,
   };
 
   it('should notify on alert.filter changed', async () => {

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 
 export type AlertsFlags = Partial<{
-  lastReferralReminderEpoch: bigint;
+  lastReferralReminder: Date | null;
 }>;
 
 @Entity()
-@Index('IDX_alerts_flags_last_referral_reminder_epoch', {
+@Index('IDX_alerts_flags_last_referral_reminder', {
   synchronize: false,
 })
 export class Alerts {
@@ -38,7 +38,7 @@ export class Alerts {
   lastBanner: Date | null;
 
   // Should not be exposed to the client
-  @Column({ type: 'jsonb', default: {} })
+  @Column({ type: 'jsonb', default: {}, select: false })
   flags: AlertsFlags = {};
 
   changelog?: boolean;

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -1,6 +1,13 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 
+export type AlertsFlags = Partial<{
+  lastReferralReminderEpoch: bigint;
+}>;
+
 @Entity()
+@Index('IDX_alerts_flags_last_referral_reminder_epoch', {
+  synchronize: false,
+})
 export class Alerts {
   @PrimaryColumn({ type: 'text' })
   @Index()
@@ -21,18 +28,25 @@ export class Alerts {
   @Column({ type: 'bool', default: true })
   squadTour: boolean;
 
+  @Column({ type: 'bool', default: false })
+  showGenericReferral: boolean;
+
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastChangelog: Date | null;
 
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastBanner: Date | null;
 
+  // Should not be exposed to the client
+  @Column({ type: 'jsonb', default: {} })
+  flags: AlertsFlags = {};
+
   changelog?: boolean;
 
   banner?: boolean;
 }
 
-export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
+export const ALERTS_DEFAULT: Omit<Alerts, 'userId' | 'flags'> = {
   filter: true,
   rankLastSeen: null,
   myFeed: null,
@@ -42,4 +56,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId'> = {
   changelog: false,
   banner: false,
   squadTour: true,
+  showGenericReferral: false,
 };

--- a/src/migration/1698838065767-AlertsFlags.ts
+++ b/src/migration/1698838065767-AlertsFlags.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlertsFlags1698838065767 implements MigrationInterface {
+  name = 'AlertsFlags1698838065767';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "showGenericReferral" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "flags" jsonb NOT NULL DEFAULT '{}'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_alerts_flags_last_referral_reminder_epoch" ON alerts (((flags->'lastReferralReminderEpoch')::integer))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_alerts_flags_last_referral_reminder_epoch"`,
+    );
+    await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "flags"`);
+    await queryRunner.query(
+      `ALTER TABLE "alerts" DROP COLUMN "showGenericReferral"`,
+    );
+  }
+}

--- a/src/migration/1698838065767-AlertsFlags.ts
+++ b/src/migration/1698838065767-AlertsFlags.ts
@@ -11,13 +11,13 @@ export class AlertsFlags1698838065767 implements MigrationInterface {
       `ALTER TABLE "alerts" ADD "flags" jsonb NOT NULL DEFAULT '{}'`,
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_alerts_flags_last_referral_reminder_epoch" ON alerts (((flags->'lastReferralReminderEpoch')::integer))`,
+      `CREATE INDEX "IDX_alerts_flags_last_referral_reminder" ON alerts (((flags->'lastReferralReminder')::text))`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `DROP INDEX "public"."IDX_alerts_flags_last_referral_reminder_epoch"`,
+      `DROP INDEX "public"."IDX_alerts_flags_last_referral_reminder"`,
     );
     await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "flags"`);
     await queryRunner.query(

--- a/src/migration/1698838065767-AlertsFlags.ts
+++ b/src/migration/1698838065767-AlertsFlags.ts
@@ -4,6 +4,16 @@ export class AlertsFlags1698838065767 implements MigrationInterface {
   name = 'AlertsFlags1698838065767';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+        CREATE OR REPLACE FUNCTION dateCastIndex(jsonObject jsonb, field text)
+        RETURNS date
+        AS
+        $$
+          SELECT (jsonObject ->> field)::date;
+        $$
+        language sql
+        IMMUTABLE;
+      `);
     await queryRunner.query(
       `ALTER TABLE "alerts" ADD "showGenericReferral" boolean NOT NULL DEFAULT false`,
     );
@@ -11,14 +21,13 @@ export class AlertsFlags1698838065767 implements MigrationInterface {
       `ALTER TABLE "alerts" ADD "flags" jsonb NOT NULL DEFAULT '{}'`,
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_alerts_flags_last_referral_reminder" ON alerts (((flags->'lastReferralReminder')::text))`,
+      `CREATE INDEX on alerts ((dateCastIndex(flags, 'lastReferralReminder')));`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `DROP INDEX "public"."IDX_alerts_flags_last_referral_reminder"`,
-    );
+    await queryRunner.query(`DROP INDEX "public"."alerts_datecastindex_idx"`);
+    await queryRunner.query('DROP FUNCTION IF EXISTS dateCastIndex');
     await queryRunner.query(`ALTER TABLE "alerts" DROP COLUMN "flags"`);
     await queryRunner.query(
       `ALTER TABLE "alerts" DROP COLUMN "showGenericReferral"`,

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -12,6 +12,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         lastChangelog
         lastBanner
         squadTour
+        showGenericReferral
       }
     }`;
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -65,7 +65,7 @@ export type Experimentation = {
 
 export type BaseBoot = {
   visit: { visitId: string; sessionId: string };
-  alerts: Omit<Alerts, 'userId'>;
+  alerts: Omit<Alerts, 'userId' | 'flags'>;
   settings: Omit<Settings, 'userId' | 'updatedAt'>;
   notifications: { unreadNotificationsCount: number };
   squads: BootSquadSource[];


### PR DESCRIPTION
Added new alerts columns as described in [DR](https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/659161109/Referral+program+and+profile+UX+improvements#Persistent-data-for-referral-reminder).
had to adjust from Date as it's not supported in JSONB, decided to go for bigint to avoid y2k issues down the line (2038)

WT-1921 #done 