### PR TITLE
revert: post notification muted for public squads

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -32,10 +32,7 @@ import { SourcePermissions } from '../src/schema/sources';
 import { SourcePermissionErrorKeys } from '../src/errors';
 import { updateFlagsStatement, WELCOME_POST_TITLE } from '../src/common';
 import { DisallowHandle } from '../src/entity/DisallowHandle';
-import {
-  NotificationPreferenceStatus,
-  NotificationType,
-} from '../src/notifications/common';
+import { NotificationType } from '../src/notifications/common';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -2056,15 +2053,7 @@ describe('mutation joinSource', () => {
 
   it('should add member to public squad without token', async () => {
     loggedUser = '1';
-    const getPreference = () =>
-      con.getRepository(NotificationPreferenceSource).findOneBy({
-        userId: '1',
-        referenceId: 's1',
-        notificationType: NotificationType.SquadPostAdded,
-      });
     await con.getRepository(Source).update({ id: 's1' }, { private: false });
-    const beforePreference = await getPreference();
-    expect(beforePreference).toBeFalsy();
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     expect(res.data.joinSource.id).toEqual('s1');
@@ -2072,8 +2061,6 @@ describe('mutation joinSource', () => {
       sourceId: 's1',
       userId: '1',
     });
-    const afterPreference = await getPreference();
-    expect(afterPreference.status).toEqual(NotificationPreferenceStatus.Muted);
   });
 
   it('should add member to private squad with token', async () => {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -48,11 +48,6 @@ import {
   ValidateRegex,
 } from '../common/object';
 import { validateAndTransformHandle } from '../common/handles';
-import {
-  NotificationPreferenceStatus,
-  NotificationType,
-  saveNotificationPreference,
-} from '../notifications/common';
 import { QueryBuilder } from '../graphorm/graphorm';
 
 export interface GQLSource {
@@ -1399,16 +1394,6 @@ export const resolvers: IResolvers<any, Context> = {
             userId: ctx.userId,
             role: SourceMemberRoles.Member,
           });
-
-          if (!source.private) {
-            await saveNotificationPreference(
-              entityManager,
-              ctx.userId,
-              sourceId,
-              NotificationType.SquadPostAdded,
-              NotificationPreferenceStatus.Muted,
-            );
-          }
 
           await entityManager
             .getRepository(Source)


### PR DESCRIPTION
As mentioned in the Slack conversation, public Squads are more like sources now, which means it is less noisy than it was before.

With that, we are bringing back the default to notify members when a new post is added.

MI-148 #done