### PR TITLE
feat: add `queryOne` without fail to graphorm

### DIFF
--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -575,6 +575,28 @@ export class GraphORM {
   }
 
   /**
+   * Queries the database to fulfill a GraphQL request.
+   * Returns the first result or null if none is found
+   *
+   * @param ctx GraphQL context of the request
+   * @param resolveInfo GraphQL resolve info of the request
+   * @param beforeQuery A callback function that is called before executing the query
+   */
+  async queryOne<T>(
+    ctx: Context,
+    resolveInfo: GraphQLResolveInfo,
+    beforeQuery?: (builder: GraphORMBuilder) => GraphORMBuilder,
+  ): Promise<T | null> {
+    const res = await this.query<T>(ctx, resolveInfo, beforeQuery);
+
+    if (!res.length) {
+      return null;
+    }
+
+    return res[0];
+  }
+
+  /**
    * Queries the database to fulfill a Partial GraphQL request
    * @param ctx GraphQL context of the request
    * @param resolveInfo GraphQL resolve info of the request

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -846,7 +846,7 @@ export const resolvers: IResolvers<any, Context> = {
         .getRawMany();
     },
     userStreak: async (_, __, ctx: Context, info): Promise<GQLUserStreak> => {
-      const streak = await graphorm.query<GQLUserStreakTz>(
+      const streak = await graphorm.queryOne<GQLUserStreakTz>(
         ctx,
         info,
         (builder) => ({
@@ -861,7 +861,7 @@ export const resolvers: IResolvers<any, Context> = {
         }),
       );
 
-      if (!streak.length) {
+      if (!streak) {
         return {
           max: 0,
           total: 0,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -871,16 +871,12 @@ export const resolvers: IResolvers<any, Context> = {
         };
       }
 
-      const hasClearedStreak = await checkAndClearUserStreak(
-        ctx,
-        info,
-        streak[0],
-      );
+      const hasClearedStreak = await checkAndClearUserStreak(ctx, info, streak);
       if (hasClearedStreak) {
-        return { ...streak[0], current: 0 };
+        return { ...streak, current: 0 };
       }
 
-      return streak[0];
+      return streak;
     },
     userReads: async (): Promise<number> => {
       // Kept for backwards compatability


### PR DESCRIPTION
We don't have a `queryOne` function that doesn't fail. Added a new one that returns `null` instead.

https://github.com/dailydotdev/daily-api/pull/1727#discussion_r1508707129