### PR TITLE
fix: encode embedded png url so that svg parser does not choke

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@sendgrid/eventwebhook": "^8.0.0",
     "@sendgrid/mail": "^8.1.0",
     "@slack/webhook": "^7.0.2",
+    "@types/he": "^1.2.3",
     "@types/shortid": "0.0.32",
     "apollo-server-errors": "^3.3.0",
     "apollo-server-types": "^3.8.0",

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance, FastifyReply } from 'fastify';
+import { encode } from 'he';
 import { DevCard, User } from '../entity';
 import createOrGetConnection from '../db';
 import { retryFetch } from '../integrations/retry';
@@ -96,7 +97,9 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
         // for svg, return the same image as png, wrapped in svg tag
         if (format === 'svg') {
-          const svgString = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image xlink:href="${process.env.URL_PREFIX}${req.originalUrl.replace('.svg', '.png')}" /></svg>`;
+          const pngUrl = `${process.env.URL_PREFIX}${req.originalUrl.replace('.svg', '.png')}`;
+          const encodedUrl = encode(pngUrl, { useNamedReferences: true });
+          const svgString = `<svg xmlns="http://www.w3.org/2000/svg"><image href="${encodedUrl}" /></svg>`;
 
           return res
             .type('image/svg+xml')


### PR DESCRIPTION
Use `he` `encode` function to encode the png URL.

Also simplify the svg itself, since the [`xlink` namespace is not needed anymore](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) and we can just use `href` attribute.