### PR TITLE
chore: update gcp orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.15.3
+  gcp-gcr: circleci/gcp-gcr@0.16.2
   pulumi: pulumi/pulumi@2.1.0
   gcp-cli: circleci/gcp-cli@3.1.1
 jobs:


### PR DESCRIPTION
CircleCI removed some runner images that this orb was using. Version `0.16.2` updated it to be latest runner image

https://github.com/CircleCI-Public/gcp-gcr-orb/pull/80

![image](https://github.com/dailydotdev/daily-api/assets/1681525/9561fd98-2ee7-43a0-83dd-0f18915d21ef)
