### PR TITLE
fix: shortened URL for referral

### DIFF
--- a/__tests__/workers/sourceSquadCreatedOwnerMailing.ts
+++ b/__tests__/workers/sourceSquadCreatedOwnerMailing.ts
@@ -80,6 +80,7 @@ describe('sourceSquadCreatedOwnerMailing worker', () => {
       user,
       [LIST_SQUAD_DRIP_CAMPAIGN],
       undefined,
+      expect.anything(),
     );
   });
 

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -106,11 +106,7 @@ const profileToContact = async (
     referralOrigin: 'generic',
     userId: profile.id,
   });
-
-  const [genericInviteURL] = await Promise.all([
-    getShortUrl(rawInviteURL.toString(), log),
-  ]);
-
+  const genericInviteURL = await getShortUrl(rawInviteURL.toString(), log);
   const contact: EmailContact = {
     id: contactId,
     email: profile.email,

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -4,7 +4,7 @@ import { MailDataRequired } from '@sendgrid/helpers/classes/mail';
 import { User } from './users';
 import { ChangeObject } from '../types';
 import { FastifyBaseLogger } from 'fastify';
-import { getInviteLink } from './links';
+import { getInviteLink, getShortUrl } from './links';
 
 if (process.env.SENDGRID_API_KEY) {
   client.setApiKey(process.env.SENDGRID_API_KEY);
@@ -97,11 +97,19 @@ interface EmailContact {
   custom_fields: Record<string, string>;
 }
 
-const profileToContact = (profile: User, contactId: string) => {
-  const genericInviteURL = getInviteLink({
+const profileToContact = async (
+  profile: User,
+  contactId: string,
+  log: FastifyBaseLogger,
+) => {
+  const rawInviteURL = getInviteLink({
     referralOrigin: 'generic',
     userId: profile.id,
   });
+
+  const [genericInviteURL] = await Promise.all([
+    getShortUrl(rawInviteURL.toString(), log),
+  ]);
 
   const contact: EmailContact = {
     id: contactId,
@@ -124,17 +132,19 @@ const profileToContact = (profile: User, contactId: string) => {
   return contact;
 };
 
-export const addUserToContacts = (
+export const addUserToContacts = async (
   profile: User,
   lists: string[],
   contactId: string,
+  log: FastifyBaseLogger,
 ) => {
+  const contact = await profileToContact(profile, contactId, log);
   const request = {
     method: 'PUT' as HttpMethod,
     url: '/v3/marketing/contacts',
     body: {
       list_ids: lists || undefined,
-      contacts: [profileToContact(profile, contactId)],
+      contacts: [contact],
     },
   };
   return client.request(request);
@@ -198,7 +208,7 @@ export const updateUserContactLists = async (
         removeUserFromList(LIST_SQUAD_DRIP_CAMPAIGN, contactId),
       ]);
     }
-    await addUserToContacts(newProfile, lists, contactId);
+    await addUserToContacts(newProfile, lists, contactId, log);
   } catch (err) {
     if (
       err.code === 400 &&

--- a/src/workers/sourceSquadCreatedOwnerMailing.ts
+++ b/src/workers/sourceSquadCreatedOwnerMailing.ts
@@ -14,7 +14,7 @@ interface Data {
 
 const worker: Worker = {
   subscription: 'api.source-created-squad-owner-mailing',
-  handler: async (message, con) => {
+  handler: async (message, con, logger) => {
     const data: Data = messageToJson(message);
 
     const { source } = data;
@@ -52,7 +52,12 @@ const worker: Worker = {
 
       const contactId = await getContactIdByEmail(user.email);
 
-      await addUserToContacts(user, [LIST_SQUAD_DRIP_CAMPAIGN], contactId);
+      await addUserToContacts(
+        user,
+        [LIST_SQUAD_DRIP_CAMPAIGN],
+        contactId,
+        logger,
+      );
     }
   },
 };


### PR DESCRIPTION
Add shortened URL for sendgrid.

WT-1980

@idoshamun We only need to worry about the data loader in graphQL requests? (thus can omit like in this PR?)