### PR TITLE
fix: truncate title for slug

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -161,6 +161,21 @@ describe('slug field', () => {
     expect(res.data.post.slug).toBe('gem-se--p1');
   });
 
+  it('should return the post slug truncated if title is too long', async () => {
+    const repo = con.getRepository(ArticlePost);
+    await repo.update(
+      { id: 'p1' },
+      {
+        title:
+          'Donec vulputate neque a est convallis, at interdum ligula fermentum. Pellentesque euismod semper urna, ac eleifend felis viverra nec. Phasellus sit am',
+      },
+    );
+    const res = await client.query(QUERY);
+    expect(res.data.post.slug).toBe(
+      'donec-vulputate-neque-a-est-convallis-at-interdum-ligula-fermentum-pellentesque-euismod-semper-urn-p1',
+    );
+  });
+
   it('should return the post slug when searching for slug', async () => {
     const SUB_QUERY = `{
     post(id: "p1-p1") {

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -238,7 +238,7 @@ export class Post {
     nullable: false,
     unique: true,
     generatedType: 'STORED',
-    asExpression: `trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(post.title,'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))`,
+    asExpression: `trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(post.title,100),'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))`,
   })
   @Index('IDX_post_slug', { unique: true })
   slug: string;

--- a/src/migration/1712315208717-PostSlugMaxLength.ts
+++ b/src/migration/1712315208717-PostSlugMaxLength.ts
@@ -1,0 +1,72 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostSlugMaxLength1712315208717 implements MigrationInterface {
+  name = 'PostSlugMaxLength1712315208717';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "typeorm_metadata" REPLICA IDENTITY FULL`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_post_slug"`);
+    await queryRunner.query(
+      `ALTER TABLE "post" DROP CONSTRAINT "UQ_cd1bddce36edc3e766798eab376"`,
+    );
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "slug"`);
+    await queryRunner.query(
+      `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "database" = $3 AND "schema" = $4 AND "table" = $5`,
+      ['GENERATED_COLUMN', 'slug', 'api', 'public', 'post'],
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post" ADD "slug" text GENERATED ALWAYS AS (trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(post.title,100),'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))) STORED NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post" ADD CONSTRAINT "UQ_cd1bddce36edc3e766798eab376" UNIQUE ("slug")`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        'api',
+        'public',
+        'post',
+        'GENERATED_COLUMN',
+        'slug',
+        "trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(post.title,100),'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))",
+      ],
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_post_slug" ON "post" ("slug") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_post_slug"`);
+    await queryRunner.query(
+      `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "database" = $3 AND "schema" = $4 AND "table" = $5`,
+      ['GENERATED_COLUMN', 'slug', 'api', 'public', 'post'],
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post" DROP CONSTRAINT "UQ_cd1bddce36edc3e766798eab376"`,
+    );
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "slug"`);
+    await queryRunner.query(
+      `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        'api',
+        'public',
+        'post',
+        'GENERATED_COLUMN',
+        'slug',
+        "trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(post.title,'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))",
+      ],
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post" ADD "slug" text GENERATED ALWAYS AS (trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(post.title,'')||'-'||post.id)), '[^a-z0-9-]+', '-', 'gi'))) STORED NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post" ADD CONSTRAINT "UQ_cd1bddce36edc3e766798eab376" UNIQUE ("slug")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_post_slug" ON "post" ("slug") `,
+    );
+  }
+}


### PR DESCRIPTION
Added truncate of 100 to title part.
Had to add replica to typeorm table (some of the old migration downs would actually fail if we ever needed to run them)

Added specific test case as well to ensure it.