### PR TITLE
fix: variation_id should be sent as string

### DIFF
--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -417,7 +417,7 @@ describe('personalizedDigestEmail worker', () => {
       event_timestamp: expect.any(Date),
       experiment_id: 'personalized_digest',
       user_id: '1',
-      variation_id: 0,
+      variation_id: '0',
     });
   });
 

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -44,7 +44,7 @@ export type ExperimentAllocationEvent = {
   event_timestamp: Date;
   user_id: string;
   experiment_id: string;
-  variation_id: number;
+  variation_id: string;
 };
 
 export async function sendExperimentAllocationEvent<

--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -89,7 +89,7 @@ const worker: Worker = {
           event_timestamp: new Date(),
           user_id: user.id,
           experiment_id: experiment.key,
-          variation_id: result.variationId,
+          variation_id: result.variationId.toString(),
         });
       },
     });


### PR DESCRIPTION
See [discussion](https://dailydotdev.slack.com/archives/C05G8BHHVBR/p1709034207244029?thread_ts=1709018432.641809&cid=C05G8BHHVBR)

This basically failed our allocation events for digest due to schema validation not going through on analytics side. 