### PR TITLE
fix: source by tag query

### DIFF
--- a/src/entity/PostKeyword.ts
+++ b/src/entity/PostKeyword.ts
@@ -4,6 +4,11 @@ import { Post } from './posts';
 @Entity()
 @Index('IDX_post_keyword_postId_status', ['postId', 'status'])
 @Index('IDX_post_keyword_keyword_postid', ['keyword', 'postId'])
+@Index('IDX_post_keyword_status_keyword_postid', [
+  'status',
+  'keyword',
+  'postId',
+])
 export class PostKeyword {
   @PrimaryColumn({ type: 'text' })
   @Index('IDX_post_keyword_postId')

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -74,6 +74,8 @@ export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;
   'deleted',
   'createdAt',
 ])
+@Index('IDX_post_sourceid_createdat', ['sourceId', 'createdAt'])
+@Index('IDX_post_sourceid_deleted', ['sourceId', 'deleted'])
 @TableInheritance({
   column: { type: 'varchar', name: 'type', default: PostType.Article },
 })

--- a/src/migration/1712910394483-KeywordIndexes.ts
+++ b/src/migration/1712910394483-KeywordIndexes.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class KeywordIndexes1712910394483 implements MigrationInterface {
+  name = 'KeywordIndexes1712910394483';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_sourceid_deleted" ON "post" ("sourceId", "deleted") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_sourceid_createdat" ON "post" ("sourceId", "createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_post_keyword_status_keyword_postid" ON "post_keyword" ("status", "keyword", "postId") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_sourceid_createdat"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_post_sourceid_deleted"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_post_keyword_status_keyword_postid"`,
+    );
+  }
+}


### PR DESCRIPTION
It was either this query or the reverse double one (query post-keyword then do where IN [sourceId], but felt one query might be easier.

Could potentially be a heavy one due to count, so let's monitor everSQL closely with this :) 
Decided to make it a paginated one in case we want to use it for something else later on.

It can get a list of sources ranked by how many of the keyword occurrences happen on post it has.  (excluding private sources)

![Screenshot 2024-04-12 at 10 00 59](https://github.com/dailydotdev/daily-api/assets/554874/947c16e1-5949-4177-a7ae-754b49529bdd)

On prod run:
![Screenshot 2024-04-12 at 10 05 13](https://github.com/dailydotdev/daily-api/assets/554874/7ddd72fd-a63d-4b22-9e00-76ffc9d7a4fd)
![Screenshot 2024-04-12 at 10 05 41](https://github.com/dailydotdev/daily-api/assets/554874/b4210489-c97a-4635-9ef3-fb52d4ff31d6)
