### PR TITLE
feat: notification v2 triggers

### DIFF
--- a/__tests__/triggers/notifications.ts
+++ b/__tests__/triggers/notifications.ts
@@ -1,0 +1,205 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { saveFixtures } from '../helpers';
+import {
+  ArticlePost,
+  Comment,
+  Post,
+  Source,
+  SourceType,
+  User,
+} from '../../src/entity';
+import { sourcesFixture } from '../fixture/source';
+import { postsFixture } from '../fixture/post';
+import { usersFixture } from '../fixture/user';
+import { NotificationAvatarV2 } from '../../src/entity/notifications/NotificationAvatarV2';
+import { NotificationV2 } from '../../src/entity/notifications/NotificationV2';
+import { NotificationType } from '../../src/notifications/common';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, ArticlePost, postsFixture);
+  await saveFixtures(con, User, usersFixture);
+});
+
+describe('update_source_avatar', () => {
+  it('should do nothing if no avatar', async () => {
+    await con
+      .getRepository(Source)
+      .update(sourcesFixture[0].id, { name: 'Test' });
+    const actual = await con.getRepository(NotificationAvatarV2).find();
+    expect(actual.length).toEqual(0);
+  });
+
+  it('should update existing avatar', async () => {
+    await con.getRepository(NotificationAvatarV2).insert({
+      type: 'source',
+      referenceId: sourcesFixture[0].id,
+      targetUrl: '',
+      name: '',
+      image: '',
+    });
+    await con
+      .getRepository(Source)
+      .update(sourcesFixture[0].id, { name: 'Test' });
+    const actual = await con.getRepository(NotificationAvatarV2).find();
+    expect(actual).toEqual([
+      {
+        id: expect.any(String),
+        image: 'http://image.com/a',
+        name: 'Test',
+        referenceId: 'a',
+        targetUrl: 'http://localhost:5002/sources/a',
+        type: 'source',
+      },
+    ]);
+  });
+
+  it('should support squads', async () => {
+    await con.getRepository(NotificationAvatarV2).insert({
+      type: 'source',
+      referenceId: sourcesFixture[0].id,
+      targetUrl: '',
+      name: '',
+      image: '',
+    });
+    await con
+      .getRepository(Source)
+      .update(sourcesFixture[0].id, { name: 'Test', type: SourceType.Squad });
+    const actual = await con.getRepository(NotificationAvatarV2).find();
+    expect(actual).toEqual([
+      {
+        id: expect.any(String),
+        image: 'http://image.com/a',
+        name: 'Test',
+        referenceId: 'a',
+        targetUrl: 'http://localhost:5002/squads/a',
+        type: 'source',
+      },
+    ]);
+  });
+});
+
+describe('update_user_avatar', () => {
+  it('should do nothing if no avatar', async () => {
+    await con.getRepository(User).update(usersFixture[0].id, { name: 'Test' });
+    const actual = await con.getRepository(NotificationAvatarV2).find();
+    expect(actual.length).toEqual(0);
+  });
+
+  it('should update existing avatar', async () => {
+    await con.getRepository(NotificationAvatarV2).insert({
+      type: 'user',
+      referenceId: usersFixture[0].id,
+      targetUrl: '',
+      name: '',
+      image: '',
+    });
+    await con.getRepository(User).update(usersFixture[0].id, { name: 'Test' });
+    const actual = await con.getRepository(NotificationAvatarV2).find();
+    expect(actual).toEqual([
+      {
+        id: expect.any(String),
+        image: 'https://daily.dev/ido.jpg',
+        name: 'Test',
+        referenceId: '1',
+        targetUrl: 'http://localhost:5002/idoshamun',
+        type: 'user',
+      },
+    ]);
+  });
+});
+
+describe('delete_post_notifications', () => {
+  beforeEach(async () => {
+    await con.getRepository(NotificationV2).insert([
+      {
+        type: NotificationType.ArticleUpvoteMilestone,
+        public: true,
+        targetUrl: '',
+        referenceId: postsFixture[0].id,
+        referenceType: 'post',
+        icon: '',
+        description: '',
+        title: '',
+      },
+      {
+        type: NotificationType.ArticleUpvoteMilestone,
+        public: true,
+        targetUrl: '',
+        referenceId: postsFixture[1].id,
+        referenceType: 'post',
+        icon: '',
+        description: '',
+        title: '',
+      },
+    ]);
+  });
+
+  it('should do nothing if post is not deleted', async () => {
+    await con.getRepository(Post).update(postsFixture[0].id, { title: 'Test' });
+    const actual = await con.getRepository(NotificationV2).find();
+    expect(actual.length).toEqual(2);
+  });
+
+  it('should delete relevant notifications', async () => {
+    await con.getRepository(Post).update(postsFixture[0].id, { deleted: true });
+    const actual = await con.getRepository(NotificationV2).find();
+    expect(actual.length).toEqual(1);
+    expect(actual[0].referenceId).toEqual(postsFixture[1].id);
+  });
+});
+
+describe('delete_comment_notifications', () => {
+  beforeEach(async () => {
+    await con.getRepository(Comment).insert({
+      id: '1',
+      userId: usersFixture[0].id,
+      content: '',
+      contentHtml: '',
+      postId: postsFixture[0].id,
+    });
+    await con.getRepository(NotificationV2).insert([
+      {
+        type: NotificationType.CommentUpvoteMilestone,
+        public: true,
+        targetUrl: '',
+        referenceId: '1',
+        referenceType: 'comment',
+        icon: '',
+        description: '',
+        title: '',
+      },
+      {
+        type: NotificationType.CommentUpvoteMilestone,
+        public: true,
+        targetUrl: '',
+        referenceId: '2',
+        referenceType: 'comment',
+        icon: '',
+        description: '',
+        title: '',
+      },
+    ]);
+  });
+
+  it('should do nothing if comment is not deleted', async () => {
+    await con.getRepository(Comment).update('1', { content: 'Test' });
+    const actual = await con.getRepository(NotificationV2).find();
+    expect(actual.length).toEqual(2);
+  });
+
+  it('should delete relevant notifications', async () => {
+    await con.getRepository(Comment).delete({ id: '1' });
+    const actual = await con.getRepository(NotificationV2).find();
+    expect(actual.length).toEqual(1);
+    expect(actual[0].referenceId).toEqual('2');
+  });
+});

--- a/src/migration/1702224104423-NotificationV2Triggers.ts
+++ b/src/migration/1702224104423-NotificationV2Triggers.ts
@@ -1,0 +1,108 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationV2Triggers1702224104423 implements MigrationInterface {
+  name = 'NotificationV2Triggers1702224104423';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        CREATE OR REPLACE FUNCTION update_source_avatar()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          IF NEW."name" <> OLD."name" OR NEW."image" <> OLD."image" OR NEW."handle" <> OLD."handle" THEN
+            UPDATE notification_avatar_v2
+            SET name = NEW."name", image = NEW."image",
+              "targetUrl" = '${process.env.COMMENTS_PREFIX}/' || (case when NEW."type" = 'squad' then 'squads' else 'sources' end) || '/' || NEW."handle"
+            WHERE "referenceId" = NEW."id" AND type = 'source';
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    await queryRunner.query(
+      'CREATE TRIGGER update_source_avatar AFTER UPDATE ON "source" FOR EACH ROW EXECUTE PROCEDURE update_source_avatar()',
+    );
+
+    await queryRunner.query(`
+        CREATE OR REPLACE FUNCTION update_user_avatar()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          IF NEW."name" <> OLD."name" OR NEW."image" <> OLD."image" OR NEW."username" <> OLD."username" THEN
+            UPDATE notification_avatar_v2
+            SET name = NEW."name", image = NEW."image",
+              "targetUrl" = '${process.env.COMMENTS_PREFIX}/' || NEW."username"
+            WHERE "referenceId" = NEW."id" AND type = 'user';
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    await queryRunner.query(
+      'CREATE TRIGGER update_user_avatar AFTER UPDATE ON "user" FOR EACH ROW EXECUTE PROCEDURE update_user_avatar()',
+    );
+
+    await queryRunner.query(`
+        CREATE OR REPLACE FUNCTION delete_post_notifications()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          IF NOT OLD."deleted" AND NEW."deleted" THEN
+            DELETE FROM notification_v2
+            WHERE "referenceId" = NEW."id" AND "referenceType" = 'post';
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    await queryRunner.query(
+      'CREATE TRIGGER delete_post_notifications AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE delete_post_notifications()',
+    );
+
+    await queryRunner.query(`
+        CREATE OR REPLACE FUNCTION delete_comment_notifications()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          DELETE FROM notification_v2
+          WHERE "referenceId" = OLD."id" AND "referenceType" = 'comment';
+          RETURN OLD;
+        END;
+        $$
+      `);
+    await queryRunner.query(
+      'CREATE TRIGGER delete_comment_notifications AFTER DELETE ON "comment" FOR EACH ROW EXECUTE PROCEDURE delete_comment_notifications()',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP TRIGGER IF EXISTS update_source_avatar ON "source"',
+    );
+    await queryRunner.query('DROP FUNCTION IF EXISTS update_source_avatar');
+    await queryRunner.query(
+      'DROP TRIGGER IF EXISTS update_user_avatar ON "user"',
+    );
+    await queryRunner.query('DROP FUNCTION IF EXISTS update_user_avatar');
+    await queryRunner.query(
+      'DROP TRIGGER IF EXISTS delete_post_notifications ON "post"',
+    );
+    await queryRunner.query(
+      'DROP FUNCTION IF EXISTS delete_post_notifications',
+    );
+    await queryRunner.query(
+      'DROP TRIGGER IF EXISTS delete_comment_notifications ON "comment"',
+    );
+    await queryRunner.query(
+      'DROP FUNCTION IF EXISTS delete_comment_notifications',
+    );
+  }
+}


### PR DESCRIPTION
Prerequisite for: https://github.com/dailydotdev/daily-api/pull/1572

New triggers to update avatars when needed and delete relevant notifications.

I don't delete avatars and attachments, I feel like after the optimization the hassle doesn't worth it. I will have to index these fields in the notifications table and update the array too much effort for too little value.