### PR TITLE
fix: add query to get related tags for source

### DIFF
--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -16,7 +16,7 @@ interface GQLTagSearchResults {
   hits: GQLTag[];
 }
 
-type GQLTagResults = Pick<GQLTagSearchResults, 'hits'>;
+export type GQLTagResults = Pick<GQLTagSearchResults, 'hits'>;
 
 export const RECOMMENDED_TAGS_LIMIT = 5;
 


### PR DESCRIPTION
Add query to sources to get relatedTags for the source.
Based on:
- last 90 days post
- keyword count
- allowed keywords

![Screenshot 2024-04-11 at 16 16 23](https://github.com/dailydotdev/daily-api/assets/554874/f7b734ca-c2a3-47f5-8663-4c74c55cccc3)
(subnote: would actually be nice to have a postman collection shared 😅)