### PR TITLE
fix: remove the graphql operation type from metrics

### DIFF
--- a/src/schema/trace.ts
+++ b/src/schema/trace.ts
@@ -26,7 +26,6 @@ export function traceResolver<TSource, TArgs, TReturn>(
       context.metricGraphqlCounter.add(1, {
         ['graphql.field.name']: info.fieldName,
         ['graphql.operation.name']: info.operation?.name?.value,
-        ['graphql.operation.type']: info.operation?.operation,
       });
     }
     return next(source, args, context, info);


### PR DESCRIPTION
This removes the `graphql_operation_type` column. Not really useful data since we don't re-use function names for query and mutation.

![image](https://github.com/dailydotdev/daily-api/assets/1681525/d5542ede-bdaf-4d29-8cf1-25f2f7ad7f1e)