### PR TITLE
fix: post-join-squad stale state of the source query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,6 @@ export default async function app(
           },
           postUpvotes: true,
           sources: true,
-          source: true,
           searchTags: true,
           userReadingRankHistory: true,
           userReadHistory: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,6 @@ export default async function app(
             extendKey: userExtendKey,
           },
           postUpvotes: true,
-          sources: true,
           searchTags: true,
           userReadingRankHistory: true,
           userReadHistory: true,


### PR DESCRIPTION
In the meantime, we will remove caching of the `source` query to properly display user membership after joining/leaving.