### PR TITLE
chore: reduce requested cores for api-private

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -299,7 +299,7 @@ if (isAdhocEnv) {
       maxReplicas: 2,
       limits: {
         memory: '256Mi',
-        cpu: '500m',
+        cpu: '25m',
       },
       readinessProbe,
       livenessProbe,


### PR DESCRIPTION
Last 180 days it's never really passed 10milli cpu