### PR TITLE
fix: make tilt ignore build directory

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,7 +5,7 @@ docker_build(
   'api-image',
   context='.',
   dockerfile='./Dockerfile.dev',
-  ignore=['./node_modules', './.infra', '__tests__', './seeds'],
+  ignore=['./node_modules', './.infra', '__tests__', './seeds', './build'],
   live_update=[
     sync('./src', '/opt/app/src'),
     sync('./bin', '/opt/app/bin'),


### PR DESCRIPTION
tilt doesn't need to care about build directory