### PR TITLE
feat: collection post type can have state without image

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -989,7 +989,11 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
-const nullableImageType = [PostType.Freeform, PostType.Welcome];
+const nullableImageType = [
+  PostType.Freeform,
+  PostType.Welcome,
+  PostType.Collection,
+];
 
 const saveHiddenPost = async (
   con: DataSource,


### PR DESCRIPTION
Basically this enables following case when post does not have an image, until this point it returned a placeholder.
<img width="239" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/76320396-a89e-4554-a9ce-57169f2d126b">
