### PR TITLE
refactor: type safety pubsub implementation

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -33,7 +33,6 @@ import {
   notifySourceFeedAdded,
   notifySourceFeedRemoved,
   notifySourcePrivacyUpdated,
-  notifySourceRequest,
   notifySubmissionGrantedAccess,
   notifySubmissionRejected,
   notifyUserCreated,
@@ -52,6 +51,7 @@ import {
   notifyPostYggdrasilIdSet,
   notifyPostCollectionUpdated,
   notifyUserReadmeUpdated,
+  triggerTypedEvent,
 } from '../../../src/common';
 import worker from '../../../src/workers/cdc/primary';
 import {
@@ -97,7 +97,7 @@ import { usersFixture } from '../../fixture/user';
 
 jest.mock('../../../src/common', () => ({
   ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
-  notifySourceRequest: jest.fn(),
+  triggerTypedEvent: jest.fn(),
   notifyPostUpvoted: jest.fn(),
   notifyPostUpvoteCanceled: jest.fn(),
   notifyCommentUpvoteCanceled: jest.fn(),
@@ -189,10 +189,10 @@ describe('source request', () => {
         table: 'source_request',
       }),
     );
-    expect(notifySourceRequest).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
-      'new',
-      after,
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'pub-request',
+      { reason: 'new', sourceRequest: after },
     ]);
   });
 
@@ -214,10 +214,10 @@ describe('source request', () => {
         table: 'source_request',
       }),
     );
-    expect(notifySourceRequest).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
-      'publish',
-      after,
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'pub-request',
+      { reason: 'publish', sourceRequest: after },
     ]);
   });
 
@@ -238,10 +238,10 @@ describe('source request', () => {
         table: 'source_request',
       }),
     );
-    expect(notifySourceRequest).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
-      'decline',
-      after,
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'pub-request',
+      { reason: 'decline', sourceRequest: after },
     ]);
   });
 
@@ -262,10 +262,10 @@ describe('source request', () => {
         table: 'source_request',
       }),
     );
-    expect(notifySourceRequest).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(notifySourceRequest).mock.calls[0].slice(1)).toEqual([
-      'approve',
-      after,
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'pub-request',
+      { reason: 'approve', sourceRequest: after },
     ]);
   });
 });

--- a/__tests__/workers/sourceRequestApproved.ts
+++ b/__tests__/workers/sourceRequestApproved.ts
@@ -1,11 +1,12 @@
-import { ReputationEvent } from './../../src/entity/ReputationEvent';
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { ReputationEvent } from '../../src/entity';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/sourceRequestApprovedRep';
 import { Source, SourceRequest, User } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import { NotificationReason } from '../../src/common';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { ChangeObject } from '../../src/types';
 
 let con: DataSource;
 
@@ -37,12 +38,12 @@ beforeEach(async () => {
 });
 
 it('should create a reputation event that increases reputation', async () => {
-  await expectSuccessfulBackground(worker, {
+  await expectSuccessfulTypedBackground(worker, {
     reason: NotificationReason.Publish,
     sourceRequest: {
       id,
       userId: '1',
-    },
+    } as unknown as ChangeObject<SourceRequest>,
   });
   const event = await con
     .getRepository(ReputationEvent)
@@ -51,12 +52,12 @@ it('should create a reputation event that increases reputation', async () => {
 });
 
 it('should not create a reputation event that increases reputation when type is not publish', async () => {
-  await expectSuccessfulBackground(worker, {
+  await expectSuccessfulTypedBackground(worker, {
     sourceRequest: {
       id,
       userId: '1',
-    },
-    type: NotificationReason.Approve,
+    } as unknown as ChangeObject<SourceRequest>,
+    reason: NotificationReason.Approve,
   });
   const event = await con.getRepository(ReputationEvent).find();
   expect(event.length).toEqual(0);

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,9 +5,10 @@ import pino from 'pino';
 
 import './config';
 
-import { workers } from './workers';
+import { typedWorkers, workers } from './workers';
 import createOrGetConnection from './db';
 import { workerSubscribe } from './common';
+import { messageToJson } from './workers/worker';
 
 export default async function app(): Promise<void> {
   const logger = pino({
@@ -34,6 +35,26 @@ export default async function app(): Promise<void> {
           {
             messageId: message.id,
             data: message.data,
+          },
+          con,
+          logger,
+          pubsub,
+        ),
+    ),
+  );
+
+  typedWorkers.forEach((worker) =>
+    workerSubscribe(
+      logger,
+      pubsub,
+      connection,
+      worker.subscription,
+      meter,
+      (message, con, logger, pubsub) =>
+        worker.handler(
+          {
+            messageId: message.id,
+            data: messageToJson(message),
           },
           con,
           logger,

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -13,3 +13,4 @@ export * from './mailing';
 export * from './post';
 export * from './links';
 export * from './utils';
+export * from './typedPubsub';

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -2,7 +2,6 @@ import { PubSub, Topic } from '@google-cloud/pubsub';
 import { FastifyBaseLogger } from 'fastify';
 import {
   Post,
-  SourceRequest,
   Settings,
   Submission,
   User,
@@ -34,8 +33,7 @@ import { DataSource } from 'typeorm';
 import { FastifyLoggerInstance } from 'fastify';
 import pino from 'pino';
 
-const pubsub = new PubSub();
-const sourceRequestTopic = pubsub.topic('pub-request');
+export const pubsub = new PubSub();
 const postUpvotedTopic = pubsub.topic('post-upvoted');
 const postUpvoteCanceledTopic = pubsub.topic('post-upvote-canceled');
 const commentUpvotedTopic = pubsub.topic('comment-upvoted');
@@ -95,7 +93,7 @@ export enum NotificationReason {
 // Need to support console as well
 export type EventLogger = Omit<FastifyBaseLogger, 'fatal'>;
 
-const publishEvent = async (
+export const publishEvent = async (
   log: EventLogger,
   topic: Topic,
   payload: Record<string, unknown>,
@@ -123,16 +121,6 @@ const publishEvent = async (
       kind: opentelemetry.SpanKind.PRODUCER,
     },
   );
-
-export const notifySourceRequest = async (
-  log: EventLogger,
-  reason: NotificationReason,
-  sourceRequest: ChangeObject<SourceRequest>,
-): Promise<void> =>
-  publishEvent(log, sourceRequestTopic, {
-    reason,
-    sourceRequest,
-  });
 
 export const notifyPostUpvoted = async (
   log: EventLogger,

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -1,0 +1,27 @@
+import { ChangeObject } from '../types';
+import { SourceRequest } from '../entity';
+import {
+  EventLogger,
+  NotificationReason,
+  publishEvent,
+  pubsub,
+} from './pubsub';
+
+export type PubSubSchema = {
+  'pub-request': {
+    reason: NotificationReason;
+    sourceRequest: ChangeObject<SourceRequest>;
+  };
+  'post-upvoted': {
+    postId: string;
+    userId: string;
+  };
+};
+
+export async function triggerTypedEvent<T extends keyof PubSubSchema>(
+  log: EventLogger,
+  topic: T,
+  data: PubSubSchema[T],
+): Promise<void> {
+  await publishEvent(log, pubsub.topic(topic), data);
+}

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -75,11 +75,11 @@ import {
   notifyPostYggdrasilIdSet,
   notifyPostCollectionUpdated,
   notifyUserReadmeUpdated,
+  triggerTypedEvent,
 } from '../../common';
 import { ChangeMessage } from '../../types';
 import { DataSource } from 'typeorm';
 import { FastifyBaseLogger } from 'fastify';
-import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { PostReport, ContentImage } from '../../entity';
 import { reportReasons } from '../../schema/posts';
 import { updateAlerts } from '../../schema/alerts';
@@ -88,7 +88,6 @@ import { TypeOrmError } from '../../errors';
 import { CommentReport } from '../../entity/CommentReport';
 import { reportCommentReasons } from '../../schema/comments';
 import { getTableName, isChanged } from './common';
-import { triggerTypedEvent } from '../common/typedPubsub';
 
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -1,4 +1,4 @@
-import { Worker } from './worker';
+import { BaseTypedWorker, Worker } from './worker';
 import newView from './newView';
 import commentUpvotedRep from './commentUpvotedRep';
 import commentUpvoteCanceledRep from './commentUpvoteCanceledRep';
@@ -69,7 +69,6 @@ export const workers: Worker[] = [
   postUpvotedRedis,
   postBannedRep,
   postDeletedCommentsCleanup,
-  sourceRequestApprovedRep,
   usernameChanged,
   updateComments,
   newNotificationRealTime,
@@ -89,6 +88,10 @@ export const workers: Worker[] = [
   cdc,
   cdcNotifications,
   ...notificationWorkers,
+];
+
+export const typedWorkers: BaseTypedWorker<unknown>[] = [
+  sourceRequestApprovedRep,
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/src/workers/sourceRequestApprovedRep.ts
+++ b/src/workers/sourceRequestApprovedRep.ts
@@ -1,18 +1,12 @@
 import { ReputationEvent, ReputationReason, ReputationType } from '../entity';
-import { messageToJson, Worker } from './worker';
-import { SourceRequest } from '../entity';
+import { TypedWorker } from './worker';
 import { NotificationReason } from '../common';
 
-interface Data {
-  reason: NotificationReason;
-  sourceRequest: Pick<SourceRequest, 'id' | 'userId'>;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'pub-request'> = {
   subscription: 'pub-request-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
-    const { reason, sourceRequest }: Data = messageToJson(message);
+    const { data } = message;
+    const { reason, sourceRequest } = data;
 
     if (reason !== NotificationReason.Publish) {
       return;

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -1,13 +1,14 @@
 import { FastifyLoggerInstance } from 'fastify';
 import { PubSub } from '@google-cloud/pubsub';
 import { DataSource } from 'typeorm';
+import { PubSubSchema } from '../common/typedPubsub';
 
 export interface Message {
   messageId: string;
   data: Buffer;
 }
 
-export const messageToJson = <T>(message: Message): T =>
+export const messageToJson = <T>(message: Pick<Message, 'data'>): T =>
   JSON.parse(message.data.toString('utf-8').trim());
 
 export interface Worker {
@@ -20,3 +21,22 @@ export interface Worker {
   ) => Promise<void>;
   maxMessages?: number;
 }
+
+export interface TypedMessage<T> {
+  messageId: string;
+  data: T;
+}
+
+export interface BaseTypedWorker<T> {
+  subscription: string;
+  handler: (
+    data: TypedMessage<T>,
+    con: DataSource,
+    logger: FastifyLoggerInstance,
+    pubsub: PubSub,
+  ) => Promise<void>;
+  maxMessages?: number;
+}
+
+export interface TypedWorker<T extends keyof PubSubSchema>
+  extends BaseTypedWorker<PubSubSchema[T]> {}


### PR DESCRIPTION
**This PR is a proposal nothing that should go to production at the moment.**

The main goal is to ensure type safety when using pubsub both on the publisher and consumer side and keep them consistent.

My approach uses a centralized schema type that is enforced by a single function for sending events (`triggerTypedEvent`) and on the worker side by a new `TypedWorker` interface. The DX is significantly improved as you get auto complete and validation for topic names and payload as long as we have the schema up to date.

In this PR, I migrated some topics and a single worker to show how we can make it work if we agree on this approach. I wanted to demo how it's gonna look before suggesting an action plan so if you don't like it at all, say it explicitly.