### PR TITLE
feat: support personalization threshold experiment

### DIFF
--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -29,7 +29,11 @@ import {
 import { SourceMemberRoles } from '../../src/roles';
 import { sourcesFixture } from '../fixture/source';
 import { usersFixture } from '../fixture/user';
-import { ISnotraClient, UserState } from '../../src/integrations/snotra';
+import {
+  ISnotraClient,
+  SnotraClient,
+  UserState,
+} from '../../src/integrations/snotra';
 import { FeedUserStateConfigGenerator } from '../../src/integrations/feed/configs';
 
 let con: DataSource;
@@ -266,5 +270,28 @@ describe('FeedUserStateConfigGenerator', () => {
       offset: 3,
     });
     expect(actual.feed_config_name).toEqual('personalise');
+  });
+
+  it('should send proper parameters to snotra', async () => {
+    const client = new SnotraClient();
+    nock('http://localhost:6001')
+      .post('/api/v1/user/profile', {
+        user_id: '1',
+        providers: {
+          personalise: {},
+        },
+        post_rank_count: 8,
+      })
+      .reply(200, { personalise: { state: 'personalised' } });
+    const generator: FeedConfigGenerator = new FeedUserStateConfigGenerator(
+      client,
+      generators,
+      8,
+    );
+    await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
   });
 });

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -88,13 +88,16 @@ export class FeedPreferencesConfigGenerator implements FeedConfigGenerator {
 export class FeedUserStateConfigGenerator implements FeedConfigGenerator {
   private readonly snotraClient: ISnotraClient;
   private readonly generators: Record<UserState, FeedConfigGenerator>;
+  private readonly personalizationThreshold?: number;
 
   constructor(
     snotraClient: ISnotraClient,
     generators: Record<UserState, FeedConfigGenerator>,
+    personalizationThreshold?: number,
   ) {
     this.snotraClient = snotraClient;
     this.generators = generators;
+    this.personalizationThreshold = personalizationThreshold;
   }
 
   async generate(ctx, opts): Promise<FeedConfig> {
@@ -102,6 +105,7 @@ export class FeedUserStateConfigGenerator implements FeedConfigGenerator {
       const userState = await this.snotraClient.fetchUserState({
         user_id: opts.user_id,
         providers: { personalise: {} },
+        post_rank_count: this.personalizationThreshold,
       });
       return this.generators[userState.personalise.state].generate(ctx, opts);
     });

--- a/src/integrations/snotra/types.ts
+++ b/src/integrations/snotra/types.ts
@@ -1,5 +1,6 @@
 export type UserStatePayload = {
   user_id: string;
+  post_rank_count?: number;
   providers: {
     personalise: Record<string, never>;
   };


### PR DESCRIPTION
Downstream the personalization threshold based on the feed version to snotra.

Currently, there's no real change just support for future experiments.