### PR TITLE
fix: send proper time in the daily digest

### DIFF
--- a/__tests__/cron/dailyDigest.ts
+++ b/__tests__/cron/dailyDigest.ts
@@ -16,7 +16,7 @@ import {
 import { logger } from '../../src/logger';
 import { getTimezoneOffset } from 'date-fns-tz';
 import { crons } from '../../src/cron/index';
-import { setDay } from 'date-fns';
+import { setDay, startOfHour } from 'date-fns';
 
 let con: DataSource;
 
@@ -362,7 +362,7 @@ describe('dailyDigest cron', () => {
       })),
     );
 
-    const timestampBeforeCron = Date.now();
+    const timestampBeforeCron = startOfHour(new Date()).getTime();
 
     await expectSuccessfulCron(cron);
 

--- a/src/cron/dailyDigest.ts
+++ b/src/cron/dailyDigest.ts
@@ -9,11 +9,9 @@ import {
   UserPersonalizedDigestSendType,
 } from '../entity';
 import { Cron } from './cron';
-import { isWeekend } from 'date-fns';
+import { isWeekend, addHours, startOfHour, subDays } from 'date-fns';
 
 const sendType = UserPersonalizedDigestSendType.workdays;
-const oneHourMs = 60 * 60 * 1000;
-const oneDayMs = 24 * oneHourMs;
 
 const cron: Cron = {
   name: 'daily-digest',
@@ -31,15 +29,18 @@ const cron: Cron = {
         sendType,
       });
 
-    const timestamp = Date.now();
+    // Make sure digest is sent at the beginning of the hour
+    const timestamp = startOfHour(new Date());
 
     await schedulePersonalizedDigestSubscriptions({
       queryBuilder: personalizedDigestQuery,
       logger,
       handler: async ({ personalizedDigest, emailBatchId }) => {
-        const hourOffsetMs = digestPreferredHourOffset * oneHourMs;
-        const emailSendTimestamp = timestamp + hourOffsetMs; // schedule send in X hours to match digest offset
-        const previousSendTimestamp = timestamp - oneDayMs;
+        const emailSendTimestamp = addHours(
+          timestamp,
+          digestPreferredHourOffset,
+        ).getTime(); // schedule send in X hours to match digest offset
+        const previousSendTimestamp = subDays(timestamp, 1).getTime();
 
         const sendDateInTimezone = utcToZonedTime(
           emailSendTimestamp,


### PR DESCRIPTION
Make the cron job agnostic to when it was triggered to make sure digest is sent on the same time every day.