### PR TITLE
fix: do not update reading streak for non-existing user

### DIFF
--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -14,6 +14,8 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  await con.getRepository(UserStreak).clear();
+  await con.getRepository(View).clear();
   await saveFixtures(
     con,
     User,
@@ -121,15 +123,15 @@ describe('reading streaks', () => {
   const prepareTest = async (
     currentDate: Date | string | undefined,
     previousDate: Date | string | undefined,
-    previousStreak = defaultStreak,
+    previousStreak: Partial<UserStreak> | null | undefined = defaultStreak,
   ) => {
-    await con.getRepository(UserStreak).update(
-      { userId: 'u1' },
-      {
+    if (previousStreak) {
+      await con.getRepository(UserStreak).save({
         ...previousStreak,
+        userId: previousStreak.userId ?? 'u1',
         lastViewAt: previousDate ? new Date(previousDate) : undefined,
-      },
-    );
+      });
+    }
 
     const data = {
       postId: 'p1',
@@ -145,7 +147,7 @@ describe('reading streaks', () => {
   const runTest = async (
     currentDate: Date | string,
     previousDate: Date | string | undefined,
-    previousStreak = defaultStreak,
+    previousStreak: Partial<UserStreak> | null | undefined = defaultStreak,
     expectedStreak?: Partial<UserStreak>,
   ) => {
     await prepareTest(currentDate, previousDate, previousStreak);
@@ -199,13 +201,6 @@ describe('reading streaks', () => {
   });
 
   it('does not update reading streak if view does not have userId', async () => {
-    await prepareTest('2024-01-25T17:17Z', '2024-01-24T14:17Z');
-
-    const streak1 = await con
-      .getRepository(UserStreak)
-      .findOne({ where: { userId: 'u1', currentStreak: 5 } });
-    expect(streak1).not.toBeNull();
-
     const data = {
       postId: 'p1',
       referer: 'referer',
@@ -215,16 +210,13 @@ describe('reading streaks', () => {
     };
     await expectSuccessfulBackground(worker, data);
 
-    const streak2 = await con
-      .getRepository(UserStreak)
-      .findOne({ where: { userId: 'u1' } });
-    expect(streak2?.updatedAt).toEqual(streak1?.updatedAt);
-    expect(streak2?.currentStreak).toEqual(streak1?.currentStreak);
+    const streak = await con.getRepository(UserStreak).findOne({
+      where: { lastViewAt: new Date('2024-01-26T17:17Z') },
+    });
+    expect(streak).toBeNull();
   });
 
   it('does not update reading streak if userId does not match existing user', async () => {
-    await prepareTest('2024-01-25T17:17Z', '2024-01-24T14:17Z');
-
     const data = {
       postId: 'p1',
       userId: '__this_userId_should_not_exist__',
@@ -235,10 +227,19 @@ describe('reading streaks', () => {
     };
     await expectSuccessfulBackground(worker, data);
 
-    const streak = await con
-      .getRepository(UserStreak)
-      .findOne({ where: { userId: '__this_userId_should_not_exist__' } });
+    const streak = await con.getRepository(UserStreak).findOne({
+      where: { lastViewAt: new Date('2024-01-26T17:17Z') },
+    });
     expect(streak).toBeNull();
+  });
+
+  it('should start a reading streak if there was no row in user_streak table', async () => {
+    await runTest('2024-01-26T17:17Z', undefined, null, {
+      currentStreak: 1,
+      totalStreak: 1,
+      maxStreak: 1,
+      lastViewAt: new Date('2024-01-26T17:17Z'),
+    });
   });
 
   it('should start a reading streak if there was none before', async () => {

--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -222,6 +222,25 @@ describe('reading streaks', () => {
     expect(streak2?.currentStreak).toEqual(streak1?.currentStreak);
   });
 
+  it('does not update reading streak if userId does not match existing user', async () => {
+    await prepareTest('2024-01-25T17:17Z', '2024-01-24T14:17Z');
+
+    const data = {
+      postId: 'p1',
+      userId: '__this_userId_should_not_exist__',
+      referer: 'referer',
+      agent: 'agent',
+      ip: '127.0.0.1',
+      timestamp: new Date('2024-01-26T17:17Z'),
+    };
+    await expectSuccessfulBackground(worker, data);
+
+    const streak = await con
+      .getRepository(UserStreak)
+      .findOne({ where: { userId: '__this_userId_should_not_exist__' } });
+    expect(streak).toBeNull();
+  });
+
   it('should start a reading streak if there was none before', async () => {
     await runTest(
       '2024-01-26T17:17Z',

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -1,4 +1,4 @@
-import { DataSource, DeepPartial, createQueryBuilder } from 'typeorm';
+import { DataSource, DeepPartial } from 'typeorm';
 import { User, UserStreak, View } from '../entity';
 import { messageToJson, Worker } from './worker';
 import { TypeOrmError } from '../errors';

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -1,5 +1,5 @@
-import { DataSource, DeepPartial } from 'typeorm';
-import { UserStreak, View } from '../entity';
+import { DataSource, DeepPartial, createQueryBuilder } from 'typeorm';
+import { User, UserStreak, View } from '../entity';
 import { messageToJson, Worker } from './worker';
 import { TypeOrmError } from '../errors';
 
@@ -56,6 +56,7 @@ const incrementReadingStreak = async (
   con: DataSource,
   data: DeepPartial<View>,
 ): Promise<boolean> => {
+  const users = con.getRepository(User);
   const repo = con.getRepository(UserStreak);
   const { userId, timestamp } = data;
 
@@ -68,8 +69,11 @@ const incrementReadingStreak = async (
   // TODO: This code is temporary here for now because we didn't run the migration yet,
   // so not every user is going to have a row in the user_streak table and we need to create it.
   // We can get rid of it once/if we implement the migration in https://dailydotdev.atlassian.net/browse/MI-70
-  const existing = await repo.findOne({ where: { userId } });
-  if (!existing) {
+  const user = await users.findOne({
+    where: { id: userId },
+    relations: ['streak'],
+  });
+  if (user && !user.streak) {
     await repo.save(
       repo.create({
         userId,

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -73,7 +73,8 @@ const incrementReadingStreak = async (
     where: { id: userId },
     relations: ['streak'],
   });
-  if (user && !user.streak) {
+  const streak = await user?.streak;
+  if (user && !streak) {
     await repo.save(
       repo.create({
         userId,


### PR DESCRIPTION
On anonymous events, the newView worker receives a message with `userId`, but there is no such user with the userId. Our temporary code for inserting rows into the `user_streak` table when there is none didn't work correctly for such cases.

Rewritten to first get the user and only try to insert if the user exists.