### PR TITLE
feat: get user streak

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -304,6 +304,26 @@ describe('query userStats', () => {
   });
 });
 
+describe('query userStreaks', () => {
+  const QUERY = `query UserStreak {
+    userStreak {
+      max
+      total
+      current
+      lastViewAt
+    }
+  }`;
+
+  it('should not allow unauthenticated users', () =>
+    testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED'));
+
+  it('should return the user stats', async () => {
+    loggedUser = '1';
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+  });
+});
+
 describe('query referredUsers', () => {
   const QUERY = `query ReferredUsers {
     referredUsers {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -74,6 +74,13 @@ const obj = new GraphORM({
   CommentUpvote: {
     requiredColumns: ['createdAt'],
   },
+  UserStreak: {
+    fields: {
+      max: { select: 'maxStreak' },
+      total: { select: 'totalStreak' },
+      current: { select: 'currentStreak' },
+    },
+  },
   Post: {
     additionalQuery: (ctx, alias, qb) =>
       qb

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -97,6 +97,13 @@ export interface GQLUser {
   readmeHtml?: string;
 }
 
+export interface GQLUserStreak {
+  max?: number;
+  total?: number;
+  current?: number;
+  lastViewAt?: Date;
+}
+
 export interface GQLView {
   post: Post;
   timestamp: Date;
@@ -410,6 +417,13 @@ export const typeDefs = /* GraphQL */ `
     edges: [UserEdge!]!
   }
 
+  type UserStreak {
+    max: Int
+    total: Int
+    current: Int
+    lastViewAt: DateTime
+  }
+
   extend type Query {
     """
     Get user based on logged in session
@@ -419,6 +433,10 @@ export const typeDefs = /* GraphQL */ `
     Get the statistics of the user
     """
     userStats(id: ID!): UserStats
+    """
+    Get User Streak
+    """
+    userStreak: UserStreak @auth
     """
     Get the reading rank of the user
     """
@@ -832,6 +850,14 @@ export const resolvers: IResolvers<any, Context> = {
         .orderBy('date')
         .getRawMany();
     },
+    userStreak: (_, __, ctx: Context, info): Promise<GQLUserStreak> =>
+      graphorm.queryOneOrFail<GQLUserStreak>(ctx, info, (builder) => ({
+        queryBuilder: builder.queryBuilder.where(
+          `"${builder.alias}"."userId" = :id`,
+          { id: ctx.userId },
+        ),
+        ...builder,
+      })),
     userReads: async (): Promise<number> => {
       // Kept for backwards compatability
       return 0;


### PR DESCRIPTION
Introduce a new query to fetch the user's reading streak.

Note: this PR is purely retrieval. The additional logic that resets the user's current streak based on some checks will be for a different ticket/PR.

MI-72 #done