### PR TITLE
fix: divide video duration by 60 to get minutes

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -794,7 +794,7 @@ describe('on youtube post', () => {
       url: 'https://youtu.be/FftMDvlYDIg',
       extra: {
         content_curation: ['news', 'story', 'release'],
-        duration: 12,
+        duration: 300,
         keywords: ['mongodb', 'alpinejs'],
         description: 'A description of a video',
         summary: 'A short summary of a video',
@@ -813,7 +813,7 @@ describe('on youtube post', () => {
       yggdrasilId: 'a7edf0c8-aec7-4586-b411-b1dd431ce8d6',
       url: 'https://youtu.be/FftMDvlYDIg',
       contentCuration: ['news', 'story', 'release'],
-      readTime: 12,
+      readTime: 5,
       description: 'A description of a video',
       summary: 'A short summary of a video',
     });
@@ -827,7 +827,7 @@ describe('on youtube post', () => {
       source_id: 'a',
       extra: {
         content_curation: ['news', 'story', 'release'],
-        duration: 12,
+        duration: 300,
         keywords: ['mongodb', 'alpinejs'],
         description: 'A description of a video',
         summary: 'A short summary of a video',
@@ -856,7 +856,7 @@ describe('on youtube post', () => {
       yggdrasilId: '3cf9ba23-ff30-4578-b232-a98ea733ba0a',
       url: 'https://youtu.be/T_AbQGe7fuU',
       contentCuration: ['news', 'story', 'release'],
-      readTime: 12,
+      readTime: 5,
       description: 'A description of a video',
       summary: 'A short summary of a video',
       videoId: 'T_AbQGe7fuU',
@@ -907,7 +907,7 @@ describe('on youtube post', () => {
     expect(post).toMatchObject({
       contentCuration: ['release'],
       description: 'Try it out: https://daily.dev/daily-dev-search',
-      readTime: 63,
+      readTime: 1,
       sourceId: 'unknown',
       summary:
         'Introducing daily.dev Search, a feature that allows users to dive deeper into topics they have read about on daily.dev. With search recommendations, users can easily find relevant content in their feeds.',

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -452,6 +452,7 @@ const fixData = async ({
   }
 
   const becomesVisible = !!data?.title?.length;
+  const duration = data?.extra?.duration / 60;
 
   // Try and fix generic data here
   return {
@@ -467,7 +468,7 @@ const fixData = async ({
       image: data?.image,
       sourceId: data?.source_id,
       title: data?.title && he.decode(data?.title),
-      readTime: parseReadTime(data?.extra?.read_time || data?.extra?.duration),
+      readTime: parseReadTime(data?.extra?.read_time || duration),
       publishedAt: data?.published_at && new Date(data?.published_at),
       metadataChangedAt:
         (data?.updated_at && new Date(data.updated_at)) || new Date(),


### PR DESCRIPTION
We expect the readTime to be minutes, but duration is seconds, so we need to divide by 60.