### PR TITLE
chore: remove additional logging from digest worker

### DIFF
--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -207,11 +207,6 @@ const worker: Worker = {
     ).execute();
 
     if (posts.length === 0) {
-      logger.warn(
-        { data: messageToJson(message) },
-        'no posts found for personalized digest',
-      );
-
       return;
     }
 


### PR DESCRIPTION
Currently for each user that does not get any recommendations for the digest the worker writes two log entries:
<img width="754" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/34a9e062-bd55-4b4e-81dd-cbfc6bbe95af">

Second one contains user id and feed config that was requested so it allows us to debug those when we want. 

First one I am removing in this PR since it is a duplicate and contains digest subscription data which is not relevant in that case.