### PR TITLE
fix: zombie process for images

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -569,6 +569,7 @@ describe('comment', () => {
       'p1',
       '1',
       'c1',
+      '<p>comment</p>',
     ]);
   });
 
@@ -592,6 +593,7 @@ describe('comment', () => {
       '1',
       'c2',
       'c1',
+      '<p>comment</p>',
     ]);
   });
 

--- a/bin/retroFixCommentImages.ts
+++ b/bin/retroFixCommentImages.ts
@@ -1,0 +1,34 @@
+import '../src/config';
+import { Comment, ContentImage, ContentImageUsedByType } from '../src/entity';
+import createOrGetConnection from '../src/db';
+import { DataSource, IsNull, Like } from 'typeorm';
+
+export const retroFixCommentImages = async (ds?: DataSource): Promise<void> => {
+  console.log('starting connection');
+  const con = ds ?? (await createOrGetConnection());
+  const result = await con.getRepository(ContentImage).findBy({
+    usedById: IsNull(),
+  });
+
+  await Promise.all(
+    result.map(async (image) => {
+      const comment = await con.getRepository(Comment).findOne({
+        where: { contentHtml: Like(`%${image.url}%`) },
+      });
+
+      if (comment) {
+        // Found comment, update the content image record
+        await con.getRepository(ContentImage).update(image.url, {
+          usedById: comment.id,
+          usedByType: ContentImageUsedByType.Comment,
+        });
+      }
+    }),
+  );
+  console.log('finished retro checking');
+  process.exit();
+};
+
+if (process.env.NODE_ENV !== 'test') {
+  retroFixCommentImages();
+}

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -125,11 +125,13 @@ export const notifyPostCommented = async (
   postId: string,
   userId: string,
   commentId: string,
+  contentHtml: string,
 ): Promise<void> =>
   publishEvent(log, postCommentedTopic, {
     postId,
     userId,
     commentId,
+    contentHtml,
   });
 
 export const notifyCommentCommented = async (
@@ -138,12 +140,14 @@ export const notifyCommentCommented = async (
   userId: string,
   parentCommentId: string,
   childCommentId: string,
+  contentHtml: string,
 ): Promise<void> =>
   publishEvent(log, commentCommentedTopic, {
     postId,
     userId,
     parentCommentId,
     childCommentId,
+    contentHtml,
   });
 
 export const notifyCommentFeatured = async (

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -371,6 +371,7 @@ const onCommentChange = async (
         data.payload.after.userId,
         data.payload.after.parentId,
         data.payload.after.id,
+        data.payload.after.contentHtml,
       );
     } else {
       await notifyPostCommented(
@@ -378,6 +379,7 @@ const onCommentChange = async (
         data.payload.after.postId,
         data.payload.after.userId,
         data.payload.after.id,
+        data.payload.after.contentHtml,
       );
     }
   } else if (data.payload.op === 'u') {


### PR DESCRIPTION
Classic reason why we need the type safe topics.
Didn't implement here though because this topic has way too many subscribers to quickly iterate "please note we should eventually do this as backlog ticket" :hidethepain:

Subscription expects `contentHtml` from the topic.
Topic never publishes this.
```js
export const generateNewImagesHandler =
  <T extends Data<Content> = Data<Content>>(
    key: keyof T,
    type: ContentImageUsedByType,
    contentKey: keyof Data<Content> = 'contentHtml',
  ) =>
  async (message, con): Promise<void> => {
    const data: T = messageToJson(message);
    const obj = data[key];

    if (!obj || !obj?.id || !obj?.[contentKey]) return;

    await updateUsedImagesInContent(con, type, obj.id, obj[contentKey]);
  };
```

Resulting in comment cleaned every 30 days, we can't retro bring these back 😢 
However added a bin script we need to run to fix existing 227 records 

AS-243 #done 