### PR TITLE
fix: reduce the freeform minimum content length to 50 chars

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1026,11 +1026,59 @@ describe('post', () => {
     ).toEqual(after);
   });
 
+  it('should notify for new freeform post when title and content is greater than the required amount characters', async () => {
+    const after = {
+      ...base,
+      type: PostType.Freeform,
+      content: '1'.repeat(
+        FREEFORM_POST_MINIMUM_CONTENT_LENGTH - base.title.length,
+      ),
+    };
+
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before: null,
+        op: 'c',
+        table: 'post',
+      }),
+    );
+
+    expect(notifyFreeformContentRequested).toHaveBeenCalledTimes(1);
+    expect(
+      jest.mocked(notifyFreeformContentRequested).mock.calls[0][1].payload
+        .after,
+    ).toEqual(after);
+  });
+
   it('should not notify for new freeform post less than the required amount characters', async () => {
     const after = {
       ...base,
       type: PostType.Freeform,
       content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH - 1),
+    };
+
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before: null,
+        op: 'c',
+        table: 'post',
+      }),
+    );
+
+    expect(notifyFreeformContentRequested).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not notify for new freeform post when title and content is less than the required amount characters', async () => {
+    const after = {
+      ...base,
+      type: PostType.Freeform,
+      content: '1'.repeat(
+        FREEFORM_POST_MINIMUM_CONTENT_LENGTH - base.title.length - 1,
+      ),
     };
 
     await expectSuccessfulBackground(

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1052,26 +1052,6 @@ describe('post', () => {
     ).toEqual(after);
   });
 
-  it('should not notify for new freeform post less than the required amount characters', async () => {
-    const after = {
-      ...base,
-      type: PostType.Freeform,
-      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH - 1),
-    };
-
-    await expectSuccessfulBackground(
-      worker,
-      mockChangeMessage<ObjectType>({
-        after,
-        before: null,
-        op: 'c',
-        table: 'post',
-      }),
-    );
-
-    expect(notifyFreeformContentRequested).toHaveBeenCalledTimes(0);
-  });
-
   it('should not notify for new freeform post when title and content is less than the required amount characters', async () => {
     const after = {
       ...base,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -13,6 +13,8 @@ import {
   CollectionPost,
   PostRelation,
   PostRelationType,
+  FREEFORM_POST_MINIMUM_CONTENT_LENGTH,
+  FREEFORM_POST_MINIMUM_CHANGE_LENGTH,
 } from '../../../src/entity';
 import {
   notifyCommentCommented,
@@ -1000,11 +1002,11 @@ describe('post', () => {
     );
   });
 
-  it('should notify for new freeform post greater than 1000 characters', async () => {
+  it('should notify for new freeform post greater than the required amount characters', async () => {
     const after = {
       ...base,
       type: PostType.Freeform,
-      content: '1'.repeat(1000),
+      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH),
     };
 
     await expectSuccessfulBackground(
@@ -1024,11 +1026,11 @@ describe('post', () => {
     ).toEqual(after);
   });
 
-  it('should not notify for new freeform post less than 1000 characters', async () => {
+  it('should not notify for new freeform post less than the required amount characters', async () => {
     const after = {
       ...base,
       type: PostType.Freeform,
-      content: '1'.repeat(999),
+      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH - 1),
     };
 
     await expectSuccessfulBackground(
@@ -1048,7 +1050,7 @@ describe('post', () => {
     const after = {
       ...base,
       type: PostType.Welcome,
-      content: '1'.repeat(1000),
+      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH),
     };
 
     await expectSuccessfulBackground(
@@ -1068,7 +1070,7 @@ describe('post', () => {
     const after = {
       ...base,
       type: PostType.Share,
-      content: '1'.repeat(1000),
+      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH),
     };
 
     await expectSuccessfulBackground(
@@ -1084,7 +1086,7 @@ describe('post', () => {
     expect(notifyContentRequested).toHaveBeenCalledTimes(0);
   });
 
-  it('should notify for edited freeform post greater than 200 edited characters', async () => {
+  it('should notify for edited freeform post greater than the required amount edited characters', async () => {
     const before = {
       ...base,
       type: PostType.Freeform,
@@ -1093,7 +1095,7 @@ describe('post', () => {
 
     const after = {
       ...before,
-      content: before.content + '2'.repeat(200),
+      content: before.content + '2'.repeat(FREEFORM_POST_MINIMUM_CHANGE_LENGTH),
     };
 
     await expectSuccessfulBackground(
@@ -1117,7 +1119,7 @@ describe('post', () => {
     ).toEqual(after);
   });
 
-  it('should not notify for edited freeform post less than 200 edited characters', async () => {
+  it('should not notify for edited freeform post less than the required amount edited characters', async () => {
     const before = {
       ...base,
       type: PostType.Freeform,
@@ -1126,7 +1128,8 @@ describe('post', () => {
 
     const after = {
       ...before,
-      content: before.content + '2'.repeat(100),
+      content:
+        before.content + '2'.repeat(FREEFORM_POST_MINIMUM_CHANGE_LENGTH - 1),
     };
 
     await expectSuccessfulBackground(

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -379,7 +379,10 @@ type ContentRequestedSubmission = { submissionId: string } & Pick<
   'sourceId' | 'url'
 >;
 type ContentRequestedURL = Pick<ArticlePost, 'id' | 'origin' | 'url'>;
-type ContentRequestedFreeForm = Pick<FreeformPost, 'id' | 'content'> & {
+type ContentRequestedFreeForm = Pick<
+  FreeformPost,
+  'id' | 'content' | 'title'
+> & {
   post_type;
 };
 export type ContentRequested =
@@ -399,6 +402,7 @@ export const notifyFreeformContentRequested = async (
   notifyContentRequested(logger, {
     id: freeform.payload.after.id,
     content: freeform.payload.after.content,
+    title: freeform.payload.after.title,
     post_type: freeform.payload.after.type,
   });
 

--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -2,7 +2,7 @@ import { ChildEntity, Column } from 'typeorm';
 import { Post, PostType } from './Post';
 
 // Minimun content length required for new posts to trigger content-requested
-export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 1000;
+export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 50;
 
 // Minimun content length required for updated posts to trigger content-requested
 export const FREEFORM_POST_MINIMUM_CHANGE_LENGTH = 200;

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -92,7 +92,8 @@ import { getTableName, isChanged } from './common';
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,
 ): boolean =>
-  freeform.payload.after.content.length >= FREEFORM_POST_MINIMUM_CONTENT_LENGTH;
+  freeform.payload.after.title.length + freeform.payload.after.content.length >=
+  FREEFORM_POST_MINIMUM_CONTENT_LENGTH;
 
 const isFreeformPostChangeLongEnough = (
   freeform: ChangeMessage<FreeformPost>,


### PR DESCRIPTION
Reduces the amount required amount of characters for triggered content requested on freeform.