### PR TITLE
fix: prevent rep decrease if you delete own posts

### DIFF
--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -39,6 +39,7 @@ export type PostFlags = Partial<{
   visible: boolean;
   showOnFeed: boolean;
   promoteToPublic: number;
+  deletedBy: string;
 }>;
 
 export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1367,7 +1367,10 @@ export const resolvers: IResolvers<any, Context> = {
           { id },
           {
             deleted: true,
-            flags: updateFlagsStatement<Post>({ deleted: true }),
+            flags: updateFlagsStatement<Post>({
+              deleted: true,
+              deletedBy: ctx.userId,
+            }),
           },
         );
         return { _: true };
@@ -1387,7 +1390,10 @@ export const resolvers: IResolvers<any, Context> = {
           { id },
           {
             deleted: true,
-            flags: updateFlagsStatement<Post>({ deleted: true }),
+            flags: updateFlagsStatement<Post>({
+              deleted: true,
+              deletedBy: ctx.userId,
+            }),
           },
         );
       });


### PR DESCRIPTION
Prevent decrease of reputation if you delete your own post.
Seeing that we only work based of post table deletion with CDC i introduced a flag for `deletedBy` (might come in handy one day anyway)

I added some logic to say if the scout is the one deleting we don't decrease anyone, as they might spam posts of one user to attack their reputation.
(CC: @idoshamun not sure this is ok, let me know if not)

AS-239 #done 