### PR TITLE
fix: ignore `/graphql` from requests counter

### DIFF
--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -162,6 +162,10 @@ export const tracer = (serviceName: string) => {
     fastify.addHook('onResponse', async (req, res) => {
       addApiSpanLabels(req.span, req, res);
 
+      if (req.routeOptions.url === '/graphql') {
+        return;
+      }
+
       requestCounter.add(1, {
         [TelemetrySemanticAttributes.HTTP_METHOD]: req.method,
         [TelemetrySemanticAttributes.HTTP_ROUTE]: req.routeOptions.url,


### PR DESCRIPTION
It is already counted in the graphql counter, so we don't really need it twice.