### PR TITLE
fix: do not flip visible condition when post is already visible

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -323,6 +323,7 @@ it('should update freeform post and only modify allowed fields', async () => {
   expect(post.metadataChangedAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
   expect(post.visible).toEqual(true);
   expect(post.flags.visible).toEqual(true);
+  expect(post.visibleAt).toEqual(new Date('2023-01-05T12:00:00.000Z'));
   expect(post.contentCuration).toEqual(['news', 'story', 'release']);
   expect(post.yggdrasilId).toEqual('f99a445f-e2fb-48e8-959c-e02a17f5e816');
   expect(post.title).toEqual('freeform post');

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -738,6 +738,30 @@ describe('on post update', () => {
       );
     });
   });
+
+  it('should resolve post id from yggdrasil id when post id is missing', async () => {
+    const postId = 'p1';
+
+    const existingPost = await con.getRepository(ArticlePost).save({
+      id: postId,
+      title: 'Post title',
+      yggdrasilId: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+    });
+
+    expect(existingPost).not.toBeNull();
+    expect(existingPost.title).toEqual('Post title');
+
+    await expectSuccessfulBackground(worker, {
+      id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+      post_id: undefined,
+      title: 'New title 2',
+    });
+
+    const updatedPost = await con.getRepository(ArticlePost).findOneBy({
+      id: postId,
+    });
+    expect(updatedPost!.title).toEqual('New title 2');
+  });
 });
 
 describe('on youtube post', () => {

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -504,3 +504,7 @@ export const normalizeCollectionPostSources = async ({
     collectionSources: distinctSources.map((item) => item.id),
   });
 };
+
+export const getPostVisible = ({ post }: { post: Pick<Post, 'title'> }) => {
+  return !!post?.title?.length;
+};

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -9,6 +9,7 @@ import {
   CollectionPost,
   findAuthor,
   FreeformPost,
+  getPostVisible,
   mergeKeywords,
   parseReadTime,
   Post,
@@ -203,7 +204,7 @@ const createPost = async ({
   data.origin = data?.scoutId
     ? PostOrigin.CommunityPicks
     : data.origin ?? PostOrigin.Crawler;
-  data.visible = !!data.title?.length;
+  data.visible = getPostVisible({ post: data });
   data.visibleAt = data.visible ? postCreatedAt : null;
   data.flags = {
     ...data.flags,
@@ -308,7 +309,7 @@ const updatePost = async ({
   let updateBecameVisible = false;
 
   if (!databasePost.visible) {
-    updateBecameVisible = !!title?.length;
+    updateBecameVisible = getPostVisible({ post: { title } });
   }
 
   if (updateBecameVisible) {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -316,7 +316,7 @@ const updatePost = async ({
     data.visibleAt = data.metadataChangedAt;
   } else {
     data.visible = databasePost.visible;
-    data.visibleAt = databasePost.visibleAt;
+    data.visibleAt = databasePost.visibleAt ?? data.metadataChangedAt;
   }
 
   if (content_type in allowedFieldsMapping) {

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -301,7 +301,6 @@ const updatePost = async ({
 
   data.id = databasePost.id;
   data.title = title;
-  data.visible = updateBecameVisible;
   data.visibleAt = updateBecameVisible
     ? databasePost.visibleAt ?? data.metadataChangedAt
     : null;

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -524,6 +524,20 @@ const worker: Worker = {
         }
 
         let postId = data.post_id;
+
+        if (!postId) {
+          const matchedYggdrasilPost = await con
+            .createQueryBuilder()
+            .from(Post, 'p')
+            .select('p.id as id')
+            .where('p."yggdrasilId" = :id', { id: data.id })
+            .getRawOne<{
+              id: string;
+            }>();
+
+          postId = matchedYggdrasilPost?.id;
+        }
+
         const { mergedKeywords, questions, content_type, fixedData } =
           await fixData({
             logger,

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -314,10 +314,12 @@ const updatePost = async ({
 
   if (updateBecameVisible) {
     data.visible = true;
-    data.visibleAt = data.metadataChangedAt;
   } else {
     data.visible = databasePost.visible;
-    data.visibleAt = databasePost.visibleAt ?? data.metadataChangedAt;
+  }
+
+  if (data.visible && !databasePost.visibleAt) {
+    data.visibleAt = data.metadataChangedAt;
   }
 
   if (content_type in allowedFieldsMapping) {


### PR DESCRIPTION
Basically a bug when post was already visible the condition was flipped with becomes visible. Everything else logic wise looks fine and platform DOES send whole payload during updates. 

Requirements for post visible updates:
- visible is once off, once post is visible it can't become invisible
- post becomes visible if it has the title
- post visibleAt is updated when post becomes visible (default null during creation)