### PR TITLE
fix: collection notification integration

### DIFF
--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -240,6 +240,10 @@ export const workers: Worker[] = [
     topic: 'api.v1.source-created',
     subscription: 'api.source-created-squad-owner-mailing',
   },
+  {
+    topic: 'api.v1.post-collection-updated',
+    subscription: 'api.post-collection-updated-notification',
+  }
 ];
 
 export const personalizedDigestWorkers = [

--- a/__tests__/workers/notifications/collectionUpdated.ts
+++ b/__tests__/workers/notifications/collectionUpdated.ts
@@ -206,6 +206,12 @@ describe('collectionUpdated worker', () => {
 
     const notification = notifications.find((item) => item.userId === '1');
 
+    const collectionPost = await con
+      .getRepository(CollectionPost)
+      .findOneBy({ id: 'c1' });
+
+    expect(collectionPost).not.toBeNull();
+
     expect(notification).toMatchObject({
       userId: '1',
       type: 'collection_updated',
@@ -218,6 +224,7 @@ describe('collectionUpdated worker', () => {
       referenceId: 'c1',
       referenceType: 'post',
       numTotalAvatars: 4,
+      uniqueKey: collectionPost?.metadataChangedAt.toString(),
     });
 
     const avatars = await notification!.avatars;

--- a/__tests__/workers/notifications/collectionUpdated.ts
+++ b/__tests__/workers/notifications/collectionUpdated.ts
@@ -156,12 +156,11 @@ beforeEach(async () => {
 
 describe('collectionUpdated worker', () => {
   it('should be registered', () => {
-    const worker = workers.find(
-      (item) =>
-        item.subscription === 'api.post-collection-updated-notification',
+    const registeredWorker = workers.find(
+      (item) => item.subscription === worker.subscription,
     );
 
-    expect(worker).toBeDefined();
+    expect(registeredWorker).toBeDefined();
   });
 
   it('should notifiy when a collection is updated', async () => {

--- a/__tests__/workers/notifications/collectionUpdated.ts
+++ b/__tests__/workers/notifications/collectionUpdated.ts
@@ -25,7 +25,10 @@ import {
 } from '../../../src/notifications/common';
 import { usersFixture } from '../../fixture/user';
 import { NotificationCollectionContext } from '../../../src/notifications';
-import { notificationWorkerToWorker } from '../../../src/workers/notifications';
+import {
+  notificationWorkerToWorker,
+  workers,
+} from '../../../src/workers/notifications';
 
 let con: DataSource;
 
@@ -152,6 +155,15 @@ beforeEach(async () => {
 });
 
 describe('collectionUpdated worker', () => {
+  it('should be registered', () => {
+    const worker = workers.find(
+      (item) =>
+        item.subscription === 'api.post-collection-updated-notification',
+    );
+
+    expect(worker).toBeDefined();
+  });
+
   it('should notifiy when a collection is updated', async () => {
     const actual = await invokeNotificationWorker(worker, {
       post: {
@@ -197,9 +209,9 @@ describe('collectionUpdated worker', () => {
     expect(notification).toMatchObject({
       userId: '1',
       type: 'collection_updated',
-      icon: 'DailyDev',
+      icon: 'Bell',
       title:
-        'The collection <b>My collection</b> just got updated with new details',
+        'The collection "<b>My collection</b>" just got updated with new details',
       description: null,
       targetUrl: 'http://localhost:5002/posts/c1',
       public: true,

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -461,9 +461,8 @@ export const notifyPostYggdrasilIdSet = async (
 
 export const notifyPostCollectionUpdated = async (
   log: EventLogger,
-  collection: ChangeObject<CollectionPost>,
-): Promise<void> =>
-  publishEvent(log, postCollectionUpdatedTopic, { collection });
+  post: ChangeObject<CollectionPost>,
+): Promise<void> => publishEvent(log, postCollectionUpdatedTopic, { post });
 
 export const workerSubscribe = (
   logger: pino.Logger,

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -447,9 +447,6 @@ const obj = new GraphORM({
           parentColumn: 'id',
         },
       },
-      numTotalAvatars: {
-        select: 'numTotalAvatars',
-      },
     },
   },
   UserPost: {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -447,6 +447,9 @@ const obj = new GraphORM({
           parentColumn: 'id',
         },
       },
+      numTotalAvatars: {
+        select: 'numTotalAvatars',
+      },
     },
   },
   UserPost: {

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -91,7 +91,7 @@ export const notificationTitleMap: Record<
   post_mention: (ctx: NotificationPostContext & NotificationDoneByContext) =>
     `<b>${ctx.doneBy.username}</b> <span class="text-theme-color-cabbage">mentioned you</span> on a post in <b>${ctx.source.name}</b>.`,
   collection_updated: (ctx: NotificationPostContext) =>
-    `The collection <b>${ctx.post.title}</b> just got updated with new details`,
+    `The collection "<b>${ctx.post.title}</b>" just got updated with new details`,
 };
 
 export const generateNotificationMap: Record<
@@ -284,9 +284,10 @@ export const generateNotificationMap: Record<
       ]),
   collection_updated: (builder, ctx: NotificationCollectionContext) =>
     builder
-      .icon(NotificationIcon.DailyDev)
+      .icon(NotificationIcon.Bell)
       .referencePost(ctx.post)
       .targetPost(ctx.post)
       .avatarManySources(ctx.distinctSources)
-      .numTotalAvatars(ctx.total),
+      .numTotalAvatars(ctx.total)
+      .uniqueKey(ctx.post.metadataChangedAt?.toString()),
 };

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -137,6 +137,10 @@ export const typeDefs = /* GraphQL */ `
     Attachments of the notification
     """
     attachments: [NotificationAttachment!]
+    """
+    Total number of avatars
+    """
+    numTotalAvatars: Int
   }
 
   type NotificationEdge {

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -22,6 +22,7 @@ import { TypeOrmError } from '../../errors';
 import postMention from './postMention';
 import commentDeleted from './commentDeleted';
 import postDeleted from './postDeleted';
+import { collectionUpdated } from './collectionUpdated';
 
 export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
   return {
@@ -68,6 +69,7 @@ const notificationWorkers: NotificationWorker[] = [
   postAdded,
   memberJoinedSource,
   sourceMemberRoleChanged,
+  collectionUpdated,
 ];
 
 export const workers = [


### PR DESCRIPTION
Integration fixes found when connecting on frontend and e2e testing:
- missing worker subscription
- missing worker registration in export
- notification icon and template
- notification unique key, using `metadataUpdatedAt` because without it `ID_notification_uniqueness` would fail and any notification after first one would not save to DB thus any collection updated after first one would be missed
- expose `numTotalAvatars` field for frontend