### PR TITLE
feat: return post id for search suggestion hit

### DIFF
--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -202,7 +202,7 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
       { query }: { query: string },
       ctx,
     ): Promise<GQLSearchPostSuggestionsResults> => {
-      const hits: { title: string }[] = await ctx.con.query(
+      const hits: GQLSearchPostSuggestion[] = await ctx.con.query(
         `
             WITH search AS (${getSearchQuery('$1')})
             select post.id, ts_headline(process_text(title), search.query,

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -24,6 +24,7 @@ import { GQLPost } from './posts';
 type GQLSearchSession = Pick<SearchSession, 'id' | 'prompt' | 'createdAt'>;
 
 interface GQLSearchPostSuggestion {
+  id: string;
   title: string;
 }
 
@@ -83,6 +84,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type SearchPostSuggestion {
+    id: String!
     title: String!
   }
 
@@ -203,7 +205,7 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
       const hits: { title: string }[] = await ctx.con.query(
         `
             WITH search AS (${getSearchQuery('$1')})
-            select ts_headline(process_text(title), search.query,
+            select post.id, ts_headline(process_text(title), search.query,
                                'StartSel = <strong>, StopSel = </strong>') as title
             from post
                    inner join search on true


### PR DESCRIPTION
Based on the [discussion](https://dailydotdev.slack.com/archives/C063RS0QZTM/p1706698311092559) adding support to return post id for search suggestions. This will allow to open the suggested post directly from search panel suggestions vs searching and then clicking the card.  