### PR TITLE
fix: targetUrl would be constructed with undefined due to missing handle

### DIFF
--- a/__tests__/workers/notifications/collectionUpdated.ts
+++ b/__tests__/workers/notifications/collectionUpdated.ts
@@ -256,6 +256,13 @@ describe('collectionUpdated worker', () => {
     avatars.forEach((item) => {
       expect(['a', 'b', 'c'].includes(item.referenceId));
       expect(item.targetUrl).toBeTruthy();
+      const source = sourcesFixture.find(
+        (source) => source.id === item.referenceId,
+      );
+      expect(source!.handle).toBeTruthy();
+      expect(item.targetUrl).toBe(
+        `http://localhost:5002/sources/${source!.handle}`,
+      );
     });
   });
 

--- a/src/workers/notifications/collectionUpdated.ts
+++ b/src/workers/notifications/collectionUpdated.ts
@@ -41,7 +41,7 @@ export const collectionUpdated: NotificationWorker = {
       relationType: PostRelationType.Collection,
     })
       .select(
-        's.id as id, s."name" as name, s."image" as image, count(s."id") OVER() AS total',
+        's.id as id, s."name" as name, s."image" as image, count(s."id") OVER() AS total, s."handle" as handle',
       )
       .limit(3)
       .getRawMany<Source & { total: number }>();


### PR DESCRIPTION
NotificationV2 system is optimized and reuses avatars between multiple notifications (and notification types). Which means that for all notifications referencing avatar X, there will be only one instance of that avatar in notification avatar table.

Due to missing `handle` column in `SELECT` inside `collectionsUpdated` worker this avatar would be created with:
<img width="423" alt="image" src="https://github.com/dailydotdev/daily-api/assets/9803078/eba372d8-b964-42c3-b195-1238899f4c14">

I added column to select and adjusted test to specifically look for URL structure.  

This edge case would happen specifically when there was a collection created that was connected to source X and then when notification was created in `source_post_added` due to new post being added to source the new notification would reuse avatar created by collections notification bundle which would contain `undefined` instead of proper handle.

I pulled the query in the DB and looks like only 51 sources that were affected. Some notable: `cloudflare`, `hn`. After merge I'll run a script to fix those notification avatars retroactively. 

Fixes https://github.com/dailydotdev/daily/issues/1135

