### PR TITLE
fix: create devcard if not exists and remove 404 checks

### DIFF
--- a/__tests__/devcard.ts
+++ b/__tests__/devcard.ts
@@ -198,7 +198,7 @@ describe('mutation generateDevCardV2', () => {
     expect(devCards[0].theme).toEqual(DevCardTheme.Gold);
     expect(res.data.generateDevCardV2.imageUrl).toMatch(
       new RegExp(
-        `http://localhost:4000/devcards/v2/${devCards[0].userId}.png\\?type=X&r=.*`,
+        `http://localhost:4000/devcards/v2/${devCards[0].userId}.png\\?type=x&r=.*`,
       ),
     );
   });
@@ -289,10 +289,27 @@ describe('query devCard(id)', () => {
       },
     ));
 
-  it('should return not found if there is no devcard', async () => {
-    const res = await client.query(QUERY, { variables: { id: '42' } });
-    expect(res.errors).toBeTruthy();
-    expect(res.errors?.[0].message).toMatch(/not found/i);
+  it('should create a new devcard with defaults if none is found', async () => {
+    const res = await client.query(QUERY, { variables: { id: '3' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.devCard).toEqual({
+      id: expect.any(String),
+      user: {
+        bio: null,
+        id: '3',
+        image: 'https://daily.dev/lee.jpg',
+        name: 'Lee',
+        permalink: 'http://localhost:5002/lee',
+        reputation: 10,
+        username: 'lee',
+      },
+      createdAt: expect.any(String),
+      theme: DevCardTheme.Default,
+      isProfileCover: false,
+      showBorder: true,
+      articlesRead: 0,
+      tags: [],
+    });
   });
 
   it('should return stored devcard', async () => {

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -86,12 +86,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       if (format !== 'png') {
         return res.status(404).send();
       }
-      const con = await createOrGetConnection();
       try {
-        const devCard = await con.getRepository(DevCard).findOneBy({ userId });
-        if (!devCard) {
-          return res.status(404).send();
-        }
         const type = req.query?.type?.toLowerCase() ?? 'default';
         const url = new URL(`https://preview.app.daily.dev/devcards/${userId}`);
         url.searchParams.set('type', type);

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyReply } from 'fastify';
-import { DevCard } from '../entity';
+import { DevCard, User } from '../entity';
 import createOrGetConnection from '../db';
 import { retryFetch } from '../integrations/retry';
 import { getDevCardDataV1 } from '../common/devcard';
@@ -86,7 +86,12 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       if (format !== 'png') {
         return res.status(404).send();
       }
+      const con = await createOrGetConnection();
       try {
+        const user = await con.getRepository(User).findOneBy({ id: userId });
+        if (!user) {
+          return res.status(404).send();
+        }
         const type = req.query?.type?.toLowerCase() ?? 'default';
         const url = new URL(`https://preview.app.daily.dev/devcards/${userId}`);
         url.searchParams.set('type', type);

--- a/src/schema/devcards.ts
+++ b/src/schema/devcards.ts
@@ -152,10 +152,14 @@ export const resolvers: IResolvers<any, Context> = {
       const repo = await ctx.con.getRepository(DevCard);
       let res = await repo.findOneBy({ userId: id });
       if (res == null) {
-        // create devcard row if none found
-        res = await repo.save({
-          userId: id,
-        });
+        try {
+          // create devcard row if none found
+          res = await repo.save({
+            userId: id,
+          });
+        } catch (e) {
+          throw new NotFoundError('DevCard not found');
+        }
       }
 
       const data = await getDevCardData(id, ctx.con);


### PR DESCRIPTION
- Removed the check from the REST API `/devcards/v2/` route that checks if the devcard exists. No 404 returned there anymore.
- Modified the logic, so that when we query a devcard with the graphql query, it is created if it not exists, instead of returning a 404.