### PR TITLE
feat: add new source post added notification type and notify logic

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1079,11 +1079,11 @@ describe('storeNotificationBundle', () => {
     expect(actual.notification.type).toEqual(type);
     expect(actual.userIds).toEqual([userId]);
     expect(actual.notification.public).toEqual(true);
-    expect(actual.notification.referenceId).toEqual('a');
-    expect(actual.notification.referenceType).toEqual('source');
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
     expect(actual.notification.description).toBeFalsy();
     expect(actual.notification.targetUrl).toEqual(
-      'http://localhost:5002/sources/a',
+      'http://localhost:5002/posts/p1',
     );
     expect(actual.avatars).toEqual([
       {
@@ -1095,7 +1095,15 @@ describe('storeNotificationBundle', () => {
         type: 'source',
       },
     ]);
-    expect(actual.attachments!.length).toEqual(0);
-    expect(actual.notification.uniqueKey).toEqual('p1');
+    expect(actual.attachments!.length).toEqual(1);
+    expect(actual.attachments).toEqual([
+      {
+        image: 'https://daily.dev/image.jpg',
+
+        referenceId: 'p1',
+        title: 'P1',
+        type: 'post',
+      },
+    ]);
   });
 });

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1066,4 +1066,36 @@ describe('storeNotificationBundle', () => {
     expect(actual.notification.description).toEqual('Create your new Squad');
     expect(actual.attachments.length).toEqual(0);
   });
+
+  it('should generate source_post_added notification', () => {
+    const type = NotificationType.SourcePostAdded;
+    const ctx: NotificationSourceContext & NotificationPostContext = {
+      userIds: [userId],
+      source: sourcesFixture[0] as Reference<Source>,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.userIds).toEqual([userId]);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('a');
+    expect(actual.notification.referenceType).toEqual('source');
+    expect(actual.notification.description).toBeFalsy();
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/sources/a',
+    );
+    expect(actual.avatars).toEqual([
+      {
+        image: 'http://image.com/a',
+        name: 'A',
+
+        referenceId: 'a',
+        targetUrl: 'http://localhost:5002/sources/a',
+        type: 'source',
+      },
+    ]);
+    expect(actual.attachments!.length).toEqual(0);
+    expect(actual.notification.uniqueKey).toEqual('p1');
+  });
 });

--- a/__tests__/triggers/feedSource.ts
+++ b/__tests__/triggers/feedSource.ts
@@ -1,0 +1,139 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import {
+  Feed,
+  FeedSource,
+  MachineSource,
+  NotificationPreferenceSource,
+  User,
+} from '../../src/entity';
+import {
+  NotificationPreferenceStatus,
+  NotificationType,
+} from '../../src/notifications/common';
+import { sourcesFixture } from '../fixture/source';
+import { usersFixture } from '../fixture/user';
+import { saveFixtures } from '../helpers';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+});
+
+describe('unsubscribe_notification_source_post_added', () => {
+  beforeEach(async () => {
+    await saveFixtures(con, User, usersFixture);
+    await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
+    await saveFixtures(con, MachineSource, sourcesFixture);
+  });
+
+  it('should remove source_post_added subscribe notification preference on feed source block (insert)', async () => {
+    await con.getRepository(NotificationPreferenceSource).save({
+      userId: '1',
+      sourceId: 'a',
+      referenceId: 'a',
+      status: NotificationPreferenceStatus.Subscribed,
+      notificationType: NotificationType.SourcePostAdded,
+    });
+
+    const subscription = await con
+      .getRepository(NotificationPreferenceSource)
+      .findOneBy({
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        notificationType: NotificationType.SourcePostAdded,
+      });
+
+    expect(subscription).toBeTruthy();
+
+    await con.getRepository(FeedSource).save({
+      feedId: '1',
+      sourceId: 'a',
+    });
+
+    const subscriptionAfter = await con
+      .getRepository(NotificationPreferenceSource)
+      .findOneBy({
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        notificationType: NotificationType.SourcePostAdded,
+      });
+
+    expect(subscriptionAfter).toBeFalsy();
+  });
+
+  it('should not remove other notification preference on feed source block (insert)', async () => {
+    await con.getRepository(NotificationPreferenceSource).save([
+      {
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        status: NotificationPreferenceStatus.Subscribed,
+        notificationType: NotificationType.SourcePostAdded,
+      },
+      {
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        status: NotificationPreferenceStatus.Muted,
+        notificationType: NotificationType.SquadPostAdded,
+      },
+      {
+        userId: '1',
+        sourceId: 'b',
+        referenceId: 'b',
+        status: NotificationPreferenceStatus.Subscribed,
+        notificationType: NotificationType.SquadPostAdded,
+      },
+      {
+        userId: '2',
+        sourceId: 'a',
+        referenceId: 'a',
+        status: NotificationPreferenceStatus.Subscribed,
+        notificationType: NotificationType.SourcePostAdded,
+      },
+    ]);
+
+    const subscription = await con
+      .getRepository(NotificationPreferenceSource)
+      .findOneBy({
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        notificationType: NotificationType.SourcePostAdded,
+      });
+    const subscriptionCount = await con
+      .getRepository(NotificationPreferenceSource)
+      .count();
+
+    expect(subscription).toBeTruthy();
+    expect(subscriptionCount).toEqual(4);
+
+    await con.getRepository(FeedSource).save({
+      feedId: '1',
+      sourceId: 'a',
+    });
+
+    const subscriptionAfter = await con
+      .getRepository(NotificationPreferenceSource)
+      .findOneBy({
+        userId: '1',
+        sourceId: 'a',
+        referenceId: 'a',
+        notificationType: NotificationType.SourcePostAdded,
+      });
+    const subscriptionsCountAfter = await con
+      .getRepository(NotificationPreferenceSource)
+      .count();
+
+    expect(subscriptionAfter).toBeFalsy();
+    expect(subscriptionsCountAfter).toEqual(3);
+  });
+});

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -540,6 +540,26 @@ describe('post added notifications', () => {
     );
     expect(subscribe).toBeFalsy();
   });
+
+  it('should add source post added notification to all source members', async () => {
+    const worker = await import('../../src/workers/notifications/postAdded');
+    await con.getRepository(NotificationPreferenceSource).save({
+      userId: '3',
+      sourceId: 'a',
+      referenceId: 'a',
+      status: NotificationPreferenceStatus.Subscribed,
+      notificationType: NotificationType.SourcePostAdded,
+    });
+    const actual = await invokeNotificationWorker(worker.default, {
+      post: postsFixture[0],
+    });
+    expect(actual.length).toEqual(1);
+    const bundle = actual[0];
+    expect(bundle.type).toEqual(NotificationType.SourcePostAdded);
+    expect((bundle.ctx as NotificationPostContext).post.id).toEqual('p1');
+    expect((bundle.ctx as NotificationPostContext).source.id).toEqual('a');
+    expect(bundle.ctx.userIds).toEqual(['3']);
+  });
 });
 
 describe('article new comment', () => {

--- a/src/migration/1709739543179-FeedSourceBlockUnsubscribe.ts
+++ b/src/migration/1709739543179-FeedSourceBlockUnsubscribe.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FeedSourceBlockUnsubscribe1709739543179 implements MigrationInterface {
+    name = 'FeedSourceBlockUnsubscribe1709739543179'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query(`
+        CREATE OR REPLACE FUNCTION unsubscribe_notification_source_post_added()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          DELETE FROM notification_preference WHERE
+            "sourceId" = NEW."sourceId"
+             AND "userId" = NEW."feedId"
+             AND "notificationType" = 'source_post_added'
+             AND type = 'source'
+             AND status = 'subscribed';
+          RETURN NEW;
+        END;
+        $$
+      `)
+      queryRunner.query('CREATE TRIGGER unsubscribe_notification_source_post_added_trigger AFTER INSERT ON "feed_source" FOR EACH ROW EXECUTE PROCEDURE unsubscribe_notification_source_post_added()')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      queryRunner.query('DROP TRIGGER IF EXISTS unsubscribe_notification_source_post_added_trigger ON feed_source')
+      queryRunner.query('DROP FUNCTION IF EXISTS unsubscribe_notification_source_post_added')
+    }
+
+}

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -41,6 +41,7 @@ export enum NotificationType {
   PostMention = 'post_mention',
   CollectionUpdated = 'collection_updated',
   DevCardUnlocked = 'dev_card_unlocked',
+  SourcePostAdded = 'source_post_added',
 }
 
 export enum NotificationPreferenceType {
@@ -64,6 +65,7 @@ export const notificationPreferenceMap: Partial<
   [NotificationType.SquadPostAdded]: NotificationPreferenceType.Source,
   [NotificationType.SquadMemberJoined]: NotificationPreferenceType.Source,
   [NotificationType.CollectionUpdated]: NotificationPreferenceType.Post,
+  [NotificationType.SourcePostAdded]: NotificationPreferenceType.Source,
 };
 
 export const commentReplyNotificationTypes = [

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -315,9 +315,7 @@ export const generateNotificationMap: Record<
     ctx: NotificationPostContext & NotificationDoneByContext,
   ) =>
     builder
-      .referenceSource(ctx.source)
       .icon(NotificationIcon.Bell)
       .avatarSource(ctx.source)
-      .targetSource(ctx.source)
-      .uniqueKey(ctx.post.id),
+      .objectPost(ctx.post, ctx.source, ctx.sharedPost),
 };

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -96,7 +96,7 @@ export const notificationTitleMap: Record<
   dev_card_unlocked: () => 'DevCard unlocked!',
   source_post_added: (
     ctx: NotificationPostContext & NotificationDoneByContext,
-  ) => `New posts from <b>${ctx.source.name}</b>, check them out now!`,
+  ) => `New post from <b>${ctx.source.name}</b>, check it out now!`,
 };
 
 export const generateNotificationMap: Record<

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -92,8 +92,11 @@ export const notificationTitleMap: Record<
   post_mention: (ctx: NotificationPostContext & NotificationDoneByContext) =>
     `<b>${ctx.doneBy.username}</b> <span class="text-theme-color-cabbage">mentioned you</span> on a post in <b>${ctx.source.name}</b>.`,
   collection_updated: (ctx: NotificationPostContext) =>
-    `The collection "<b>${ctx.post.title}</b>" just got updated with new details`,
+    `The collection "New posts from <b>${ctx.post.title}</b>" just got updated with new details`,
   dev_card_unlocked: () => 'DevCard unlocked!',
+  source_post_added: (
+    ctx: NotificationPostContext & NotificationDoneByContext,
+  ) => `New posts from <b>${ctx.source.name}</b>, check them out now!`,
 };
 
 export const generateNotificationMap: Record<
@@ -307,4 +310,14 @@ export const generateNotificationMap: Record<
       )
       .targetUrl(generateDevCard)
       .uniqueKey(ctx.userIds[0]),
+  source_post_added: (
+    builder,
+    ctx: NotificationPostContext & NotificationDoneByContext,
+  ) =>
+    builder
+      .referenceSource(ctx.source)
+      .icon(NotificationIcon.Bell)
+      .avatarSource(ctx.source)
+      .targetSource(ctx.source)
+      .uniqueKey(ctx.post.id),
 };

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -92,7 +92,7 @@ export const notificationTitleMap: Record<
   post_mention: (ctx: NotificationPostContext & NotificationDoneByContext) =>
     `<b>${ctx.doneBy.username}</b> <span class="text-theme-color-cabbage">mentioned you</span> on a post in <b>${ctx.source.name}</b>.`,
   collection_updated: (ctx: NotificationPostContext) =>
-    `The collection "New posts from <b>${ctx.post.title}</b>" just got updated with new details`,
+    `The collection "<b>${ctx.post.title}</b>" just got updated with new details`,
   dev_card_unlocked: () => 'DevCard unlocked!',
   source_post_added: (
     ctx: NotificationPostContext & NotificationDoneByContext,

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -71,6 +71,7 @@ const notificationToTemplateId: Record<NotificationType, string> = {
   squad_subscribe_to_notification: '',
   collection_updated: 'd-c051ffef97a148b6a6f14d5edb46b553',
   dev_card_unlocked: 'd-3d3402ec873640e788f549a0680c40bb',
+  source_post_added: '',
 };
 
 type TemplateData = Record<string, string | number>;

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -637,6 +637,9 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       },
     };
   },
+  source_post_added: async () => {
+    return null;
+  },
 };
 
 const formatTemplateDate = <T extends TemplateData>(data: T): T => {

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -11,6 +11,7 @@ import {
 import {
   NotificationDoneByContext,
   NotificationPostContext,
+  NotificationSourceContext,
 } from '../../notifications';
 import {
   NotificationPreferenceStatus,
@@ -127,7 +128,7 @@ const worker: NotificationWorker = {
             ctx: {
               ...baseCtx,
               userIds: members.map(({ userId }) => userId),
-            } as NotificationPostContext & Partial<NotificationDoneByContext>,
+            } as NotificationSourceContext & NotificationPostContext,
           });
         }
       }


### PR DESCRIPTION
AS-154

- add new notification type
  - allow it for frontend subscribe
- update `postAdded` worker to notify for `machine` sources
- tested notification dispatch locally
- added trigger to unsubscribe user when he blocks a source automatically so we don't have to run requests from frontend, also added [automatic cache invalidation on frontend](https://github.com/dailydotdev/apps/pull/2750/commits/3c7d32fbeb4a69bb076345a4161b8096bd47bfd4)

<img width="673" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/04bc7ca8-8622-4426-bc08-ccbb76bf43a2">
