### PR TITLE
fix: update the post type on youtube video when we get it from Yggdrasil

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -748,6 +748,7 @@ describe('on youtube post', () => {
         title: 'youtube post',
         score: 0,
         url: 'https://youtu.be/T_AbQGe7fuU',
+        videoId: 'T_AbQGe7fuU',
         metadataChangedAt: new Date('01-05-2020 12:00:00'),
         sourceId: 'a',
         visible: true,
@@ -818,7 +819,7 @@ describe('on youtube post', () => {
       id: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
       post_id: 'yt1',
       updated_at: new Date('01-05-2023 12:00:00'),
-      source_id: 'squad',
+      source_id: 'a',
       extra: {
         content_curation: ['news', 'story', 'release'],
         duration: 12,
@@ -853,6 +854,7 @@ describe('on youtube post', () => {
       readTime: 12,
       description: 'A description of a video',
       summary: 'A short summary of a video',
+      videoId: 'T_AbQGe7fuU',
     });
   });
 
@@ -868,6 +870,9 @@ describe('on youtube post', () => {
       updated_at: new Date('01-05-2023 12:00:00'),
       source_id: 'squad',
       content_type: PostType.VideoYouTube,
+      extra: {
+        video_id: 'Oso6dYXw5lc',
+      },
     });
 
     const post = await con.getRepository(YouTubePost).findOneBy({
@@ -881,6 +886,7 @@ describe('on youtube post', () => {
       sourceId: 'squad',
       yggdrasilId: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
       url: 'https://youtu.be/Oso6dYXw5lc',
+      videoId: 'Oso6dYXw5lc',
     });
   });
 });

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -749,17 +749,35 @@ describe('on youtube post', () => {
         score: 0,
         url: 'https://youtu.be/T_AbQGe7fuU',
         metadataChangedAt: new Date('01-05-2020 12:00:00'),
-        sourceId: 'squad',
+        sourceId: 'a',
         visible: true,
         createdAt: new Date('01-05-2020 12:00:00'),
         type: PostType.VideoYouTube,
-        origin: PostOrigin.Squad,
+        origin: PostOrigin.Crawler,
         yggdrasilId: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
+      },
+    ]);
+
+    await con.getRepository(ArticlePost).save([
+      {
+        id: 'yt2',
+        shortId: 'yt2',
+        title: 'youtube post',
+        score: 0,
+        url: 'https://youtu.be/Oso6dYXw5lc',
+        metadataChangedAt: new Date('01-05-2020 12:00:00'),
+        sourceId: 'squad',
+        visible: true,
+        createdAt: new Date('01-05-2020 12:00:00'),
+        type: PostType.Article,
+        origin: PostOrigin.Squad,
+        yggdrasilId: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
       },
     ]);
 
     await createDefaultKeywords();
   });
+
   it('should create a new video post', async () => {
     await expectSuccessfulBackground(worker, {
       id: 'a7edf0c8-aec7-4586-b411-b1dd431ce8d6',
@@ -825,17 +843,44 @@ describe('on youtube post', () => {
       },
     });
     expect(postKeywords.length).toEqual(2);
-
     expect(post).toMatchObject({
       type: 'video:youtube',
       title: 'youtube post',
-      sourceId: 'squad',
+      sourceId: 'a',
       yggdrasilId: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
       url: 'https://youtu.be/T_AbQGe7fuU',
       contentCuration: ['news', 'story', 'release'],
       readTime: 12,
       description: 'A description of a video',
       summary: 'A short summary of a video',
+    });
+  });
+
+  it('should update the post type to youtube video when the post is a youtube video', async () => {
+    const beforePost = await con.getRepository(ArticlePost).findOneBy({
+      yggdrasilId: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
+    });
+    expect(beforePost?.type).toBe(PostType.Article);
+
+    await expectSuccessfulBackground(worker, {
+      id: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
+      post_id: 'yt2',
+      updated_at: new Date('01-05-2023 12:00:00'),
+      source_id: 'squad',
+      content_type: PostType.VideoYouTube,
+    });
+
+    const post = await con.getRepository(YouTubePost).findOneBy({
+      yggdrasilId: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
+    });
+
+    expect(post?.type).toBe(PostType.VideoYouTube);
+    expect(post).toMatchObject({
+      type: 'video:youtube',
+      title: 'youtube post',
+      sourceId: 'squad',
+      yggdrasilId: 'd1053f05-4d41-4fc7-885c-c0f7c841a7b6',
+      url: 'https://youtu.be/Oso6dYXw5lc',
     });
   });
 });

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -261,11 +261,11 @@ const updatePost = async ({
 
   // If we don't find the post, we need to check if it's a youtube video and
   // try to find it again as an article
-  if (!databasePost && content_type === PostType.VideoYouTube) {
+  if (!databasePost) {
     await entityManager
       .createQueryBuilder()
       .update(Post)
-      .set({ type: PostType.VideoYouTube })
+      .set({ type: content_type })
       .where('id = :id', { id })
       .execute();
 

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -217,6 +217,7 @@ const createPost = async ({
 const allowedFieldsMapping = {
   [PostType.VideoYouTube]: [
     'type',
+    'videoId',
     'contentCuration',
     'description',
     'metadataChangedAt',

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -215,16 +215,6 @@ const createPost = async ({
 };
 
 const allowedFieldsMapping = {
-  [PostType.VideoYouTube]: [
-    'type',
-    'videoId',
-    'contentCuration',
-    'description',
-    'metadataChangedAt',
-    'readTime',
-    'summary',
-    'tagsStr',
-  ],
   freeform: [
     'contentCuration',
     'description',
@@ -264,7 +254,7 @@ const updatePost = async ({
   questions,
   content_type = PostType.Article,
 }: UpdatePostProps) => {
-  let postType = contentTypeFromPostType[content_type];
+  const postType = contentTypeFromPostType[content_type];
   let databasePost = await entityManager
     .getRepository(postType)
     .findOneBy({ id });
@@ -272,7 +262,13 @@ const updatePost = async ({
   // If we don't find the post, we need to check if it's a youtube video and
   // try to find it again as an article
   if (!databasePost && content_type === PostType.VideoYouTube) {
-    postType = ArticlePost;
+    await entityManager.getRepository(ArticlePost).update(
+      { id },
+      {
+        type: PostType.VideoYouTube,
+      },
+    );
+
     databasePost = await entityManager
       .getRepository(postType)
       .findOneBy({ id });

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -262,12 +262,12 @@ const updatePost = async ({
   // If we don't find the post, we need to check if it's a youtube video and
   // try to find it again as an article
   if (!databasePost && content_type === PostType.VideoYouTube) {
-    await entityManager.getRepository(ArticlePost).update(
-      { id },
-      {
-        type: PostType.VideoYouTube,
-      },
-    );
+    await entityManager
+      .createQueryBuilder()
+      .update(Post)
+      .set({ type: PostType.VideoYouTube })
+      .where('id = :id', { id })
+      .execute();
 
     databasePost = await entityManager
       .getRepository(postType)


### PR DESCRIPTION
When we share a YouTube link in a Squad, it is saved as an `article`. So we need to update it to `video:youtube` when we get the updated data from Yggdrasil.