### PR TITLE
fix: set upload limit to match FE limit

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -10,6 +10,7 @@ import {
   SourceMember,
   User,
   UserPost,
+  UserNotification,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -23,7 +24,6 @@ import { GQLBookmarkList } from '../schema/bookmarks';
 import { base64 } from '../common';
 import { GQLComment } from '../schema/comments';
 import { GQLUserPost } from '../schema/posts';
-import { UserNotification } from '../entity/notifications/UserNotification';
 
 const existsByUserAndPost =
   (entity: string, build?: (queryBuilder: QueryBuilder) => QueryBuilder) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export default async function app(
   // });
 
   app.register(MercuriusGQLUpload, {
-    maxFileSize: 1024 * 1024 * 5,
+    maxFileSize: 1024 * 1024 * 20,
     maxFiles: 1,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export default async function app(
   // });
 
   app.register(MercuriusGQLUpload, {
-    maxFileSize: 1024 * 1024 * 2,
+    maxFileSize: 1024 * 1024 * 5,
     maxFiles: 1,
   });
 


### PR DESCRIPTION
After checking we actually set the FE limit to 5MB:
```
export const imageSizeLimitMB = 5;
```

So decided to set this one to match so we will catch it on both sides correctly.