### PR TITLE
refactor: split notifications to a new cdc handler

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -13,10 +13,13 @@ debezium.source.plugin.name=pgoutput
 debezium.source.heartbeat.interval.ms=60000
 debezium.source.topic.prefix=t
 debezium.source.tombstones.on.delete=false
-debezium.transforms=Reroute,ReadOperationFilter,PostsFilter
+debezium.transforms=Reroute,Notifications,ReadOperationFilter,PostsFilter
 debezium.transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
-debezium.transforms.Reroute.topic.regex=(.*)
+debezium.transforms.Reroute.topic.regex=^((?!\.notification_v2).)*$
 debezium.transforms.Reroute.topic.replacement=%topic%
+debezium.transforms.Notifications.type=io.debezium.transforms.ByLogicalTableRouter
+debezium.transforms.Notifications.topic.regex=.*\.notification_v2
+debezium.transforms.Notifications.topic.replacement=api.v1.cdc-notifications
 debezium.transforms.ReadOperationFilter.type=io.debezium.transforms.Filter
 debezium.transforms.ReadOperationFilter.language=jsr223.groovy
 debezium.transforms.ReadOperationFilter.condition=!(valueSchema.field('op') && value.op == 'r')

--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -105,6 +105,10 @@ export const workers: Worker[] = [
     args: { enableMessageOrdering: true },
   },
   {
+    topic: 'api.v1.cdc-notifications',
+    subscription: 'api.cdc-notifications',
+  },
+  {
     topic: 'api.v1.new-notification',
     subscription: 'api.new-notification-real-time',
   },

--- a/__tests__/workers/cdc/notifications.ts
+++ b/__tests__/workers/cdc/notifications.ts
@@ -1,0 +1,51 @@
+import nock from 'nock';
+import worker from '../../../src/workers/cdc/notifications';
+import { NotificationV2 } from '../../../src/entity';
+import { randomUUID } from 'crypto';
+import { ChangeObject } from '../../../src/types';
+import { NotificationType } from '../../../src/notifications/common';
+import { expectSuccessfulBackground, mockChangeMessage } from '../../helpers';
+import { notifyNewNotification } from '../../../src/common';
+
+jest.mock('../../../src/common', () => ({
+  ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
+  notifyNewNotification: jest.fn(),
+}));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+});
+
+describe('notification', () => {
+  type ObjectType = NotificationV2;
+  const id = randomUUID();
+  const base: ChangeObject<ObjectType> = {
+    id,
+    type: NotificationType.CommunityPicksGranted,
+    title: 'hello',
+    targetUrl: 'target',
+    icon: 'icon',
+    public: true,
+    createdAt: Date.now(),
+    attachments: [],
+    avatars: [],
+  };
+
+  it('should notify new notification', async () => {
+    const after: ChangeObject<ObjectType> = base;
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before: null,
+        op: 'c',
+        table: 'notification_v2',
+      }),
+    );
+    expect(notifyNewNotification).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(notifyNewNotification).mock.calls[0].slice(1)).toEqual([
+      after,
+    ]);
+  });
+});

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -13,8 +13,7 @@ import {
   CollectionPost,
   PostRelation,
   PostRelationType,
-  NotificationV2,
-} from '../../src/entity';
+} from '../../../src/entity';
 import {
   notifyCommentCommented,
   notifyCommentUpvoteCanceled,
@@ -23,7 +22,6 @@ import {
   notifyMemberJoinedSource,
   notifyNewPostMention,
   notifyNewCommentMention,
-  notifyNewNotification,
   notifyPostBannedOrRemoved,
   notifyPostCommented,
   notifyPostReport,
@@ -53,13 +51,13 @@ import {
   notifyBannerRemoved,
   notifyPostYggdrasilIdSet,
   notifyPostCollectionUpdated,
-} from '../../src/common';
-import worker from '../../src/workers/cdc';
+} from '../../../src/common';
+import worker from '../../../src/workers/cdc/primary';
 import {
   expectSuccessfulBackground,
   mockChangeMessage,
   saveFixtures,
-} from '../helpers';
+} from '../../helpers';
 import {
   Alerts,
   ArticlePost,
@@ -83,22 +81,21 @@ import {
   UserState,
   UserStateKey,
   ContentImage,
-} from '../../src/entity';
-import { ChangeObject } from '../../src/types';
-import { sourcesFixture } from '../fixture/source';
-import { postsFixture } from '../fixture/post';
+} from '../../../src/entity';
+import { ChangeObject } from '../../../src/types';
+import { sourcesFixture } from '../../fixture/source';
+import { postsFixture } from '../../fixture/post';
 import { randomUUID } from 'crypto';
-import { submissionAccessThreshold } from '../../src/schema/submissions';
+import { submissionAccessThreshold } from '../../../src/schema/submissions';
 import { DataSource } from 'typeorm';
-import createOrGetConnection from '../../src/db';
-import { TypeOrmError } from '../../src/errors';
-import { SourceMemberRoles } from '../../src/roles';
-import { CommentReport } from '../../src/entity/CommentReport';
-import { usersFixture } from '../fixture/user';
-import { NotificationType } from '../../src/notifications/common';
+import createOrGetConnection from '../../../src/db';
+import { TypeOrmError } from '../../../src/errors';
+import { SourceMemberRoles } from '../../../src/roles';
+import { CommentReport } from '../../../src/entity/CommentReport';
+import { usersFixture } from '../../fixture/user';
 
-jest.mock('../../src/common', () => ({
-  ...(jest.requireActual('../../src/common') as Record<string, unknown>),
+jest.mock('../../../src/common', () => ({
+  ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
   notifySourceRequest: jest.fn(),
   notifyPostUpvoted: jest.fn(),
   notifyPostUpvoteCanceled: jest.fn(),
@@ -1630,39 +1627,6 @@ describe('submission', () => {
     expect(
       jest.mocked(notifySubmissionRejected).mock.calls[0].slice(1),
     ).toEqual([after]);
-  });
-});
-
-describe('notification', () => {
-  type ObjectType = NotificationV2;
-  const id = randomUUID();
-  const base: ChangeObject<ObjectType> = {
-    id,
-    type: NotificationType.CommunityPicksGranted,
-    title: 'hello',
-    targetUrl: 'target',
-    icon: 'icon',
-    public: true,
-    createdAt: Date.now(),
-    attachments: [],
-    avatars: [],
-  };
-
-  it('should notify new notification', async () => {
-    const after: ChangeObject<ObjectType> = base;
-    await expectSuccessfulBackground(
-      worker,
-      mockChangeMessage<ObjectType>({
-        after,
-        before: null,
-        op: 'c',
-        table: 'notification_v2',
-      }),
-    );
-    expect(notifyNewNotification).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(notifyNewNotification).mock.calls[0].slice(1)).toEqual([
-      after,
-    ]);
   });
 });
 

--- a/pull.ts
+++ b/pull.ts
@@ -1,7 +1,7 @@
 import { PubSub } from '@google-cloud/pubsub';
 import pino from 'pino';
 import './src/config';
-import worker from './src/workers/cdc';
+import worker from './src/workers/cdc/primary';
 import createOrGetConnection from './src/db';
 
 (async () => {

--- a/src/workers/cdc/common.ts
+++ b/src/workers/cdc/common.ts
@@ -1,0 +1,10 @@
+import { DataSource } from 'typeorm';
+import { EntityTarget } from 'typeorm/common/EntityTarget';
+
+export const isChanged = <T>(before: T, after: T, property: keyof T): boolean =>
+  before[property] != after[property];
+
+export const getTableName = <Entity>(
+  con: DataSource,
+  target: EntityTarget<Entity>,
+): string => con.getRepository(target).metadata.tableName;

--- a/src/workers/cdc/notifications.ts
+++ b/src/workers/cdc/notifications.ts
@@ -1,0 +1,50 @@
+import { messageToJson, Worker } from '../worker';
+import { ChangeMessage } from '../../types';
+import { getTableName } from './common';
+import { NotificationV2 } from '../../entity';
+import { DataSource } from 'typeorm';
+import { FastifyBaseLogger } from 'fastify';
+import { notifyNewNotification } from '../../common';
+
+const onNotificationsChange = async (
+  con: DataSource,
+  logger: FastifyBaseLogger,
+  data: ChangeMessage<NotificationV2>,
+): Promise<void> => {
+  if (data.payload.op === 'c') {
+    await notifyNewNotification(logger, data.payload.after);
+  }
+};
+
+const worker: Worker = {
+  subscription: 'api.cdc-notifications',
+  maxMessages: parseInt(process.env.CDC_WORKER_MAX_MESSAGES) || null,
+  handler: async (message, con, logger): Promise<void> => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data: ChangeMessage<any> = messageToJson(message);
+      if (
+        data.schema.name === 'io.debezium.connector.common.Heartbeat' ||
+        data.payload.op === 'r'
+      ) {
+        return;
+      }
+      switch (data.payload.source.table) {
+        case getTableName(con, NotificationV2):
+          await onNotificationsChange(con, logger, data);
+          break;
+      }
+    } catch (err) {
+      logger.error(
+        {
+          messageId: message.messageId,
+          err,
+        },
+        'failed to handle notification cdc message',
+      );
+      throw err;
+    }
+  },
+};
+
+export default worker;

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -14,7 +14,8 @@ import postDeletedCommentsCleanup from './postDeletedCommentsCleanup';
 import usernameChanged from './usernameChanged';
 import sourceRequestApprovedRep from './sourceRequestApprovedRep';
 import updateComments from './updateComments';
-import cdc from './cdc';
+import cdc from './cdc/primary';
+import cdcNotifications from './cdc/notifications';
 import updateMailingList from './updateMailingList';
 import deleteUserFromMailingList from './deleteUserFromMailingList';
 import newNotificationRealTime from './newNotificationV2RealTime';
@@ -84,6 +85,7 @@ export const workers: Worker[] = [
   sourceSquadCreatedUserAction,
   sourceSquadCreatedOwnerMailing,
   cdc,
+  cdcNotifications,
   ...notificationWorkers,
 ];
 


### PR DESCRIPTION
To overcome the ordering constraint of CDC, we separate the notifications to a new topic to allow much faster handling with spikes

WT-2048 #done