### PR TITLE
fix: add email so deleted users get unsubscribed in sendgrid

### DIFF
--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -213,10 +213,12 @@ export const notifyUserDeleted = async (
   log: EventLogger,
   userId: string,
   kratosUser = false,
+  email: string,
 ): Promise<void> =>
   publishEvent(log, userDeletedTopic, {
     id: userId,
     kratosUser,
+    email,
   });
 
 export const notifyUserUpdated = (

--- a/src/workers/cdc.ts
+++ b/src/workers/cdc.ts
@@ -317,7 +317,12 @@ const onUserChange = async (
     }
   }
   if (data.payload.op === 'd') {
-    await notifyUserDeleted(logger, data.payload.before.id, true);
+    await notifyUserDeleted(
+      logger,
+      data.payload.before.id,
+      true,
+      data.payload.before.email,
+    );
   }
 };
 


### PR DESCRIPTION
Add email prop as we need it in our API `user-deleted-api-mailing` worker.
I didn't want to be to intrusive to add the whole change object for now.

WT-2016

Do note: This meant for whenever this change was made deleted users have not been unsubscribed in sendgrid.