### PR TITLE
feat: resolve post id from yggdrasil id when post id is missing

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -738,6 +738,30 @@ describe('on post update', () => {
       );
     });
   });
+
+  it('should resolve post id from yggdrasil id when post id is missing', async () => {
+    const postId = 'p1';
+
+    const existingPost = await con.getRepository(ArticlePost).save({
+      id: postId,
+      title: 'Post title',
+      yggdrasilId: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+    });
+
+    expect(existingPost).not.toBeNull();
+    expect(existingPost.title).toEqual('Post title');
+
+    await expectSuccessfulBackground(worker, {
+      id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+      post_id: undefined,
+      title: 'New title 2',
+    });
+
+    const updatedPost = await con.getRepository(ArticlePost).findOneBy({
+      id: postId,
+    });
+    expect(updatedPost!.title).toEqual('New title 2');
+  });
 });
 
 describe('on youtube post', () => {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -524,6 +524,20 @@ const worker: Worker = {
         }
 
         let postId = data.post_id;
+
+        if (!postId) {
+          const matchedYggdrasilPost = await con
+            .createQueryBuilder()
+            .from(Post, 'p')
+            .select('p.id as id')
+            .where('p."yggdrasilId" = :id', { id: data.id })
+            .getRawOne<{
+              id: string;
+            }>();
+
+          postId = matchedYggdrasilPost?.id;
+        }
+
         const { mergedKeywords, questions, content_type, fixedData } =
           await fixData({
             logger,


### PR DESCRIPTION
Solves [thread](https://dailydotdev.slack.com/archives/C0601MRBJJU/p1702556332306539?thread_ts=1701787711.730699&cid=C0601MRBJJU)

Yggdrasil is unaware of api post id.