### PR TITLE
fix: notification v2 select readAt properly

### DIFF
--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -378,6 +378,26 @@ describe('query notifications', () => {
     });
     expect(res2.data).toMatchSnapshot();
   });
+
+  it('should populate the readAt field', async () => {
+    loggedUser = '1';
+    const notifs = await con
+      .getRepository(NotificationV2)
+      .save([{ ...notificationV2Fixture }]);
+    const date = new Date();
+    await con.getRepository(UserNotification).insert([
+      {
+        userId: '1',
+        notificationId: notifs[0].id,
+        createdAt: notificationV2Fixture.createdAt,
+        readAt: date,
+      },
+    ]);
+    const res = await client.query(QUERY);
+    expect(res.data.notifications.edges[0].node.readAt).toEqual(
+      date.toISOString(),
+    );
+  });
 });
 
 const prepareNotificationPreferences = async ({

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -433,11 +433,13 @@ const obj = new GraphORM({
   Notification: {
     from: 'NotificationV2',
     additionalQuery: (ctx, alias, qb) =>
-      qb.innerJoin(
-        UserNotification,
-        'un',
-        `"${alias}".id = un."notificationId"`,
-      ),
+      qb
+        .innerJoin(
+          UserNotification,
+          'un',
+          `"${alias}".id = un."notificationId"`,
+        )
+        .addSelect('un."readAt"'),
     fields: {
       avatars: {
         relation: {


### PR DESCRIPTION
Thanks to Ole-Martin for hunting this one. This fixes the issue of not reading properly the `readAt` field