### PR TITLE
fix: create rules for protecting the ghost user from accidental deletion or modification

### DIFF
--- a/__tests__/cron/cleanZombieUsers.ts
+++ b/__tests__/cron/cleanZombieUsers.ts
@@ -23,7 +23,7 @@ it('should delete users with info confirmed false that are older than one hour',
 
   await expectSuccessfulCron(cron);
   const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-  expect(users.length).toEqual(2);
+  expect(users.length).toEqual(3);
   expect(users[0].id).toEqual('1');
   expect(users[1].id).toEqual('2');
 });

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -225,9 +225,9 @@ describe('POST /p/newUser', () => {
 
     const users = await con.getRepository(User).find();
     expect(users.length).toEqual(2);
-    expect(users[0].id).toEqual(usersFixture[0].id);
-    expect(users[0].infoConfirmed).toBeTruthy();
-    expect(users[0].createdAt).not.toBeNull();
+    expect(users[1].id).toEqual(usersFixture[0].id);
+    expect(users[1].infoConfirmed).toBeTruthy();
+    expect(users[1].createdAt).not.toBeNull();
   });
 
   it('should allow underscore in username', async () => {
@@ -264,8 +264,8 @@ describe('POST /p/newUser', () => {
 
     const users = await con.getRepository(User).find();
     expect(users.length).toEqual(2);
-    expect(users[0].id).toEqual(usersFixture[0].id);
-    expect(users[0].infoConfirmed).toBeFalsy();
+    expect(users[1].id).toEqual(usersFixture[0].id);
+    expect(users[1].infoConfirmed).toBeFalsy();
   });
 
   it('should add a new user with GitHub handle', async () => {
@@ -287,8 +287,8 @@ describe('POST /p/newUser', () => {
 
     const users = await con.getRepository(User).find();
     expect(users.length).toEqual(2);
-    expect(users[0].id).toEqual(usersFixture[0].id);
-    expect(users[0].github).toEqual(usersFixture[0].github);
+    expect(users[1].id).toEqual(usersFixture[0].id);
+    expect(users[1].github).toEqual(usersFixture[0].github);
   });
 
   it('should ignore GitHub handle if it already exists', async () => {
@@ -336,9 +336,8 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(2);
-    expect(users[0].id).toEqual(usersFixture[0].id);
-    expect(users[0].twitter).toEqual(usersFixture[0].twitter);
+    expect(users[1].id).toEqual(usersFixture[0].id);
+    expect(users[1].twitter).toEqual(usersFixture[0].twitter);
   });
 
   it('should ignore Twitter handle if it already exists', async () => {

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -224,7 +224,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(1);
+    expect(users.length).toEqual(2);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].infoConfirmed).toBeTruthy();
     expect(users[0].createdAt).not.toBeNull();
@@ -263,7 +263,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(1);
+    expect(users.length).toEqual(2);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].infoConfirmed).toBeFalsy();
   });
@@ -286,7 +286,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(1);
+    expect(users.length).toEqual(2);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].github).toEqual(usersFixture[0].github);
   });
@@ -313,7 +313,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(2);
+    expect(users.length).toEqual(3);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].github).toEqual(null);
   });
@@ -336,7 +336,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(1);
+    expect(users.length).toEqual(2);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].twitter).toEqual(usersFixture[0].twitter);
   });
@@ -363,7 +363,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(2);
+    expect(users.length).toEqual(3);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].twitter).toEqual(null);
   });
@@ -388,7 +388,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(2);
+    expect(users.length).toEqual(3);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].referralId).toEqual(usersFixture[1].id);
   });
@@ -413,7 +413,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(2);
+    expect(users.length).toEqual(3);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].referralId).toEqual(usersFixture[1].id);
     expect(users[0].referralOrigin).toEqual('squad');
@@ -440,7 +440,7 @@ describe('POST /p/newUser', () => {
     expect(body).toEqual({ status: 'ok', userId: usersFixture[0].id });
 
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(2);
+    expect(users.length).toEqual(3);
     expect(users[0].id).toEqual(usersFixture[0].id);
     expect(users[0].referralId).toEqual(usersFixture[1].id);
     expect(users[0].referralOrigin).toEqual('knightcampaign');
@@ -664,7 +664,7 @@ describe('POST /p/updateUserEmail', () => {
     expect(body).toEqual({ status: 'failed', reason: 'USER_DOESNT_EXIST' });
 
     const users = await con.getRepository(User).find();
-    expect(users.length).toBe(0);
+    expect(users.length).toBe(1);
   });
 
   it('should return correct response if exists', async () => {

--- a/src/migration/1704948666033-GhostUserProtect.ts
+++ b/src/migration/1704948666033-GhostUserProtect.ts
@@ -4,11 +4,13 @@ export class GhostUserProtect1704948666033 implements MigrationInterface {
     name = 'GhostUserProtect1704948666033'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`UPDATE "user" SET "infoConfirmed" = true WHERE "id" = '404';`);
       await queryRunner.query(`CREATE RULE prototect_ghostuser_deletion AS ON DELETE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
       await queryRunner.query(`CREATE RULE prototect_ghostuser_update AS ON UPDATE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`UPDATE "user" SET "infoConfirmed" = false WHERE "id" = '404';`);
       await queryRunner.query(`DROP RULE prototect_ghostuser_deletion on "user";`);
       await queryRunner.query(`DROP RULE prototect_ghostuser_update on "user";`);
     }

--- a/src/migration/1704948666033-GhostUserProtect.ts
+++ b/src/migration/1704948666033-GhostUserProtect.ts
@@ -6,12 +6,10 @@ export class GhostUserProtect1704948666033 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
       await queryRunner.query(`UPDATE "user" SET "infoConfirmed" = true WHERE "id" = '404';`);
       await queryRunner.query(`CREATE RULE prototect_ghostuser_deletion AS ON DELETE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
-      await queryRunner.query(`CREATE RULE prototect_ghostuser_update AS ON UPDATE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
       await queryRunner.query(`UPDATE "user" SET "infoConfirmed" = false WHERE "id" = '404';`);
       await queryRunner.query(`DROP RULE prototect_ghostuser_deletion on "user";`);
-      await queryRunner.query(`DROP RULE prototect_ghostuser_update on "user";`);
     }
 }

--- a/src/migration/1704948666033-GhostUserProtect.ts
+++ b/src/migration/1704948666033-GhostUserProtect.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class GhostUserProtect1704948666033 implements MigrationInterface {
+    name = 'GhostUserProtect1704948666033'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`CREATE RULE prototect_ghostuser_deletion AS ON DELETE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
+      await queryRunner.query(`CREATE RULE prototect_ghostuser_update AS ON UPDATE TO "user" WHERE old.id IN ('404') DO INSTEAD nothing;`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP RULE prototect_ghostuser_deletion on "user";`);
+      await queryRunner.query(`DROP RULE prototect_ghostuser_update on "user";`);
+    }
+}


### PR DESCRIPTION
As discovered while debugging deletion of users, I noticed that the 404 / ghost user had disappeared.
So this migration creates a rule to prevent `DELETE` and `UPDATE` of the row.