### PR TITLE
fix: do nothing in `updateMailingList` if user is ghost user

### DIFF
--- a/__tests__/workers/updateMailingList.ts
+++ b/__tests__/workers/updateMailingList.ts
@@ -1,0 +1,47 @@
+import nock from 'nock';
+import worker from '../../src/workers/updateMailingList';
+import { ChangeObject } from '../../src/types';
+import { expectSuccessfulBackground } from '../helpers';
+import { User } from '../../src/entity';
+import { updateUserContactLists } from '../../src/common';
+
+jest.mock('../../src/common', () => ({
+  ...(jest.requireActual('../../src/common') as Record<string, unknown>),
+  updateUserContactLists: jest.fn(),
+}));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+  process.env.SENDGRID_API_KEY = 'wolololo';
+});
+
+describe('updateMailingList', () => {
+  type ObjectType = Partial<User>;
+  const base: ChangeObject<ObjectType> = {
+    id: '404',
+    username: 'inactive_user',
+    name: 'Inactive user',
+    infoConfirmed: false,
+  };
+
+  it('should update user contact list if user is regular user', async () => {
+    const before: ChangeObject<ObjectType> = { ...base, id: '1' };
+    const after: ChangeObject<ObjectType> = { ...before, infoConfirmed: true };
+    await expectSuccessfulBackground(worker, {
+      newProfile: after,
+      user: before,
+    });
+    expect(updateUserContactLists).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not update user contact list if user is ghost user', async () => {
+    const before: ChangeObject<ObjectType> = base;
+    const after: ChangeObject<ObjectType> = { ...before, infoConfirmed: true };
+    await expectSuccessfulBackground(worker, {
+      newProfile: after,
+      user: before,
+    });
+    expect(updateUserContactLists).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -3,6 +3,11 @@ import { zonedTimeToUtc } from 'date-fns-tz';
 
 const REMOVE_SPECIAL_CHARACTERS_REGEX = /[^a-zA-Z0-9-_#.]/g;
 
+export const ghostUser = {
+  id: '404',
+  username: 'inactive_user',
+};
+
 interface GetTimezonedIsoWeekProps {
   date: Date;
   timezone: string;

--- a/src/workers/updateMailingList.ts
+++ b/src/workers/updateMailingList.ts
@@ -1,4 +1,4 @@
-import { updateUserContactLists, User } from '../common';
+import { ghostUser, updateUserContactLists, User } from '../common';
 import { messageToJson, Worker } from './worker';
 
 interface Data {
@@ -14,6 +14,11 @@ const worker: Worker = {
     }
     const data = messageToJson<Data>(message);
     const { user: oldProfile, newProfile } = data;
+
+    if (oldProfile.id === ghostUser.id) {
+      return;
+    }
+
     if (
       newProfile.infoConfirmed &&
       (newProfile.email !== oldProfile.email ||


### PR DESCRIPTION
This fixes a long hanging unacked pubsub message on the `user-updated-api-mailing` subscription because we had to re-add the ghost user to the database.