### PR TITLE
fix: vote change handling and move to typed workers

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -387,6 +387,19 @@ describe('post upvote', () => {
       { postId: 'p1', userId: '1' },
     ]);
   });
+
+  it('should not notify when vote stays the same', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: base,
+        before: base,
+        op: 'u',
+        table: 'user_post',
+      }),
+    );
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe('comment upvote', () => {
@@ -507,6 +520,19 @@ describe('comment upvote', () => {
       'comment-upvoted',
       { commentId: 'c1', userId: '1' },
     ]);
+  });
+
+  it('should not notify when vote stays the same', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: base,
+        before: base,
+        op: 'u',
+        table: 'user_comment',
+      }),
+    );
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -2236,6 +2262,19 @@ describe('post downvote', () => {
       { postId: 'p1', userId: '1' },
     ]);
   });
+
+  it('should not notify when vote stays the same', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: base,
+        before: base,
+        op: 'u',
+        table: 'user_post',
+      }),
+    );
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe('comment downvote', () => {
@@ -2356,5 +2395,18 @@ describe('comment downvote', () => {
       'api.v1.comment-downvoted',
       { commentId: 'c1', userId: '1' },
     ]);
+  });
+
+  it('should not notify when vote stays the same', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: base,
+        before: base,
+        op: 'u',
+        table: 'user_comment',
+      }),
+    );
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(0);
   });
 });

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -17,8 +17,6 @@ import {
 } from '../../../src/entity';
 import {
   notifyCommentCommented,
-  notifyCommentUpvoteCanceled,
-  notifyCommentUpvoted,
   notifyFeatureAccess,
   notifyMemberJoinedSource,
   notifyNewPostMention,
@@ -27,8 +25,6 @@ import {
   notifyPostCommented,
   notifyPostReport,
   notifyCommentReport,
-  notifyPostUpvoteCanceled,
-  notifyPostUpvoted,
   notifySendAnalyticsReport,
   notifySettingsUpdated,
   notifySourceFeedAdded,
@@ -54,8 +50,6 @@ import {
   notifyUserReadmeUpdated,
   triggerTypedEvent,
   notifyReputationIncrease,
-  notifyPostDownvoted,
-  notifyPostDownvoteCanceled,
 } from '../../../src/common';
 import worker from '../../../src/workers/cdc/primary';
 import {
@@ -103,10 +97,6 @@ import { UserComment } from '../../../src/entity/user/UserComment';
 jest.mock('../../../src/common', () => ({
   ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
   triggerTypedEvent: jest.fn(),
-  notifyPostUpvoted: jest.fn(),
-  notifyPostUpvoteCanceled: jest.fn(),
-  notifyCommentUpvoteCanceled: jest.fn(),
-  notifyCommentUpvoted: jest.fn(),
   notifyCommentCommented: jest.fn(),
   notifyPostCommented: jest.fn(),
   notifyCommentEdited: jest.fn(),
@@ -142,8 +132,6 @@ jest.mock('../../../src/common', () => ({
   notifyPostCollectionUpdated: jest.fn(),
   notifyUserReadmeUpdated: jest.fn(),
   notifyReputationIncrease: jest.fn(),
-  notifyPostDownvoted: jest.fn(),
-  notifyPostDownvoteCanceled: jest.fn(),
 }));
 
 let con: DataSource;
@@ -303,11 +291,13 @@ describe('post upvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostUpvoted).toHaveBeenCalledTimes(1);
-    expect(notifyPostUpvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyPostUpvoted).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'post-upvoted',
+      {
+        postId: 'p1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -321,11 +311,11 @@ describe('post upvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostUpvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyPostUpvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['p1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'post-upvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 
   it('should notify on upvote updated', async () => {
@@ -341,11 +331,13 @@ describe('post upvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostUpvoted).toHaveBeenCalledTimes(1);
-    expect(notifyPostUpvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyPostUpvoted).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'post-upvoted',
+      {
+        postId: 'p1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -362,20 +354,20 @@ describe('post upvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostUpvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyPostUpvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['p1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'post-upvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 
-  it('should not notify if entity is not upvote', async () => {
+  it('should notify on upvote from downvote', async () => {
     await expectSuccessfulBackground(
       worker,
       mockChangeMessage<ObjectType>({
         after: {
           ...base,
-          vote: UserVote.None,
+          vote: UserVote.Up,
         },
         before: {
           ...base,
@@ -385,8 +377,15 @@ describe('post upvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostUpvoteCanceled).toHaveBeenCalledTimes(0);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.post-downvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1].slice(1)).toEqual([
+      'post-upvoted',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 });
 
@@ -413,11 +412,13 @@ describe('comment upvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(notifyCommentUpvoted).toHaveBeenCalledTimes(1);
-    expect(notifyCommentUpvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyCommentUpvoted).mock.calls[0].slice(1)).toEqual([
-      'c1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'comment-upvoted',
+      {
+        commentId: 'c1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -431,11 +432,11 @@ describe('comment upvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(notifyCommentUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyCommentUpvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyCommentUpvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['c1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'comment-upvote-canceled',
+      { commentId: 'c1', userId: '1' },
+    ]);
   });
 
   it('should notify on upvote updated', async () => {
@@ -451,11 +452,13 @@ describe('comment upvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(notifyCommentUpvoted).toHaveBeenCalledTimes(1);
-    expect(notifyCommentUpvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyCommentUpvoted).mock.calls[0].slice(1)).toEqual([
-      'c1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'comment-upvoted',
+      {
+        commentId: 'c1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -472,20 +475,20 @@ describe('comment upvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(notifyCommentUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyCommentUpvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyCommentUpvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['c1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'comment-upvote-canceled',
+      { commentId: 'c1', userId: '1' },
+    ]);
   });
 
-  it('should not notify if entity is not upvote', async () => {
+  it('should notify on upvote from downvote', async () => {
     await expectSuccessfulBackground(
       worker,
       mockChangeMessage<ObjectType>({
         after: {
           ...base,
-          vote: UserVote.None,
+          vote: UserVote.Up,
         },
         before: {
           ...base,
@@ -495,8 +498,15 @@ describe('comment upvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(notifyCommentUpvoted).toHaveBeenCalledTimes(0);
-    expect(notifyCommentUpvoteCanceled).toHaveBeenCalledTimes(0);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.comment-downvote-canceled',
+      { commentId: 'c1', userId: '1' },
+    ]);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1].slice(1)).toEqual([
+      'comment-upvoted',
+      { commentId: 'c1', userId: '1' },
+    ]);
   });
 });
 
@@ -2130,11 +2140,13 @@ describe('post downvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostDownvoted).toHaveBeenCalledTimes(1);
-    expect(notifyPostDownvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyPostDownvoted).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.post-downvoted',
+      {
+        postId: 'p1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -2148,11 +2160,11 @@ describe('post downvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostDownvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostDownvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyPostDownvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['p1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.post-downvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 
   it('should notify on downvote updated', async () => {
@@ -2168,11 +2180,13 @@ describe('post downvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostDownvoted).toHaveBeenCalledTimes(1);
-    expect(notifyPostDownvoteCanceled).toHaveBeenCalledTimes(0);
-    expect(jest.mocked(notifyPostDownvoted).mock.calls[0].slice(1)).toEqual([
-      'p1',
-      '1',
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.post-downvoted',
+      {
+        postId: 'p1',
+        userId: '1',
+      },
     ]);
   });
 
@@ -2189,20 +2203,20 @@ describe('post downvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostDownvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostDownvoteCanceled).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(notifyPostDownvoteCanceled).mock.calls[0].slice(1),
-    ).toEqual(['p1', '1']);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'api.v1.post-downvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 
-  it('should not notify if entity is not downvote', async () => {
+  it('should notify on downvote from upvote', async () => {
     await expectSuccessfulBackground(
       worker,
       mockChangeMessage<ObjectType>({
         after: {
           ...base,
-          vote: UserVote.None,
+          vote: UserVote.Down,
         },
         before: {
           ...base,
@@ -2212,8 +2226,15 @@ describe('post downvote', () => {
         table: 'user_post',
       }),
     );
-    expect(notifyPostDownvoted).toHaveBeenCalledTimes(0);
-    expect(notifyPostDownvoteCanceled).toHaveBeenCalledTimes(0);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'post-upvote-canceled',
+      { postId: 'p1', userId: '1' },
+    ]);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1].slice(1)).toEqual([
+      'api.v1.post-downvoted',
+      { postId: 'p1', userId: '1' },
+    ]);
   });
 });
 
@@ -2310,13 +2331,13 @@ describe('comment downvote', () => {
     ]);
   });
 
-  it('should not notify if entity is not downvote', async () => {
+  it('should notify on downvote from upvote', async () => {
     await expectSuccessfulBackground(
       worker,
       mockChangeMessage<ObjectType>({
         after: {
           ...base,
-          vote: UserVote.None,
+          vote: UserVote.Down,
         },
         before: {
           ...base,
@@ -2326,6 +2347,14 @@ describe('comment downvote', () => {
         table: 'user_comment',
       }),
     );
-    expect(triggerTypedEvent).toHaveBeenCalledTimes(0);
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+      'comment-upvote-canceled',
+      { commentId: 'c1', userId: '1' },
+    ]);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1].slice(1)).toEqual([
+      'api.v1.comment-downvoted',
+      { commentId: 'c1', userId: '1' },
+    ]);
   });
 });

--- a/__tests__/workers/commentUpvoteCanceledRep.ts
+++ b/__tests__/workers/commentUpvoteCanceledRep.ts
@@ -1,4 +1,4 @@
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/commentUpvoteCanceledRep';
 import {
   ArticlePost,
@@ -13,6 +13,7 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { typedWorkers } from '../../src/workers';
 
 let con: DataSource;
 
@@ -20,51 +21,61 @@ beforeAll(async () => {
   con = await createOrGetConnection();
 });
 
-beforeEach(async () => {
-  jest.resetAllMocks();
-  await saveFixtures(con, Source, sourcesFixture);
-  await saveFixtures(con, ArticlePost, postsFixture);
-  await con.getRepository(User).save([
-    {
-      id: '1',
-      name: 'Ido',
-      image: 'https://daily.dev/ido.jpg',
-      reputation: 250,
-    },
-  ]);
-  await con.getRepository(Comment).save([
-    {
-      id: 'c1',
-      postId: 'p1',
-      userId: '1',
-      content: 'parent comment',
-      createdAt: new Date(2020, 1, 6, 0, 0),
-      upvotes: 1,
-    },
-  ]);
-});
+describe('commentUpvoteCanceledRep worker', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, ArticlePost, postsFixture);
+    await con.getRepository(User).save([
+      {
+        id: '1',
+        name: 'Ido',
+        image: 'https://daily.dev/ido.jpg',
+        reputation: 250,
+      },
+    ]);
+    await con.getRepository(Comment).save([
+      {
+        id: 'c1',
+        postId: 'p1',
+        userId: '1',
+        content: 'parent comment',
+        createdAt: new Date(2020, 1, 6, 0, 0),
+        upvotes: 1,
+      },
+    ]);
+  });
 
-it('should delete the reputation event relevant to granting of reputation', async () => {
-  const repo = con.getRepository(ReputationEvent);
-  await repo.save(
-    repo.create({
+  it('should be registered', () => {
+    const registeredWorker = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+
+    expect(registeredWorker).toBeDefined();
+  });
+
+  it('should delete the reputation event relevant to granting of reputation', async () => {
+    const repo = con.getRepository(ReputationEvent);
+    await repo.save(
+      repo.create({
+        grantById: '2',
+        grantToId: '1',
+        targetId: 'c1',
+        targetType: ReputationType.Comment,
+        reason: ReputationReason.CommentUpvoted,
+      }),
+    );
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      commentId: 'c1',
+    });
+    const deleted = await repo.findOneBy({
       grantById: '2',
       grantToId: '1',
       targetId: 'c1',
-      targetType: ReputationType.Comment,
-      reason: ReputationReason.CommentUpvoted,
-    }),
-  );
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    commentId: 'c1',
+      targetType: ReputationType.Post,
+      reason: ReputationReason.PostUpvoted,
+    });
+    expect(deleted).toEqual(null);
   });
-  const deleted = await repo.findOneBy({
-    grantById: '2',
-    grantToId: '1',
-    targetId: 'c1',
-    targetType: ReputationType.Post,
-    reason: ReputationReason.PostUpvoted,
-  });
-  expect(deleted).toEqual(null);
 });

--- a/__tests__/workers/commentUpvotedRep.ts
+++ b/__tests__/workers/commentUpvotedRep.ts
@@ -1,4 +1,4 @@
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/commentUpvotedRep';
 import {
   ArticlePost,
@@ -11,6 +11,7 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { typedWorkers } from '../../src/workers';
 
 let con: DataSource;
 
@@ -18,63 +19,73 @@ beforeAll(async () => {
   con = await createOrGetConnection();
 });
 
-beforeEach(async () => {
-  jest.resetAllMocks();
-  await saveFixtures(con, Source, sourcesFixture);
-  await saveFixtures(con, ArticlePost, postsFixture);
-  await con.getRepository(User).save([
-    {
-      id: '1',
-      name: 'Ido',
-      image: 'https://daily.dev/ido.jpg',
-      reputation: 53,
-    },
-    {
-      id: '2',
-      name: 'Lee',
-      image: 'https://daily.dev/lee.jpg',
-      reputation: 251,
-    },
-  ]);
-  await con.getRepository(Comment).save([
-    {
-      id: 'c1',
-      postId: 'p1',
+describe('commentUpvotedRep worker', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, ArticlePost, postsFixture);
+    await con.getRepository(User).save([
+      {
+        id: '1',
+        name: 'Ido',
+        image: 'https://daily.dev/ido.jpg',
+        reputation: 53,
+      },
+      {
+        id: '2',
+        name: 'Lee',
+        image: 'https://daily.dev/lee.jpg',
+        reputation: 251,
+      },
+    ]);
+    await con.getRepository(Comment).save([
+      {
+        id: 'c1',
+        postId: 'p1',
+        userId: '1',
+        content: 'parent comment',
+        createdAt: new Date(2020, 1, 6, 0, 0),
+        upvotes: 1,
+      },
+    ]);
+  });
+
+  it('should be registered', () => {
+    const registeredWorker = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+
+    expect(registeredWorker).toBeDefined();
+  });
+
+  it('should create a reputation event that increases reputation', async () => {
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      commentId: 'c1',
+    });
+    const event = await con
+      .getRepository(ReputationEvent)
+      .findOne({ where: { targetId: 'c1', grantById: '2', grantToId: '1' } });
+    expect(event!.amount).toEqual(50);
+  });
+
+  it('should not create a reputation event when the upvoting user is ineligible', async () => {
+    await con.getRepository(User).update({ id: '2' }, { reputation: 1 });
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      commentId: 'c1',
+    });
+    const events = await con.getRepository(ReputationEvent).find();
+    expect(events.length).toEqual(0);
+  });
+
+  it('should not create a reputation event when the author is the upvote user', async () => {
+    await expectSuccessfulTypedBackground(worker, {
       userId: '1',
-      content: 'parent comment',
-      createdAt: new Date(2020, 1, 6, 0, 0),
-      upvotes: 1,
-    },
-  ]);
-});
+      commentId: 'c1',
+    });
 
-it('should create a reputation event that increases reputation', async () => {
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    commentId: 'c1',
+    const events = await con.getRepository(ReputationEvent).find();
+    expect(events.length).toEqual(0);
   });
-  const event = await con
-    .getRepository(ReputationEvent)
-    .findOne({ where: { targetId: 'c1', grantById: '2', grantToId: '1' } });
-  expect(event.amount).toEqual(50);
-});
-
-it('should not create a reputation event when the upvoting user is ineligible', async () => {
-  await con.getRepository(User).update({ id: '2' }, { reputation: 1 });
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    commentId: 'c1',
-  });
-  const events = await con.getRepository(ReputationEvent).find();
-  expect(events.length).toEqual(0);
-});
-
-it('should not create a reputation event when the author is the upvote user', async () => {
-  await expectSuccessfulBackground(worker, {
-    userId: '1',
-    commentId: 'c1',
-  });
-
-  const events = await con.getRepository(ReputationEvent).find();
-  expect(events.length).toEqual(0);
 });

--- a/__tests__/workers/postDownvoteCanceledRep.ts
+++ b/__tests__/workers/postDownvoteCanceledRep.ts
@@ -1,4 +1,4 @@
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/postDownvoteCanceledRep';
 import {
   ArticlePost,
@@ -13,7 +13,7 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
-import { workers } from '../../src/workers';
+import { typedWorkers } from '../../src/workers';
 
 let con: DataSource;
 
@@ -35,9 +35,9 @@ beforeEach(async () => {
   ]);
   await con.getRepository(Post).update('p1', { authorId: '1' });
 });
-describe('postDownvotedCanceledRep worker', () => {
+describe('postDownvoteCanceledRep worker', () => {
   it('should be registered', () => {
-    const registeredWorker = workers.find(
+    const registeredWorker = typedWorkers.find(
       (item) => item.subscription === worker.subscription,
     );
 
@@ -54,7 +54,7 @@ describe('postDownvotedCanceledRep worker', () => {
         reason: ReputationReason.PostDownvoted,
       }),
     );
-    await expectSuccessfulBackground(worker, {
+    await expectSuccessfulTypedBackground(worker, {
       userId: '2',
       postId: 'p1',
     });
@@ -82,7 +82,7 @@ describe('postDownvotedCanceledRep worker', () => {
         reason: ReputationReason.PostDownvoted,
       }),
     ]);
-    await expectSuccessfulBackground(worker, {
+    await expectSuccessfulTypedBackground(worker, {
       userId: '2',
       postId: 'p1',
     });

--- a/__tests__/workers/postUpvoteCanceledRep.ts
+++ b/__tests__/workers/postUpvoteCanceledRep.ts
@@ -1,4 +1,4 @@
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/postUpvoteCanceledRep';
 import {
   ArticlePost,
@@ -13,6 +13,7 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { typedWorkers } from '../../src/workers';
 
 let con: DataSource;
 
@@ -20,70 +21,80 @@ beforeAll(async () => {
   con = await createOrGetConnection();
 });
 
-beforeEach(async () => {
-  jest.resetAllMocks();
-  await saveFixtures(con, Source, sourcesFixture);
-  await saveFixtures(con, ArticlePost, postsFixture);
-  await con.getRepository(User).save([
-    {
-      id: '1',
-      name: 'Ido',
-      image: 'https://daily.dev/ido.jpg',
-      reputation: 250,
-    },
-  ]);
-  await con.getRepository(Post).update('p1', { authorId: '1' });
-});
-
-it('should delete the reputation event relevant to granting of reputation', async () => {
-  const repo = con.getRepository(ReputationEvent);
-  await repo.save(
-    repo.create({
-      grantById: '2',
-      grantToId: '1',
-      targetId: 'p1',
-      targetType: ReputationType.Post,
-      reason: ReputationReason.PostUpvoted,
-    }),
-  );
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    postId: 'p1',
+describe('postUpvoteCanceledRep worker', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, ArticlePost, postsFixture);
+    await con.getRepository(User).save([
+      {
+        id: '1',
+        name: 'Ido',
+        image: 'https://daily.dev/ido.jpg',
+        reputation: 250,
+      },
+    ]);
+    await con.getRepository(Post).update('p1', { authorId: '1' });
   });
-  const events = await repo.find();
-  expect(events.length).toEqual(0);
-});
 
-it('should delete scout reputation event relevant to granting of reputation', async () => {
-  await con.getRepository(User).save([
-    {
-      id: '3',
-      name: 'Scout',
-      image: 'https://daily.dev/scout.jpg',
-      reputation: 250,
-    },
-  ]);
-  await con.getRepository(Post).update('p1', { scoutId: '3' });
-  const repo = con.getRepository(ReputationEvent);
-  await repo.save([
-    repo.create({
+  it('should be registered', () => {
+    const registeredWorker = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+
+    expect(registeredWorker).toBeDefined();
+  });
+
+  it('should delete the reputation event relevant to granting of reputation', async () => {
+    const repo = con.getRepository(ReputationEvent);
+    await repo.save(
+      repo.create({
+        grantById: '2',
+        grantToId: '1',
+        targetId: 'p1',
+        targetType: ReputationType.Post,
+        reason: ReputationReason.PostUpvoted,
+      }),
+    );
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      postId: 'p1',
+    });
+    const events = await repo.find();
+    expect(events.length).toEqual(0);
+  });
+
+  it('should delete scout reputation event relevant to granting of reputation', async () => {
+    await con.getRepository(User).save([
+      {
+        id: '3',
+        name: 'Scout',
+        image: 'https://daily.dev/scout.jpg',
+        reputation: 250,
+      },
+    ]);
+    await con.getRepository(Post).update('p1', { scoutId: '3' });
+    const repo = con.getRepository(ReputationEvent);
+    await repo.save([
+      repo.create({
+        grantById: '2',
+        grantToId: '3',
+        targetId: 'p1',
+        targetType: ReputationType.Post,
+        reason: ReputationReason.PostUpvoted,
+      }),
+    ]);
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      postId: 'p1',
+    });
+    const event = await repo.findOneBy({
       grantById: '2',
       grantToId: '3',
       targetId: 'p1',
       targetType: ReputationType.Post,
       reason: ReputationReason.PostUpvoted,
-    }),
-  ]);
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    postId: 'p1',
+    });
+    expect(event).toBeNull();
   });
-  const event = await repo.findOneBy({
-    grantById: '2',
-    grantToId: '3',
-    targetId: 'p1',
-    targetType: ReputationType.Post,
-    reason: ReputationReason.PostUpvoted,
-  });
-  expect(event).toBeNull();
 });

--- a/__tests__/workers/postUpvotedRep.ts
+++ b/__tests__/workers/postUpvotedRep.ts
@@ -1,4 +1,4 @@
-import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/postUpvotedRep';
 import {
   ArticlePost,
@@ -11,6 +11,7 @@ import { sourcesFixture } from '../fixture/source';
 import { postsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { typedWorkers } from '../../src/workers';
 
 let con: DataSource;
 
@@ -18,58 +19,68 @@ beforeAll(async () => {
   con = await createOrGetConnection();
 });
 
-beforeEach(async () => {
-  jest.resetAllMocks();
-  await saveFixtures(con, Source, sourcesFixture);
-  await saveFixtures(con, ArticlePost, postsFixture);
-  await con.getRepository(User).save([
-    {
-      id: '1',
-      name: 'Ido',
-      image: 'https://daily.dev/ido.jpg',
-      reputation: 3,
-    },
-    {
-      id: '2',
-      name: 'Lee',
-      image: 'https://daily.dev/lee.jpg',
-      reputation: 251,
-    },
-  ]);
-  await con.getRepository(Post).update('p1', { authorId: '1' });
-});
-
-it('should create a reputation event that increases reputation', async () => {
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    postId: 'p1',
-  });
-  const event = await con
-    .getRepository(ReputationEvent)
-    .findOne({ where: { targetId: 'p1', grantById: '2', grantToId: '1' } });
-  expect(event.amount).toEqual(10);
-});
-
-it('should not create a reputation event when the upvoting user is ineligible', async () => {
-  await con.getRepository(User).update({ id: '2' }, { reputation: 249 });
-  await expectSuccessfulBackground(worker, {
-    userId: '2',
-    postId: 'p1',
-  });
-  const event = await con
-    .getRepository(ReputationEvent)
-    .findOneBy({ targetId: 'p1', grantById: '2', grantToId: '1' });
-  expect(event).toEqual(null);
-});
-
-it('should not create a reputation event when the author is the upvote user', async () => {
-  await expectSuccessfulBackground(worker, {
-    userId: '1',
-    postId: 'p1',
+describe('postUpvotedRep worker', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, ArticlePost, postsFixture);
+    await con.getRepository(User).save([
+      {
+        id: '1',
+        name: 'Ido',
+        image: 'https://daily.dev/ido.jpg',
+        reputation: 3,
+      },
+      {
+        id: '2',
+        name: 'Lee',
+        image: 'https://daily.dev/lee.jpg',
+        reputation: 251,
+      },
+    ]);
+    await con.getRepository(Post).update('p1', { authorId: '1' });
   });
 
-  const event = await con
-    .getRepository(ReputationEvent)
-    .findOneBy({ targetId: 'p1', grantById: '2', grantToId: '1' });
-  expect(event).toEqual(null);
+  it('should be registered', () => {
+    const registeredWorker = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+
+    expect(registeredWorker).toBeDefined();
+  });
+
+  it('should create a reputation event that increases reputation', async () => {
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      postId: 'p1',
+    });
+    const event = await con
+      .getRepository(ReputationEvent)
+      .findOne({ where: { targetId: 'p1', grantById: '2', grantToId: '1' } });
+    expect(event!.amount).toEqual(10);
+  });
+
+  it('should not create a reputation event when the upvoting user is ineligible', async () => {
+    await con.getRepository(User).update({ id: '2' }, { reputation: 249 });
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '2',
+      postId: 'p1',
+    });
+    const event = await con
+      .getRepository(ReputationEvent)
+      .findOneBy({ targetId: 'p1', grantById: '2', grantToId: '1' });
+    expect(event).toEqual(null);
+  });
+
+  it('should not create a reputation event when the author is the upvote user', async () => {
+    await expectSuccessfulTypedBackground(worker, {
+      userId: '1',
+      postId: 'p1',
+    });
+
+    const event = await con
+      .getRepository(ReputationEvent)
+      .findOneBy({ targetId: 'p1', grantById: '2', grantToId: '1' });
+    expect(event).toEqual(null);
+  });
 });

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -35,11 +35,6 @@ import pino from 'pino';
 import { PersonalizedDigestFeatureConfig } from '../growthbook';
 
 export const pubsub = new PubSub();
-const postUpvotedTopic = pubsub.topic('post-upvoted');
-const postUpvoteCanceledTopic = pubsub.topic('post-upvote-canceled');
-const postDownvotedTopic = pubsub.topic('api.v1.post-downvoted');
-const postDownvoteCanceledTopic = pubsub.topic('api.v1.post-downvote-canceled');
-const commentUpvotedTopic = pubsub.topic('comment-upvoted');
 const postCommentedTopic = pubsub.topic('post-commented');
 const commentCommentedTopic = pubsub.topic('comment-commented');
 const commentFeaturedTopic = pubsub.topic('comment-featured');
@@ -48,7 +43,6 @@ const userDeletedTopic = pubsub.topic('user-deleted');
 const userUpdatedTopic = pubsub.topic('user-updated');
 const usernameChangedTopic = pubsub.topic('username-changed');
 const settingsUpdatedTopic = pubsub.topic('settings-updated');
-const commentUpvoteCanceledTopic = pubsub.topic('comment-upvote-canceled');
 const sendAnalyticsReportTopic = pubsub.topic('send-analytics-report');
 const viewsTopic = pubsub.topic('views');
 const postBannedOrRemovedTopic = pubsub.topic('post-banned-or-removed');
@@ -125,56 +119,6 @@ export const publishEvent = async (
       kind: opentelemetry.SpanKind.PRODUCER,
     },
   );
-
-export const notifyPostUpvoted = async (
-  log: EventLogger,
-  postId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, postUpvotedTopic, {
-    postId,
-    userId,
-  });
-
-export const notifyPostUpvoteCanceled = async (
-  log: EventLogger,
-  postId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, postUpvoteCanceledTopic, {
-    postId,
-    userId,
-  });
-
-export const notifyPostDownvoted = async (
-  log: EventLogger,
-  postId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, postDownvotedTopic, {
-    postId,
-    userId,
-  });
-
-export const notifyPostDownvoteCanceled = async (
-  log: EventLogger,
-  postId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, postDownvoteCanceledTopic, {
-    postId,
-    userId,
-  });
-
-export const notifyCommentUpvoted = async (
-  log: EventLogger,
-  commentId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, commentUpvotedTopic, {
-    commentId,
-    userId,
-  });
 
 export const notifyPostCommented = async (
   log: EventLogger,
@@ -262,16 +206,6 @@ export const notifySourcePrivacyUpdated = (
   log: EventLogger,
   source: ChangeObject<Source>,
 ): Promise<void> => publishEvent(log, sourcePrivacyUpdatedTopic, { source });
-
-export const notifyCommentUpvoteCanceled = async (
-  log: EventLogger,
-  commentId: string,
-  userId: string,
-): Promise<void> =>
-  publishEvent(log, commentUpvoteCanceledTopic, {
-    commentId,
-    userId,
-  });
 
 export const notifySendAnalyticsReport = async (
   log: EventLogger,

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -16,6 +16,26 @@ export type PubSubSchema = {
     postId: string;
     userId: string;
   };
+  'post-upvote-canceled': {
+    postId: string;
+    userId: string;
+  };
+  'api.v1.post-downvoted': {
+    postId: string;
+    userId: string;
+  };
+  'api.v1.post-downvote-canceled': {
+    postId: string;
+    userId: string;
+  };
+  'comment-upvoted': {
+    commentId: string;
+    userId: string;
+  };
+  'comment-upvote-canceled': {
+    commentId: string;
+    userId: string;
+  };
   'api.v1.comment-downvoted': {
     commentId: string;
     userId: string;

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -183,10 +183,16 @@ const handleVoteUpdated = async <TVoteTopic extends keyof PubSubSchema>({
   payloadBefore: PubSubSchema[TVoteTopic];
   voteBefore: UserVote;
 }) => {
-  const isVoteCanceled = vote !== voteBefore && voteBefore !== UserVote.None;
+  const isVoteChanged = vote !== voteBefore;
+
+  if (!isVoteChanged) {
+    return;
+  }
+
+  const isVoteCanceled = voteBefore !== UserVote.None;
 
   if (isVoteCanceled) {
-    handleVoteDeleted({
+    await handleVoteDeleted({
       log,
       upvoteCanceledTopic,
       downvoteCanceledTopic,
@@ -196,7 +202,7 @@ const handleVoteUpdated = async <TVoteTopic extends keyof PubSubSchema>({
   }
 
   if (vote !== UserVote.None) {
-    handleVoteCreated({
+    await handleVoteCreated({
       log,
       upvoteTopic,
       downvoteTopic,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -33,14 +33,10 @@ import {
 } from '../../entity';
 import {
   notifyCommentCommented,
-  notifyCommentUpvoteCanceled,
-  notifyCommentUpvoted,
   notifyPostBannedOrRemoved,
   notifyPostCommented,
   notifyPostReport,
   notifyCommentReport,
-  notifyPostUpvoteCanceled,
-  notifyPostUpvoted,
   notifySendAnalyticsReport,
   notifySourceFeedAdded,
   notifySourceFeedRemoved,
@@ -75,8 +71,7 @@ import {
   notifyUserReadmeUpdated,
   triggerTypedEvent,
   notifyReputationIncrease,
-  notifyPostDownvoted,
-  notifyPostDownvoteCanceled,
+  PubSubSchema,
 } from '../../common';
 import { ChangeMessage, UserVote } from '../../types';
 import { DataSource } from 'typeorm';
@@ -147,101 +142,83 @@ const onSourceRequestChange = async (
   }
 };
 
-const handlePostUpvoteChange = async (
-  con: DataSource,
-  logger: FastifyBaseLogger,
-  data: ChangeMessage<UserPost>,
-): Promise<void> => {
-  switch (data.payload.op) {
-    case 'c':
-      await notifyPostUpvoted(
-        logger,
-        data.payload.after.postId,
-        data.payload.after.userId,
-      );
-      break;
-    case 'u': {
-      const isUpvoteCanceled = data.payload.after.vote === UserVote.None;
-
-      if (isUpvoteCanceled) {
-        await notifyPostUpvoteCanceled(
-          logger,
-          data.payload.before.postId,
-          data.payload.before.userId,
-        );
-      } else {
-        await notifyPostUpvoted(
-          logger,
-          data.payload.after.postId,
-          data.payload.after.userId,
-        );
-      }
-      break;
-    }
-    case 'd': {
-      const wasUpvoted = data.payload.before.vote === UserVote.Up;
-
-      if (wasUpvoted) {
-        await notifyPostUpvoteCanceled(
-          logger,
-          data.payload.before.postId,
-          data.payload.before.userId,
-        );
-      }
-
-      break;
-    }
-    default:
-      break;
+const handleVoteCreated = async <TVoteTopic extends keyof PubSubSchema>({
+  log,
+  upvoteTopic,
+  downvoteTopic,
+  payload,
+  vote,
+}: {
+  log: FastifyBaseLogger;
+  upvoteTopic: TVoteTopic;
+  downvoteTopic: TVoteTopic;
+  payload: PubSubSchema[TVoteTopic];
+  vote: UserVote;
+}) => {
+  if (vote === UserVote.Up) {
+    await triggerTypedEvent(log, upvoteTopic, payload);
+  } else if (vote === UserVote.Down) {
+    await triggerTypedEvent(log, downvoteTopic, payload);
   }
 };
 
-const handlePostDownvoteChange = async (
-  con: DataSource,
-  logger: FastifyBaseLogger,
-  data: ChangeMessage<UserPost>,
-): Promise<void> => {
-  switch (data.payload.op) {
-    case 'c':
-      await notifyPostDownvoted(
-        logger,
-        data.payload.after.postId,
-        data.payload.after.userId,
-      );
-      break;
-    case 'u': {
-      const isDownvoteCanceled = data.payload.after.vote === UserVote.None;
+const handleVoteUpdated = async <TVoteTopic extends keyof PubSubSchema>({
+  log,
+  upvoteTopic,
+  downvoteTopic,
+  upvoteCanceledTopic,
+  downvoteCanceledTopic,
+  payload,
+  vote,
+  payloadBefore,
+  voteBefore,
+}: {
+  log: FastifyBaseLogger;
+  upvoteTopic: TVoteTopic;
+  downvoteTopic: TVoteTopic;
+  upvoteCanceledTopic: TVoteTopic;
+  downvoteCanceledTopic: TVoteTopic;
+  payload: PubSubSchema[TVoteTopic];
+  vote: UserVote;
+  payloadBefore: PubSubSchema[TVoteTopic];
+  voteBefore: UserVote;
+}) => {
+  const isVoteCanceled = vote !== voteBefore && voteBefore !== UserVote.None;
 
-      if (isDownvoteCanceled) {
-        await notifyPostDownvoteCanceled(
-          logger,
-          data.payload.before.postId,
-          data.payload.before.userId,
-        );
-      } else {
-        await notifyPostDownvoted(
-          logger,
-          data.payload.after.postId,
-          data.payload.after.userId,
-        );
-      }
-      break;
-    }
-    case 'd': {
-      const wasDownvoted = data.payload.before.vote === UserVote.Down;
+  if (isVoteCanceled) {
+    await triggerTypedEvent(
+      log,
+      voteBefore === UserVote.Up ? upvoteCanceledTopic : downvoteCanceledTopic,
+      payloadBefore,
+    );
+  }
 
-      if (wasDownvoted) {
-        await notifyPostDownvoteCanceled(
-          logger,
-          data.payload.before.postId,
-          data.payload.before.userId,
-        );
-      }
+  if (vote !== UserVote.None) {
+    await triggerTypedEvent(
+      log,
+      vote === UserVote.Up ? upvoteTopic : downvoteTopic,
+      payload,
+    );
+  }
+};
 
-      break;
-    }
-    default:
-      break;
+const handleVoteDeleted = async <TVoteTopic extends keyof PubSubSchema>({
+  log,
+  upvoteCanceledTopic,
+  downvoteCanceledTopic,
+  payloadBefore,
+  voteBefore,
+}: {
+  log: FastifyBaseLogger;
+  upvoteCanceledTopic: TVoteTopic;
+  downvoteCanceledTopic: TVoteTopic;
+  payloadBefore: PubSubSchema[TVoteTopic];
+  voteBefore: UserVote;
+}) => {
+  if (voteBefore === UserVote.Up) {
+    await triggerTypedEvent(log, upvoteCanceledTopic, payloadBefore);
+  } else if (voteBefore === UserVote.Down) {
+    await triggerTypedEvent(log, downvoteCanceledTopic, payloadBefore);
   }
 };
 
@@ -250,116 +227,53 @@ const onPostVoteChange = async (
   logger: FastifyBaseLogger,
   data: ChangeMessage<UserPost>,
 ): Promise<void> => {
-  const isUpvote =
-    data.payload.after?.vote === UserVote.Up ||
-    data.payload.before?.vote === UserVote.Up;
-  const isDownvote =
-    data.payload.after?.vote === UserVote.Down ||
-    data.payload.before?.vote === UserVote.Down;
-
-  if (isUpvote) {
-    await handlePostUpvoteChange(con, logger, data);
-  }
-
-  if (isDownvote) {
-    await handlePostDownvoteChange(con, logger, data);
+  switch (data.payload.op) {
+    case 'c':
+      await handleVoteCreated({
+        log: logger,
+        upvoteTopic: 'post-upvoted',
+        downvoteTopic: 'api.v1.post-downvoted',
+        payload: {
+          postId: data.payload.after.postId,
+          userId: data.payload.after.userId,
+        },
+        vote: data.payload.after.vote,
+      });
+      break;
+    case 'u':
+      await handleVoteUpdated({
+        log: logger,
+        upvoteTopic: 'post-upvoted',
+        downvoteTopic: 'api.v1.post-downvoted',
+        upvoteCanceledTopic: 'post-upvote-canceled',
+        downvoteCanceledTopic: 'api.v1.post-downvote-canceled',
+        payload: {
+          postId: data.payload.after.postId,
+          userId: data.payload.after.userId,
+        },
+        vote: data.payload.after.vote,
+        payloadBefore: {
+          postId: data.payload.before.postId,
+          userId: data.payload.before.userId,
+        },
+        voteBefore: data.payload.before.vote,
+      });
+      break;
+    case 'd':
+      await handleVoteDeleted({
+        log: logger,
+        upvoteCanceledTopic: 'post-upvote-canceled',
+        downvoteCanceledTopic: 'api.v1.post-downvote-canceled',
+        payloadBefore: {
+          postId: data.payload.before.postId,
+          userId: data.payload.before.userId,
+        },
+        voteBefore: data.payload.before.vote,
+      });
+      break;
   }
 
   return;
-};
-
-const handleCommentUpvoteChange = async (
-  con: DataSource,
-  logger: FastifyBaseLogger,
-  data: ChangeMessage<UserComment>,
-): Promise<void> => {
-  switch (data.payload.op) {
-    case 'c':
-      await notifyCommentUpvoted(
-        logger,
-        data.payload.after.commentId,
-        data.payload.after.userId,
-      );
-      break;
-    case 'u': {
-      const isUpvoteCanceled = data.payload.after.vote === UserVote.None;
-
-      if (isUpvoteCanceled) {
-        await notifyCommentUpvoteCanceled(
-          logger,
-          data.payload.before.commentId,
-          data.payload.before.userId,
-        );
-      } else {
-        await notifyCommentUpvoted(
-          logger,
-          data.payload.after.commentId,
-          data.payload.after.userId,
-        );
-      }
-      break;
-    }
-    case 'd': {
-      const wasUpvoted = data.payload.before.vote === UserVote.Up;
-
-      if (wasUpvoted) {
-        await notifyCommentUpvoteCanceled(
-          logger,
-          data.payload.before.commentId,
-          data.payload.before.userId,
-        );
-      }
-
-      break;
-    }
-    default:
-      break;
-  }
-};
-
-const handleCommentDownvoteChange = async (
-  con: DataSource,
-  logger: FastifyBaseLogger,
-  data: ChangeMessage<UserComment>,
-): Promise<void> => {
-  switch (data.payload.op) {
-    case 'c':
-      await triggerTypedEvent(logger, 'api.v1.comment-downvoted', {
-        commentId: data.payload.after.commentId,
-        userId: data.payload.after.userId,
-      });
-      break;
-    case 'u': {
-      const isDownvoteCanceled = data.payload.after.vote === UserVote.None;
-
-      if (isDownvoteCanceled) {
-        await triggerTypedEvent(logger, 'api.v1.comment-downvote-canceled', {
-          commentId: data.payload.before.commentId,
-          userId: data.payload.before.userId,
-        });
-      } else {
-        await triggerTypedEvent(logger, 'api.v1.comment-downvoted', {
-          commentId: data.payload.after.commentId,
-          userId: data.payload.after.userId,
-        });
-      }
-      break;
-    }
-    case 'd': {
-      const wasDownvoted = data.payload.before.vote === UserVote.Down;
-
-      if (wasDownvoted) {
-        await triggerTypedEvent(logger, 'api.v1.comment-downvote-canceled', {
-          commentId: data.payload.before.commentId,
-          userId: data.payload.before.userId,
-        });
-      }
-
-      break;
-    }
-    default:
-      break;
-  }
 };
 
 const onCommentVoteChange = async (
@@ -367,19 +281,50 @@ const onCommentVoteChange = async (
   logger: FastifyBaseLogger,
   data: ChangeMessage<UserComment>,
 ): Promise<void> => {
-  const isUpvote =
-    data.payload.after?.vote === UserVote.Up ||
-    data.payload.before?.vote === UserVote.Up;
-  const isDownvote =
-    data.payload.after?.vote === UserVote.Down ||
-    data.payload.before?.vote === UserVote.Down;
-
-  if (isUpvote) {
-    await handleCommentUpvoteChange(con, logger, data);
-  }
-
-  if (isDownvote) {
-    await handleCommentDownvoteChange(con, logger, data);
+  switch (data.payload.op) {
+    case 'c':
+      await handleVoteCreated({
+        log: logger,
+        upvoteTopic: 'comment-upvoted',
+        downvoteTopic: 'api.v1.comment-downvoted',
+        payload: {
+          commentId: data.payload.after.commentId,
+          userId: data.payload.after.userId,
+        },
+        vote: data.payload.after.vote,
+      });
+      break;
+    case 'u':
+      await handleVoteUpdated({
+        log: logger,
+        upvoteTopic: 'comment-upvoted',
+        downvoteTopic: 'api.v1.comment-downvoted',
+        upvoteCanceledTopic: 'comment-upvote-canceled',
+        downvoteCanceledTopic: 'api.v1.comment-downvote-canceled',
+        payload: {
+          commentId: data.payload.after.commentId,
+          userId: data.payload.after.userId,
+        },
+        vote: data.payload.after.vote,
+        payloadBefore: {
+          commentId: data.payload.before.commentId,
+          userId: data.payload.before.userId,
+        },
+        voteBefore: data.payload.before.vote,
+      });
+      break;
+    case 'd':
+      await handleVoteDeleted({
+        log: logger,
+        upvoteCanceledTopic: 'comment-upvote-canceled',
+        downvoteCanceledTopic: 'api.v1.comment-downvote-canceled',
+        payloadBefore: {
+          commentId: data.payload.before.commentId,
+          userId: data.payload.before.userId,
+        },
+        voteBefore: data.payload.before.vote,
+      });
+      break;
   }
 };
 

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -186,19 +186,23 @@ const handleVoteUpdated = async <TVoteTopic extends keyof PubSubSchema>({
   const isVoteCanceled = vote !== voteBefore && voteBefore !== UserVote.None;
 
   if (isVoteCanceled) {
-    await triggerTypedEvent(
+    handleVoteDeleted({
       log,
-      voteBefore === UserVote.Up ? upvoteCanceledTopic : downvoteCanceledTopic,
+      upvoteCanceledTopic,
+      downvoteCanceledTopic,
       payloadBefore,
-    );
+      voteBefore,
+    });
   }
 
   if (vote !== UserVote.None) {
-    await triggerTypedEvent(
+    handleVoteCreated({
       log,
-      vote === UserVote.Up ? upvoteTopic : downvoteTopic,
+      upvoteTopic,
+      downvoteTopic,
       payload,
-    );
+      vote,
+    });
   }
 };
 

--- a/src/workers/commentUpvoteCanceledRep.ts
+++ b/src/workers/commentUpvoteCanceledRep.ts
@@ -1,4 +1,4 @@
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 import {
   Comment,
   ReputationEvent,
@@ -6,15 +6,10 @@ import {
   ReputationType,
 } from '../entity';
 
-interface Data {
-  userId: string;
-  commentId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'comment-upvote-canceled'> = {
   subscription: 'comment-upvote-canceled-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     const logDetails = { data, messageId: message.messageId };
 
     try {

--- a/src/workers/commentUpvotedRep.ts
+++ b/src/workers/commentUpvotedRep.ts
@@ -4,18 +4,13 @@ import {
   ReputationType,
   REPUTATION_THRESHOLD,
 } from './../entity/ReputationEvent';
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 import { Comment, User } from '../entity';
 
-interface Data {
-  userId: string;
-  commentId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'comment-upvoted'> = {
   subscription: 'comment-upvoted-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     const logDetails = { data, messageId: message.messageId };
     try {
       await con.transaction(async (transaction) => {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -58,8 +58,6 @@ export const workers: Worker[] = [
   newView,
   updateMailingList,
   deleteUserFromMailingList,
-  commentUpvotedRep,
-  commentUpvoteCanceledRep,
   postCommentedWorker,
   commentCommentedWorker,
   commentEditedWorker,
@@ -67,10 +65,6 @@ export const workers: Worker[] = [
   postScoutMatchedSlack,
   commentCommentedSlackMessage,
   postCommentedSlackMessage,
-  postUpvotedRep,
-  postUpvoteCanceledRep,
-  postDownvotedRep,
-  postDownvoteCanceledRep,
   postCommentedRedis,
   postUpvotedRedis,
   postBannedRep,
@@ -100,6 +94,12 @@ export const typedWorkers: BaseTypedWorker<unknown>[] = [
   sourceRequestApprovedRep,
   commentDownvotedRep,
   commentDownvoteCanceledRep,
+  commentUpvotedRep,
+  commentUpvoteCanceledRep,
+  postUpvotedRep,
+  postUpvoteCanceledRep,
+  postDownvotedRep,
+  postDownvoteCanceledRep,
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/src/workers/postDownvoteCanceledRep.ts
+++ b/src/workers/postDownvoteCanceledRep.ts
@@ -4,18 +4,13 @@ import {
   ReputationType,
   Post,
 } from '../entity';
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 import { In } from 'typeorm';
 
-interface Data {
-  userId: string;
-  postId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'api.v1.post-downvote-canceled'> = {
   subscription: 'api.post-downvote-canceled-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     try {
       const post = await con.getRepository(Post).findOneBy({ id: data.postId });
       if (!post?.authorId && !post?.scoutId) {

--- a/src/workers/postDownvotedRep.ts
+++ b/src/workers/postDownvotedRep.ts
@@ -6,17 +6,12 @@ import {
   Post,
   User,
 } from '../entity';
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 
-interface Data {
-  userId: string;
-  postId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'api.v1.post-downvoted'> = {
   subscription: 'api.post-downvoted-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     const logDetails = { data, messageId: message.messageId };
     try {
       await con.transaction(async (transaction) => {

--- a/src/workers/postUpvoteCanceledRep.ts
+++ b/src/workers/postUpvoteCanceledRep.ts
@@ -3,19 +3,14 @@ import {
   ReputationReason,
   ReputationType,
 } from './../entity/ReputationEvent';
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 import { Post } from '../entity';
 import { In } from 'typeorm';
 
-interface Data {
-  userId: string;
-  postId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'post-upvote-canceled'> = {
   subscription: 'post-upvote-canceled-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     try {
       const post = await con.getRepository(Post).findOneBy({ id: data.postId });
       if (!post?.authorId && !post?.scoutId) {

--- a/src/workers/postUpvotedRep.ts
+++ b/src/workers/postUpvotedRep.ts
@@ -4,18 +4,13 @@ import {
   ReputationType,
   REPUTATION_THRESHOLD,
 } from './../entity/ReputationEvent';
-import { messageToJson, Worker } from './worker';
+import { TypedWorker } from './worker';
 import { Post, User } from '../entity';
 
-interface Data {
-  userId: string;
-  postId: string;
-}
-
-const worker: Worker = {
+const worker: TypedWorker<'post-upvoted'> = {
   subscription: 'post-upvoted-rep',
   handler: async (message, con, logger): Promise<void> => {
-    const data: Data = messageToJson(message);
+    const { data } = message;
     const logDetails = { data, messageId: message.messageId };
     try {
       await con.transaction(async (transaction) => {


### PR DESCRIPTION
AS-237

Current worker logic that was applied from post never worked when user changes from upvote to downvote or vice verse. This fixes it and adds additional tests to cover the case.

Also refactored rep workers to typed workers because it allowed me to streamline cdc logic for any kind of future vote entities.