### PR TITLE
fix: increase cardinality for GraphQL metrics

### DIFF
--- a/src/schema/trace.ts
+++ b/src/schema/trace.ts
@@ -23,6 +23,7 @@ export function traceResolver<TSource, TArgs, TReturn>(
       });
 
       context.metricGraphqlCounter.add(1, {
+        ['graphql.field.name']: info.fieldName,
         ['graphql.operation.name']: info.operation?.name?.value,
         ['graphql.operation.type']: info.operation?.operation,
       });


### PR DESCRIPTION
Currently the query `TagCategories` is according to the metrics the most requested query, however it turns out if a `Query` contains multiple sub queries, just like `TagCategories` does, it increments the counter for each sub query, therefore skewing the metrics to show that this query is the most requested. When in reality it should have 1/3 of the amount of requests it currently have.

Before
```
graphql_operations_total{graphql_operation_name="TagCategories",graphql_operation_type="query"} 3
```

After
```promql
graphql_operations_total{graphql_fieldName="tagsCategories",graphql_operation_name="TagCategories",graphql_operation_type="query"} 1
graphql_operations_total{graphql_fieldName="feedSettings",graphql_operation_name="TagCategories",graphql_operation_type="query"} 1
graphql_operations_total{graphql_fieldName="advancedSettings",graphql_operation_name="TagCategories",graphql_operation_type="query"} 1
```