### PR TITLE
chore: reduce api requests resources

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -132,7 +132,7 @@ const wsLimits: pulumi.Input<{
 
 const bgLimits: pulumi.Input<{
   [key: string]: pulumi.Input<string>;
-}> = { cpu: '250m', memory: '256Mi' };
+}> = { cpu: '50m', memory: '150Mi' };
 
 const initialDelaySeconds = 20;
 const readinessProbe: k8s.types.input.core.v1.Probe = {

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -114,11 +114,11 @@ if (isPersonalizedDigestEnabled) {
   );
 }
 
-const memory = 640;
+const memory = 400;
 const limits: pulumi.Input<{
   [key: string]: pulumi.Input<string>;
 }> = {
-  cpu: '1',
+  cpu: '800m',
   memory: `${memory}Mi`,
 };
 

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -126,7 +126,7 @@ const wsMemory = 2048;
 const wsLimits: pulumi.Input<{
   [key: string]: pulumi.Input<string>;
 }> = {
-  cpu: '500m',
+  cpu: '300m',
   memory: `${wsMemory}Mi`,
 };
 


### PR DESCRIPTION
Reduces the requested resources as they're a bit over requested compared to the actual usage.

<table>
<tr>
 <td>Memory usage
 <td>CPU usage
<tr>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/811f6640-13e5-4152-b4db-7c6029f82b71>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/8ed77628-f3c1-4146-9852-165235ccbdb7>
<tr>
 <td colspan=2>
  Reduces the requested memory from 640MiB to 400MiB<br />
  And CPU request from 1000m to 800m
 </td>
<tr>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/a9c54e50-e7a1-429d-af54-43b833487e48>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/dd9c22ec-7339-4d45-b9e0-33b616588f59>
<tr>
 <td colspan=2>
  Reduces the requested memory from 256MiB to 150MiB<br />
  And CPU request from 250m to 50m
 </td>
<tr>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/c7034170-2908-4693-a8d0-22d15e942963>
 <td><img src=https://github.com/dailydotdev/daily-api/assets/1681525/a24b8241-669f-434e-b8ee-606e886a0e61>
<tr>
 <td colspan=2>
  Reduces the cpu request from 500m to 300m. Leaving memory as is.
 </td>
</table>