### PR TITLE
fix: shared post trigger

### DIFF
--- a/__tests__/triggers/post.ts
+++ b/__tests__/triggers/post.ts
@@ -38,3 +38,21 @@ it('should set tags str of shared post on insert and update', async () => {
     .find({ where: { tagsStr: 'a,b' }, order: { id: 'ASC' }, select: ['id'] });
   expect(obj2.map((x) => x.id)).toEqual(['p1', 'sp']);
 });
+
+it('should set tags str of shared post on update when original post had no tags', async () => {
+  await con.getRepository(SharePost).insert({
+    id: 'sp',
+    shortId: 'sp',
+    title: 'T',
+    sharedPostId: 'p2',
+    sourceId: postsFixture[0].sourceId,
+  });
+  const obj = await con.getRepository(Post).findOneBy({ id: 'sp' });
+  expect(obj.tagsStr).toBeFalsy();
+  await con.getRepository(ArticlePost).update({ id: 'p2' }, { tagsStr: 'a,b' });
+  // Make sure only sp gets affected
+  const obj2 = await con
+    .getRepository(Post)
+    .find({ where: { tagsStr: 'a,b' }, order: { id: 'ASC' }, select: ['id'] });
+  expect(obj2.map((x) => x.id)).toEqual(['p2', 'sp']);
+});

--- a/src/migration/1706779866978-SharedPostTriggerFix.ts
+++ b/src/migration/1706779866978-SharedPostTriggerFix.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SharedPostTriggerFix1706779866978 implements MigrationInterface {
+  name = 'SharedPostTriggerFix1706779866978';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION update_shared_post_tags()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          IF NEW."tagsStr" IS DISTINCT FROM OLD."tagsStr" THEN
+            UPDATE post
+            SET "tagsStr" = NEW."tagsStr", "metadataChangedAt" = now()
+            WHERE "sharedPostId" = NEW.id;
+          END IF;
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await queryRunner.query(`
+      CREATE OR REPLACE TRIGGER trigger_update_shared_post_tags
+      AFTER UPDATE ON public.post
+      FOR EACH ROW
+      EXECUTE FUNCTION update_shared_post_tags();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION update_shared_post_tags()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          IF NEW."tagsStr" <> OLD."tagsStr" THEN
+            UPDATE post
+            SET "tagsStr" = NEW."tagsStr", "metadataChangedAt" = now()
+            WHERE "sharedPostId" = NEW.id;
+          END IF;
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await queryRunner.query(`
+      CREATE OR REPLACE TRIGGER trigger_update_shared_post_tags
+      AFTER UPDATE ON public.post
+      FOR EACH ROW
+      EXECUTE FUNCTION update_shared_post_tags();
+    `);
+  }
+}


### PR DESCRIPTION
For some odd reason PG not equal operator doesn't care about null 😅

This means if a value was null and then changed it will not be captured by `<>`

#FML