### PR TITLE
refactor: query user streak - clear when possible

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -421,7 +421,7 @@ describe('query userStreaks', () => {
     await expectStreak(5, 5, lastViewAt);
   });
 
-  it('should not reset streak on if last view is the same day today', async () => {
+  it('should not reset streak if last view is the same day today', async () => {
     loggedUser = '1';
     const fakeToday = new Date(2024, 0, 9); // Tuesday
     const lastViewAt = subDays(fakeToday, 0); // Tuesday

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -36,6 +36,7 @@ import {
   User,
   View,
   UserPersonalizedDigest,
+  UserStreak,
 } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { getTimezonedStartOfISOWeek } from '../src/common';
@@ -314,13 +315,119 @@ describe('query userStreaks', () => {
     }
   }`;
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should not allow unauthenticated users', () =>
     testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED'));
 
-  it('should return the user stats', async () => {
+  it('should return the user streaks', async () => {
     loggedUser = '1';
     const res = await client.query(QUERY);
     expect(res.errors).toBeFalsy();
+  });
+
+  it('should return the user streaks when last view is null', async () => {
+    loggedUser = '1';
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+  });
+
+  const expectStreak = async (
+    currentStreak: number,
+    expectedCurrentStreak: number,
+    lastViewAt: Date,
+  ) => {
+    const repo = con.getRepository(UserStreak);
+    await repo.update({ userId: loggedUser }, { currentStreak, lastViewAt });
+
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+
+    const streak = await repo.findOneBy({ userId: loggedUser });
+    expect(streak.currentStreak).toEqual(expectedCurrentStreak);
+  };
+
+  it('should reset streak on Saturday when last read is Thursday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 6); // Saturday
+    const lastViewAt = subDays(fakeToday, 2); // Thursday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 0, lastViewAt);
+  });
+
+  it('should reset streak on Sunday when last read is Thursday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 7); // Sunday
+    const lastViewAt = subDays(fakeToday, 3); // Thursday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 0, lastViewAt);
+  });
+
+  it('should not reset streak on Saturday when last read is Friday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 6); // Saturday
+    const lastViewAt = subDays(fakeToday, 1); // Friday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
+  });
+
+  it('should not reset streak on Sunday when last read is Friday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 7); // Sunday
+    const lastViewAt = subDays(fakeToday, 2); // Friday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
+  });
+
+  it('should reset streak on Monday when last read was Thursday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 8); // Monday
+    const lastViewAt = subDays(fakeToday, 4); // Thursday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 0, lastViewAt);
+  });
+
+  it('should not reset streak on Monday when last read was Friday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 8); // Monday
+    const lastViewAt = subDays(fakeToday, 3); // Friday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
+  });
+
+  it('should reset streak on Tuesday when last read was Friday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 9); // Tuesday
+    const lastViewAt = subDays(fakeToday, 4); // Friday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 0, lastViewAt);
+  });
+
+  it('should not reset streak on Tuesday when last read was Monday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 9); // Tuesday
+    const lastViewAt = subDays(fakeToday, 1); // Monday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
+  });
+
+  it('should not reset streak on if last view is the same day today', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 9); // Tuesday
+    const lastViewAt = subDays(fakeToday, 0); // Tuesday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
   });
 });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -435,12 +435,13 @@ describe('query userStreaks', () => {
     const tz = 'America/Tijuana';
     await con.getRepository(User).update({ id: loggedUser }, { timezone: tz });
     const fakeToday = new Date(2024, 0, 6); // Saturday
+    const fakeTodayTz = addHours(fakeToday, 16); // To ensure UTC offset would not make today as Friday
     const lastViewAt = subDays(fakeToday, 2); // Thursday
     const lastViewAtTz = addHours(lastViewAt, 22); // by UTC time, this should be Friday
     // No reset should happen if we are not considering timezone
     // but here, it should reset
 
-    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    jest.useFakeTimers({ advanceTimers: true, now: fakeTodayTz });
     await expectStreak(5, 0, lastViewAtTz);
   });
 
@@ -449,12 +450,13 @@ describe('query userStreaks', () => {
     const tz = 'Asia/Manila';
     await con.getRepository(User).update({ id: loggedUser }, { timezone: tz });
     const fakeToday = new Date(2024, 0, 6); // Saturday
+    const fakeTodayTz = addHours(fakeToday, 12); // To ensure UTC offset would not make today as Friday
     const lastViewAt = subDays(fakeToday, 2); // Thursday
     const lastViewAtTz = addHours(lastViewAt, 22); // by UTC time, this should still be Thursday
     // Reset should happen if we are not considering timezone
     // but here, it should not reset since from that time in Asia/Manila, it is already Friday
 
-    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    jest.useFakeTimers({ advanceTimers: true, now: fakeTodayTz });
     await expectStreak(5, 5, lastViewAtTz);
   });
 });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -435,14 +435,13 @@ describe('query userStreaks', () => {
     const tz = 'America/Tijuana';
     await con.getRepository(User).update({ id: loggedUser }, { timezone: tz });
     const fakeToday = new Date(2024, 0, 6); // Saturday
-    const fakeTodayTz = addHours(fakeToday, 16); // To ensure UTC offset would not make today as Friday
-    const lastViewAt = subDays(fakeToday, 2); // Thursday
-    const lastViewAtTz = addHours(lastViewAt, 22); // by UTC time, this should be Friday
+    const fakeTodayTz = addHours(fakeToday, 12); // To ensure UTC offset would not make today as Friday
+    const lastViewAt = subDays(fakeToday, 1); // Friday on UTC - but on user's timezone, this is still Thursday
     // No reset should happen if we are not considering timezone
     // but here, it should reset
 
     jest.useFakeTimers({ advanceTimers: true, now: fakeTodayTz });
-    await expectStreak(5, 0, lastViewAtTz);
+    await expectStreak(5, 0, lastViewAt);
   });
 
   it('should not reset streak when considering user timezone', async () => {

--- a/src/common/date.ts
+++ b/src/common/date.ts
@@ -1,0 +1,5 @@
+export const getTodayTz = (timeZone: string) => {
+  const now = new Date();
+  const timeZonedToday = now.toLocaleDateString('en', { timeZone });
+  return new Date(timeZonedToday);
+};

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -376,8 +376,8 @@ export enum Day {
   Saturday,
 }
 
-export const WEEKENDS = [Day.Sunday, Day.Saturday];
-export const FREEZE_DAYS_IN_A_WEEK = WEEKENDS.length;
+export const Weekends = [Day.Sunday, Day.Saturday];
+export const FREEZE_DAYS_IN_A_WEEK = Weekends.length;
 
 export const getUserStreak = (
   ctx: Context,

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -351,21 +351,6 @@ export const getUserReadingRank = async (
   };
 };
 
-export const getStreakLastView = async (
-  con: DataSource | EntityManager,
-  streak: GQLUserStreak,
-): Promise<Date> => {
-  if (streak.lastViewAt) {
-    return streak.lastViewAt;
-  }
-
-  const view = await con
-    .getRepository(View)
-    .findOneBy({ userId: streak.userId });
-
-  return view?.timestamp;
-};
-
 export enum Day {
   Sunday,
   Monday,
@@ -400,7 +385,7 @@ export const clearThenGetUserStreak = (
   return ctx.con.transaction(async (manager) => {
     await manager
       .getRepository(UserStreak)
-      .update({ userId }, { currentStreak: 0 });
+      .update({ userId }, { currentStreak: 0, updatedAt: new Date() });
 
     return getUserStreak(ctx, info, userId);
   });

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -6,6 +6,7 @@ import { CommentMention, Comment, View, Source, SourceMember } from '../entity';
 import { getTimezonedStartOfISOWeek, getTimezonedEndOfISOWeek } from './utils';
 import { Context } from '../Context';
 import { GraphQLResolveInfo } from 'graphql';
+import { getTodayTz } from './date';
 
 export interface User {
   id: string;
@@ -385,15 +386,13 @@ export const checkAndClearUserStreak = async (
   info: GraphQLResolveInfo,
   streak: GQLUserStreakTz,
 ): Promise<boolean> => {
-  const { lastViewAtTz: lastViewAt, timezone: timeZone } = streak;
+  const { lastViewAtTz: lastViewAt, timezone } = streak;
 
   if (!lastViewAt) {
     return false;
   }
 
-  const now = new Date();
-  const timeZonedToday = now.toLocaleDateString('en', { timeZone });
-  const today = new Date(timeZonedToday);
+  const today = getTodayTz(timezone);
   const day = today.getDay();
   const difference = differenceInDays(today, lastViewAt);
 

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -391,7 +391,8 @@ export const checkAndClearUserStreak = async (
     return false;
   }
 
-  const timeZonedToday = new Date().toLocaleDateString('en', { timeZone });
+  const now = new Date();
+  const timeZonedToday = now.toLocaleDateString('en', { timeZone });
   const today = new Date(timeZonedToday);
   const day = today.getDay();
   const difference = differenceInDays(today, lastViewAt);

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -379,6 +379,19 @@ export enum Day {
 export const WEEKENDS = [Day.Sunday, Day.Saturday];
 export const FREEZE_DAYS_IN_A_WEEK = WEEKENDS.length;
 
+export const getUserStreak = (
+  ctx: Context,
+  info: GraphQLResolveInfo,
+  userId: string,
+) =>
+  graphorm.queryOneOrFail<GQLUserStreak>(ctx, info, (builder) => ({
+    queryBuilder: builder.queryBuilder.where(
+      `"${builder.alias}"."userId" = :id`,
+      { id: userId },
+    ),
+    ...builder,
+  }));
+
 export const clearThenGetUserStreak = (
   ctx: Context,
   info: GraphQLResolveInfo,
@@ -389,12 +402,6 @@ export const clearThenGetUserStreak = (
       .getRepository(UserStreak)
       .update({ userId }, { currentStreak: 0 });
 
-    return graphorm.queryOneOrFail<GQLUserStreak>(ctx, info, (builder) => ({
-      queryBuilder: builder.queryBuilder.where(
-        `"${builder.alias}"."userId" = :id`,
-        { id: userId },
-      ),
-      ...builder,
-    }));
+    return getUserStreak(ctx, info, userId);
   });
 };

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -390,10 +390,6 @@ export const checkAndClearUserStreak = async (
   const day = today.getDay();
   const difference = differenceInDays(today, lastViewAt);
 
-  if (difference === 0) {
-    return false;
-  }
-
   // Even though it is the weekend, we should still clear the streak for when the user's last read was Thursday
   // Due to the fact that when Monday comes, we will clear it anyway when we notice the gap in Friday
   if (

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -29,6 +29,11 @@ export interface GQLUserStreak {
   userId: string;
 }
 
+export interface GQLUserStreakTz extends GQLUserStreak {
+  timezone: string;
+  lastViewAtTz: Date;
+}
+
 export const fetchUser = async (
   userId: string,
   con: DataSource,
@@ -378,15 +383,16 @@ export const clearUserStreak = async (
 export const checkAndClearUserStreak = async (
   ctx: Context,
   info: GraphQLResolveInfo,
-  streak: GQLUserStreak,
+  streak: GQLUserStreakTz,
 ): Promise<boolean> => {
-  const { lastViewAt } = streak;
+  const { lastViewAtTz: lastViewAt, timezone: timeZone } = streak;
 
   if (!lastViewAt) {
     return false;
   }
 
-  const today = new Date();
+  const timeZonedToday = new Date().toLocaleDateString('en', { timeZone });
+  const today = new Date(timeZonedToday);
   const day = today.getDay();
   const difference = differenceInDays(today, lastViewAt);
 

--- a/src/entity/user/UserStreak.ts
+++ b/src/entity/user/UserStreak.ts
@@ -34,9 +34,4 @@ export class UserStreak {
 
   @Column({ type: 'timestamptz', default: () => 'now()' })
   updatedAt: Date;
-
-  @BeforeUpdate()
-  private setUpdatedAt(): void {
-    this.updatedAt = new Date();
-  }
 }

--- a/src/entity/user/UserStreak.ts
+++ b/src/entity/user/UserStreak.ts
@@ -1,4 +1,11 @@
-import { Column, PrimaryColumn, Entity, OneToOne, JoinColumn } from 'typeorm';
+import {
+  Column,
+  PrimaryColumn,
+  Entity,
+  OneToOne,
+  JoinColumn,
+  BeforeUpdate,
+} from 'typeorm';
 import { User } from './';
 
 @Entity()
@@ -27,4 +34,9 @@ export class UserStreak {
 
   @Column({ type: 'timestamptz', default: () => 'now()' })
   updatedAt: Date;
+
+  @BeforeUpdate()
+  private setUpdatedAt(): void {
+    this.updatedAt = new Date();
+  }
 }

--- a/src/entity/user/UserStreak.ts
+++ b/src/entity/user/UserStreak.ts
@@ -1,11 +1,4 @@
-import {
-  Column,
-  PrimaryColumn,
-  Entity,
-  OneToOne,
-  JoinColumn,
-  BeforeUpdate,
-} from 'typeorm';
+import { Column, PrimaryColumn, Entity, OneToOne, JoinColumn } from 'typeorm';
 import { User } from './';
 
 @Entity()

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -75,6 +75,7 @@ const obj = new GraphORM({
     requiredColumns: ['createdAt'],
   },
   UserStreak: {
+    requiredColumns: ['lastViewAt'],
     fields: {
       max: { select: 'maxStreak' },
       total: { select: 'totalStreak' },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -892,11 +892,11 @@ export const resolvers: IResolvers<any, Context> = {
       }
 
       if (dayToday === Day.Monday) {
-        if (difference - FREEZE_DAYS_IN_A_WEEK < 2) {
-          return streak;
+        if (difference > FREEZE_DAYS_IN_A_WEEK + 1) {
+          return clearThenGetUserStreak(ctx, info, ctx.userId);
         }
 
-        return clearThenGetUserStreak(ctx, info, ctx.userId);
+        return streak;
       }
 
       if (difference > 1) {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -39,7 +39,7 @@ import {
   getUserReadingRank,
   GQLUserStreak,
   isValidHttpUrl,
-  WEEKENDS,
+  Weekends,
   TagsReadingStatus,
   uploadAvatar,
   uploadDevCardBackground,
@@ -876,7 +876,7 @@ export const resolvers: IResolvers<any, Context> = {
 
       // Even though it is the weekend, we should still clear the streak for when the user's last read was Thursday
       // Due to the fact that when Monday comes, we will clear it anyway when we notice the gap in Friday
-      if (WEEKENDS.includes(dayToday)) {
+      if (Weekends.includes(dayToday)) {
         if (dayToday === Day.Saturday && difference > 1) {
           return clearThenGetUserStreak(ctx, info, ctx.userId);
         }

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -855,6 +855,7 @@ export const resolvers: IResolvers<any, Context> = {
             .addSelect(
               `(date_trunc('day', "${builder.alias}"."lastViewAt" at time zone COALESCE(u.timezone, 'utc'))::date) AS "lastViewAtTz"`,
             )
+            .addSelect('u.timezone', 'timezone')
             .innerJoin(User, 'u', `"${builder.alias}"."userId" = u.id`)
             .where(`"${builder.alias}"."userId" = :id`, { id: ctx.userId }),
           ...builder,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -17,7 +17,6 @@ import {
   Invite,
   UserPersonalizedDigest,
   getAuthorPostStats,
-  UserStreak,
 } from '../entity';
 import {
   AuthenticationError,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -35,7 +35,6 @@ import {
   clearThenGetUserStreak,
   getInviteLink,
   getShortUrl,
-  getStreakLastView,
   getUserReadingRank,
   GQLUserStreak,
   isValidHttpUrl,
@@ -858,17 +857,18 @@ export const resolvers: IResolvers<any, Context> = {
         .createQueryBuilder()
         .select('"lastViewAt"') // needs to consider user's timezone
         .addSelect('"userId"')
-        .getRawOne();
-      const getStreak = () => getUserStreak(ctx, info, ctx.userId);
-      const lastView = await getStreakLastView(ctx.con, streak);
+        .getRawOne<UserStreak>();
 
-      if (!lastView) {
+      const getStreak = () => getUserStreak(ctx, info, ctx.userId);
+      const { lastViewAt } = streak;
+
+      if (!lastViewAt) {
         return getStreak();
       }
 
       const today = new Date();
       const dayToday = today.getDay();
-      const difference = differenceInDays(today, lastView);
+      const difference = differenceInDays(today, lastViewAt);
 
       if (difference === 0) {
         return getStreak();


### PR DESCRIPTION
- Update the `userStreak` query to clear the user's `currentStreak` whenever applicable.
- The test cases have covered all the possible cases which involve weekends. Feel free to go through it.

MI-108 #done