### PR TITLE
feat: change the message key from `msg` to `message`

### DIFF
--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -107,7 +107,9 @@ describe('personalizedDigest cron', () => {
       })),
     );
 
-    const logger = pino();
+    const logger = pino({
+      messageKey: 'message',
+    });
     const infoSpy = jest.spyOn(logger, 'info');
     await expectSuccessfulCron(cron, logger);
     expect(infoSpy).toHaveBeenCalledTimes(2);
@@ -130,7 +132,9 @@ describe('personalizedDigest cron', () => {
       })),
     );
 
-    const logger = pino();
+    const logger = pino({
+      messageKey: 'message',
+    });
     const infoSpy = jest.spyOn(logger, 'info');
 
     await expectSuccessfulCron(cron, logger);

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -195,7 +195,9 @@ export const invokeBackground = async (
 ): Promise<void> => {
   const con = await createOrGetConnection();
   const pubsub = new PubSub();
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   await worker.handler(mockMessage(data).message, con, logger, pubsub);
 };
 
@@ -209,7 +211,9 @@ export const invokeNotificationWorker = async (
   data: Record<string, unknown>,
 ): Promise<NotificationHandlerReturn> => {
   const con = await createOrGetConnection();
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   return worker.handler(mockMessage(data).message, con, logger);
 };
 
@@ -221,7 +225,9 @@ export const invokeCron = async (cron: Cron, logger: Logger): Promise<void> => {
 
 export const expectSuccessfulCron = (
   cron: Cron,
-  logger: Logger = pino(),
+  logger: Logger = pino({
+    messageKey: 'message',
+  }),
 ): Promise<void> => invokeCron(cron, logger);
 
 export const mockChangeMessage = <T>({

--- a/pull.ts
+++ b/pull.ts
@@ -7,7 +7,9 @@ import createOrGetConnection from './src/db';
 (async () => {
   const pubsub = new PubSub();
   const con = await createOrGetConnection();
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   const sub = pubsub.subscription('api-cdc', {
     flowControl: {
       maxMessages: 20,

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,9 @@ import createOrGetConnection from './db';
 import { workerSubscribe } from './common';
 
 export default async function app(): Promise<void> {
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   const connection = await runInRootSpan(
     'createOrGetConnection',
     createOrGetConnection,

--- a/src/commands/personalizedDigest.ts
+++ b/src/commands/personalizedDigest.ts
@@ -10,7 +10,9 @@ import { workerSubscribe } from '../common';
 import { personalizedDigestWorkers as workers } from '../workers';
 
 export default async function app(): Promise<void> {
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   const connection = await runInRootSpan(
     'createOrGetConnection',
     createOrGetConnection,

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -8,7 +8,9 @@ import { crons } from './cron/index';
 import createOrGetConnection from './db';
 
 export default async function app(cronName: string): Promise<void> {
-  const logger = pino();
+  const logger = pino({
+    messageKey: 'message',
+  });
   const connection = await createOrGetConnection();
   const pubsub = new PubSub();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export default async function app(
   const app = fastify({
     logger: {
       level: process.env.LOG_LEVEL || 'info',
+      messageKey: 'message',
     },
     disableRequestLogging: true,
     trustProxy: true,


### PR DESCRIPTION
This lets Google Cloud Logs Explorer to automagically show the log message instead of the entire payload

Docs: https://getpino.io/#/docs/api?id=messagekey-string