### PR TITLE
fix: bring back post similarity provider

### DIFF
--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -19,6 +19,7 @@ import { traceResolvers } from './trace';
 import {
   anonymousFeedBuilder,
   AnonymousFeedFilters,
+  applyFeedWhere,
   base64,
   configuredFeedBuilder,
   FeedArgs,
@@ -1193,32 +1194,32 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       ctx,
       info,
     ): Promise<GQLPost[]> => {
-      // if (args.post && ctx.userId) {
-      //   const res = await feedGenerators['post_similarity'].generate(ctx, {
-      //     user_id: ctx.userId,
-      //     page_size: args.first || 3,
-      //     post_id: args.post,
-      //   });
-      //   if (res?.data?.length) {
-      //     return graphorm.query(ctx, info, (builder) => {
-      //       builder.queryBuilder = applyFeedWhere(
-      //         ctx,
-      //         fixedIdsFeedBuilder(
-      //           ctx,
-      //           res.data.map(([postId]) => postId as string),
-      //           builder.queryBuilder,
-      //           builder.alias,
-      //         ),
-      //         builder.alias,
-      //         ['article'],
-      //         true,
-      //         true,
-      //         false,
-      //       );
-      //       return builder;
-      //     });
-      //   }
-      // }
+      if (args.post && ctx.userId) {
+        const res = await feedGenerators['post_similarity'].generate(ctx, {
+          user_id: ctx.userId,
+          page_size: args.first || 3,
+          post_id: args.post,
+        });
+        if (res?.data?.length) {
+          return graphorm.query(ctx, info, (builder) => {
+            builder.queryBuilder = applyFeedWhere(
+              ctx,
+              fixedIdsFeedBuilder(
+                ctx,
+                res.data.map(([postId]) => postId as string),
+                builder.queryBuilder,
+                builder.alias,
+              ),
+              builder.alias,
+              ['article'],
+              true,
+              true,
+              false,
+            );
+            return builder;
+          });
+        }
+      }
       return legacySimilarPostsResolver(source, args, ctx, info);
     },
     randomDiscussedPosts: randomPostsResolver(


### PR DESCRIPTION
Since we solved some memory issues, maybe a good try to test this again.