### PR TITLE
chore: enable cron for referral reminder

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -4,7 +4,7 @@ interface Cron {
   limits?: {
     cpu: string;
     memory: string;
-  }
+  };
 }
 
 export const crons: Cron[] = [
@@ -49,17 +49,17 @@ export const crons: Cron[] = [
     schedule: '15 0 * * *',
     limits: {
       cpu: '250m',
-      memory: '1Gi'
-    }
+      memory: '1Gi',
+    },
   },
   {
     name: 'generate-search-invites',
     schedule: '15 1 * * *',
   },
-  // {
-  //   name: 'generic-referral-reminder',
-  //   schedule: '12 3 * * *',
-  // },
+  {
+    name: 'generic-referral-reminder',
+    schedule: '12 3 * * *',
+  },
   {
     name: 'update-tag-recommendations',
     schedule: '5 3 * * 0',


### PR DESCRIPTION
The count of users with `false` for `showGenericReferral` is 77k. If it goes down, it means the cron has updated users mistakenly since everyone has either the `true` value of the said property or has seen it.

Again, thank you to @rebelchris for running the scripts on a day-to-day basis 🥳 

Note: kindly ignore the changes on other lines, made by prettier automatically.