### PR TITLE
fix: avoid sending daily digest on weekends

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -66,7 +66,7 @@ export const crons: Cron[] = [
   },
   {
     name: 'daily-digest',
-    schedule: '7 * * * 1-5',
+    schedule: '7 * * * *',
     limits: {
       cpu: '250m',
       memory: '1Gi',


### PR DESCRIPTION
With cron schedule it would leak for timezones with large offset where cron would not run or would run early while still in workday.

1. Friday 19:00 UTC is Saturday 04:00 Australia/Brisbane
2. cron runs since it is still Friday in UTC and schedules email
3. User gets the email on Saturday morning 08:00

Example [logs](https://cloudlogging.app.goo.gl/dx2J4ok7LddnAdgN6)

Same thing can happen for western timezones behind UTC but it would happen from Sunday->Monday where people would not get an email on Monday.

Checking in cron logic we can verify local time and skip send if it is a weekend. 