### PR TITLE
feat: block search from api.daily.dev

### DIFF
--- a/__tests__/redirector.ts
+++ b/__tests__/redirector.ts
@@ -63,7 +63,7 @@ describe('GET /r/:postId', () => {
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
       .expect('link', `<http://p1.com/?ref=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev"></head></html>',
       );
     expect(notifyView).toBeCalledWith(
       expect.anything(),
@@ -84,7 +84,7 @@ describe('GET /r/:postId', () => {
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
       .expect('link', `<http://p1.com/?ref=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev#id"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev#id"></head></html>',
       );
   });
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -38,7 +38,9 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(sitemaps, { prefix: '/sitemaps' });
 
   fastify.get('/robots.txt', (req, res) => {
-    return res.type('text/plain').send('User-agent: *\nDisallow: /');
+    return res.type('text/plain').send(`User-agent: *
+Allow: /devcards/
+Disallow: /`);
   });
 
   if (process.env.NODE_ENV === 'development') {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -37,6 +37,10 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(automations, { prefix: '/auto' });
   fastify.register(sitemaps, { prefix: '/sitemaps' });
 
+  fastify.get('/robots.txt', (req, res) => {
+    return res.type('text/plain').send('User-agent: *\nDisallow: /');
+  });
+
   if (process.env.NODE_ENV === 'development') {
     fastify.register(localAds);
   }

--- a/src/routes/redirector.ts
+++ b/src/routes/redirector.ts
@@ -51,7 +51,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         })
         .type('text/html')
         .send(
-          `<html><head><meta http-equiv="refresh" content="0;URL=${encodedUri}${
+          `<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=${encodedUri}${
             req.query.a ? `#${req.query.a}` : ''
           }"></head></html>`,
         );


### PR DESCRIPTION
Set robots.txt to block all traffic, add noindex to redirector endpoints just in case