### PR TITLE
fix: hotfix too many posts returned from feed

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -360,7 +360,7 @@ describe('query anonymousFeed', () => {
   it('should return anonymous feed v2', async () => {
     nock('http://localhost:6000')
       .post('/feed.json', {
-        total_pages: 40,
+        total_pages: 1,
         page_size: 10,
         fresh_page_size: '4',
         offset: 0,
@@ -415,7 +415,7 @@ describe('query anonymousFeed', () => {
 
     nock('http://localhost:6000')
       .post('/feed.json', {
-        total_pages: 40,
+        total_pages: 1,
         page_size: 10,
         fresh_page_size: '4',
         offset: 0,
@@ -698,7 +698,7 @@ describe('query feed', () => {
       .reply(200, { personalise: { state: 'personalised' } });
     nock('http://localhost:6000')
       .post('/feed.json', {
-        total_pages: 40,
+        total_pages: 1,
         page_size: 10,
         offset: 0,
         fresh_page_size: '4',
@@ -856,7 +856,7 @@ describe('query feedByConfig', () => {
     nock('http://localhost:6000')
       .post('/feed.json', {
         key: 'value',
-        total_pages: 40,
+        total_pages: 1,
         page_size: 10,
         fresh_page_size: '4',
         offset: 0,

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -21,7 +21,7 @@ function getDefaultConfig(
   const config: FeedConfig = {
     ...baseConfig,
     ...dynamicConfig,
-    total_pages: baseConfig.total_pages || 40,
+    total_pages: baseConfig.total_pages || 1,
     fresh_page_size: freshPageSize,
   };
   if (config.user_id === null) {


### PR DESCRIPTION
Since we no longer cache locally the feed, we need to limit the total pages to 1 not 40 :P