### PR TITLE
feat: get users favorite sources

### DIFF
--- a/src/common/devcard.ts
+++ b/src/common/devcard.ts
@@ -30,7 +30,7 @@ interface FavoriteSourcesProps {
   limit: number;
 }
 
-export const generateGetFavoriteSources = (
+export const generateFavoriteSourcesQuery = (
   con: DataSource,
   userId: string,
   { alias = 'source', limit = 5 }: Partial<FavoriteSourcesProps> = {},
@@ -67,7 +67,7 @@ export const getFavoriteSourcesIds = async (
   userId: string,
   limit = 5,
 ): Promise<string[]> => {
-  const query = generateGetFavoriteSources(con, userId, { limit });
+  const query = generateFavoriteSourcesQuery(con, userId, { limit });
   const sources = await query.getRawMany();
 
   return sources.map((source) => source.id);
@@ -78,7 +78,7 @@ export const getFavoriteSourcesLogos = async (
   userId: string,
 ): Promise<string[]> => {
   const alias = 'source';
-  const query = generateGetFavoriteSources(con, userId, {
+  const query = generateFavoriteSourcesQuery(con, userId, {
     alias,
     limit: 5,
   }).addSelect(`min("${alias}".image)`, 'image');

--- a/src/common/devcard.ts
+++ b/src/common/devcard.ts
@@ -25,10 +25,15 @@ export const getMostReadTags = async (
   }));
 };
 
+interface FavoriteSourcesProps {
+  alias: string;
+  limit: number;
+}
+
 export const generateGetFavoriteSources = (
   con: DataSource,
   userId: string,
-  alias = 'source',
+  { alias = 'source', limit = 5 }: Partial<FavoriteSourcesProps> = {},
 ) => {
   return con
     .createQueryBuilder()
@@ -54,14 +59,15 @@ export const generateGetFavoriteSources = (
     .andWhere(`s.count > 10`)
     .groupBy('p."sourceId"')
     .orderBy('count(*) * 1.0 / min(s.count)', 'DESC')
-    .limit(5);
+    .limit(limit);
 };
 
 export const getFavoriteSourcesIds = async (
   con: DataSource,
   userId: string,
+  limit = 5,
 ): Promise<string[]> => {
-  const query = generateGetFavoriteSources(con, userId);
+  const query = generateGetFavoriteSources(con, userId, { limit });
   const sources = await query.getRawMany();
 
   return sources.map((source) => source.id);
@@ -72,10 +78,10 @@ export const getFavoriteSourcesLogos = async (
   userId: string,
 ): Promise<string[]> => {
   const alias = 'source';
-  const query = generateGetFavoriteSources(con, userId, alias).addSelect(
-    `min("${alias}".image)`,
-    'image',
-  );
+  const query = generateGetFavoriteSources(con, userId, {
+    alias,
+    limit: 5,
+  }).addSelect(`min("${alias}".image)`, 'image');
   const sources = await query.getRawMany();
 
   return sources.map((source) => source.image);

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -91,6 +91,11 @@ interface SourceMemberArgs extends ConnectionArguments {
   role?: SourceMemberRoles;
 }
 
+interface FavoriteSourcesArgs {
+  userId: string;
+  limit?: number;
+}
+
 export const typeDefs = /* GraphQL */ `
   """
   Source to discover posts from (usually blogs)
@@ -287,7 +292,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get user's favorite sources
     """
-    favoriteSources(userId: ID!): [Source]
+    favoriteSources(userId: ID!, limit: Int): [Source]
 
     """
     Get source by ID
@@ -991,11 +996,11 @@ export const resolvers: IResolvers<any, Context> = {
     },
     favoriteSources: async (
       _,
-      { userId }: { userId: string },
+      { userId, limit }: FavoriteSourcesArgs,
       ctx,
       info,
     ): Promise<GQLSource[]> => {
-      const sourceIds = await getFavoriteSourcesIds(ctx.con, userId);
+      const sourceIds = await getFavoriteSourcesIds(ctx.con, userId, limit);
 
       if (sourceIds.length === 0) {
         return [];


### PR DESCRIPTION
Due to having different variations of the devcard, we are rendering it as an actual HTML element. With that, we need to pull the user's favorite sources.

Instead of just returning the actual logos, we are returning the sources since we need more information for redirection when users click the logos.

Note: the existing query doesn't include returning private source reads