### PR TITLE
feat: include user streak related attributes in personalized digest

### DIFF
--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -76,7 +76,9 @@ Object {
     "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
     "user": Object {
+      "currentStreak": 0,
       "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
       "reputation": 10,
       "username": "idoshamun",
     },
@@ -197,7 +199,9 @@ Object {
     "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
     "user": Object {
+      "currentStreak": 0,
       "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
       "reputation": 10,
       "username": "idoshamun",
     },
@@ -441,7 +445,9 @@ Object {
     "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
     "user": Object {
+      "currentStreak": 0,
       "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
       "reputation": 10,
       "username": "idoshamun",
     },

--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -1,5 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`personalizedDigestEmail worker properly set showStreak to false if there is no user streak record 1`] = `
+Object {
+  "asm": Object {
+    "groupId": 23809,
+  },
+  "batchId": "test-email-batch-id",
+  "category": "Digests",
+  "dynamicTemplateData": Object {
+    "date": Any<String>,
+    "day_name": "Monday",
+    "first_name": "Ido",
+    "posts": Array [
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p1?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque...",
+        "post_title": "P1",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p2?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque...",
+        "post_title": "P2",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p3?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque...",
+        "post_title": "P3",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/c",
+        "source_name": "C",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p4?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque...",
+        "post_title": "P4",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p5?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque...",
+        "post_title": "P5",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+    ],
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "title": "Ido, your personal weekly update from daily.dev is ready",
+    "user": Object {
+      "currentStreak": 0,
+      "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
+      "reputation": 10,
+      "showStreak": false,
+      "username": "idoshamun",
+    },
+  },
+  "from": Object {
+    "email": "informer@daily.dev",
+    "name": "daily.dev",
+  },
+  "hideWarnings": false,
+  "ipPoolName": "Transactional",
+  "replyTo": Object {
+    "email": "hi@daily.dev",
+    "name": "daily.dev",
+  },
+  "sendAt": Any<Number>,
+  "templateId": "d-328d1104d2e04fa1ab91e410e02751cb",
+  "to": Object {
+    "email": "ido@daily.dev",
+    "name": "Ido",
+  },
+  "trackingSettings": Object {
+    "clickTracking": Object {
+      "enable": true,
+    },
+    "openTracking": Object {
+      "enable": true,
+    },
+  },
+}
+`;
+
 exports[`personalizedDigestEmail worker should generate personalized digest for user in timezone ahead UTC 1`] = `
 Object {
   "asm": Object {
@@ -80,6 +191,7 @@ Object {
       "image": "https://daily.dev/ido.jpg",
       "maxStreak": 0,
       "reputation": 10,
+      "showStreak": true,
       "username": "idoshamun",
     },
   },
@@ -203,6 +315,7 @@ Object {
       "image": "https://daily.dev/ido.jpg",
       "maxStreak": 0,
       "reputation": 10,
+      "showStreak": true,
       "username": "idoshamun",
     },
   },
@@ -326,6 +439,7 @@ Object {
       "image": "https://daily.dev/ido.jpg",
       "maxStreak": 0,
       "reputation": 10,
+      "showStreak": true,
       "username": "idoshamun",
     },
   },
@@ -449,6 +563,7 @@ Object {
       "image": "https://daily.dev/ido.jpg",
       "maxStreak": 0,
       "reputation": 10,
+      "showStreak": true,
       "username": "idoshamun",
     },
   },

--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -318,7 +318,9 @@ Object {
     "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
     "title": "Ido, your personal weekly update from daily.dev is ready",
     "user": Object {
+      "currentStreak": 0,
       "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
       "reputation": 10,
       "username": "idoshamun",
     },

--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -2,7 +2,13 @@ import { expectSuccessfulBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/personalizedDigestEmail';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
-import { Post, Source, User, UserPersonalizedDigest } from '../../src/entity';
+import {
+  Post,
+  Source,
+  User,
+  UserPersonalizedDigest,
+  UserStreak,
+} from '../../src/entity';
 import { usersFixture } from '../fixture/user';
 import { postsFixture } from '../fixture/post';
 import { sourcesFixture } from '../fixture/source';
@@ -526,6 +532,42 @@ describe('personalizedDigestEmail worker', () => {
     }));
 
     await saveFixtures(con, Post, postsFixtureWithAddedData);
+
+    const personalizedDigest = await con
+      .getRepository(UserPersonalizedDigest)
+      .findOneBy({
+        userId: '1',
+      });
+
+    await expectSuccessfulBackground(worker, {
+      personalizedDigest,
+      ...getDates(personalizedDigest!, Date.now()),
+      emailBatchId: 'test-email-batch-id',
+    });
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const emailData = (sendEmail as jest.Mock).mock.calls[0][0];
+    expect(emailData).toMatchSnapshot({
+      sendAt: expect.any(Number),
+      dynamicTemplateData: {
+        date: expect.any(String),
+      },
+    });
+  });
+
+  it('properly set showStreak to false if there is no user streak record', async () => {
+    const postsFixtureWithAddedData = postsFixture.map((item) => ({
+      ...item,
+      readTime: 15,
+      summary:
+        'In quis nulla lorem. Suspendisse potenti. Quisque gravida convallis urna, ut venenatis sapien. Maecenas sem odio, blandit vel auctor ut, pellentesque ac magna.',
+      upvotes: 10,
+      comments: 5,
+      views: 200,
+    }));
+
+    await saveFixtures(con, Post, postsFixtureWithAddedData);
+    await con.getRepository(UserStreak).delete({ userId: '1' });
 
     const personalizedDigest = await con
       .getRepository(UserPersonalizedDigest)

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -129,8 +129,9 @@ const getEmailVariation = async ({
       username: user.username,
       image: user.image,
       reputation: user.reputation,
-      currentStreak: userStreak?.currentStreak,
-      maxStreak: userStreak?.maxStreak,
+      currentStreak: userStreak?.currentStreak || 0,
+      maxStreak: userStreak?.maxStreak || 0,
+      showStreak: !!userStreak,
     },
   };
 

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -4,6 +4,7 @@ import {
   Source,
   User,
   UserPersonalizedDigest,
+  UserStreak,
 } from '../entity';
 import { DayOfWeek } from '../types';
 import { MailDataRequired } from '@sendgrid/mail';
@@ -104,12 +105,14 @@ const getEmailVariation = async ({
   personalizedDigest,
   posts,
   user,
+  userStreak,
   feature,
   currentDate,
 }: {
   personalizedDigest: UserPersonalizedDigest;
   posts: TemplatePostData[];
   user: User;
+  userStreak?: UserStreak;
   feature: typeof features.personalizedDigest.defaultValue;
   currentDate: Date;
 }): Promise<Partial<MailDataRequired>> => {
@@ -126,6 +129,8 @@ const getEmailVariation = async ({
       username: user.username,
       image: user.image,
       reputation: user.reputation,
+      currentStreak: userStreak?.currentStreak,
+      maxStreak: userStreak?.maxStreak,
     },
   };
 
@@ -221,10 +226,15 @@ export const getPersonalizedDigestEmailPayload = async ({
     return undefined;
   }
 
+  const userStreak = await con.getRepository(UserStreak).findOneBy({
+    userId: user.id,
+  });
+
   const variationProps = await getEmailVariation({
     personalizedDigest,
     posts,
     user,
+    userStreak,
     feature,
     currentDate,
   });

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -105,7 +105,6 @@ const getEmailVariation = async ({
   personalizedDigest,
   posts,
   user,
-  userStreak,
   feature,
   currentDate,
 }: {
@@ -120,6 +119,7 @@ const getEmailVariation = async ({
     ([, value]) => value === personalizedDigest.preferredDay,
   );
   const userName = user.name?.trim().split(' ')[0] || user.username;
+  const userStreak = await user.streak;
   const data = {
     day_name: dayName,
     first_name: userName,
@@ -226,15 +226,10 @@ export const getPersonalizedDigestEmailPayload = async ({
     return undefined;
   }
 
-  const userStreak = await con.getRepository(UserStreak).findOneBy({
-    userId: user.id,
-  });
-
   const variationProps = await getEmailVariation({
     personalizedDigest,
     posts,
     user,
-    userStreak,
     feature,
     currentDate,
   });

--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -66,8 +66,13 @@ const worker: Worker = {
     const emailSendDate = new Date(emailSendTimestamp);
     const previousSendDate = new Date(previousSendTimestamp);
 
-    const user = await con.getRepository(User).findOneBy({
-      id: personalizedDigest.userId,
+    const user = await con.getRepository(User).findOne({
+      where: {
+        id: personalizedDigest.userId,
+      },
+      relations: {
+        streak: true,
+      },
     });
 
     if (!user?.infoConfirmed) {


### PR DESCRIPTION
This ticket just adds the properties, to actually display them in the digest we need to update the template in sendgrid. 

Todo:
- [ ] ~~update the sendgrid template to display streaks information~~
