### PR TITLE
fix: use different slot name for debezium in adhoc to crash with other debezium instances

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -1,4 +1,5 @@
 debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
+debezium.source.slot.name=%slot_name%
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
 debezium.source.database.hostname=%hostname%

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -353,6 +353,7 @@ const [apps] = deployApplicationSuite(
       topicName: debeziumTopicName,
       propsPath: './application.properties',
       propsVars: {
+        slot_name: isAdhocEnv ? "debzium_api" : "debzium",
         database_pass: config.require('debeziumDbPass'),
         database_user: config.require('debeziumDbUser'),
         database_dbname: name,


### PR DESCRIPTION
In adhoc, there are two instances of debezium, and both are trying to create a replication slot with the name `debezium`, and it is a race to which one gets there first.
So this change just sets the slot name to be something different in adhoc env.

It should not cause any changes in production