### PR TITLE
test: collections should not be editable

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2899,6 +2899,16 @@ describe('mutation editPost', () => {
 
     await con
       .getRepository(Post)
+      .update({ id: 'p1' }, { type: PostType.Collection });
+
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: params },
+      'FORBIDDEN',
+    );
+
+    await con
+      .getRepository(Post)
       .update({ id: 'p1' }, { type: PostType.Article });
 
     return testMutationErrorCode(


### PR DESCRIPTION
Since it is explicitly defined which types should only be edited, we just need to add a test to ensure collection type of post should never be allowed.

WT-1960 #done