### PR TITLE
fix: query params mismatch

### DIFF
--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1257,8 +1257,8 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
           .innerJoin(
             UserPost,
             'up',
-            `up."postId" = ${alias}.id AND up."userId" = :userId AND vote = :vote`,
-            { userId, vote: UserPostVote.Up },
+            `up."postId" = ${alias}.id AND up."userId" = :author AND vote = :vote`,
+            { author: userId, vote: UserPostVote.Up },
           ),
       upvotedPageGenerator,
       applyUpvotedPaging,


### PR DESCRIPTION
I used twice the `userId` param with different values and it caused the wrong output