### PR TITLE
fix: handle duplicate notifications

### DIFF
--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -141,27 +141,27 @@ const upsertAndReturnIds = async <Entity>(
   ]);
   const res = await entityManager.query(
     `
-    with new_values (i, ${colsStr}) as (values ${parametrizedValues}),
-         ins as (
-    insert
-    into ${table} (${colsStr})
-    select ${colsStr}
-    from new_values on conflict do nothing
+      with new_values (i, ${colsStr}) as (values ${parametrizedValues}),
+           ins as (
+      insert
+      into ${table} (${colsStr})
+      select ${colsStr}
+      from new_values on conflict do nothing
       returning id, ${uniqueStr}
-      )
-       , recs as (
-    select id, ${uniqueStr}
-    from ins
-    union all
-    select id, ${uniqueStr}
-    from ${table}
-      join new_values using (${uniqueStr})
-      )
-    select id
-    from new_values
-           join recs using (${uniqueStr})
-    order by i;
-  `,
+        )
+         , recs as (
+      select id, ${uniqueStr}
+      from ins
+      union all
+      select id, ${uniqueStr}
+      from ${table}
+        join new_values using (${uniqueStr})
+        )
+      select id
+      from new_values
+             join recs using (${uniqueStr})
+      order by i;
+    `,
     params,
   );
   return res.map(({ id }) => id);
@@ -201,12 +201,28 @@ export async function storeNotificationBundleV2(
     upsertAvatarsV2(entityManager, bundle.avatars || []),
     upsertAttachments(entityManager, bundle.attachments || []),
   ]);
-  const notification = await entityManager.getRepository(NotificationV2).save({
-    ...bundle.notification,
-    avatars,
-    attachments,
-  });
+  const { generatedMaps } = await entityManager
+    .createQueryBuilder()
+    .insert()
+    .into(NotificationV2)
+    .values({
+      ...bundle.notification,
+      avatars,
+      attachments,
+    })
+    .returning('*')
+    .orIgnore()
+    .execute();
+  if (!generatedMaps?.[0]?.id) {
+    if (!bundle.notification.uniqueKey) {
+      throw new Error(
+        'Notification was not inserted and no unique key was provided',
+      );
+    }
+    return;
+  }
 
+  const notification = generatedMaps[0];
   await entityManager
     .createQueryBuilder()
     .insert()


### PR DESCRIPTION
Hotfix to ignore duplicate notifications, unless unique key is not set. In this case I'd like to get an alert to check manually if it's a bug.