### PR TITLE
fix: ignore dates before unix time

### DIFF
--- a/__tests__/commons/utils.ts
+++ b/__tests__/commons/utils.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { ArticlePost, Post, PostTag, Source } from '../../src/entity';
 import {
+  parseDate,
   removeEmptyValues,
   removeSpecialCharacters,
   uniqueifyArray,
@@ -101,5 +102,37 @@ describe('removeEmptyValues', () => {
   it('should remove empty values from a array of strings', () => {
     const actual = removeEmptyValues(['a', 'b', '', 'c', '']);
     expect(actual).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('parseDate', () => {
+  it('should return undefined for falsy values', () => {
+    expect(parseDate(undefined as unknown as Date)).toBeUndefined();
+    expect(parseDate(null as unknown as Date)).toBeUndefined();
+    expect(parseDate('')).toBeUndefined();
+  });
+
+  it('should return undefined for invalid Date string', () => {
+    expect(parseDate('55-22 Date')).toBeUndefined();
+  });
+
+  it('should return undefined for Date before UNIX time', () => {
+    expect(parseDate('0001-01-01T00:00:00Z')).toBeUndefined();
+  });
+
+  it('should return undefined for invalid Date', () => {
+    expect(parseDate(new Date('55-22 Date'))).toBeUndefined();
+  });
+
+  it('should return Date for valid Date string', () => {
+    expect(parseDate('2020-01-01T00:00:00Z')).toEqual(
+      new Date('2020-01-01T00:00:00Z'),
+    );
+  });
+
+  it('should return Date for valid Date', () => {
+    expect(parseDate(new Date('2020-01-01T00:00:00Z'))).toEqual(
+      new Date('2020-01-01T00:00:00Z'),
+    );
   });
 });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -61,3 +61,21 @@ export const removeEmptyValues = <T>(array: T[]): T[] => array.filter(Boolean);
  * @returns boolean
  */
 export const isProd = process.env.NODE_ENV === 'production';
+
+export const parseDate = (date: string | Date): Date | undefined => {
+  if (!date) {
+    return undefined;
+  }
+
+  const parsedDate = new Date(date);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return undefined;
+  }
+
+  if (parsedDate.getTime() < 0) {
+    return undefined;
+  }
+
+  return parsedDate;
+};

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -31,7 +31,7 @@ import { SubmissionFailErrorKeys, SubmissionFailErrorMessage } from '../errors';
 import { generateShortId } from '../ids';
 import { FastifyBaseLogger } from 'fastify';
 import { EntityManager } from 'typeorm';
-import { updateFlagsStatement } from '../common';
+import { parseDate, updateFlagsStatement } from '../common';
 import { opentelemetry } from '../telemetry/opentelemetry';
 import { markdown } from '../common/markdown';
 
@@ -483,9 +483,8 @@ const fixData = async ({
       sourceId: data?.source_id,
       title: data?.title && he.decode(data?.title),
       readTime: parseReadTime(data?.extra?.read_time || duration),
-      publishedAt: data?.published_at && new Date(data?.published_at),
-      metadataChangedAt:
-        (data?.updated_at && new Date(data.updated_at)) || new Date(),
+      publishedAt: parseDate(data?.published_at),
+      metadataChangedAt: parseDate(data?.updated_at) || new Date(),
       tagsStr: allowedKeywords?.join(',') || null,
       private: privacy,
       sentAnalyticsReport: privacy || !authorId,


### PR DESCRIPTION
Platform can send date strings before UNIX timestamp `0001-01-01T00:00:00Z` as empty values, those get parsed as valid Dates in Node but in DB they are nulls. Thread [here](https://dailydotdev.slack.com/archives/C0601MRBJJU/p1702974255027129).

Current issue is avoided during creation because TypeORM filters out extra columns with `create` but on update it tries to write it out. 

Since those values are empty I added the new `parseDate` which handles the case for all date parsing in `fixData` function in our updated worker. It also ignores any falsy or invalid date values. 

Alternative was to add `allowedFieldsMapping` for collection type but seemed wasteful since we don really need publishedAt at the first place since its empty. 