### PR TITLE
fix: return value for incrementing reading streaks

### DIFF
--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -198,6 +198,30 @@ describe('reading streaks', () => {
     expect(streak2?.currentStreak).toEqual(streak1?.currentStreak);
   });
 
+  it('does not update reading streak if view does not have userId', async () => {
+    await prepareTest('2024-01-25T17:17Z', '2024-01-24T14:17Z');
+
+    const streak1 = await con
+      .getRepository(UserStreak)
+      .findOne({ where: { userId: 'u1', currentStreak: 5 } });
+    expect(streak1).not.toBeNull();
+
+    const data = {
+      postId: 'p1',
+      referer: 'referer',
+      agent: 'agent',
+      ip: '127.0.0.1',
+      timestamp: new Date('2024-01-26T17:17Z'),
+    };
+    await expectSuccessfulBackground(worker, data);
+
+    const streak2 = await con
+      .getRepository(UserStreak)
+      .findOne({ where: { userId: 'u1' } });
+    expect(streak2?.updatedAt).toEqual(streak1?.updatedAt);
+    expect(streak2?.currentStreak).toEqual(streak1?.currentStreak);
+  });
+
   it('should start a reading streak if there was none before', async () => {
     await runTest(
       '2024-01-26T17:17Z',

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -79,7 +79,6 @@ const incrementReadingStreak = async (
         lastViewAt: viewTime,
       }),
     );
-    return;
   } else {
     await repo.query(INC_STREAK_QUERY, [userId, viewTime, DEFAULT_TIMEZONE]);
   }
@@ -133,8 +132,8 @@ const worker: Worker = {
       throw err;
     }
 
-    // no need to touch reading streaks if we didn't save a new view event
-    if (!didSave) {
+    // no need to touch reading streaks if we didn't save a new view event or if we don't have a userId
+    if (!didSave || !data.userId) {
       return;
     }
 


### PR DESCRIPTION
Fixes bad return value if we create the reading streak record from the newView worker.

Fixes trying to write data without having the userId on the message.

More details in slack: https://dailydotdev.slack.com/archives/C05TQL6HWTH/p1706694707591509?thread_ts=1706621305.668089&cid=C05TQL6HWTH