### PR TITLE
fix: set showStreakMilestone to true when currentStreak >= maxStreak

### DIFF
--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -324,6 +324,25 @@ describe('reading streaks', () => {
       await con.getRepository(Alerts).clear();
     });
 
+    it('should set showStreakMilestone to true if current streak is same as max streak and not a fibonacci number', async () => {
+      await runTest(
+        '2024-01-26T19:17Z',
+        '2024-01-25T17:23Z',
+        { ...defaultStreak, currentStreak: 5, maxStreak: 5 },
+        {
+          currentStreak: 6,
+          totalStreak: 43,
+          maxStreak: 6,
+          lastViewAt: new Date('2024-01-26T19:17Z'),
+        },
+      );
+
+      const alerts = await con
+        .getRepository(Alerts)
+        .findOne({ where: { userId: 'u1' } });
+      expect(alerts?.showStreakMilestone).toBe(true);
+    });
+
     it('should set showStreakMilestone to true if current streak is a fibonacci number', async () => {
       await runTest('2024-01-26T19:17Z', '2024-01-25T17:23Z', defaultStreak, {
         currentStreak: 5,
@@ -338,7 +357,7 @@ describe('reading streaks', () => {
       expect(alerts?.showStreakMilestone).toBe(true);
     });
 
-    it('should set showStreakMilestone to false if current streak is NOT a fibonacci number', async () => {
+    it('should set showStreakMilestone to false if current streak is NOT a fibonacci number and maxStreak is bigger', async () => {
       await runTest(
         '2024-01-26T19:17Z',
         '2024-01-25T17:23Z',

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -50,7 +50,7 @@ UPDATE user_streak AS us SET
   "maxStreak" = CASE WHEN shouldIncrementStreak THEN GREATEST(us."maxStreak", us."currentStreak" + 1) ELSE us."maxStreak" END
 FROM u
 WHERE us."userId" = u.id
-RETURNING "currentStreak"
+RETURNING "currentStreak", "maxStreak"
 `;
 
 const incrementReadingStreak = async (
@@ -92,11 +92,12 @@ const incrementReadingStreak = async (
       DEFAULT_TIMEZONE,
     ]);
 
-    const currentStreak = results?.[0]?.[0]?.currentStreak;
+    const { currentStreak, maxStreak } = results?.[0]?.[0] ?? {};
 
-    if (currentStreak !== null && currentStreak > 0) {
+    if (currentStreak > 0) {
       // milestones are currently defined on fibonacci sequence
-      const showStreakMilestone = isFibonacci(currentStreak);
+      const showStreakMilestone =
+        isFibonacci(currentStreak) || currentStreak >= maxStreak;
       await con.getRepository(Alerts).save({
         userId,
         showStreakMilestone,


### PR DESCRIPTION
We need to set `showStreakMilestone` to true when the user meets a new streak record as well.

Related issue: 
- MI-192

Related PR: 
- https://github.com/dailydotdev/apps/pull/2710