### PR TITLE
fix: move at timezone into date_trunc for submission check

### DIFF
--- a/src/schema/submissions.ts
+++ b/src/schema/submissions.ts
@@ -94,7 +94,7 @@ const getSubmissionsToday = (con: DataSource, user: User) => {
     .createQueryBuilder()
     .select('*')
     .where(
-      `date_trunc('day', "createdAt")::timestamptz ${atTimezone} = date_trunc('day', now())::timestamptz ${atTimezone}`,
+      `date_trunc('day', timezone('UTC', "createdAt") ${atTimezone})::timestamptz = date_trunc('day', now() ${atTimezone})::timestamptz`,
     )
     .andWhere('"userId" = :id', { id: user.id })
     .execute();


### PR DESCRIPTION
I noticed that the submission date check was dependent on the date of the database server, and actually not on the user.

So `2024-04-13 01:33:54` at `Europe/Oslo` would be `2024-04-12 23:33:54` at `UTC`, but when casting the timezones, that would become `2024-04-12 02:00:00`.
The same would `2024-04-12 23:59:59` at `Europe/Oslo` become `2024-04-12 02:00:00` at `UTC`.