### PR TITLE
fix: clear boot cache on user assignment to Marketing CTA campaign

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -2617,6 +2617,55 @@ describe('marketing cta', () => {
     });
   });
 
+  describe('on user assign', () => {
+    it('should clear boot cache for the user when they are assigned to the campaign', async () => {
+      expect(
+        await getRedisObject(
+          generateStorageKey(
+            StorageTopic.Boot,
+            StorageKey.MarketingCta,
+            usersFixture[0].id as string,
+          ),
+        ),
+      ).not.toBeNull();
+
+      await expectSuccessfulBackground(
+        worker,
+        mockChangeMessage<UserMarketingCta>({
+          after: {
+            marketingCtaId: 'worlds-best-campaign',
+            marketingCta: {
+              ...base,
+              createdAt: new Date('2024-03-13 12:00:00'),
+            },
+            userId: usersFixture[0].id as string,
+            createdAt: 0,
+            readAt: null,
+          },
+          before: null,
+          op: 'c',
+          table: 'user_marketing_cta',
+        }),
+      );
+
+      expect(
+        await getRedisObject(
+          generateStorageKey(
+            StorageTopic.Boot,
+            StorageKey.MarketingCta,
+            usersFixture[0].id as string,
+          ),
+        ),
+      ).toBeNull();
+
+      expect(
+        await getRedisKeysByPattern(
+          generateStorageKey(StorageTopic.Boot, StorageKey.MarketingCta, '*'),
+        ),
+      ).toHaveLength(3);
+    });
+  });
+
   describe('on user unassign', () => {
     it('should clear boot cache for the user when they are unassigned from the campaign', async () => {
       expect(

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -773,17 +773,25 @@ const onMarketingCtaChange = async (
 const onUserMarketingCtaChange = async (
   data: ChangeMessage<UserMarketingCta>,
 ) => {
-  // Only run on delete and if the user has read the Marketing CTA
-  if (data.payload.op !== 'd') return;
-  if (data.payload.before.readAt !== null) return;
+  if (data.payload.op === 'c') {
+    await deleteRedisKey(
+      generateStorageKey(
+        StorageTopic.Boot,
+        StorageKey.MarketingCta,
+        data.payload.after.userId,
+      ),
+    );
+  } else if (data.payload.op === 'd') {
+    if (data.payload.before.readAt !== null) return;
 
-  await deleteRedisKey(
-    generateStorageKey(
-      StorageTopic.Boot,
-      StorageKey.MarketingCta,
-      data.payload.before.userId,
-    ),
-  );
+    await deleteRedisKey(
+      generateStorageKey(
+        StorageTopic.Boot,
+        StorageKey.MarketingCta,
+        data.payload.before.userId,
+      ),
+    );
+  }
 };
 
 const worker: Worker = {


### PR DESCRIPTION
Clears the boot cache when a user is assigned to a campaign.

Important to note, all this logic will most likely be refactored when the customer.io integration is implemented