### PR TITLE
fix: object used for query params

### DIFF
--- a/__tests__/devcard.ts
+++ b/__tests__/devcard.ts
@@ -187,6 +187,22 @@ describe('mutation generateDevCardV2', () => {
     );
   });
 
+  it('should generate new dev card based on type', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: { theme: DevCardTheme.Gold.toLocaleUpperCase(), type: 'X' },
+    });
+    expect(res.errors).toBeFalsy();
+    const devCards = await con.getRepository(DevCard).find();
+    expect(devCards.length).toEqual(1);
+    expect(devCards[0].theme).toEqual(DevCardTheme.Gold);
+    expect(res.data.generateDevCardV2.imageUrl).toMatch(
+      new RegExp(
+        `http://localhost:4000/devcards/v2/${devCards[0].userId}.png\\?type=X&r=.*`,
+      ),
+    );
+  });
+
   it('should use an existing dev card entity', async () => {
     loggedUser = '1';
     await con.getRepository(DevCard).insert({ userId: '1' });

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -79,11 +79,10 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   //   },
   // );
 
-  fastify.get<{ Params: { name: string; type: string } }>(
+  fastify.get<{ Params: { name: string }; Querystring: { type: string } }>(
     '/v2/:name',
     async (req, res): Promise<FastifyReply> => {
-      const { name, type } = req.params;
-      const [userId, format] = name.split('.');
+      const [userId, format] = req.params.name.split('.');
       if (format !== 'png') {
         return res.status(404).send();
       }
@@ -93,8 +92,9 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         if (!devCard) {
           return res.status(404).send();
         }
+        const type = req.query?.type?.toLowerCase() ?? 'default';
         const url = new URL(`https://preview.app.daily.dev/devcards/${userId}`);
-        url.searchParams.set('type', type?.toLocaleLowerCase() ?? 'default');
+        url.searchParams.set('type', type);
         const response = await retryFetch(
           `${process.env.SCRAPER_URL}/screenshot`,
           {


### PR DESCRIPTION
The `Params` and `Querystring` are two different objects. The former is for required values and the latter is for optional, the type is for the latter.

Should fix (and verified locally) that the correct type is passed.