### PR TITLE
feat: replace send type feature with daily digest config

### DIFF
--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -359,6 +359,130 @@ Object {
 }
 `;
 
+exports[`personalizedDigestEmail worker should generate personalized digest for user with provided config 1`] = `
+Object {
+  "asm": Object {
+    "groupId": 23809,
+  },
+  "batchId": "test-email-batch-id",
+  "category": "Digests",
+  "dynamicTemplateData": Object {
+    "date": Any<String>,
+    "day_name": "Monday",
+    "first_name": "Ido",
+    "posts": Array [
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p1?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "test summary",
+        "post_title": "P1",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p2?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "test summary",
+        "post_title": "P2",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p3?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "test summary",
+        "post_title": "P3",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/c",
+        "source_name": "C",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p4?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "test summary",
+        "post_title": "P4",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/a",
+        "source_name": "A",
+      },
+      Object {
+        "post_comments": 5,
+        "post_image": "https://daily.dev/image.jpg",
+        "post_link": "http://localhost:5002/posts/p5?utm_source=notification&utm_medium=email&utm_campaign=digest",
+        "post_read_time": 15,
+        "post_summary": "test summary",
+        "post_title": "P5",
+        "post_upvotes": 10,
+        "post_views": 200,
+        "source_image": "http://image.com/b",
+        "source_name": "B",
+      },
+    ],
+    "preview": "Every Monday, we'll send you five posts you haven't read. Each post was carefully picked based on topics you love reading about. Let's get to it!",
+    "title": "Ido, your personal weekly update from daily.dev is ready",
+    "user": Object {
+      "currentStreak": 0,
+      "image": "https://daily.dev/ido.jpg",
+      "maxStreak": 0,
+      "reputation": 10,
+      "showStreak": true,
+      "username": "idoshamun",
+    },
+  },
+  "from": Object {
+    "email": "informer@daily.dev",
+    "name": "daily.dev",
+  },
+  "hideWarnings": false,
+  "ipPoolName": "Transactional",
+  "replyTo": Object {
+    "email": "hi@daily.dev",
+    "name": "daily.dev",
+  },
+  "sendAt": Any<Number>,
+  "templateId": "d-testtemplateidfromconfig",
+  "to": Object {
+    "email": "ido@daily.dev",
+    "name": "Ido",
+  },
+  "trackingSettings": Object {
+    "clickTracking": Object {
+      "enable": true,
+    },
+    "openTracking": Object {
+      "enable": true,
+    },
+  },
+}
+`;
+
+exports[`personalizedDigestEmail worker should generate personalized digest for user with provided config 2`] = `
+Object {
+  "allowed_tags": Array [],
+  "blocked_sources": Array [],
+  "blocked_tags": Array [],
+  "date_from": Any<String>,
+  "date_to": Any<String>,
+  "feed_config_name": "testfeedconfig",
+  "total_posts": 3,
+  "user_id": "1",
+}
+`;
+
 exports[`personalizedDigestEmail worker should generate personalized digest for user with subscription 1`] = `
 Object {
   "asm": Object {

--- a/__tests__/workers/userCreatedPersonalizedDigestSendType.ts
+++ b/__tests__/workers/userCreatedPersonalizedDigestSendType.ts
@@ -152,7 +152,7 @@ describe('userCreatedAddPersonalizedDigest worker', () => {
     expect(sendExperimentAllocationEvent).toHaveBeenCalledTimes(1);
     expect(sendExperimentAllocationEvent).toHaveBeenCalledWith({
       event_timestamp: expect.any(Date),
-      experiment_id: features.personalizedDigestSendType.id,
+      experiment_id: features.dailyDigest.id,
       user_id: '1',
       variation_id: '0',
     });

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -10,7 +10,7 @@ import {
 import { DayOfWeek } from '../types';
 import { MailDataRequired } from '@sendgrid/mail';
 import { format, nextDay, previousDay } from 'date-fns';
-import { features } from '../growthbook';
+import { PersonalizedDigestFeatureConfig } from '../growthbook';
 import { feedToFilters, fixedIdsFeedBuilder } from './feedGenerator';
 import { FeedClient } from '../integrations/feed';
 import {
@@ -82,7 +82,7 @@ const getPostsTemplateData = ({
   feature,
 }: {
   posts: TemplatePostData[];
-  feature: typeof features.personalizedDigest.defaultValue;
+  feature: PersonalizedDigestFeatureConfig;
 }) => {
   return posts.map((post) => {
     return {
@@ -118,7 +118,7 @@ const getEmailVariation = async ({
   posts: TemplatePostData[];
   user: User;
   userStreak?: UserStreak;
-  feature: typeof features.personalizedDigest.defaultValue;
+  feature: PersonalizedDigestFeatureConfig;
   currentDate: Date;
 }): Promise<Partial<MailDataRequired>> => {
   const [dayName] = Object.entries(DayOfWeek).find(
@@ -179,7 +179,7 @@ export const getPersonalizedDigestEmailPayload = async ({
   emailSendDate: Date;
   currentDate: Date;
   previousSendDate: Date;
-  feature: typeof features.personalizedDigest.defaultValue;
+  feature: PersonalizedDigestFeatureConfig;
 }): Promise<MailDataRequired | undefined> => {
   const feedConfig = await feedToFilters(
     con,

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -32,6 +32,7 @@ import { Message } from '@google-cloud/pubsub';
 import { DataSource } from 'typeorm';
 import { FastifyLoggerInstance } from 'fastify';
 import pino from 'pino';
+import { PersonalizedDigestFeatureConfig } from '../growthbook';
 
 export const pubsub = new PubSub();
 const postUpvotedTopic = pubsub.topic('post-upvoted');
@@ -462,6 +463,7 @@ export const notifyGeneratePersonalizedDigest = async ({
   previousSendTimestamp,
   emailBatchId,
   deduplicate,
+  config,
 }: {
   log: EventLogger;
   personalizedDigest: UserPersonalizedDigest;
@@ -469,6 +471,7 @@ export const notifyGeneratePersonalizedDigest = async ({
   previousSendTimestamp: number;
   emailBatchId?: string;
   deduplicate?: boolean;
+  config?: PersonalizedDigestFeatureConfig;
 }): Promise<void> =>
   publishEvent(log, generatePersonalizedDigestTopic, {
     personalizedDigest,
@@ -476,6 +479,7 @@ export const notifyGeneratePersonalizedDigest = async ({
     previousSendTimestamp,
     emailBatchId,
     deduplicate: deduplicate ?? true,
+    config,
   });
 
 export const notifyPostYggdrasilIdSet = async (

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -103,25 +103,32 @@ export class Feature<T extends JSONValue> {
   }
 }
 
+const digestFeatureBaseConfig = {
+  templateId: 'd-328d1104d2e04fa1ab91e410e02751cb',
+  meta: {
+    from: {
+      email: 'informer@daily.dev',
+      name: 'daily.dev',
+    },
+    category: 'Digests',
+    asmGroupId: 23809,
+  },
+  feedConfig: 'digest',
+  maxPosts: 5,
+  longTextLimit: 150,
+  newUserSendType: UserPersonalizedDigestSendType.weekly,
+};
+
+export type PersonalizedDigestFeatureConfig = typeof digestFeatureBaseConfig;
+
 export const features = {
   personalizedDigest: new Feature('personalized_digest', {
-    templateId: 'd-328d1104d2e04fa1ab91e410e02751cb',
-    meta: {
-      from: {
-        email: 'informer@daily.dev',
-        name: 'daily.dev',
-      },
-      category: 'Digests',
-      asmGroupId: 23809,
-    },
-    feedConfig: 'digest',
-    maxPosts: 5,
-    longTextLimit: 150,
+    ...digestFeatureBaseConfig,
   }),
-  personalizedDigestSendType: new Feature(
-    'personalized_digest_send_type',
-    UserPersonalizedDigestSendType.weekly,
-  ),
+  dailyDigest: new Feature('daily_personalized_digest', {
+    ...digestFeatureBaseConfig,
+    templateId: 'd-925d2759ddd641f99220b3c7c6836458',
+  }),
 };
 
 export class ExperimentAllocationClient {

--- a/src/workers/userCreatedPersonalizedDigestSendType.ts
+++ b/src/workers/userCreatedPersonalizedDigestSendType.ts
@@ -1,3 +1,4 @@
+import deepmerge from 'deepmerge';
 import { updateFlagsStatement, User } from '../common';
 import { UserPersonalizedDigest } from '../entity';
 import { features, getUserGrowthBookInstace } from '../growthbook';
@@ -23,10 +24,15 @@ const worker = workerToExperimentWorker({
       allocationClient,
     });
 
-    const sendType = growthbookClient.getFeatureValue(
-      features.personalizedDigestSendType.id,
-      features.personalizedDigestSendType.defaultValue,
-    ) as typeof features.personalizedDigestSendType.defaultValue;
+    const featureValue = growthbookClient.getFeatureValue(
+      features.dailyDigest.id,
+      features.dailyDigest.defaultValue,
+    ) as typeof features.dailyDigest.defaultValue;
+
+    const digestFeature = deepmerge(
+      features.dailyDigest.defaultValue,
+      featureValue,
+    );
 
     await con.getRepository(UserPersonalizedDigest).update(
       {
@@ -34,7 +40,7 @@ const worker = workerToExperimentWorker({
       },
       {
         flags: updateFlagsStatement<UserPersonalizedDigest>({
-          sendType,
+          sendType: digestFeature.newUserSendType,
         }),
       },
     );


### PR DESCRIPTION
Idea to [solve](https://dailydotdev.slack.com/archives/C06L6UB03U0/p1711028492991389), discussion and enable experimentation on both digest types.

Also request [here](https://dailydotdev.slack.com/archives/C06L6UB03U0/p1711097204217649?thread_ts=1711096239.730069&channel=C06L6UB03U0&message_ts=1711097204.217649)

- added new property `newUserSendType` to enrol new users to either send type (replaces current `personalized_digest_send_type` feature flag)
- weekly send type uses current personalized_digest config for weekly digest
- workdays send type uses new daily_personalized_digest config for daily digest