### PR TITLE
fix: proper arguments for error when logged

### DIFF
--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -187,11 +187,15 @@ export class FeedLofnConfigGenerator implements FeedConfigGenerator {
 
         return result;
       } catch (error) {
-        ctx.log.error('Failed to generate feed config', error, {
-          userIdExists: !!opts.user_id,
-          feedVersion: this.opts.feed_version,
-          generator: 'FeedLofnConfigGenerator',
-        });
+        ctx.log.error(
+          {
+            err: error,
+            userIdExists: !!opts.user_id,
+            feedVersion: this.opts.feed_version,
+            generator: 'FeedLofnConfigGenerator',
+          },
+          'Failed to generate feed config',
+        );
 
         throw error;
       }


### PR DESCRIPTION
I missed the order so errors don't show up as they should in GC.