### PR TITLE
feat: add updatedAt field for post

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -199,6 +199,9 @@ const obj = new GraphORM({
           return value;
         },
       },
+      updatedAt: {
+        select: 'metadataChangedAt',
+      },
     },
   },
   Source: {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -492,6 +492,11 @@ export const typeDefs = /* GraphQL */ `
     User state for the post
     """
     userState: UserPost @auth
+
+    """
+    Time the post was updated
+    """
+    updatedAt: DateTime
   }
 
   type PostConnection {


### PR DESCRIPTION
We need updated at value to show in collections post page. `metadataUpdatedAt` is `updated_at` from platform so it should suffice and we can always adjust it with other field thus i called it `updatedAt` generically. 

<img width="917" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/73d1326d-7b10-4b6d-a766-51ffa7706f11">
