### PR TITLE
fix: sources should not be deduplicated

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1907,7 +1907,7 @@ describe('post relation collection', () => {
     expect(collectionAfterWorker.collectionSources).toMatchObject(['a', 'b']);
   });
 
-  it('should deduplicate collection sources', async () => {
+  it(`shouldn't deduplicate collection sources`, async () => {
     const collection = await con.getRepository(CollectionPost).findOneByOrFail({
       id: 'pc1',
     });
@@ -1956,7 +1956,7 @@ describe('post relation collection', () => {
         id: 'pc1',
       });
 
-    expect(collectionAfterWorker.collectionSources.length).toBe(1);
-    expect(collectionAfterWorker.collectionSources).toMatchObject(['a']);
+    expect(collectionAfterWorker.collectionSources.length).toBe(2);
+    expect(collectionAfterWorker.collectionSources).toMatchObject(['a', 'a']);
   });
 });

--- a/__tests__/workers/newNotificationV2Mail.ts
+++ b/__tests__/workers/newNotificationV2Mail.ts
@@ -1123,7 +1123,7 @@ describe('collection_post notification', () => {
     const ctx: NotificationCollectionContext = {
       ...postContext!,
       userIds: ['3'],
-      distinctSources: [sourceA!],
+      sources: [sourceA!],
       total: 4,
     };
 
@@ -1181,7 +1181,7 @@ describe('collection_post notification', () => {
     const ctx: NotificationCollectionContext = {
       ...postContext!,
       userIds: ['3'],
-      distinctSources: [sourceA!],
+      sources: [sourceA!],
       total: 4,
     };
 

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -464,7 +464,7 @@ export const relatePosts = async ({
   return posts;
 };
 
-export const getDistinctSourcesBaseQuery = ({
+export const getAllSourcesBaseQuery = ({
   con,
   postId,
   relationType,
@@ -480,7 +480,6 @@ export const getDistinctSourcesBaseQuery = ({
     .leftJoin(Source, 's', 's.id = p."sourceId"')
     .where('pr."postId" = :postId', { postId })
     .andWhere('pr."type" = :type', { type: relationType })
-    .groupBy('s.id, pr."createdAt"')
     .orderBy('pr."createdAt"', 'DESC')
     .clone();
 
@@ -491,7 +490,7 @@ export const normalizeCollectionPostSources = async ({
   con: DataSource | EntityManager;
   postId: CollectionPost['id'];
 }) => {
-  const distinctSources = await getDistinctSourcesBaseQuery({
+  const sources = await getAllSourcesBaseQuery({
     con,
     postId,
     relationType: PostRelationType.Collection,
@@ -501,7 +500,7 @@ export const normalizeCollectionPostSources = async ({
 
   await con.getRepository(CollectionPost).save({
     id: postId,
-    collectionSources: distinctSources.map((item) => item.id),
+    collectionSources: sources.map((item) => item.id),
   });
 };
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -293,7 +293,7 @@ export const generateNotificationMap: Record<
       .icon(NotificationIcon.Bell)
       .referencePost(ctx.post)
       .targetPost(ctx.post)
-      .avatarManySources(ctx.distinctSources)
+      .avatarManySources(ctx.sources)
       .numTotalAvatars(ctx.total)
       .uniqueKey(ctx.post.metadataChangedAt?.toString()),
 };

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -65,6 +65,6 @@ export type NotificationSourceMemberRoleContext = NotificationSourceContext & {
 };
 
 export type NotificationCollectionContext = NotificationPostContext & {
-  distinctSources: Reference<Source>[];
+  sources: Reference<Source>[];
   total: number;
 };

--- a/src/workers/notifications/collectionUpdated.ts
+++ b/src/workers/notifications/collectionUpdated.ts
@@ -5,7 +5,7 @@ import {
   PostRelationType,
   PostType,
   Source,
-  getDistinctSourcesBaseQuery,
+  getAllSourcesBaseQuery,
 } from '../../entity';
 import { ChangeObject } from '../../types';
 import { NotificationWorker } from './worker';
@@ -35,7 +35,7 @@ export const collectionUpdated: NotificationWorker = {
       return;
     }
 
-    const distinctSources = await getDistinctSourcesBaseQuery({
+    const sources = await getAllSourcesBaseQuery({
       con,
       postId: post.id,
       relationType: PostRelationType.Collection,
@@ -46,7 +46,7 @@ export const collectionUpdated: NotificationWorker = {
       .limit(3)
       .getRawMany<Source & { total: number }>();
 
-    const numTotalAvatars = distinctSources[0]?.total || 0;
+    const numTotalAvatars = sources[0]?.total || 0;
 
     const members = await con.getRepository(NotificationPreferencePost).findBy({
       notificationType: NotificationType.CollectionUpdated,
@@ -59,7 +59,7 @@ export const collectionUpdated: NotificationWorker = {
         type: NotificationType.CollectionUpdated,
         ctx: {
           ...baseCtx,
-          distinctSources,
+          sources,
           total: numTotalAvatars,
           userIds: members.map(({ userId }) => userId),
         } as NotificationCollectionContext,


### PR DESCRIPTION
Previously we ensured sources where distinct de-duplicated, however according to new insights we should allow all sources including duplicates.

Secondary effort for this task will be to run a query to update existing post-relations and once-off update the `collectionSources` to reflect this change. (My suggestion is a query, but please let me know if you have different ideas)