### PR TITLE
fix: we missed two indexes according to everSQL

### DIFF
--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -17,6 +17,11 @@ export type KeywordFlagsPublic = never;
 @Entity()
 @Index('IDX_status_value', ['status', 'value'])
 @Index('IDX_keyword_flags_onboarding_value_text', { synchronize: false })
+@Index('IDX_keyword_status_value_occurrences', [
+  'status',
+  'value',
+  'occurrences',
+])
 export class Keyword {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_keyword_value')

--- a/src/entity/PostKeyword.ts
+++ b/src/entity/PostKeyword.ts
@@ -3,6 +3,7 @@ import { Post } from './posts';
 
 @Entity()
 @Index('IDX_post_keyword_postId_status', ['postId', 'status'])
+@Index('IDX_post_keyword_keyword_postid', ['keyword', 'postId'])
 export class PostKeyword {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_post_keyword_postId')

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -26,6 +26,7 @@ export const UNKNOWN_SOURCE = 'unknown';
 
 @Entity()
 @Index('IDX_source_active_private_image', ['active', 'private', 'image'])
+@Index('IDX_source_type_id', ['type', 'id'])
 @TableInheritance({
   column: { type: 'varchar', name: 'type', default: SourceType.Machine },
 })

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -27,6 +27,7 @@ export const UNKNOWN_SOURCE = 'unknown';
 @Entity()
 @Index('IDX_source_active_private_image', ['active', 'private', 'image'])
 @Index('IDX_source_type_id', ['type', 'id'])
+@Index('IDX_source_private_id', ['private', 'id'])
 @TableInheritance({
   column: { type: 'varchar', name: 'type', default: SourceType.Machine },
 })

--- a/src/entity/SourceMember.ts
+++ b/src/entity/SourceMember.ts
@@ -19,6 +19,7 @@ export type SourceMemberFlagsPublic = Pick<
 
 @Entity()
 @Index('IDX_source_member_userId_flags_hideFeedPosts', { synchronize: false })
+@Index('IDX_source_member_userId_role', ['userId', 'role'])
 export class SourceMember {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_source_member_sourceId')

--- a/src/entity/UserPost.ts
+++ b/src/entity/UserPost.ts
@@ -25,6 +25,7 @@ export enum UserPostVote {
 @Entity()
 @Index(['postId', 'userId'], { unique: true })
 @Index(['userId', 'vote', 'votedAt'])
+@Index('IDX_user_post_postid_userid_hidden', ['postId', 'userId', 'hidden'])
 export class UserPost {
   @PrimaryColumn({ type: 'text' })
   postId: string;

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -50,6 +50,20 @@ export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;
 @Index('IDX_post_visible_metadatachanged', ['visible', 'metadataChangedAt'])
 @Index('IDX_post_visible_sourceid', ['visible', 'sourceId'])
 @Index('IDX_post_visible_type', ['visible', 'type'])
+@Index('IDX_post_visible_deleted_id', ['visible', 'deleted', 'id'])
+@Index('IDX_post_deleted_visible_banned_showonfeed_id_type', [
+  'deleted',
+  'visible',
+  'banned',
+  'showOnFeed',
+  'id',
+  'type',
+])
+@Index('IDX_post_visible_deleted_createdat', [
+  'visible',
+  'deleted',
+  'createdAt',
+])
 @TableInheritance({
   column: { type: 'varchar', name: 'type', default: PostType.Article },
 })

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -47,6 +47,9 @@ export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;
   'pinnedAt',
   'createdAt',
 ])
+@Index('IDX_post_visible_metadatachanged', ['visible', 'metadataChangedAt'])
+@Index('IDX_post_visible_sourceid', ['visible', 'sourceId'])
+@Index('IDX_post_visible_type', ['visible', 'type'])
 @TableInheritance({
   column: { type: 'varchar', name: 'type', default: PostType.Article },
 })

--- a/src/migration/1703422184359-AdditionalMissingIndexes.ts
+++ b/src/migration/1703422184359-AdditionalMissingIndexes.ts
@@ -12,12 +12,26 @@ export class AdditionalMissingIndexes1703422184359
     await queryRunner.query(
       `CREATE INDEX "IDX_source_type_id" ON "source" ("type", "id") `,
     );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_visible_type" ON "post" ("visible", "type") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_visible_sourceid" ON "post" ("visible", "sourceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_visible_metadatachanged" ON "post" ("visible", "metadataChangedAt") `,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP INDEX "public"."IDX_source_type_id"`);
     await queryRunner.query(
       `DROP INDEX "public"."IDX_source_member_userId_role"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_post_visible_type"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_post_visible_sourceid"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_visible_metadatachanged"`,
     );
   }
 }

--- a/src/migration/1703422184359-AdditionalMissingIndexes.ts
+++ b/src/migration/1703422184359-AdditionalMissingIndexes.ts
@@ -21,6 +21,27 @@ export class AdditionalMissingIndexes1703422184359
     await queryRunner.query(
       `CREATE INDEX "IDX_post_visible_metadatachanged" ON "post" ("visible", "metadataChangedAt") `,
     );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_keyword_status_value_occurrences" ON "keyword" ("status", "value", "occurrences") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_visible_deleted_id" ON "post" ("visible", "deleted", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_deleted_visible_banned_showonfeed_id_type" ON "post" ("deleted", "visible", "banned", "showOnFeed", "id", "type") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_visible_deleted_createdat" ON "post" ("visible", "deleted", "createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_keyword_keyword_postid" ON "post_keyword" ("keyword", "postId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_source_private_id" ON "source" ("private", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_user_post_postid_userid_hidden" ON "user_post" ("postId", "userId", "hidden") `,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -32,6 +53,25 @@ export class AdditionalMissingIndexes1703422184359
     await queryRunner.query(`DROP INDEX "public"."IDX_post_visible_sourceid"`);
     await queryRunner.query(
       `DROP INDEX "public"."IDX_post_visible_metadatachanged"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_keyword_status_value_occurrences"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_visible_deleted_id"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_deleted_visible_banned_showonfeed_id_type"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_visible_deleted_createdat"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_keyword_keyword_postid"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_source_private_id"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_user_post_postid_userid_hidden"`,
     );
   }
 }

--- a/src/migration/1703422184359-AdditionalMissingIndexes.ts
+++ b/src/migration/1703422184359-AdditionalMissingIndexes.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AdditionalMissingIndexes1703422184359
+  implements MigrationInterface
+{
+  name = 'AdditionalMissingIndexes1703422184359';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_source_member_userId_role" ON "source_member" ("userId", "role") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_source_type_id" ON "source" ("type", "id") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_source_type_id"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_source_member_userId_role"`,
+    );
+  }
+}


### PR DESCRIPTION
According to [everSQL](https://www.eversql.com/sql-query-optimizer/?code=fb8424a3-d3fc-4a6e-9ae8-414754aaf52b#/) we missed the following to optimal indexes.

<img width="720" alt="Screenshot 2023-12-24 at 13 51 02" src="https://github.com/dailydotdev/daily-api/assets/554874/28deb7c3-76cb-4e00-851d-d6cf321087a9">

And [this](https://www.eversql.com/sql-query-optimizer/?code=fb8424a3-d3fc-4a6e-9ae8-414754aaf52b#/) one:
<img width="741" alt="Screenshot 2023-12-24 at 13 57 05" src="https://github.com/dailydotdev/daily-api/assets/554874/ce658587-26fe-49da-a140-1b6aa183ef40">

And [this](https://www.eversql.com/sql-query-optimizer/?code=fb8424a3-d3fc-4a6e-9ae8-414754aaf52b#/) one:
![Uploading Screenshot 2023-12-24 at 14.17.27.png…]()


This should help improving a very slow query we had.