### PR TITLE
test: sources are excluded

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -17,18 +17,6 @@ Object {
 }
 `;
 
-exports[`function feedToFilters should return filters having excluded sources based on advanced settings 1`] = `
-Object {
-  "blockedTags": Array [],
-  "excludeSources": Array [
-    "excludedSource",
-    "settingsCombinationSource",
-  ],
-  "includeTags": Array [],
-  "sourceIds": Array [],
-}
-`;
-
 exports[`function feedToFilters should return filters with source memberships 1`] = `
 Object {
   "blockedTags": Array [],

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1634,7 +1634,11 @@ describe('function feedToFilters', () => {
   it('should return filters having excluded sources based on advanced settings', async () => {
     loggedUser = '1';
     await saveAdvancedSettingsFiltersFixtures();
-    expect(await feedToFilters(con, '1', '1')).toMatchSnapshot();
+    const filters = await feedToFilters(con, '1', '1');
+    expect(filters.excludeSources).toEqual([
+      'excludedSource',
+      'settingsCombinationSource',
+    ]);
   });
 
   it('should return filters for tags/sources based on the values from our data', async () => {


### PR DESCRIPTION
Our feed has been configured to support working with advanced settings, this means any additional item in that table would automatically be considered working as soon as it hits production.

With that, I just modified the test to return what is expected rather than the snapshot just to make it easier to understand.

The fixture saved below would make some sources have certain advanced settings IDs, namely `1` and `4`. Then those Sources IDs are found from `excludedSource` and `settingsCombinationSource` as seen from the code.

https://github.com/dailydotdev/daily-api/blob/7b6fb970a07f821629a0da2a46b9e9dc15f17cde/__tests__/feeds.ts#L166-L179