### PR TITLE
feat: allow reading comments by any user

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -1331,14 +1331,12 @@ describe('query comment', () => {
       'UNAUTHENTICATED',
     ));
 
-  it('should not return comment by id if user is not the author', async () => {
+  it('should return comment by id even if user is not the author', async () => {
     loggedUser = '2';
 
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { id: 'c1' } },
-      'NOT_FOUND',
-    );
+    const comment = await client.query(QUERY, { variables: { id: 'c1' } });
+    expect(comment.errors).toBeFalsy();
+    expect(comment.data.comment.id).toEqual('c1');
   });
 
   it('should return error when not part of private squad', async () => {

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -730,14 +730,14 @@ export const resolvers: IResolvers<any, Context> = {
         ctx,
         info,
         (builder) => ({
-          queryBuilder: builder.queryBuilder
-            .where(`"${builder.alias}"."id" = :id`, { id })
-            .andWhere(`"${builder.alias}"."userId" = :userId`, {
-              userId: ctx.userId,
-            }),
+          queryBuilder: builder.queryBuilder.where(
+            `"${builder.alias}"."id" = :id`,
+            { id },
+          ),
           ...builder,
         }),
       );
+
       const post = await ctx.con
         .getRepository(Post)
         .findOneByOrFail({ id: comment.postId });


### PR DESCRIPTION
- Removed check for same user when reading comment by ID. This is needed to show comment previews for mobile UX.

Related PR: 
- https://github.com/dailydotdev/apps/pull/2841