### PR TITLE
fix: allow anonymous users to use the new similar posts

### DIFF
--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1212,7 +1212,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       ctx,
       info,
     ): Promise<GQLPost[]> => {
-      if (args.post && ctx.userId) {
+      if (args.post) {
         const res = await feedGenerators['post_similarity'].generate(ctx, {
           user_id: ctx.userId,
           page_size: args.first || 3,


### PR DESCRIPTION
Previously we added this guard as we thought it fixes a performance issue, but actually Ole-Martin fixed the root cause. Now we can have it on for everyone