### PR TITLE
fix: popular feed

### DIFF
--- a/.env
+++ b/.env
@@ -30,6 +30,7 @@ ENABLE_SETTINGS_EXPERIMENT=
 INTERNAL_FEED=http://localhost:6000/feed.json
 SNOTRA_ORIGIN=http://localhost:6001
 PERSONALIZED_DIGEST_FEED=http://localhost:6000/feed.json
+POPULAR_FEED=http://localhost:6000/popular
 
 POST_SCRAPER_ORIGIN=http://localhost:8000
 HEIMDALL_ORIGIN=http://localhost:7000

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -72,6 +72,8 @@ config:
     otelTracesSamplerArg: 0.05
     personalizedDigestFeed:
       secure: AAABAGP/d+fM8gESq9WXxiaYwkOKuNYIkM2xsxIh0gBoFnHaoak40gPpBfPYgE2GYZGjjln+XhVt406Ci+IIPcw=
+    popularFeed:
+      secure: AAABAPkvxV6qnIyQxIS/vn7knHmUPD5vIAWDct4xtRdFFwwP8Gr2ZHYJ01ZyzEgL0AjQwF/WpIc23SrI2AJWBPkxu9p2vghyEjX0qdK5
     postScraperOrigin:
       secure: AAABAEUYh/1vRaV7hqp+NfWzHu739GHVadQkJ1veHLTdHjV2kdthStN60SD5VwdPMD7XMLaUu9Yd0jc+gNh57ABjmLigxZnzeTv7ZuEBBzAqPrm/bqCoWEfqdw==
     redisPass:

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -905,7 +905,7 @@ Object {
 }
 `;
 
-exports[`query anonymousFeed should return anonymous feed v2 and ignore existing filters 1`] = `
+exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 1`] = `
 Object {
   "anonymousFeed": Object {
     "edges": Array [

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -359,24 +359,11 @@ describe('query anonymousFeed', () => {
 
   it('should return anonymous feed v2', async () => {
     nock('http://localhost:6000')
-      .post('/feed.json', {
+      .post('/popular', {
         total_pages: 1,
         page_size: 10,
         fresh_page_size: '4',
         offset: 0,
-        providers: {
-          fresh: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 0.1,
-          },
-          engaged: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 1,
-            fallback_provider: 'fresh',
-          },
-        },
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],
@@ -389,7 +376,7 @@ describe('query anonymousFeed', () => {
   });
 
   it('should safetly handle a case where the feed is empty', async () => {
-    nock('http://localhost:6000').post('/feed.json').reply(200, {
+    nock('http://localhost:6000').post('/popular').reply(200, {
       data: [],
     });
     const res = await client.query(QUERY, {
@@ -399,7 +386,7 @@ describe('query anonymousFeed', () => {
     expect(res.data).toMatchSnapshot();
   });
 
-  it('should return anonymous feed v2 and ignore existing filters', async () => {
+  it('should return anonymous feed v2 and include blocked filters', async () => {
     loggedUser = '1';
     await con.getRepository(Feed).save({ id: '1', userId: '1' });
     await con.getRepository(FeedTag).save([
@@ -414,24 +401,13 @@ describe('query anonymousFeed', () => {
     ]);
 
     nock('http://localhost:6000')
-      .post('/feed.json', {
+      .post('/popular', {
         total_pages: 1,
         page_size: 10,
         fresh_page_size: '4',
         offset: 0,
-        providers: {
-          fresh: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 0.1,
-          },
-          engaged: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 1,
-            fallback_provider: 'fresh',
-          },
-        },
+        blocked_tags: ['python', 'java'],
+        blocked_sources: ['a', 'b'],
         user_id: '1',
       })
       .reply(200, {

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -11,7 +11,6 @@ import { FeedClient } from './clients';
 import {
   FeedPreferencesConfigGenerator,
   FeedUserStateConfigGenerator,
-  SimpleFeedConfigGenerator,
 } from './configs';
 import { SnotraClient } from '../snotra';
 
@@ -111,22 +110,15 @@ export const feedGenerators: Record<FeedVersion, FeedGenerator> = Object.freeze(
       }),
     ),
     popular: new FeedGenerator(
-      feedClient,
-      new SimpleFeedConfigGenerator({
-        providers: {
-          fresh: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 0.1,
-          },
-          engaged: {
-            enable: true,
-            remove_engaged_posts: true,
-            page_size_fraction: 1,
-            fallback_provider: 'fresh',
-          },
+      new FeedClient(process.env.POPULAR_FEED),
+      new FeedPreferencesConfigGenerator(
+        {},
+        {
+          includePostTypes: true,
+          includeBlockedSources: true,
+          includeBlockedTags: true,
         },
-      }),
+      ),
       'popular',
     ),
     onboarding: new FeedGenerator(


### PR DESCRIPTION
The popular feed configuration was broken for a while but the issue was surfaced when we introduced caching.

This PR fixes it and also includes blocking the tags and sources on this feed.