### PR TITLE
feat: comment downvote

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -87,5 +87,5 @@ export const parseDate = (date: string | Date): Date | undefined => {
 };
 
 export const toGQLEnum = (value: Record<string, string>, name: string) => {
-  return `enum ${name} { ${Object.keys(value).join(' ')} }`;
+  return `enum ${name} { ${Object.values(value).join(' ')} }`;
 };

--- a/src/common/vote.ts
+++ b/src/common/vote.ts
@@ -1,5 +1,80 @@
+import { ValidationError } from 'apollo-server-errors';
+import { NotFoundError, TypeOrmError } from '../errors';
+import { Post, UserPost } from '../entity';
+import { GQLEmptyResponse } from '../schema/common';
+import { ensureSourcePermissions } from '../schema/sources';
+import { Context } from '../Context';
+
 export enum UserVote {
   Up = 1,
   None = 0,
   Down = -1,
 }
+
+export enum UserVoteEntity {
+  Comment = 'comment',
+  Post = 'post',
+}
+
+export type UserVoteProps = {
+  ctx: Context;
+  id: string;
+  vote: UserVote;
+};
+
+export const votePost = async ({
+  ctx,
+  id,
+  vote,
+}: UserVoteProps): Promise<GQLEmptyResponse> => {
+  try {
+    if (!Object.values(UserVote).includes(vote)) {
+      throw new ValidationError('Unsupported vote type');
+    }
+
+    const post = await ctx.con.getRepository(Post).findOneByOrFail({ id });
+    await ensureSourcePermissions(ctx, post.sourceId);
+    const userPostRepo = ctx.con.getRepository(UserPost);
+
+    switch (vote) {
+      case UserVote.Up:
+        await userPostRepo.save({
+          postId: id,
+          userId: ctx.userId,
+          vote: UserVote.Up,
+          hidden: false,
+        });
+
+        break;
+      case UserVote.Down:
+        await userPostRepo.save({
+          postId: id,
+          userId: ctx.userId,
+          vote: UserVote.Down,
+          hidden: true,
+        });
+
+        break;
+      case UserVote.None:
+        await userPostRepo.save({
+          postId: id,
+          userId: ctx.userId,
+          vote: UserVote.None,
+          hidden: false,
+        });
+
+        break;
+      default:
+        throw new ValidationError('Unsupported vote type');
+    }
+  } catch (err) {
+    // Foreign key violation
+    if (err?.code === TypeOrmError.FOREIGN_KEY) {
+      throw new NotFoundError('Post or user not found');
+    }
+
+    throw err;
+  }
+
+  return { _: true };
+};

--- a/src/common/vote.ts
+++ b/src/common/vote.ts
@@ -1,9 +1,10 @@
 import { ValidationError } from 'apollo-server-errors';
 import { NotFoundError, TypeOrmError } from '../errors';
-import { Post, UserPost } from '../entity';
+import { Comment, CommentUpvote, Post, UserPost } from '../entity';
 import { GQLEmptyResponse } from '../schema/common';
 import { ensureSourcePermissions } from '../schema/sources';
 import { Context } from '../Context';
+import { UserComment } from '../entity/user/UserComment';
 
 export enum UserVote {
   Up = 1,
@@ -22,15 +23,21 @@ export type UserVoteProps = {
   vote: UserVote;
 };
 
+const validateVoteType = ({
+  vote,
+}: Pick<UserVoteProps, 'vote'>): void | never => {
+  if (!Object.values(UserVote).includes(vote)) {
+    throw new ValidationError('Unsupported vote type');
+  }
+};
+
 export const votePost = async ({
   ctx,
   id,
   vote,
 }: UserVoteProps): Promise<GQLEmptyResponse> => {
   try {
-    if (!Object.values(UserVote).includes(vote)) {
-      throw new ValidationError('Unsupported vote type');
-    }
+    validateVoteType({ vote });
 
     const post = await ctx.con.getRepository(Post).findOneByOrFail({ id });
     await ensureSourcePermissions(ctx, post.sourceId);
@@ -71,6 +78,87 @@ export const votePost = async ({
     // Foreign key violation
     if (err?.code === TypeOrmError.FOREIGN_KEY) {
       throw new NotFoundError('Post or user not found');
+    }
+
+    throw err;
+  }
+
+  return { _: true };
+};
+
+export const voteComment = async ({
+  ctx,
+  id,
+  vote,
+}: UserVoteProps): Promise<GQLEmptyResponse> => {
+  try {
+    validateVoteType({ vote });
+
+    const comment = await ctx.con.getRepository(Comment).findOne({
+      where: {
+        id,
+      },
+      relations: ['post'],
+    });
+
+    if (!comment) {
+      throw new NotFoundError('Comment not found');
+    }
+
+    const post = await comment?.post;
+    await ensureSourcePermissions(ctx, post.sourceId);
+
+    await ctx.con.transaction(async (entityManager) => {
+      const userCommentRepo = entityManager.getRepository(UserComment);
+      const commentUpvoteRepo = entityManager.getRepository(CommentUpvote);
+
+      switch (vote) {
+        case UserVote.Up:
+          await userCommentRepo.save({
+            commentId: id,
+            userId: ctx.userId,
+            vote: UserVote.Up,
+          });
+
+          // TODO AS-211 remove this when API reads votes from user_comment
+          await commentUpvoteRepo.save({
+            commentId: id,
+            userId: ctx.userId,
+          });
+          // TODO AS-211 remove this when API reads votes from user_comment
+
+          break;
+        case UserVote.Down:
+          await userCommentRepo.save({
+            commentId: id,
+            userId: ctx.userId,
+            vote: UserVote.Down,
+          });
+
+          break;
+        case UserVote.None:
+          await userCommentRepo.save({
+            commentId: id,
+            userId: ctx.userId,
+            vote: UserVote.None,
+          });
+
+          // TODO AS-211 remove this when API reads votes from user_comment
+          commentUpvoteRepo.delete({
+            commentId: id,
+            userId: ctx.userId,
+          });
+          // TODO AS-211 remove this when API reads votes from user_comment
+
+          break;
+        default:
+          throw new ValidationError('Unsupported vote type');
+      }
+    });
+  } catch (err) {
+    // Foreign key violation
+    if (err?.code === TypeOrmError.FOREIGN_KEY) {
+      throw new NotFoundError('Comment or user not found');
     }
 
     throw err;

--- a/src/migration/1711649106510-UserCommentTriggers.ts
+++ b/src/migration/1711649106510-UserCommentTriggers.ts
@@ -1,0 +1,92 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserCommentTriggers1711649106510 implements MigrationInterface {
+    name = 'UserCommentTriggers1711649106510'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE OR REPLACE FUNCTION user_comment_vote_insert_trigger_function()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                IF NEW.vote = 1 THEN
+                    UPDATE comment SET upvotes = upvotes + 1 WHERE id = NEW."commentId";
+                ELSIF NEW.vote = -1 THEN
+                    UPDATE comment SET downvotes = downvotes + 1 WHERE id = NEW."commentId";
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        `)
+        await queryRunner.query(`
+            CREATE TRIGGER user_comment_vote_insert_trigger
+            AFTER INSERT ON user_comment
+            FOR EACH ROW
+            EXECUTE FUNCTION user_comment_vote_insert_trigger_function();
+        `)
+
+        await queryRunner.query(`
+            CREATE OR REPLACE FUNCTION user_comment_vote_update_trigger_function()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                IF OLD.vote IS DISTINCT FROM NEW.vote THEN
+                    IF OLD.vote = 0 AND NEW.vote = 1 THEN
+                        UPDATE comment SET upvotes = upvotes + 1 WHERE id = NEW."commentId";
+                    ELSIF OLD.vote = 0 AND NEW.vote = -1 THEN
+                        UPDATE comment SET downvotes = downvotes + 1 WHERE id = NEW."commentId";
+                    ELSIF OLD.vote = 1 AND NEW.vote = 0 THEN
+                        UPDATE comment SET upvotes = upvotes - 1 WHERE id = NEW."commentId";
+                    ELSIF OLD.vote = -1 AND NEW.vote = 0 THEN
+                        UPDATE comment SET downvotes = downvotes - 1 WHERE id = NEW."commentId";
+                    ELSIF OLD.vote = 1 AND NEW.vote = -1 THEN
+                        UPDATE comment SET upvotes = upvotes - 1, downvotes = downvotes + 1 WHERE id = NEW."commentId";
+                    ELSIF OLD.vote = -1 AND NEW.vote = 1 THEN
+                        UPDATE comment SET downvotes = downvotes - 1, upvotes = upvotes + 1 WHERE id = NEW."commentId";
+                    END IF;
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        `)
+        await queryRunner.query(`
+            CREATE TRIGGER user_comment_vote_update_trigger
+            AFTER UPDATE ON user_comment
+            FOR EACH ROW
+            EXECUTE FUNCTION user_comment_vote_update_trigger_function();
+        `)
+
+        await queryRunner.query(`
+            CREATE OR REPLACE FUNCTION user_comment_vote_delete_trigger_function()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                IF OLD.vote = 1 THEN
+                    UPDATE comment SET upvotes = upvotes - 1 WHERE id = OLD."commentId";
+                ELSIF OLD.vote = -1 THEN
+                    UPDATE comment SET downvotes = downvotes - 1 WHERE id = OLD."commentId";
+                END IF;
+
+                RETURN OLD;
+            END;
+            $$ LANGUAGE plpgsql;
+        `)
+        await queryRunner.query(`
+            CREATE TRIGGER user_comment_vote_delete_trigger
+            AFTER DELETE ON user_comment
+            FOR EACH ROW
+            EXECUTE FUNCTION user_comment_vote_delete_trigger_function();
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP TRIGGER IF EXISTS user_comment_vote_delete_trigger ON user_comment')
+        await queryRunner.query('DROP FUNCTION IF EXISTS user_comment_vote_delete_trigger_function')
+
+        await queryRunner.query('DROP TRIGGER IF EXISTS user_comment_vote_update_trigger ON user_comment')
+        await queryRunner.query('DROP FUNCTION IF EXISTS user_comment_vote_update_trigger_function')
+
+        await queryRunner.query('DROP TRIGGER IF EXISTS user_comment_vote_insert_trigger ON user_comment')
+        await queryRunner.query('DROP FUNCTION IF EXISTS user_comment_vote_insert_trigger_function')
+    }
+
+}

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -45,6 +45,7 @@ import {
   UserVote,
   UserVoteEntity,
   votePost,
+  voteComment,
 } from '../common';
 import { getSearchQuery, GQLEmptyResponse, processSearchQuery } from './common';
 import { ActiveView } from '../entity/ActiveView';
@@ -1397,7 +1398,7 @@ export const resolvers: IResolvers<any, Context> = {
       return { _: null };
     },
     vote: async (
-      source,
+      _,
       {
         id,
         vote,
@@ -1408,6 +1409,8 @@ export const resolvers: IResolvers<any, Context> = {
       switch (entity) {
         case UserVoteEntity.Post:
           return votePost({ ctx, id, vote });
+        case UserVoteEntity.Comment:
+          return voteComment({ ctx, id, vote });
         default:
           throw new ValidationError('Unsupported vote entity');
       }

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -42,6 +42,9 @@ import {
   GQLUserStreakTz,
   toGQLEnum,
   getUserPermalink,
+  UserVote,
+  UserVoteEntity,
+  votePost,
 } from '../common';
 import { getSearchQuery, GQLEmptyResponse, processSearchQuery } from './common';
 import { ActiveView } from '../entity/ActiveView';
@@ -429,6 +432,8 @@ export const typeDefs = /* GraphQL */ `
 
   ${toGQLEnum(AcquisitionChannel, 'AcquisitionChannel')}
 
+  ${toGQLEnum(UserVoteEntity, 'UserVoteEntity')}
+
   extend type Query {
     """
     Get user based on logged in session
@@ -647,6 +652,26 @@ export const typeDefs = /* GraphQL */ `
     Clears the user marketing CTA and marks it as read
     """
     clearUserMarketingCta(campaignId: String!): EmptyResponse @auth
+
+    """
+    Vote entity
+    """
+    vote(
+      """
+      Id of the entity
+      """
+      id: ID!
+
+      """
+      Entity to vote (post, comment..)
+      """
+      entity: UserVoteEntity!
+
+      """
+      Vote type
+      """
+      vote: Int!
+    ): EmptyResponse @auth
   }
 `;
 
@@ -1370,6 +1395,22 @@ export const resolvers: IResolvers<any, Context> = {
       }
 
       return { _: null };
+    },
+    vote: async (
+      source,
+      {
+        id,
+        vote,
+        entity,
+      }: { id: string; vote: UserVote; entity: UserVoteEntity },
+      ctx: Context,
+    ): Promise<GQLEmptyResponse> => {
+      switch (entity) {
+        case UserVoteEntity.Post:
+          return votePost({ ctx, id, vote });
+        default:
+          throw new ValidationError('Unsupported vote entity');
+      }
     },
   }),
   User: {


### PR DESCRIPTION
- introduce new `vote` mutation (for all entities)
- add support for comment downvote
  - save to both `user_comment` and `comment_upvote` from old and new mutation
- switch to triggers to increment comment upvote/downvote (works with old and new mutations)
- update tests to confirm old/new use cases work