### PR TITLE
feat: add source tag materialized view

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -7,7 +7,7 @@ interface Cron {
   requests?: {
     cpu: string;
     memory: string;
-  }
+  };
 }
 
 export const crons: Cron[] = [
@@ -67,6 +67,10 @@ export const crons: Cron[] = [
     schedule: '12 3 * * *',
   },
   {
+    name: 'update-source-tag-view',
+    schedule: '20 3 * * 0',
+  },
+  {
     name: 'update-tag-recommendations',
     schedule: '5 3 * * 0',
   },
@@ -80,5 +84,5 @@ export const crons: Cron[] = [
       cpu: '250m',
       memory: '1Gi',
     },
-  }
+  },
 ];

--- a/src/cron/updateSourceTagView.ts
+++ b/src/cron/updateSourceTagView.ts
@@ -1,0 +1,20 @@
+import { Cron } from './cron';
+import { SourceTagView } from '../entity/SourceTagView';
+
+const cron: Cron = {
+  name: 'update-source-tag-view',
+  handler: async (con, logger) => {
+    const materializedViewName =
+      con.getRepository(SourceTagView).metadata.tableName;
+
+    try {
+      await con.query(`REFRESH MATERIALIZED VIEW ${materializedViewName}`);
+
+      logger.info({}, 'source tag view updated');
+    } catch (err) {
+      logger.error({ err }, 'failed to update source tag view');
+    }
+  },
+};
+
+export default cron;

--- a/src/entity/SourceTagView.ts
+++ b/src/entity/SourceTagView.ts
@@ -1,0 +1,38 @@
+import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
+import { Post } from './posts';
+import { subDays } from 'date-fns';
+import { PostKeyword } from './PostKeyword';
+import { Source } from './Source';
+
+@ViewEntity({
+  materialized: true,
+  expression: (dataSource: DataSource) =>
+    dataSource
+      .createQueryBuilder()
+      .select(`s.id as sourceId`)
+      .addSelect('pk.keyword AS tag')
+      .addSelect('count(pk.keyword) AS count')
+      .from(Source, 's')
+      .innerJoin(Post, 'p', `p.sourceId = s.id AND p.createdAt > :time`, {
+        time: subDays(new Date(), 90),
+      })
+      .innerJoin(
+        PostKeyword,
+        'pk',
+        'pk.postId = p.id AND pk.status = :status',
+        { status: 'allow' },
+      )
+      .andWhere({ active: true, private: false })
+      .groupBy(`sourceId, tag`)
+      .orderBy('count', 'DESC'),
+})
+export class SourceTagView {
+  @ViewColumn()
+  sourceId: string;
+
+  @ViewColumn()
+  tag: string;
+
+  @ViewColumn()
+  count: number;
+}

--- a/src/entity/SourceTagView.ts
+++ b/src/entity/SourceTagView.ts
@@ -1,4 +1,4 @@
-import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
+import { DataSource, Index, ViewColumn, ViewEntity } from 'typeorm';
 import { Post } from './posts';
 import { subDays } from 'date-fns';
 import { PostKeyword } from './PostKeyword';
@@ -23,14 +23,15 @@ import { Source } from './Source';
         { status: 'allow' },
       )
       .andWhere({ active: true, private: false })
-      .groupBy(`sourceId, tag`)
-      .orderBy('count', 'DESC'),
+      .groupBy(`sourceId, tag`),
 })
 export class SourceTagView {
   @ViewColumn()
+  @Index('IDX_sourceTag_sourceId')
   sourceId: string;
 
   @ViewColumn()
+  @Index('IDX_sourceTag_tag')
   tag: string;
 
   @ViewColumn()

--- a/src/migration/1712930614437-SourceTagView.ts
+++ b/src/migration/1712930614437-SourceTagView.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SourceTagView1712930614437 implements MigrationInterface {
+  name = 'SourceTagView1712930614437';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const isNonProductionEnv = ['development', 'test'].includes(
+      process.env.NODE_ENV,
+    );
+    const createdAtThreshold = isNonProductionEnv
+      ? `'1970-01-01'`
+      : `(current_timestamp - interval '90 day')::date`;
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "source_tag_view" AS SELECT "s"."id" as sourceId, "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold} INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY sourceId, tag ORDER BY count DESC`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'MATERIALIZED_VIEW',
+        'source_tag_view',
+        `SELECT "s"."id" as sourceId, "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold}  INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY sourceId, tag ORDER BY count DESC`,
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['MATERIALIZED_VIEW', 'source_tag_view', 'public'],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW "source_tag_view"`);
+  }
+}

--- a/src/migration/1712930614437-SourceTagView.ts
+++ b/src/migration/1712930614437-SourceTagView.ts
@@ -11,7 +11,7 @@ export class SourceTagView1712930614437 implements MigrationInterface {
       ? `'1970-01-01'`
       : `(current_timestamp - interval '90 day')::date`;
     await queryRunner.query(
-      `CREATE MATERIALIZED VIEW "source_tag_view" AS SELECT "s"."id" as sourceId, "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold} INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY sourceId, tag ORDER BY count DESC`,
+      `CREATE MATERIALIZED VIEW "source_tag_view" AS SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold} INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag ORDER BY count DESC`,
     );
     await queryRunner.query(
       `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
@@ -19,7 +19,7 @@ export class SourceTagView1712930614437 implements MigrationInterface {
         'public',
         'MATERIALIZED_VIEW',
         'source_tag_view',
-        `SELECT "s"."id" as sourceId, "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold}  INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY sourceId, tag ORDER BY count DESC`,
+        `SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold}  INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag ORDER BY count DESC`,
       ],
     );
   }

--- a/src/migration/1712930614437-SourceTagView.ts
+++ b/src/migration/1712930614437-SourceTagView.ts
@@ -11,7 +11,7 @@ export class SourceTagView1712930614437 implements MigrationInterface {
       ? `'1970-01-01'`
       : `(current_timestamp - interval '90 day')::date`;
     await queryRunner.query(
-      `CREATE MATERIALIZED VIEW "source_tag_view" AS SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold} INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag ORDER BY count DESC`,
+      `CREATE MATERIALIZED VIEW "source_tag_view" AS SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold} INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag`,
     );
     await queryRunner.query(
       `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
@@ -19,12 +19,20 @@ export class SourceTagView1712930614437 implements MigrationInterface {
         'public',
         'MATERIALIZED_VIEW',
         'source_tag_view',
-        `SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold}  INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag ORDER BY count DESC`,
+        `SELECT "s"."id" as "sourceId", "pk"."keyword" AS tag, count("pk"."keyword") AS count FROM "public"."source" "s" INNER JOIN "public"."post" "p" ON "p"."sourceId" = "s"."id" AND "p"."createdAt" > ${createdAtThreshold}  INNER JOIN "public"."post_keyword" "pk" ON "pk"."postId" = "p"."id" AND "pk"."status" = 'allow' WHERE ("s"."active" = true AND "s"."private" = false) GROUP BY "s"."id", tag`,
       ],
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sourceTag_sourceId" ON "source_tag_view" ("sourceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sourceTag_tag" ON "source_tag_view" ("tag") `,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_sourceTag_tag"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_sourceTag_sourceId"`);
     await queryRunner.query(
       `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
       ['MATERIALIZED_VIEW', 'source_tag_view', 'public'],


### PR DESCRIPTION
Added a materialized view for source-tag-count 
Will modify use-cases in a separate PR to keep things easier to review.

Local example:
![Screenshot 2024-04-12 at 16 13 52](https://github.com/dailydotdev/daily-api/assets/554874/83fbc278-c061-464f-883b-a9f1b923238b)
