### PR TITLE
feat: open keyword query and add meta props to flags

### DIFF
--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -363,6 +363,7 @@ describe('flags field', () => {
   const QUERY = `{
     keyword(value: "react") {
       flags {
+        title
         description
       }
     }
@@ -380,12 +381,16 @@ describe('flags field', () => {
     await con.getRepository(Keyword).update(
       { value: 'react' },
       {
-        flags: updateFlagsStatement({ description: 'React is a JS library' }),
+        flags: updateFlagsStatement({
+          title: 'React',
+          description: 'React is a JS library',
+        }),
       },
     );
     const res = await client.query(QUERY);
     expect(res.errors).toBeFalsy();
     expect(res.data.keyword.flags).toEqual({
+      title: 'React',
       description: 'React is a JS library',
     });
   });
@@ -393,6 +398,7 @@ describe('flags field', () => {
   it('should return null values for unset flags', async () => {
     const res = await client.query(QUERY);
     expect(res.data.keyword.flags).toEqual({
+      title: null,
       description: null,
     });
   });

--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -16,6 +16,7 @@ import { sourcesFixture } from './fixture/source';
 import { postsFixture } from './fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
+import { updateFlagsStatement } from '../src/common';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -145,12 +146,6 @@ describe('query keyword', () => {
       value, status, occurrences
     }
   }`;
-
-  it('should not authorize when not moderator', () =>
-    testModeratorQueryAuthorization({
-      query: QUERY,
-      variables: { value: 'nodejs' },
-    }));
 
   it('should return keyword', async () => {
     roles = [Roles.Moderator];
@@ -361,5 +356,51 @@ describe('mutation setKeywordAsSynonym', () => {
       },
     });
     expect(postKeywords).toMatchSnapshot();
+  });
+});
+
+describe('flags field', () => {
+  const QUERY = `{
+    keyword(value: "react") {
+      flags {
+        description
+      }
+    }
+  }`;
+
+  beforeEach(async () => {
+    await con.getRepository(Keyword).save([
+      { value: 'react', status: 'allow', occurrences: 200 },
+      { value: 'nodejs', status: 'allow', occurrences: 300 },
+      { value: 'go', status: 'allow', occurrences: 100 },
+    ]);
+  });
+
+  it('should return all the public flags for anonymous user', async () => {
+    await con.getRepository(Keyword).update(
+      { value: 'react' },
+      {
+        flags: updateFlagsStatement({ description: 'React is a JS library' }),
+      },
+    );
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeFalsy();
+    expect(res.data.keyword.flags).toEqual({
+      description: 'React is a JS library',
+    });
+  });
+
+  it('should return null values for unset flags', async () => {
+    const res = await client.query(QUERY);
+    expect(res.data.keyword.flags).toEqual({
+      description: null,
+    });
+  });
+
+  it('should contain all default values in db query', async () => {
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'react' });
+    expect(keyword?.flags).toEqual({});
   });
 });

--- a/bin/updateKeyword.ts
+++ b/bin/updateKeyword.ts
@@ -33,6 +33,7 @@ import { Keyword } from '../src/entity/Keyword';
     keywords.push({
       value: slug,
       flags: {
+        title,
         description,
       },
     });

--- a/bin/updateKeyword.ts
+++ b/bin/updateKeyword.ts
@@ -1,0 +1,69 @@
+import '../src/config';
+import createOrGetConnection from '../src/db';
+import fs from 'fs';
+import { parse } from 'csv-parse';
+import { Keyword } from '../src/entity/Keyword';
+
+(async (): Promise<void> => {
+  const csvFilePath = process.argv[2];
+  const batch = +process.argv[3] || 100;
+  const splitBy = process.argv[4] || ',';
+
+  if (!csvFilePath) {
+    throw new Error('CSV file path is required');
+  }
+  const keywords: Partial<Keyword>[] = [];
+
+  console.log('reading csv file', csvFilePath);
+
+  const stream = fs
+    .createReadStream(csvFilePath)
+    .pipe(parse({ delimiter: splitBy, from_line: 2 }));
+
+  stream.on('error', (err) => {
+    console.error('failed to read file: ', err.message);
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  stream.on('data', function ([slug, url, title, description]) {
+    if (!slug || !description) {
+      return;
+    }
+
+    keywords.push({
+      value: slug,
+      flags: {
+        description,
+      },
+    });
+  });
+
+  await new Promise((resolve) => {
+    stream.on('end', resolve);
+  });
+
+  console.log('running db query');
+
+  const con = await createOrGetConnection();
+
+  for (let i = 0; i < keywords.length; i += batch) {
+    await con.transaction(async (manager) => {
+      const keywordsBatch = keywords.slice(i, i + batch);
+
+      console.log('processing batch', i, 'of', keywords.length);
+
+      for (const keyword of keywordsBatch) {
+        await manager.query(
+          `
+            UPDATE keyword
+            SET flags = flags || $1
+            WHERE value = $2
+          `,
+          [JSON.stringify(keyword.flags), keyword.value],
+        );
+      }
+    });
+  }
+
+  process.exit();
+})();

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -9,11 +9,11 @@ import {
 export type KeywordStatus = 'pending' | 'allow' | 'deny' | 'synonym';
 
 export type KeywordFlags = Partial<{
-  onboarding: boolean;
+  title: string;
   description: string;
 }>;
 
-export type KeywordFlagsPublic = Pick<KeywordFlags, 'description'>;
+export type KeywordFlagsPublic = Pick<KeywordFlags, 'title' | 'description'>;
 
 @Entity()
 @Index('IDX_status_value', ['status', 'value'])

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -10,9 +10,10 @@ export type KeywordStatus = 'pending' | 'allow' | 'deny' | 'synonym';
 
 export type KeywordFlags = Partial<{
   onboarding: boolean;
+  description: string;
 }>;
 
-export type KeywordFlagsPublic = never;
+export type KeywordFlagsPublic = Pick<KeywordFlags, 'description'>;
 
 @Entity()
 @Index('IDX_status_value', ['status', 'value'])

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -9,6 +9,7 @@ import {
 export type KeywordStatus = 'pending' | 'allow' | 'deny' | 'synonym';
 
 export type KeywordFlags = Partial<{
+  onboarding: boolean;
   title: string;
   description: string;
 }>;

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -1,7 +1,12 @@
 import { IResolvers } from '@graphql-tools/utils';
 import { Context } from '../Context';
 import { traceResolvers } from './trace';
-import { Keyword, KeywordStatus, PostKeyword } from '../entity';
+import {
+  Keyword,
+  KeywordFlagsPublic,
+  KeywordStatus,
+  PostKeyword,
+} from '../entity';
 import graphorm from '../graphorm';
 import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
 import { GQLEmptyResponse } from './common';
@@ -11,6 +16,7 @@ interface GQLKeyword {
   value: string;
   status: KeywordStatus;
   occurrences: number;
+  flags?: KeywordFlagsPublic;
 }
 
 interface GQLKeywordSearchResults {
@@ -28,6 +34,13 @@ interface GQLSynonymKeywordArgs {
 }
 
 export const typeDefs = /* GraphQL */ `
+  type KeywordFlagsPublic {
+    """
+    Description of the keyword
+    """
+    description: String
+  }
+
   """
   Post keyword
   """
@@ -44,6 +57,10 @@ export const typeDefs = /* GraphQL */ `
     Number of posts containing this keyword
     """
     occurrences: Int!
+    """
+    The keyword's flags
+    """
+    flags: KeywordFlagsPublic
   }
 
   """
@@ -77,7 +94,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get a keyword
     """
-    keyword(value: String!): Keyword @auth(requires: [MODERATOR])
+    keyword(value: String!): Keyword
   }
 
   extend type Mutation {

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -36,6 +36,11 @@ interface GQLSynonymKeywordArgs {
 export const typeDefs = /* GraphQL */ `
   type KeywordFlagsPublic {
     """
+    Title of the keyword
+    """
+    title: String
+
+    """
     Description of the keyword
     """
     description: String


### PR DESCRIPTION
AS-241

- add title and description to `flags` 
- open keyword query so we can fetch it on `/tags/:tag` on frontend and get `description`
- added script for CSV import
- also added [Retool app](https://dailydotdev.retool.com/apps/8470354e-f745-11ee-b6ec-8b108f7c86be/%5BWIP%5D%20Update%20keyword%20(tag)) for keyword description update 