### PR TITLE
ci: split tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
       - run:
           name: Test
           command: |
-            TEST=$(find __tests__ -name "*.ts" -not -path "*/fixture/*")
-            echo "$TEST" | circleci tests run --command="xargs -I{} npm run test -- {} --ci --reporters=default --reporters=jest-junit" --split-by=timings
+            TEST=$(find __tests__ -name "*.ts" -not -path "*/fixture/*" -not -name "setup.ts" -not -name "helpers.ts")
+            echo "$TEST" | circleci tests run --command="xargs -I{} npm run test -- --ci {} --reporters=default --reporters=jest-junit" --split-by=timings
           environment:
             - NODE_OPTIONS: --max-old-space-size=4096
             - JEST_JUNIT_OUTPUT_DIR: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           name: Test
           command: |
             TEST=$(find __tests__ -name "*.ts" -not -path "*/fixture/*")
-            echo "$TEST" | circleci tests run --command="xargs npm run test -- --ci --reporters=default --reporters=jest-junit" --split-by=timings
+            echo "$TEST" | circleci tests run --command="xargs -I{} npm run test -- {} --ci --reporters=default --reporters=jest-junit" --split-by=timings
           environment:
             - NODE_OPTIONS: --max-old-space-size=4096
             - JEST_JUNIT_OUTPUT_DIR: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
       - run:
           name: Test
           command: |
-            TEST=$(find __tests__ -name "*.ts" -not -path "*/fixture/*" -not -name "setup.ts" -not -name "helpers.ts")
-            echo "$TEST" | circleci tests run --command="xargs -I{} npm run test -- --ci {} --reporters=default --reporters=jest-junit" --split-by=timings
+            TEST=$(circleci tests glob "__tests__/**/*.ts" | circleci tests split --split-by=timings)
+            npm run test -- --ci $TEST --reporters=default --reporters=jest-junit
           environment:
             - NODE_OPTIONS: --max-old-space-size=4096
             - JEST_JUNIT_OUTPUT_DIR: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           - POSTGRES_DB: api_test
           - POSTGRES_PASSWORD: 12345
       - image: redis:6
+    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -60,7 +61,9 @@ jobs:
             echo Failed waiting for Redis && exit 1
       - run:
           name: Test
-          command: npm run test -- --ci --reporters=default --reporters=jest-junit
+          command: |
+            TEST=$(find __tests__ -name "*.ts" -not -path "*/fixture/*")
+            echo "$TEST" | circleci tests run --command="xargs npm run test -- --ci --reporters=default --reporters=jest-junit" --split-by=timings
           environment:
             - NODE_OPTIONS: --max-old-space-size=4096
             - JEST_JUNIT_OUTPUT_DIR: ./test-results


### PR DESCRIPTION
Use CircleCI to run tests in parallel to reduce the CI time