### PR TITLE
feat: referred users query

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -37,7 +37,7 @@ import {
 } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { getTimezonedStartOfISOWeek } from '../src/common';
-import { DataSource } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import request from 'supertest';
 import { FastifyInstance } from 'fastify';
@@ -307,6 +307,50 @@ describe('query userStats', () => {
     const res = await client.query(QUERY, { variables: { id: '2' } });
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('query referredUsers', () => {
+  const QUERY = `query ReferredUsers {
+    referredUsers {
+      edges {
+        node {
+          id
+          name
+          username
+          bio
+          image
+        }
+      }
+    }
+  }`;
+
+  it('should return users that have been referred by the logged in user', async () => {
+    loggedUser = '1';
+    const referred = ['4', '2', '3'];
+    await con
+      .getRepository(User)
+      .update({ id: In(referred) }, { referralId: '1' });
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+    const isAllReferred = res.data.referredUsers.edges.every(({ node }) =>
+      referred.includes(node.id),
+    );
+    expect(isAllReferred).toBeTruthy();
+  });
+
+  it('should not return users that have been referred by the logged in user', async () => {
+    loggedUser = '1';
+    const outsideReferred = ['1', '5', '6'];
+    await con
+      .getRepository(User)
+      .update({ id: In(['4', '2', '3']) }, { referralId: '1' });
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+    const noUnReferred = res.data.referredUsers.edges.every(
+      ({ node }) => !outsideReferred.includes(node.id),
+    );
+    expect(noUnReferred).toBeTruthy();
   });
 });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -331,6 +331,7 @@ describe('query referredUsers', () => {
   it('should return users that have been referred by the logged in user', async () => {
     loggedUser = '1';
     const referred = ['4', '2', '3'];
+    const outsideReferred = ['1', '5', '6'];
     await con
       .getRepository(User)
       .update({ id: In(referred) }, { referralId: '1' });
@@ -340,16 +341,6 @@ describe('query referredUsers', () => {
       referred.includes(node.id),
     );
     expect(isAllReferred).toBeTruthy();
-  });
-
-  it('should not return users that have been referred by the logged in user', async () => {
-    loggedUser = '1';
-    const outsideReferred = ['1', '5', '6'];
-    await con
-      .getRepository(User)
-      .update({ id: In(['4', '2', '3']) }, { referralId: '1' });
-    const res = await client.query(QUERY);
-    expect(res.errors).toBeFalsy();
     const noUnReferred = res.data.referredUsers.edges.every(
       ({ node }) => !outsideReferred.includes(node.id),
     );

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -325,6 +325,9 @@ describe('query referredUsers', () => {
     }
   }`;
 
+  it('should not allow unauthenticated users', () =>
+    testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED'));
+
   it('should return users that have been referred by the logged in user', async () => {
     loggedUser = '1';
     const referred = ['4', '2', '3'];

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -159,6 +159,7 @@ const defaultUser: ChangeObject<User> = {
   infoConfirmed: true,
   acceptedMarketing: true,
   notificationEmail: true,
+  createdAt: new Date(2023, 1, 1).getTime(),
 };
 
 describe('source request', () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -145,7 +145,7 @@ beforeEach(async () => {
   nock.cleanAll();
 });
 
-const defaultUser: ChangeObject<User> = {
+const defaultUser: ChangeObject<Omit<User, 'createdAt'>> = {
   id: '1',
   name: 'Ido',
   email: 'ido@daily.dev',
@@ -159,7 +159,6 @@ const defaultUser: ChangeObject<User> = {
   infoConfirmed: true,
   acceptedMarketing: true,
   notificationEmail: true,
-  createdAt: new Date(2023, 1, 1).getTime(),
 };
 
 describe('source request', () => {

--- a/__tests__/workers/cdc.ts
+++ b/__tests__/workers/cdc.ts
@@ -516,7 +516,7 @@ describe('comment', () => {
 });
 
 describe('user', () => {
-  type ObjectType = User;
+  type ObjectType = Omit<User, 'createdAt'>;
   const base: ChangeObject<ObjectType> = { ...defaultUser };
 
   it('should notify on user created', async () => {

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -97,7 +97,7 @@ export class User {
 
   @Column({ nullable: false, default: () => 'now()' })
   @Index('IDX_user_createdAt')
-  createdAt?: Date;
+  createdAt: Date;
 
   @Column({ nullable: true })
   updatedAt?: Date;

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -51,7 +51,7 @@ const nullIfNotSameUser = <T>(
 
 const obj = new GraphORM({
   User: {
-    requiredColumns: ['id', 'username'],
+    requiredColumns: ['id', 'username', 'createdAt'],
     fields: {
       infoConfirmed: {
         transform: nullIfNotSameUser,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1129,7 +1129,6 @@ export const resolvers: IResolvers<any, Context> = {
 
       return { _: true };
     },
-
     acceptFeatureInvite: async (
       _,
       {


### PR DESCRIPTION
Fetch all the users that have been referred by the login user.

From the entity itself, the `createdAt` is not nullable, hence, updated the types.

Made the `createdAt` to be always required as it is part of the query for fetching the list which does not necessarily need to be displayed in FE.