### PR TITLE
fix: add referral link to sendgrid users

### DIFF
--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -1,4 +1,5 @@
 import { Source, SourceType } from '../entity';
+import type { Invite, User } from '../entity';
 import { Headers } from 'node-fetch';
 import { FastifyBaseLogger } from 'fastify';
 import { retryFetchParse } from '../integrations/retry';
@@ -55,6 +56,25 @@ export function isValidHttpUrl(link: string): boolean {
     return false;
   }
 }
+
+type GetInviteLinkProps = {
+  referralOrigin: string;
+  userId: User['id'];
+  token?: Invite['token'];
+};
+export const getInviteLink = ({
+  referralOrigin,
+  userId,
+  token,
+}: GetInviteLinkProps): URL => {
+  const campaignUrl = new URL('/join', process.env.COMMENTS_PREFIX);
+  campaignUrl.searchParams.append('cid', referralOrigin);
+  campaignUrl.searchParams.append('userid', userId);
+  if (token) {
+    campaignUrl.searchParams.append('ctoken', token);
+  }
+  return campaignUrl;
+};
 
 export const getShortUrl = async (
   url: string,

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -4,6 +4,7 @@ import { MailDataRequired } from '@sendgrid/helpers/classes/mail';
 import { User } from './users';
 import { ChangeObject } from '../types';
 import { FastifyBaseLogger } from 'fastify';
+import { getInviteLink } from './links';
 
 if (process.env.SENDGRID_API_KEY) {
   client.setApiKey(process.env.SENDGRID_API_KEY);
@@ -90,10 +91,18 @@ interface EmailContact {
 }
 
 const profileToContact = (profile: User, contactId: string) => {
+  const genericInviteURL = getInviteLink({
+    referralOrigin: 'generic',
+    userId: profile.id,
+  });
+
   const contact: EmailContact = {
     id: contactId,
     email: profile.email,
-    custom_fields: { e1_T: profile.id },
+    custom_fields: {
+      e1_T: profile.id,
+      e2_T: genericInviteURL.toString(),
+    },
   };
 
   const name = profile.name && profile.name.trim();

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -26,6 +26,7 @@ import { Context } from '../Context';
 import { traceResolverObject } from './trace';
 import { queryPaginatedByDate } from '../common/datePageGenerator';
 import {
+  getInviteLink,
   getShortUrl,
   getUserReadingRank,
   isValidHttpUrl,
@@ -885,18 +886,16 @@ export const resolvers: IResolvers<any, Context> = {
       const { referralOrigin } = args;
       const userRepo = ctx.getRepository(User);
 
-      const campaignUrl = new URL('/join', process.env.COMMENTS_PREFIX);
-      campaignUrl.searchParams.append('cid', referralOrigin);
-      campaignUrl.searchParams.append('userid', ctx.userId);
-
       const userInvite = await ctx.getRepository(Invite).findOneBy({
         userId: ctx.userId,
         campaign: referralOrigin as CampaignType,
       });
 
-      if (userInvite) {
-        campaignUrl.searchParams.append('ctoken', userInvite.token);
-      }
+      const campaignUrl = getInviteLink({
+        referralOrigin,
+        userId: ctx.userId,
+        token: userInvite?.token,
+      });
 
       const [referredUsersCount, url] = await Promise.all([
         userInvite?.count ||


### PR DESCRIPTION
Ensure new parsed people get their referral link added to the new custom field in Sendgrid.
Next step is to do a batch CSV to insert all existing users with this field set.

WT-1978 #done 