### PR TITLE
feat: share post tags trigger

### DIFF
--- a/__tests__/triggers/post.ts
+++ b/__tests__/triggers/post.ts
@@ -1,0 +1,40 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { saveFixtures } from '../helpers';
+import { ArticlePost, Source, SharePost, Post } from '../../src/entity';
+import { sourcesFixture } from '../fixture/source';
+import { postsFixture } from '../fixture/post';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, ArticlePost, postsFixture);
+});
+
+it('should set tags str of shared post on insert and update', async () => {
+  await con.getRepository(SharePost).insert({
+    id: 'sp',
+    shortId: 'sp',
+    title: 'T',
+    sharedPostId: 'p1',
+    sourceId: postsFixture[0].sourceId,
+  });
+  const obj = await con.getRepository(Post).findOneBy({ id: 'sp' });
+  expect(obj.tagsStr).toEqual(postsFixture[0].tagsStr);
+  await con.getRepository(ArticlePost).update({ id: 'p1' }, { tagsStr: 'a,b' });
+  // Make sure only sp gets affected
+  const obj2 = await con
+    .getRepository(Post)
+    .find({ where: { tagsStr: 'a,b' }, order: { id: 'ASC' }, select: ['id'] });
+  expect(obj2.map((x) => x.id)).toEqual(['p1', 'sp']);
+});

--- a/src/entity/posts/SharePost.ts
+++ b/src/entity/posts/SharePost.ts
@@ -1,9 +1,10 @@
-import { ChildEntity, Column, OneToOne } from 'typeorm';
+import { ChildEntity, Column, Index, OneToOne } from 'typeorm';
 import { Post, PostType } from './Post';
 
 @ChildEntity(PostType.Share)
 export class SharePost extends Post {
   @Column({ type: 'text' })
+  @Index('IDX_sharedPostId')
   sharedPostId: string;
 
   @OneToOne(() => Post, { lazy: true, onDelete: 'SET NULL' })

--- a/src/migration/1706363895498-SharePostTrigger.ts
+++ b/src/migration/1706363895498-SharePostTrigger.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SharePostTrigger1706363895498 implements MigrationInterface {
+  name = 'SharePostTrigger1706363895498';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sharedPostId" ON "post" ("sharedPostId") `,
+    );
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION shared_post_tags_on_insert()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        tags_str text;
+      BEGIN
+          IF NEW."sharedPostId" IS NOT NULL THEN
+            SELECT "tagsStr" INTO tags_str
+            FROM post
+            WHERE id = NEW."sharedPostId";
+            NEW."tagsStr" := tags_str;
+          END IF;
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await queryRunner.query(`
+      CREATE TRIGGER trigger_shared_post_tags_on_insert
+      BEFORE INSERT ON public.post
+      FOR EACH ROW
+      EXECUTE FUNCTION shared_post_tags_on_insert();
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION update_shared_post_tags()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          IF NEW."tagsStr" <> OLD."tagsStr" THEN
+            UPDATE post
+            SET "tagsStr" = NEW."tagsStr", "metadataChangedAt" = now()
+            WHERE "sharedPostId" = NEW.id;
+          END IF;
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await queryRunner.query(`
+      CREATE TRIGGER trigger_update_shared_post_tags
+      AFTER UPDATE ON public.post
+      FOR EACH ROW
+      EXECUTE FUNCTION update_shared_post_tags();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS trigger_update_shared_post_tags ON public.post;`,
+    );
+    await queryRunner.query(`DROP FUNCTION IF EXISTS update_shared_post_tags;`);
+
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS trigger_shared_post_tags_on_insert ON public.post;`,
+    );
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS shared_post_tags_on_insert;`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_sharedPostId"`);
+  }
+}


### PR DESCRIPTION
Introduce new triggers to keep SharePost tagsStr up-to-date with the tags of the shared post itself.