### PR TITLE
feat: add db:seed:upsert npm script

### DIFF
--- a/bin/import.ts
+++ b/bin/import.ts
@@ -3,25 +3,40 @@ import createOrGetConnection from '../src/db';
 import { DataSource } from 'typeorm';
 import { TagRecommendation } from '../src/entity/TagRecommendation';
 
-const importEntity = async (con: DataSource, name: string): Promise<void> => {
+const importEntity = async (
+  con: DataSource,
+  name: string,
+  throwOnError = true,
+): Promise<void> => {
   console.log(`importing ${name}`);
   const entities = JSON.parse(readFileSync(`./seeds/${name}.json`).toString());
   const repository = con.getRepository(name);
+
   // Batch insert with dirty hack
   for (let i = 0; i < entities.length; i += 1000) {
-    await repository.insert(entities.slice(i, i + 1000));
+    await repository.insert(entities.slice(i, i + 1000)).catch((err) => {
+      if (throwOnError) {
+        throw err;
+      } else {
+        // Swallow the error if we're ignoring them
+        // this will allow the next importEntity call to run
+        console.error(err);
+      }
+    });
   }
 };
 
+const throwOnError = !process.argv.includes('--ignore-insert-errors');
+
 const start = async (): Promise<void> => {
   const con = await createOrGetConnection();
-  await importEntity(con, 'AdvancedSettings');
-  await importEntity(con, 'Source');
-  await importEntity(con, 'Post');
-  await importEntity(con, 'YouTubePost');
-  await importEntity(con, 'Category');
-  await importEntity(con, 'PostKeyword');
-  await importEntity(con, 'User');
+  await importEntity(con, 'AdvancedSettings', throwOnError);
+  await importEntity(con, 'Source', throwOnError);
+  await importEntity(con, 'Post', throwOnError);
+  await importEntity(con, 'YouTubePost', throwOnError);
+  await importEntity(con, 'Category', throwOnError);
+  await importEntity(con, 'PostKeyword', throwOnError);
+  await importEntity(con, 'User', throwOnError);
   // Manually have to reset these as insert has a issue with `type` columns
   await con.query(`update post set type = 'article' where type = 'Post'`);
   await con.query(`update source set type = 'machine' where type = 'Source'`);

--- a/bin/import.ts
+++ b/bin/import.ts
@@ -1,42 +1,65 @@
 import { readFileSync } from 'fs';
 import createOrGetConnection from '../src/db';
-import { DataSource } from 'typeorm';
+import { DataSource, ObjectLiteral, Repository } from 'typeorm';
 import { TagRecommendation } from '../src/entity/TagRecommendation';
+
+const getConflictPaths = (repository: Repository<ObjectLiteral>) => {
+  // Get primary key columns
+  const primaryKeyColumns = repository.metadata.columns
+    .filter((column) => column.isPrimary)
+    .map((column) => column.propertyName);
+  // Get unique constraint columns
+  const uniqueConstraintColumns = repository.metadata.uniques.flatMap(
+    (constraint) => constraint.columns.map((c) => c.propertyName),
+  );
+
+  // make sure we do not have duplicates in the list
+  const paths = new Set([
+    ...primaryKeyColumns,
+    ...uniqueConstraintColumns,
+  ]).keys();
+  return [...paths];
+};
 
 const importEntity = async (
   con: DataSource,
   name: string,
-  throwOnError = true,
+  isUpsert = false,
 ): Promise<void> => {
-  console.log(`importing ${name}`);
+  const opName = isUpsert ? 'upsert' : 'insert';
+  console.log(`${opName}ing ${name}`);
   const entities = JSON.parse(readFileSync(`./seeds/${name}.json`).toString());
   const repository = con.getRepository(name);
+  const conflictPaths = isUpsert && getConflictPaths(repository);
+
+  const write = async (data) => {
+    if (isUpsert) {
+      await repository.upsert(data, {
+        conflictPaths,
+        skipUpdateIfNoValuesChanged: true,
+      });
+    } else {
+      await repository.insert(data);
+    }
+  };
 
   // Batch insert with dirty hack
   for (let i = 0; i < entities.length; i += 1000) {
-    await repository.insert(entities.slice(i, i + 1000)).catch((err) => {
-      if (throwOnError) {
-        throw err;
-      } else {
-        // Swallow the error if we're ignoring them
-        // this will allow the next importEntity call to run
-        console.error(err);
-      }
-    });
+    await write(entities.slice(i, i + 1000));
   }
 };
 
-const throwOnError = !process.argv.includes('--ignore-insert-errors');
+const isUpsert = process.argv.includes('--upsert');
 
 const start = async (): Promise<void> => {
   const con = await createOrGetConnection();
-  await importEntity(con, 'AdvancedSettings', throwOnError);
-  await importEntity(con, 'Source', throwOnError);
-  await importEntity(con, 'Post', throwOnError);
-  await importEntity(con, 'YouTubePost', throwOnError);
-  await importEntity(con, 'Category', throwOnError);
-  await importEntity(con, 'PostKeyword', throwOnError);
-  await importEntity(con, 'User', throwOnError);
+  await importEntity(con, 'AdvancedSettings', isUpsert);
+  await importEntity(con, 'Source', isUpsert);
+  await importEntity(con, 'Post', isUpsert);
+  await importEntity(con, 'YouTubePost', isUpsert);
+  await importEntity(con, 'Category', isUpsert);
+  await importEntity(con, 'PostKeyword', isUpsert);
+  await importEntity(con, 'User', isUpsert);
   // Manually have to reset these as insert has a issue with `type` columns
   await con.query(`update post set type = 'article' where type = 'Post'`);
   await con.query(`update source set type = 'machine' where type = 'Source'`);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:schema:sync": "npm run typeorm -- schema:sync",
     "db:seed:export": "ts-node bin/export.ts",
     "db:seed:import": "ts-node bin/import.ts",
+    "db:seed:import:ignore-errors": "ts-node bin/import.ts --ignore-insert-errors",
     "dev": "nodemon ./bin/cli api | pino-pretty",
     "dev:background": "nodemon ./bin/cli background | pino-pretty",
     "dev:personalized-digest": "nodemon ./bin/cli personalized-digest | pino-pretty",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "db:schema:sync": "npm run typeorm -- schema:sync",
     "db:seed:export": "ts-node bin/export.ts",
     "db:seed:import": "ts-node bin/import.ts",
-    "db:seed:import:ignore-errors": "ts-node bin/import.ts --ignore-insert-errors",
+    "db:seed:upsert": "ts-node bin/import.ts --upsert",
     "dev": "nodemon ./bin/cli api | pino-pretty",
     "dev:background": "nodemon ./bin/cli background | pino-pretty",
     "dev:personalized-digest": "nodemon ./bin/cli personalized-digest | pino-pretty",


### PR DESCRIPTION
Adds `--upsert` option to `import.ts` script and new npm script `db:seed:upsert`.

This allows the import script to try to upsert all of the seeds, even if there are errors/duplicates on some of the insert calls. In case there's a conflict, it updates the row instead.

Without this option the script fails on the first error/duplicate row it finds and never inserts the rest of the entities.