### PR TITLE
fix: return 0 streak when there is no record in the database

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -327,6 +327,22 @@ describe('query userStreaks', () => {
     expect(res.errors).toBeFalsy();
   });
 
+  it('should return empty streak when the user has no streak yet', async () => {
+    loggedUser = '1';
+    await con.getRepository(UserStreak).delete({ userId: loggedUser });
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      userStreak: {
+        max: 0,
+        total: 0,
+        current: 0,
+        lastViewAt: null,
+      },
+    });
+  });
+
   it('should return the user streaks when last view is null', async () => {
     loggedUser = '1';
     const res = await client.query(QUERY);


### PR DESCRIPTION
In the case the user does not have an entry in the database for their user streak, we just return an empty one.