### PR TITLE
fix: comment don't send as changeObject

### DIFF
--- a/__tests__/workers/commentMarkdownImages.ts
+++ b/__tests__/workers/commentMarkdownImages.ts
@@ -53,11 +53,10 @@ describe('worker postCommentedWorker', () => {
   `;
     const html = markdown.render(content);
     await expectSuccessfulBackground(postCommentedWorker, {
-      comment: {
-        ...comment,
-        content,
-        contentHtml: html,
-      },
+      postId: comment.postId,
+      userId: comment.userId,
+      commentId: comment.id,
+      contentHtml: html,
     });
     const actual = await con.getRepository(ContentImage).find({
       where: { usedByType: Not(IsNull()) },
@@ -92,11 +91,10 @@ describe('worker commentCommentedWorker', () => {
   `;
     const html = markdown.render(content);
     await expectSuccessfulBackground(commentCommentedWorker, {
-      comment: {
-        ...comment,
-        content,
-        contentHtml: html,
-      },
+      postId: comment.postId,
+      userId: comment.userId,
+      commentId: comment.id,
+      contentHtml: html,
     });
     const actual = await con.getRepository(ContentImage).find({
       where: { usedByType: Not(IsNull()) },

--- a/__tests__/workers/commentMarkdownImages.ts
+++ b/__tests__/workers/commentMarkdownImages.ts
@@ -93,7 +93,8 @@ describe('worker commentCommentedWorker', () => {
     await expectSuccessfulBackground(commentCommentedWorker, {
       postId: comment.postId,
       userId: comment.userId,
-      commentId: comment.id,
+      parentCommentId: comment.parentId,
+      childCommentId: comment.id,
       contentHtml: html,
     });
     const actual = await con.getRepository(ContentImage).find({

--- a/src/workers/commentMarkdownImages.ts
+++ b/src/workers/commentMarkdownImages.ts
@@ -1,13 +1,29 @@
 import { ContentImageUsedByType } from '../entity';
-import { Worker } from './worker';
+import { messageToJson, Worker } from './worker';
 import { generateNewImagesHandler } from './generators';
 
 export const postCommentedWorker: Worker = {
   subscription: 'api.post-commented-images',
-  handler: generateNewImagesHandler('comment', ContentImageUsedByType.Comment),
+  handler: async (message, con): Promise<void> => {
+    const data: { commentId: string; contentHtml: string } =
+      messageToJson(message);
+    await generateNewImagesHandler(
+      { id: data.commentId, contentHtml: data.contentHtml },
+      ContentImageUsedByType.Comment,
+      con,
+    );
+  },
 };
 
 export const commentCommentedWorker: Worker = {
   subscription: 'api.comment-commented-images',
-  handler: generateNewImagesHandler('comment', ContentImageUsedByType.Comment),
+  handler: async (message, con): Promise<void> => {
+    const data: { childCommentId: string; contentHtml: string } =
+      messageToJson(message);
+    await generateNewImagesHandler(
+      { id: data.childCommentId, contentHtml: data.contentHtml },
+      ContentImageUsedByType.Comment,
+      con,
+    );
+  },
 };

--- a/src/workers/generators/generateNewImagesHandler.ts
+++ b/src/workers/generators/generateNewImagesHandler.ts
@@ -1,41 +1,15 @@
-import { ChangeObject } from '../../types';
 import {
   ContentImageUsedByType,
   updateUsedImagesInContent,
 } from '../../entity';
-import { messageToJson } from '../worker';
+import { DataSource } from 'typeorm';
 
-interface Content {
-  id: string;
-  contentHtml: string;
-}
+export const generateNewImagesHandler = async (
+  data: { id: string; contentHtml: string },
+  type: ContentImageUsedByType,
+  con: DataSource,
+) => {
+  if (!data || !data?.id || !data?.contentHtml) return;
 
-interface Data<T extends Content> {
-  [key: string]: ChangeObject<T>;
-}
-
-export const generateNewImagesHandler =
-  <T extends Data<Content> = Data<Content>>(
-    key: keyof T,
-    type: ContentImageUsedByType,
-  ) =>
-  async (message, con): Promise<void> => {
-    const data: T = messageToJson(message);
-
-    const obj =
-      type === ContentImageUsedByType.Post
-        ? {
-            id: data[key].id,
-            contentHtml: data[key].contentHtml,
-          }
-        : { id: data?.commentId, contentHtml: data?.contentHtml };
-
-    if (!obj || !obj?.id || !obj?.contentHtml) return;
-
-    await updateUsedImagesInContent(
-      con,
-      type,
-      obj.id as string,
-      obj.contentHtml as string,
-    );
-  };
+  await updateUsedImagesInContent(con, type, data.id, data.contentHtml);
+};

--- a/src/workers/generators/generateNewImagesHandler.ts
+++ b/src/workers/generators/generateNewImagesHandler.ts
@@ -7,6 +7,7 @@ import { messageToJson } from '../worker';
 
 interface Content {
   id: string;
+  contentHtml: string;
 }
 
 interface Data<T extends Content> {
@@ -17,13 +18,24 @@ export const generateNewImagesHandler =
   <T extends Data<Content> = Data<Content>>(
     key: keyof T,
     type: ContentImageUsedByType,
-    contentKey: keyof Data<Content> = 'contentHtml',
   ) =>
   async (message, con): Promise<void> => {
     const data: T = messageToJson(message);
-    const obj = data[key];
 
-    if (!obj || !obj?.id || !obj?.[contentKey]) return;
+    const obj =
+      type === ContentImageUsedByType.Post
+        ? {
+            id: data[key].id,
+            contentHtml: data[key].contentHtml,
+          }
+        : { id: data?.commentId, contentHtml: data?.contentHtml };
 
-    await updateUsedImagesInContent(con, type, obj.id, obj[contentKey]);
+    if (!obj || !obj?.id || !obj?.contentHtml) return;
+
+    await updateUsedImagesInContent(
+      con,
+      type,
+      obj.id as string,
+      obj.contentHtml as string,
+    );
   };

--- a/src/workers/postFreeformImages.ts
+++ b/src/workers/postFreeformImages.ts
@@ -1,10 +1,20 @@
-import { ContentImageUsedByType } from '../entity';
-import { Worker } from './worker';
+import { ContentImageUsedByType, FreeformPost } from '../entity';
+import { messageToJson, Worker } from './worker';
 import { generateNewImagesHandler } from './generators';
+import { ChangeObject } from '../types';
 
 const worker: Worker = {
   subscription: 'api.post-freeform-images',
-  handler: generateNewImagesHandler('post', ContentImageUsedByType.Post),
+  handler: async (message, con): Promise<void> => {
+    const data: {
+      post: ChangeObject<FreeformPost>;
+    } = messageToJson(message);
+    await generateNewImagesHandler(
+      { id: data.post?.id, contentHtml: data.post?.contentHtml },
+      ContentImageUsedByType.Post,
+      con,
+    );
+  },
 };
 
 export default worker;


### PR DESCRIPTION
We actually send `post` as ChangeObject<Post>` but comment as raw data basically so we can't just rely on abstracting the type here.

I know it's a little bit messy, but for a quick fix the fastest solution.
Do think we should re-evaluate if we can move this topic to full object rather 🫠