### PR TITLE
fix: remove GB rollout catch

### DIFF
--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -53,7 +53,6 @@ import {
   versionToFeedGenerator,
 } from '../integrations/feed';
 import { AuthenticationError } from 'apollo-server-errors';
-import { getUserGrowthBookInstace } from '../growthbook';
 
 interface GQLTagsCategory {
   id: string;
@@ -1195,33 +1194,31 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       ctx,
       info,
     ): Promise<GQLPost[]> => {
-      const gb = getUserGrowthBookInstace(ctx.userId);
-      if (gb.isOn('post_similarity')) {
-        const res = await feedGenerators['post_similarity'].generate(ctx, {
-          user_id: ctx.userId,
-          page_size: args.first || 3,
-          post_id: args.post,
-        });
-        if (res?.data?.length) {
-          return graphorm.query(ctx, info, (builder) => {
-            builder.queryBuilder = applyFeedWhere(
+      const res = await feedGenerators['post_similarity'].generate(ctx, {
+        user_id: ctx.userId,
+        page_size: args.first || 3,
+        post_id: args.post,
+      });
+      if (res?.data?.length) {
+        return graphorm.query(ctx, info, (builder) => {
+          builder.queryBuilder = applyFeedWhere(
+            ctx,
+            fixedIdsFeedBuilder(
               ctx,
-              fixedIdsFeedBuilder(
-                ctx,
-                res.data.map(([postId]) => postId as string),
-                builder.queryBuilder,
-                builder.alias,
-              ),
+              res.data.map(([postId]) => postId as string),
+              builder.queryBuilder,
               builder.alias,
-              ['article'],
-              true,
-              true,
-              false,
-            );
-            return builder;
-          });
-        }
+            ),
+            builder.alias,
+            ['article'],
+            true,
+            true,
+            false,
+          );
+          return builder;
+        });
       }
+
       return legacySimilarPostsResolver(source, args, ctx, info);
     },
     randomDiscussedPosts: randomPostsResolver(


### PR DESCRIPTION
Remove the post_similarity GB enrolment as it seemed to work fine now.
Kept the GB function as we might need it later again.