### PR TITLE
feat: streak milestone alert computation

### DIFF
--- a/__tests__/alerts.ts
+++ b/__tests__/alerts.ts
@@ -51,6 +51,7 @@ describe('query userAlerts', () => {
       lastBanner
       squadTour
       showGenericReferral
+      showStreakMilestone
     }
   }`;
 

--- a/__tests__/common/fibonacci.ts
+++ b/__tests__/common/fibonacci.ts
@@ -1,0 +1,17 @@
+import { isFibonacci } from '../../src/common/fibonacci';
+
+describe('isFibonacci tests', () => {
+  it('should return true for fibonacci numbers', () => {
+    const fibs = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89];
+    fibs.forEach((n) => {
+      expect(isFibonacci(n)).toBeTruthy();
+    });
+  });
+
+  it('should return false for non-fibonacci numbers', () => {
+    const nonFibs = [4, 6, 7, 9, 10, 11, 12, 14, 15, 16, 99];
+    nonFibs.forEach((n) => {
+      expect(isFibonacci(n)).toBeFalsy();
+    });
+  });
+});

--- a/src/common/fibonacci.ts
+++ b/src/common/fibonacci.ts
@@ -1,0 +1,9 @@
+export const isPerfectSquare = (n: number) => {
+  return Number.isInteger(Math.sqrt(n));
+};
+
+// Number is Fibonacci if (5*n^2 + 4) or (5*n^2 - 4) is a perfect square
+export const isFibonacci = (num: number) => {
+  const x = 5 * Math.pow(num, 2);
+  return isPerfectSquare(x + 4) || isPerfectSquare(x - 4);
+};

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -381,6 +381,9 @@ export const clearUserStreak = async (
   return result.affected > 0;
 };
 
+// Computes whether we should reset user streak
+// Even though it is the weekend, we should still clear the streak for when the user's last read was Thursday
+// Due to the fact that when Monday comes, we will clear it anyway when we notice the gap in Friday
 export const shouldResetStreak = (day: number, difference: number) => {
   return (
     (day === Day.Sunday && difference > FREEZE_DAYS_IN_A_WEEK) ||
@@ -404,8 +407,6 @@ export const checkAndClearUserStreak = async (
   const day = today.getDay();
   const difference = differenceInDays(today, lastViewAt);
 
-  // Even though it is the weekend, we should still clear the streak for when the user's last read was Thursday
-  // Due to the fact that when Monday comes, we will clear it anyway when we notice the gap in Friday
   if (shouldResetStreak(day, difference)) {
     return clearUserStreak(ctx.con, ctx.userId);
   }

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -37,6 +37,9 @@ export class Alerts {
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   lastBanner: Date | null;
 
+  @Column({ type: 'bool', default: false })
+  showStreakMilestone: boolean;
+
   // Should not be exposed to the client
   @Column({ type: 'jsonb', default: {} })
   flags: AlertsFlags = {};
@@ -57,4 +60,5 @@ export const ALERTS_DEFAULT: Omit<Alerts, 'userId' | 'flags'> = {
   banner: false,
   squadTour: true,
   showGenericReferral: false,
+  showStreakMilestone: false,
 };

--- a/src/migration/1708024370161-readingStreaksAlert.ts
+++ b/src/migration/1708024370161-readingStreaksAlert.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ReadingStreaksAlert1708024370161 implements MigrationInterface {
+  name = 'ReadingStreaksAlert1708024370161';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" ADD "showStreakMilestone" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "alerts" DROP COLUMN "showStreakMilestone"`,
+    );
+  }
+}

--- a/src/routes/alerts.ts
+++ b/src/routes/alerts.ts
@@ -13,6 +13,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         lastBanner
         squadTour
         showGenericReferral
+        showStreakMilestone
       }
     }`;
 

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -64,6 +64,11 @@ export const typeDefs = /* GraphQL */ `
     Whether to show the generic referral reminder
     """
     showGenericReferral: Boolean!
+
+    """
+    Whether to show the reading streaks milestone banner
+    """
+    showStreakMilestone: Boolean!
   }
 
   input UpdateAlertsInput {
@@ -101,6 +106,11 @@ export const typeDefs = /* GraphQL */ `
     Whether to show the squad tour and sync across devices
     """
     squadTour: Boolean
+
+    """
+    Whether to show the reading streaks milestone banner
+    """
+    showStreakMilestone: Boolean
   }
 
   extend type Mutation {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -850,8 +850,7 @@ export const resolvers: IResolvers<any, Context> = {
         }),
       );
 
-      const hasClearedStreak = checkAndClearUserStreak(ctx, info, streak);
-
+      const hasClearedStreak = await checkAndClearUserStreak(ctx, info, streak);
       if (hasClearedStreak) {
         return { ...streak, current: 0 };
       }


### PR DESCRIPTION
- Adds new `column` `showStreakMilestone` boolean in `alerts` table.
- Sets value in `newView` worker to `true` if currentStreak is a number from the fibonacci sequence.
- Fixed an issue where graphQL always returned `currentStreak` as 0, because we missed an `await` keyword on a promise.
- Added unit tests, so pretty sure this works. Maybe 🤞 