### PR TITLE
fix: user constraint fail fix

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -75,6 +75,7 @@ export enum TypeOrmError {
   NULL_VIOLATION = '23502',
   FOREIGN_KEY = '23503',
   DUPLICATE_ENTRY = '23505',
+  USER_CONSTRAINT = 'FK_dce2a8927967051c447ae10bc8b',
 }
 
 export enum SourcePermissionErrorKeys {

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -40,6 +40,16 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
           );
           return;
         }
+        if (
+          err?.code === TypeOrmError.FOREIGN_KEY &&
+          err?.constraint === TypeOrmError.USER_CONSTRAINT
+        ) {
+          logger.warn(
+            { data: messageToJson(message) },
+            'user constraint failed when creating a notification',
+          );
+          return;
+        }
         throw err;
       }
     },


### PR DESCRIPTION
There was a edge-case where the user constraint would fail if the user got deleted before subscription finishes.
We said to only listen to this specific constraint for now.