### PR TITLE
chore: add eslint-plugin-unused-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,14 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
-  plugins: ['prettier'],
+  plugins: ['prettier', 'unused-imports'],
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
   rules: {
     'prettier/prettier': 'error',
+    'unused-imports/no-unused-imports': 'error',
   },
   overrides: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest-extended": "^2.0.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "eslint-plugin-unused-imports": "^3.0.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
         "jest-junit": "^16.0.0",
@@ -5764,6 +5765,36 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz",
+      "integrity": "sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest-extended": "^2.0.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "eslint-plugin-unused-imports": "^3.0.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
     "jest-junit": "^16.0.0",


### PR DESCRIPTION
This way whenever you run `eslint --fix`, it will remove all of the unused imports.