### PR TITLE
feat: add separate meter reason for deleted users

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -413,3 +413,9 @@ export const checkAndClearUserStreak = async (
 
   return false;
 };
+
+export enum LogoutReason {
+  ManualLogout = 'manual logout',
+  UserDeleted = 'user deleted',
+  KratosSessionAlreadyAvailable = 'kratos session already available',
+}

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -415,6 +415,7 @@ export const checkAndClearUserStreak = async (
 };
 
 export enum LogoutReason {
+  IncomleteOnboarding = 'incomplete onboarding',
   ManualLogout = 'manual logout',
   UserDeleted = 'user deleted',
   KratosSessionAlreadyAvailable = 'kratos session already available',

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -164,12 +164,9 @@ export const logout = async (
   isDeletion = false,
 ): Promise<FastifyReply> => {
   const query = req.query as { reason?: LogoutReason };
-  const reason =
-    LogoutReason[
-      isDeletion
-        ? LogoutReason.UserDeleted
-        : query?.reason || LogoutReason.ManualLogout
-    ];
+  const reason = Object.values(LogoutReason).includes(query?.reason)
+    ? query.reason
+    : LogoutReason.ManualLogout;
 
   try {
     const { res: logoutFlow } = await fetchKratos(
@@ -186,6 +183,11 @@ export const logout = async (
       req.log.warn({ err: e }, 'unexpected error while logging out');
     }
   }
-  await clearAuthentication(req, res, reason);
+
+  await clearAuthentication(
+    req,
+    res,
+    isDeletion ? LogoutReason.UserDeleted : reason,
+  );
   return res.status(204).send();
 };

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -160,8 +160,13 @@ export const dispatchWhoami = async (
 export const logout = async (
   req: FastifyRequest,
   res: FastifyReply,
-  isDeleted = false,
+  isDeletion = false,
 ): Promise<FastifyReply> => {
+  const query = req.query as { reason?: string };
+  const reason = isDeletion
+    ? 'deletion logout'
+    : query?.reason || 'manual logout';
+
   try {
     const { res: logoutFlow } = await fetchKratos(
       req,
@@ -177,10 +182,6 @@ export const logout = async (
       req.log.warn({ err: e }, 'unexpected error while logging out');
     }
   }
-  await clearAuthentication(
-    req,
-    res,
-    isDeleted ? 'deletion logout' : 'manual logout',
-  );
+  await clearAuthentication(req, res, reason);
   return res.status(204).send();
 };

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -160,6 +160,7 @@ export const dispatchWhoami = async (
 export const logout = async (
   req: FastifyRequest,
   res: FastifyReply,
+  isDeleted = false,
 ): Promise<FastifyReply> => {
   try {
     const { res: logoutFlow } = await fetchKratos(
@@ -176,6 +177,10 @@ export const logout = async (
       req.log.warn({ err: e }, 'unexpected error while logging out');
     }
   }
-  await clearAuthentication(req, res, 'manual logout');
+  await clearAuthentication(
+    req,
+    res,
+    isDeleted ? 'deletion logout' : 'manual logout',
+  );
   return res.status(204).send();
 };

--- a/src/kratos.ts
+++ b/src/kratos.ts
@@ -6,6 +6,7 @@ import { cookies, setCookie } from './cookies';
 import { setTrackingId } from './tracking';
 import { generateTrackingId } from './ids';
 import { HttpError, retryFetch } from './integrations/retry';
+import { LogoutReason } from './common';
 
 const heimdallOrigin = process.env.HEIMDALL_ORIGIN;
 const kratosOrigin = process.env.KRATOS_ORIGIN;
@@ -162,10 +163,13 @@ export const logout = async (
   res: FastifyReply,
   isDeletion = false,
 ): Promise<FastifyReply> => {
-  const query = req.query as { reason?: string };
-  const reason = isDeletion
-    ? 'deletion logout'
-    : query?.reason || 'manual logout';
+  const query = req.query as { reason?: LogoutReason };
+  const reason =
+    LogoutReason[
+      isDeletion
+        ? LogoutReason.UserDeleted
+        : query?.reason || LogoutReason.ManualLogout
+    ];
 
   try {
     const { res: logoutFlow } = await fetchKratos(

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -26,6 +26,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     }
 
     await deleteUser(con, req.log, userId);
-    return logout(req, res);
+    return logout(req, res, true);
   });
 }


### PR DESCRIPTION
With the surge in new users, it would be interesting to see how many of them deletes their accounts.
Saw a surge of manual logouts in the metrics, but it doesn't differentiate between actual logout or deletion of the user.
This adds a new reason, `deletion logout`, to the counter
![image](https://github.com/dailydotdev/daily-api/assets/1681525/91c19e0e-c501-48d6-93de-60d83f757f68)