### PR TITLE
fix: slack link title fallback

### DIFF
--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -45,7 +45,7 @@ export const notifyPostReport = async (
     text: 'Post was just reported!',
     attachments: [
       {
-        title: post.title ?? '',
+        title: post.title ?? `Post ${post.id}`,
         title_link: getDiscussionLink(post.id),
         fields: [
           {

--- a/src/workers/postScoutMatchedSlack.ts
+++ b/src/workers/postScoutMatchedSlack.ts
@@ -20,7 +20,7 @@ const worker: Worker = {
         text: 'New community link!',
         attachments: [
           {
-            title: post.title ?? '',
+            title: post.title ?? `Post: ${post.id}`,
             title_link: getDiscussionLink(post.id),
             fields: [
               {


### PR DESCRIPTION
Add fallback to show post id when title is not present for slack messages.
This way you can click on something in slack.

WT-2024 #done 