### PR TITLE
fix: missing meta tag for twitter preview

### DIFF
--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -96,7 +96,12 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
         // for svg, return the same image as png, wrapped in svg tag
         if (format === 'svg') {
-          const svgString = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><image xlink:href="${req.protocol}://${req.hostname}${req.originalUrl.replace('.svg', '.png')}" /></svg>`;
+          const svgString = `
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <meta name="twitter:card" content="summary_large_image">
+              <meta name="twitter:title" content="DevCard of @${user.username}">
+              <image xlink:href="${req.protocol}://${req.hostname}${req.originalUrl.replace('.svg', '.png')}" />
+            </svg>`;
 
           return res
             .type('image/svg+xml')

--- a/src/schema/devcards.ts
+++ b/src/schema/devcards.ts
@@ -200,7 +200,7 @@ export const resolvers: IResolvers<any, Context> = {
         imageUrl: `${process.env.URL_PREFIX}/devcards/${devCard.id.replace(
           /-/g,
           '',
-        )}.png?r=${randomStr}`,
+        )}.svg?r=${randomStr}`,
       };
     },
     generateDevCardV2: async (


### PR DESCRIPTION
I checked and on most social media platforms our API link works, but fails on Twitter.

After further investigation, Twitter requires a bit more information by adding meta tags.

Reference: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
![image](https://github.com/dailydotdev/daily-api/assets/13744167/bb3d127f-d4fb-4578-91d5-d5331916a6fc)

I have also utilize some online tool to troubleshoot the issue we are encountering, as can be seen from below, on a regular post, we are getting the correct meta tags, but with the API link, we are missing it.

Post link (meta tags found):
![Screenshot 2024-02-16 at 5 48 48 PM](https://github.com/dailydotdev/daily-api/assets/13744167/61b22309-8465-4e24-966b-eca7bd880a2a)

![Screenshot 2024-02-16 at 5 50 44 PM](https://github.com/dailydotdev/daily-api/assets/13744167/d2d026e4-a170-4d46-823b-d4fdf88c403b)

DevCard svg link (no meta tags found):
![Screenshot 2024-02-16 at 5 48 39 PM](https://github.com/dailydotdev/daily-api/assets/13744167/b49a88c3-51cc-410a-bc5f-6a3cd47ae31c)

![Screenshot 2024-02-16 at 5 51 23 PM](https://github.com/dailydotdev/daily-api/assets/13744167/26028152-d810-40c9-a78f-fcda3f4535be)

### After merging

We can again, easily test whether the changes would work through the online tool.