### PR TITLE
feat: disable sendgrid warnings in production

### DIFF
--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -54,6 +54,7 @@ Object {
     "email": "informer@daily.dev",
     "name": "daily.dev",
   },
+  "hideWarnings": false,
   "replyTo": Object {
     "email": "hi@daily.dev",
     "name": "daily.dev",
@@ -141,6 +142,7 @@ Object {
     "email": "informer@daily.dev",
     "name": "daily.dev",
   },
+  "hideWarnings": false,
   "replyTo": Object {
     "email": "hi@daily.dev",
     "name": "daily.dev",
@@ -228,6 +230,7 @@ Object {
     "email": "informer@daily.dev",
     "name": "daily.dev",
   },
+  "hideWarnings": false,
   "replyTo": Object {
     "email": "hi@daily.dev",
     "name": "daily.dev",
@@ -315,6 +318,7 @@ Object {
     "email": "digest@daily.dev",
     "name": "Weekly Digest",
   },
+  "hideWarnings": false,
   "replyTo": Object {
     "email": "hi@daily.dev",
     "name": "daily.dev",

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -41,7 +41,7 @@ export const formatMailDate = (date: Date): string =>
 
 export const baseNotificationEmailData: Pick<
   MailDataRequired,
-  'from' | 'replyTo' | 'trackingSettings' | 'asm' | 'category'
+  'from' | 'replyTo' | 'trackingSettings' | 'asm' | 'category' | 'hideWarnings'
 > = {
   from: {
     email: 'informer@daily.dev',
@@ -59,6 +59,7 @@ export const baseNotificationEmailData: Pick<
     groupId: 12850,
   },
   category: 'Notification',
+  hideWarnings: process.env.NODE_ENV === 'production',
 };
 
 export const sendEmail: typeof sgMail.send = (data) => {


### PR DESCRIPTION
Sendgrid logs warning whenever it detects template data contains some special chars, we don't want it in production since it spams our logs and makes hard to see any other errors.

See: https://github.com/sendgrid/sendgrid-nodejs/blob/main/docs/use-cases/hide-warnings.md