### PR TITLE
chore: reduce redis instance size

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -63,7 +63,7 @@ if (isAdhocEnv) {
 const redis = new Redis(`${name}-redis`, {
   isAdhocEnv,
   name: `${name}-redis`,
-  tier: 'STANDARD_HA',
+  tier: 'BASIC',
   memorySizeGb: 2,
   region: location,
   authEnabled: true,

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -64,7 +64,7 @@ const redis = new Redis(`${name}-redis`, {
   isAdhocEnv,
   name: `${name}-redis`,
   tier: 'STANDARD_HA',
-  memorySizeGb: 10,
+  memorySizeGb: 2,
   region: location,
   authEnabled: true,
   redisVersion: 'REDIS_6_X',

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -64,7 +64,7 @@ const redis = new Redis(`${name}-redis`, {
   isAdhocEnv,
   name: `${name}-redis`,
   tier: 'BASIC',
-  memorySizeGb: 2,
+  memorySizeGb: 3,
   region: location,
   authEnabled: true,
   redisVersion: 'REDIS_6_X',


### PR DESCRIPTION
Last week I deleted ~4 GiB worth of old and untouched Redis keys. At the time we were using 5 out of 10 GiB of memory, which had been stable for months. Now we use 1.3 out of 10 GiB, so we can reduce it to 2 GiB and disable read-replica as we're not using it.

![image](https://github.com/dailydotdev/daily-api/assets/1681525/3cd9955e-f4ad-4f6d-986a-a3f1c5f73cb8)
