### PR TITLE
feat: make sure yggdrasil id is available to avoid null queries

### DIFF
--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -525,7 +525,7 @@ const worker: Worker = {
 
         let postId = data.post_id;
 
-        if (!postId) {
+        if (!postId && data.id) {
           const matchedYggdrasilPost = await con
             .createQueryBuilder()
             .from(Post, 'p')


### PR DESCRIPTION
It should not happen but just additional guard since there could be null values for `yggdrasilId` in db.