### PR TITLE
fix: fallback to `keywords_native` on video post if no keywords are given

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -963,6 +963,34 @@ describe('on youtube post', () => {
       videoId: 'Oso6dYXw5lc',
     });
   });
+
+  it('should fallback to keywords_native if keywords is missing', async () => {
+    await expectSuccessfulBackground(worker, {
+      id: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
+      post_id: 'yt1',
+      updated_at: new Date('01-05-2023 12:00:00'),
+      source_id: 'a',
+      extra: {
+        keywords_native: ['mongodb', 'alpinejs'],
+      },
+      content_type: PostType.VideoYouTube,
+    });
+
+    const post = await con.getRepository(YouTubePost).findOneBy({
+      yggdrasilId: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
+    });
+
+    const tagsArray = post?.tagsStr.split(',');
+    ['mongodb', 'alpinejs'].forEach((item) => {
+      expect(tagsArray).toContain(item);
+    });
+    const postKeywords = await con.getRepository(PostKeyword).find({
+      where: {
+        postId: 'yt1',
+      },
+    });
+    expect(postKeywords.length).toEqual(2);
+  });
 });
 
 describe('on collection post', () => {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -52,6 +52,7 @@ interface Data {
   collections?: string[];
   extra?: {
     keywords?: string[];
+    keywords_native?: string[];
     questions?: string[];
     summary?: string;
     description?: string;
@@ -430,9 +431,14 @@ const fixData = async ({
     data,
   });
 
+  let keywords = data?.extra?.keywords;
+  if (!data?.extra?.keywords && data?.content_type === PostType.VideoYouTube) {
+    keywords = data?.extra?.keywords_native;
+  }
+
   const { allowedKeywords, mergedKeywords } = await mergeKeywords(
     entityManager,
-    data?.extra?.keywords,
+    keywords,
   );
 
   if (allowedKeywords.length > 5) {


### PR DESCRIPTION
If a video have no captions, Yggdrasil is not able to generate keywords in `keyword` field, so we can fallback to `keywords_native`.