### PR TITLE
fix: additional feed for all comments with context

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -383,6 +383,13 @@ const obj = new GraphORM({
             base64(`time:${new Date(node.createdAt).getTime()}`),
         },
       },
+      parent: {
+        relation: {
+          isMany: false,
+          childColumn: 'id',
+          parentColumn: 'parentId',
+        },
+      },
     },
   },
   FeedSettings: {

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -225,7 +225,7 @@ export const typeDefs = /* GraphQL */ `
       Paginate first
       """
       first: Int
-    ): CommentConnection!
+    ): CommentConnection! @auth
 
     """
     Get the comments of a post

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -18,6 +18,7 @@ import {
   SourceMember,
   SourceType,
   User,
+  PostType,
 } from '../entity';
 import { NotFoundError, TypeOrmError } from '../errors';
 import { GQLEmptyResponse } from './common';
@@ -138,6 +139,11 @@ export const typeDefs = /* GraphQL */ `
     Total number of upvotes
     """
     numUpvotes: Int!
+
+    """
+    Parent comment of this comment
+    """
+    parent: Comment
   }
 
   type CommentEdge {
@@ -206,6 +212,21 @@ export const typeDefs = /* GraphQL */ `
   }
 
   extend type Query {
+    """
+    Get the comments feed
+    """
+    commentFeed(
+      """
+      Paginate after opaque cursor
+      """
+      after: String
+
+      """
+      Paginate first
+      """
+      first: Int
+    ): CommentConnection!
+
     """
     Get the comments of a post
     """
@@ -535,6 +556,35 @@ export const reportCommentReasons = new Map([
 export const resolvers: IResolvers<any, Context> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Query: traceResolverObject<any, any>({
+    commentFeed: async (
+      _,
+      args: ConnectionArguments,
+      ctx,
+      info,
+    ): Promise<Connection<GQLComment>> => {
+      return queryPaginatedByDate(
+        ctx,
+        info,
+        args,
+        { key: 'createdAt' },
+        {
+          queryBuilder: (builder) => {
+            builder.queryBuilder = builder.queryBuilder
+              .innerJoin(Post, 'p', `"${builder.alias}"."postId" = p.id`)
+              .innerJoin(Source, 's', `"p"."sourceId" = s.id`)
+              .innerJoin(User, 'u', `"${builder.alias}"."userId" = u.id`)
+              .andWhere(`s.private = false`)
+              .andWhere('p.visible = true')
+              .andWhere('p.deleted = false')
+              .andWhere('p.type != :type', { type: PostType.Welcome })
+              .andWhere('u.reputation > 10');
+
+            return builder;
+          },
+          orderByKey: 'DESC',
+        },
+      );
+    },
     postComments: async (
       _,
       args: GQLPostCommentsArgs,


### PR DESCRIPTION
Added a comment feed endpoint.
Rules set are: 
- No welcome post
- Only people with over 10 reputation

Not the biggest fan of the 3 joins, but for now it should be ok to experiment quickly with.
Also needed to add the parent context since we want to showcase if you replied to set person.

AS-202