### PR TITLE
feat: get comment by id query

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -1311,3 +1311,28 @@ describe('mutation reportComment', () => {
     expect(res2.errors).toBeFalsy();
   });
 });
+
+describe('query comment', () => {
+  const QUERY = `
+    query Comment($id: ID!) {
+      comment(id: $id) {
+        id
+        content
+      }
+    }
+  `;
+
+  it('should not return comment by id when not authenticated', async () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { id: '123' } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should return comment by id', async () => {
+    loggedUser = '1';
+    const comment = await client.query(QUERY, { variables: { id: 'c1' } });
+    expect(comment.errors).toBeFalsy();
+    expect(comment.data.comment.id).toEqual('c1');
+  });
+});

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -279,6 +279,11 @@ export const typeDefs = /* GraphQL */ `
     Markdown equivalent of the user's comment
     """
     commentPreview(content: String!, sourceId: String): String @auth
+
+    """
+    Fetch a comment by id
+    """
+    comment(id: ID!): Comment @auth
   }
 
   extend type Mutation {
@@ -665,6 +670,19 @@ export const resolvers: IResolvers<any, Context> = {
 
       return markdown.render(trimmed, { mentions });
     },
+    comment: async (
+      _,
+      { id }: { id: string },
+      ctx,
+      info,
+    ): Promise<GQLComment> =>
+      graphorm.queryOneOrFail<GQLComment>(ctx, info, (builder) => ({
+        queryBuilder: builder.queryBuilder.where(
+          `"${builder.alias}"."id" = :id`,
+          { id },
+        ),
+        ...builder,
+      })),
   }),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Mutation: traceResolverObject<any, any>({


### PR DESCRIPTION
In order to lessen the load we request from the server, we will start to not fetch the markdown content on post comments as those values are unused. If need be, the app will send a query to fetch the comment's details which includes what was missed in the post comments, which is the markdown content.