### PR TITLE
refactor: reduce load from the devcard query

### DIFF
--- a/src/schema/devcards.ts
+++ b/src/schema/devcards.ts
@@ -149,7 +149,7 @@ export const resolvers: IResolvers<any, Context> = {
       { id }: { id: string },
       ctx: Context,
     ): Promise<DevCardByIdResult> => {
-      const repo = await ctx.con.getRepository(DevCard);
+      const repo = ctx.con.getRepository(DevCard);
       let res = await repo.findOneBy({ userId: id });
       if (res == null) {
         try {


### PR DESCRIPTION
I noticed the query for sources is quite heavy so I reduced the logic a bit to make it easier on the db. DevCard is gonna be more popular now that it's shown on tooltip and everywhere essentially