### PR TITLE
fix: use span processors option since other is deprecated

### DIFF
--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -136,7 +136,7 @@ export const tracer = (serviceName: string) => {
     logRecordProcessor: new logs.SimpleLogRecordProcessor(
       new logs.ConsoleLogRecordExporter(),
     ),
-    spanProcessor,
+    spanProcessors: [spanProcessor],
     instrumentations,
     resourceDetectors,
     // textMapPropagator: new CloudPropagator(),


### PR DESCRIPTION
Just [found the error](https://console.cloud.google.com/logs/query;query=labels.%22k8s-pod%2Fapp%22%3D%22api-personalized-digest%22%0Aseverity%3DERROR%0AtextPayload%3D%22The%20'spanProcessor'%20option%20is%20deprecated.%20Please%20use%20'spanProcessors'%20instead.%22;summaryFields=:false:32:beginning;cursorTimestamp=2024-04-30T09:55:01.561443039Z;duration=P7D?project=devkit-prod&authuser=2) randomly while browsing some other logs. 