### PR TITLE
feat: fetch similar posts from feed service

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1276,7 +1276,41 @@ describe('query randomSimilarPostsByTags', () => {
     }
   }`;
 
-  it('should return random similar posts by tags', async () => {
+  it('should return posts from feed service', async () => {
+    nock('http://localhost:6000')
+      .post('/feed.json', {
+        feed_config_name: 'post_similarity',
+        total_pages: 1,
+        page_size: 3,
+        post_id: 'p1',
+        fresh_page_size: '1',
+      })
+      .reply(200, {
+        data: [{ post_id: 'p3' }, { post_id: 'p5' }],
+      });
+
+    const res = await client.query(QUERY, {
+      variables: { post: 'p1', tags: ['webdev', 'javascript'] },
+    });
+    expect(res.errors).toBeFalsy();
+    expect(
+      res.data.randomSimilarPostsByTags.map((post) => post.id).sort(),
+    ).toEqual(['p3', 'p5']);
+  });
+
+  it('should fallback to old algorithm', async () => {
+    nock('http://localhost:6000')
+      .post('/feed.json', {
+        feed_config_name: 'post_similarity',
+        total_pages: 1,
+        page_size: 3,
+        post_id: 'p1',
+        fresh_page_size: '1',
+      })
+      .reply(200, {
+        data: [],
+      });
+
     const repo = con.getRepository(Post);
     const now = new Date();
     await con.getRepository(Keyword).save([
@@ -1304,7 +1338,19 @@ describe('query randomSimilarPostsByTags', () => {
     ).toEqual(['p3', 'p5']);
   });
 
-  it('should return random similar posts even when tags not provided', async () => {
+  it('should fallback to old algorithm even when tags not provided', async () => {
+    nock('http://localhost:6000')
+      .post('/feed.json', {
+        feed_config_name: 'post_similarity',
+        total_pages: 1,
+        page_size: 3,
+        post_id: 'p1',
+        fresh_page_size: '1',
+      })
+      .reply(200, {
+        data: [],
+      });
+
     const repo = con.getRepository(Post);
     const now = new Date();
     await con.getRepository(Keyword).save([

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -218,7 +218,11 @@ describe('FeedPreferencesConfigGenerator', () => {
       },
     );
 
-    const actual = await generator.generate(ctx, '1', 2, 3);
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
     expect(actual).toEqual({
       allowed_tags: expect.arrayContaining(['javascript', 'golang']),
       blocked_sources: expect.arrayContaining(['a', 'b']),
@@ -242,7 +246,11 @@ describe('FeedPreferencesConfigGenerator', () => {
       },
     );
 
-    const actual = await generator.generate(ctx, '1', 2, 3);
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
     expect(actual).toEqual({
       blocked_sources: expect.arrayContaining(['a', 'b']),
       blocked_tags: expect.arrayContaining(['python', 'java']),
@@ -260,7 +268,11 @@ describe('FeedPreferencesConfigGenerator', () => {
       config,
     );
 
-    const actual = await generator.generate(ctx, '1', 2, 3);
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
     expect(actual).toEqual({
       feed_config_name: FeedConfigName.Personalise,
       fresh_page_size: '1',
@@ -291,7 +303,11 @@ describe('FeedUserStateConfigGenerator', () => {
       mockClient,
       generators,
     );
-    const actual = await generator.generate(ctx, '1', 2, 3);
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
     expect(actual.user_id).toEqual('1');
     expect(actual.feed_config_name).toEqual('vector');
     expect(mockClient.fetchUserState).toBeCalledWith({
@@ -309,7 +325,11 @@ describe('FeedUserStateConfigGenerator', () => {
       mockClient,
       generators,
     );
-    const actual = await generator.generate(ctx, '1', 2, 3);
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
     expect(actual.feed_config_name).toEqual('personalise');
   });
 });

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -1,4 +1,5 @@
 import {
+  DynamicConfig,
   FeedConfigGenerator,
   FeedConfigName,
   FeedResponse,
@@ -33,20 +34,9 @@ export class FeedGenerator {
     this.feedId = feedId;
   }
 
-  async generate(
-    ctx: Context,
-    userId: string | undefined,
-    pageSize: number,
-    offset: number,
-    cursor?: string,
-  ): Promise<FeedResponse> {
-    const config = await this.config.generate(
-      ctx,
-      userId,
-      pageSize,
-      offset,
-      cursor,
-    );
+  async generate(ctx: Context, opts: DynamicConfig): Promise<FeedResponse> {
+    const config = await this.config.generate(ctx, opts);
+    const userId = opts.user_id;
     return this.client.fetchFeed(ctx, this.feedId ?? userId, config);
   }
 }
@@ -170,6 +160,20 @@ export const feedGenerators: Record<FeedVersion, FeedGenerator> = Object.freeze(
         opts,
       ),
       'onboarding',
+    ),
+    post_similarity: new FeedGenerator(
+      feedClient,
+      new FeedPreferencesConfigGenerator(
+        {
+          feed_config_name: FeedConfigName.PostSimilarity,
+          total_pages: 1,
+        },
+        {
+          includeBlockedTags: true,
+          includeBlockedSources: true,
+          includeSourceMemberships: true,
+        },
+      ),
     ),
   },
 );

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -17,6 +17,7 @@ export enum FeedConfigName {
   VectorE1 = 'vector_e1',
   VectorV18 = 'vector_v18',
   VectorV20 = 'vector_v20',
+  PostSimilarity = 'post_similarity',
 }
 
 export type FeedProvider = {
@@ -44,7 +45,7 @@ export type FeedConfig = {
   user_id?: string;
   feed_config_name?: FeedConfigName;
   page_size: number;
-  offset: number;
+  offset?: number;
   total_pages: number;
   fresh_page_size?: string;
   allowed_tags?: string[];
@@ -54,16 +55,13 @@ export type FeedConfig = {
   providers?: Record<string, FeedProvider>;
   source_types?: ('machine' | 'squad')[];
   cursor?: string;
+  post_id?: string;
 };
 
+export type DynamicConfig = Omit<FeedConfig, 'total_pages'>;
+
 export interface FeedConfigGenerator {
-  generate(
-    ctx: Context,
-    userId: string | undefined,
-    pageSize: number,
-    offset: number,
-    cursor?: string,
-  ): Promise<FeedConfig>;
+  generate(ctx: Context, opts: DynamicConfig): Promise<FeedConfig>;
 }
 
 /**
@@ -90,4 +88,5 @@ export type FeedVersion =
   | '19'
   | '20'
   | 'popular'
-  | 'onboarding';
+  | 'onboarding'
+  | 'post_similarity';


### PR DESCRIPTION
Feed service supports now returning similar posts which is way better than our current implementation. Not all posts support that, hence I'm keeping the old implementation as well for now.