### PR TITLE
feat: add graphql query for URL shortener

### DIFF
--- a/__tests__/urlShortener.ts
+++ b/__tests__/urlShortener.ts
@@ -1,0 +1,76 @@
+import nock from 'nock';
+import { DataSource } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+
+import createOrGetConnection from '../src/db';
+import {
+  GraphQLTestClient,
+  GraphQLTestingState,
+  MockContext,
+  disposeGraphQLTesting,
+  initializeGraphQLTesting,
+  testQueryErrorCode,
+} from './helpers';
+
+import { getShortUrl } from '../src/common';
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+
+jest.mock('../src/common', () => ({
+  ...jest.requireActual('../src/common'),
+  getShortUrl: jest.fn(),
+}));
+
+const mockGetShortUrl = getShortUrl as jest.MockedFunction<typeof getShortUrl>;
+mockGetShortUrl.mockImplementation(
+  async (): Promise<string> =>
+    Promise.resolve(`https://diy.dev/${uuidv4().slice(0, 8)}`),
+);
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(() => new MockContext(con));
+  client = state.client;
+});
+
+beforeEach(async () => {
+  nock.cleanAll();
+  mockGetShortUrl.mockClear();
+});
+
+afterAll(() => disposeGraphQLTesting(state));
+
+describe('query getShortUrl', () => {
+  const QUERY = `
+    query GetShortUrl($url: String!) {
+      getShortUrl(url: $url)
+    }
+  `;
+
+  it('should not work for invalid URL', () => {
+    testQueryErrorCode(
+      client,
+      {
+        query: QUERY,
+        variables: { url: 'hh::/not-a-valid-url.test' },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+
+    expect(mockGetShortUrl).not.toHaveBeenCalled();
+  });
+
+  it('should generate shortened URL', async () => {
+    const url = 'https://daily.dev/foo/bar';
+    const res = await client.query(QUERY, { variables: { url } });
+    expect(res.errors).toBeFalsy();
+
+    expect(mockGetShortUrl).toHaveBeenCalled();
+
+    expect(res.data.getShortUrl).toMatch(
+      new RegExp('https://diy.dev/[0-9a-f]{8}$', 'i'),
+    );
+  });
+});

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -19,6 +19,7 @@ import * as actions from './schema/actions';
 import * as search from './schema/search';
 import * as keywords from './schema/keywords';
 import * as devcards from './schema/devcards';
+import * as urlShortener from './schema/urlShortener';
 import * as authDirective from './directive/auth';
 import * as urlDirective from './directive/url';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -54,6 +55,7 @@ export const schema = urlDirective.transformer(
           actions.typeDefs,
           search.typeDefs,
           devcards.typeDefs,
+          urlShortener.typeDefs,
         ],
         resolvers: merge(
           common.resolvers,
@@ -75,6 +77,7 @@ export const schema = urlDirective.transformer(
           actions.resolvers,
           search.resolvers,
           devcards.resolvers,
+          urlShortener.resolvers,
         ),
       }),
     ),

--- a/src/schema/urlShortener.ts
+++ b/src/schema/urlShortener.ts
@@ -1,0 +1,38 @@
+import { IResolvers } from '@graphql-tools/utils';
+
+import { Context } from '../Context';
+import { traceResolverObject } from './trace';
+import { getShortUrl, isValidHttpUrl } from '../common';
+import { ValidationError } from 'apollo-server-errors';
+
+export const typeDefs = /* GraphQL */ `
+  extend type Query {
+    """
+    Shorten URL using daily.dev URL shortener
+    """
+    getShortUrl(
+      """
+      Url to shorten
+      """
+      url: String!
+    ): String
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const resolvers: IResolvers<any, Context> = {
+  Query: traceResolverObject({
+    getShortUrl: async (
+      source,
+      { url }: { url: string },
+      ctx: Context,
+    ): Promise<string> => {
+      if (!isValidHttpUrl(url)) {
+        throw new ValidationError('Invalid url');
+      }
+
+      const result = await getShortUrl(url, ctx.log);
+      return result;
+    },
+  }),
+};


### PR DESCRIPTION
Adds a graphql query so that we can request shortened URLs from the frontend.

Related: 
- MI-188