### PR TITLE
fix: don't trigger alerts multiple times on the same day

### DIFF
--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -324,7 +324,7 @@ describe('reading streaks', () => {
       await con.getRepository(Alerts).clear();
     });
 
-    it('should set showStreakMilestone to true if current streak is same as max streak and not a fibonacci number', async () => {
+    it('should not set showStreakMilestone if current streak is same as max streak and not a fibonacci number', async () => {
       await runTest(
         '2024-01-26T19:17Z',
         '2024-01-25T17:23Z',
@@ -340,7 +340,7 @@ describe('reading streaks', () => {
       const alerts = await con
         .getRepository(Alerts)
         .findOne({ where: { userId: 'u1' } });
-      expect(alerts?.showStreakMilestone).toBe(true);
+      expect(alerts?.showStreakMilestone).toBe(false);
     });
 
     it('should set showStreakMilestone to true if current streak is a fibonacci number', async () => {

--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -405,5 +405,26 @@ describe('reading streaks', () => {
         .findOne({ where: { userId: 'u1' } });
       expect(alerts?.showStreakMilestone).toBe(false);
     });
+
+    it('should not set showStreakMilestone if lastViewAt is the same day', async () => {
+      await runTest(
+        '2024-01-26T19:17Z',
+        '2024-01-26T17:23Z',
+        {
+          ...defaultStreak,
+          currentStreak: 5,
+        },
+        {
+          ...defaultStreak,
+          currentStreak: 5,
+          lastViewAt: new Date('2024-01-26T19:17Z'),
+        },
+      );
+
+      const alerts = await con
+        .getRepository(Alerts)
+        .findOne({ where: { userId: 'u1' } });
+      expect(alerts).toBeNull();
+    });
   });
 });

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -51,10 +51,10 @@ updated AS (
     "maxStreak" = CASE WHEN shouldIncrementStreak THEN GREATEST(us."maxStreak", us."currentStreak" + 1) ELSE us."maxStreak" END
   FROM u
   WHERE us."userId" = u.id
-  RETURNING us."userId", "currentStreak", "maxStreak"
+  RETURNING us."userId", "currentStreak"
 )
 /* Return the updated streak data */
-SELECT updated."currentStreak", updated."maxStreak", u.shouldIncrementStreak AS "didIncrementStreak"
+SELECT updated."currentStreak", u.shouldIncrementStreak AS "didIncrementStreak"
 FROM updated
 JOIN u ON TRUE;
 `;
@@ -98,12 +98,11 @@ const incrementReadingStreak = async (
       DEFAULT_TIMEZONE,
     ]);
 
-    const { currentStreak, maxStreak, didIncrementStreak } = results?.[0] ?? {};
+    const { currentStreak, didIncrementStreak } = results?.[0] ?? {};
 
     if (didIncrementStreak) {
       // milestones are currently defined on fibonacci sequence
-      const showStreakMilestone =
-        isFibonacci(currentStreak) || currentStreak >= maxStreak;
+      const showStreakMilestone = isFibonacci(currentStreak);
       await con.getRepository(Alerts).save({
         userId,
         showStreakMilestone,

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -41,16 +41,22 @@ WITH u AS (
   FROM public.user AS users
   INNER JOIN user_streak ON user_streak."userId" = users.id
   WHERE users.id = $1
+),
+updated AS (
+  UPDATE user_streak AS us SET
+    "lastViewAt" = $2,
+    "updatedAt" = now(),
+    "currentStreak" = CASE WHEN shouldIncrementStreak THEN us."currentStreak" + 1 ELSE us."currentStreak" END,
+    "totalStreak" = CASE WHEN shouldIncrementStreak THEN us."totalStreak" + 1 ELSE us."totalStreak" END,
+    "maxStreak" = CASE WHEN shouldIncrementStreak THEN GREATEST(us."maxStreak", us."currentStreak" + 1) ELSE us."maxStreak" END
+  FROM u
+  WHERE us."userId" = u.id
+  RETURNING us."userId", "currentStreak", "maxStreak"
 )
-UPDATE user_streak AS us SET
-  "lastViewAt" = $2,
-  "updatedAt" = now(),
-  "currentStreak" = CASE WHEN shouldIncrementStreak THEN us."currentStreak" + 1 ELSE us."currentStreak" END,
-  "totalStreak" = CASE WHEN shouldIncrementStreak THEN us."totalStreak" + 1 ELSE us."totalStreak" END,
-  "maxStreak" = CASE WHEN shouldIncrementStreak THEN GREATEST(us."maxStreak", us."currentStreak" + 1) ELSE us."maxStreak" END
-FROM u
-WHERE us."userId" = u.id
-RETURNING "currentStreak", "maxStreak"
+/* Return the updated streak data */
+SELECT updated."currentStreak", updated."maxStreak", u.shouldIncrementStreak AS "didIncrementStreak"
+FROM updated
+JOIN u ON TRUE;
 `;
 
 const incrementReadingStreak = async (
@@ -92,9 +98,9 @@ const incrementReadingStreak = async (
       DEFAULT_TIMEZONE,
     ]);
 
-    const { currentStreak, maxStreak } = results?.[0]?.[0] ?? {};
+    const { currentStreak, maxStreak, didIncrementStreak } = results?.[0] ?? {};
 
-    if (currentStreak > 0) {
+    if (didIncrementStreak) {
       // milestones are currently defined on fibonacci sequence
       const showStreakMilestone =
         isFibonacci(currentStreak) || currentStreak >= maxStreak;


### PR DESCRIPTION
Alternative approach to 
- https://github.com/dailydotdev/daily-api/pull/1729

Here we update the SQL query to return if the streak was incremented or not and based on that continue setting the alert value if needed.

Doing it via DB logic avoids the problem with timezones.