### PR TITLE
feat: set watercooler to be opt-in

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -8,6 +8,7 @@ Object {
   "excludeSources": Array [
     "b",
     "c",
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
   ],
   "excludeTypes": Array [],
   "includeTags": Array [
@@ -21,7 +22,9 @@ Object {
 exports[`function feedToFilters should return filters with source memberships 1`] = `
 Object {
   "blockedTags": Array [],
-  "excludeSources": Array [],
+  "excludeSources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
   "excludeTypes": Array [],
   "includeTags": Array [],
   "sourceIds": Array [
@@ -905,57 +908,9 @@ Object {
 }
 `;
 
-exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 1`] = `
-Object {
-  "anonymousFeed": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "id": "p1",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "javascript",
-            "webdev",
-          ],
-          "title": "P1",
-          "type": "article",
-          "url": "http://p1.com",
-        },
-      },
-      Object {
-        "node": Object {
-          "id": "p4",
-          "readTime": null,
-          "source": Object {
-            "id": "a",
-            "image": "http://image.com/a",
-            "name": "A",
-            "public": true,
-          },
-          "tags": Array [
-            "backend",
-            "data",
-            "javascript",
-          ],
-          "title": "P4",
-          "type": "article",
-          "url": "http://p4.com",
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "b",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
+exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 1`] = `null`;
+
+exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 2`] = `null`;
 
 exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
 Object {

--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -908,9 +908,57 @@ Object {
 }
 `;
 
-exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 1`] = `null`;
-
-exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 2`] = `null`;
+exports[`query anonymousFeed should return anonymous feed v2 and include blocked filters 1`] = `
+Object {
+  "anonymousFeed": Object {
+    "edges": Array [
+      Object {
+        "node": Object {
+          "id": "p1",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "javascript",
+            "webdev",
+          ],
+          "title": "P1",
+          "type": "article",
+          "url": "http://p1.com",
+        },
+      },
+      Object {
+        "node": Object {
+          "id": "p4",
+          "readTime": null,
+          "source": Object {
+            "id": "a",
+            "image": "http://image.com/a",
+            "name": "A",
+            "public": true,
+          },
+          "tags": Array [
+            "backend",
+            "data",
+            "javascript",
+          ],
+          "title": "P4",
+          "type": "article",
+          "url": "http://p4.com",
+        },
+      },
+    ],
+    "pageInfo": Object {
+      "endCursor": "b",
+      "hasNextPage": false,
+    },
+  },
+}
+`;
 
 exports[`query anonymousFeed should return anonymous feed while excluding sources 1`] = `
 Object {

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1,4 +1,9 @@
-import { createSquadWelcomePost, feedToFilters, Ranking } from '../src/common';
+import {
+  createSquadWelcomePost,
+  feedToFilters,
+  Ranking,
+  WATERCOOLER_ID,
+} from '../src/common';
 import {
   AdvancedSettings,
   ArticlePost,
@@ -368,6 +373,7 @@ describe('query anonymousFeed', () => {
         fresh_page_size: '4',
         offset: 0,
         user_id: '1',
+        blocked_sources: [WATERCOOLER_ID],
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],
@@ -683,6 +689,7 @@ describe('query feed', () => {
         offset: 0,
         fresh_page_size: '4',
         user_id: '1',
+        blocked_sources: [WATERCOOLER_ID],
         ...baseFeedConfig,
         config: {
           providers: {},
@@ -1836,6 +1843,7 @@ describe('function feedToFilters', () => {
     expect(filters.excludeSources).toEqual([
       'excludedSource',
       'settingsCombinationSource',
+      WATERCOOLER_ID,
     ]);
   });
 
@@ -1891,6 +1899,7 @@ describe('function feedToFilters', () => {
     ]);
     const filters = await feedToFilters(con, '1', '1');
     expect(filters.sourceIds).not.toContain('a');
+    expect(filters.excludeSources).toContain('a');
   });
 
   it('should return source in sourceIds if member set hideFeedPosts to false', async () => {
@@ -1966,6 +1975,7 @@ describe('query feedPreview', () => {
         fresh_page_size: '7',
         user_id: '1',
         allowed_tags: ['html'],
+        blocked_sources: [WATERCOOLER_ID],
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -418,7 +418,7 @@ describe('query anonymousFeed', () => {
         fresh_page_size: '4',
         offset: 0,
         blocked_tags: ['python', 'java'],
-        blocked_sources: ['a', 'b'],
+        blocked_sources: ['a', 'b', WATERCOOLER_ID],
         user_id: '1',
       })
       .reply(200, {

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -39,6 +39,7 @@ import {
   FeedUserStateConfigGenerator,
 } from '../../src/integrations/feed/configs';
 import { ILofnClient } from '../../src/integrations/lofn';
+import { WATERCOOLER_ID } from '../../src/common';
 
 let con: DataSource;
 let ctx: Context;
@@ -423,7 +424,7 @@ describe('FeedLofnConfigGenerator', () => {
         fresh_page_size: '4',
         allowed_tags: ['javascript', 'golang'],
         blocked_tags: ['python', 'java'],
-        blocked_sources: ['a', 'b'],
+        blocked_sources: ['a', 'b', WATERCOOLER_ID],
         squad_ids: ['a', 'b'],
         allowed_post_types: [
           'article',

--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -225,7 +225,9 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user in timezone ahead UTC 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [],
+  "blocked_sources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -349,7 +351,9 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user in timezone behind UTC 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [],
+  "blocked_sources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -473,7 +477,9 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user with provided config 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [],
+  "blocked_sources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -597,7 +603,9 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user with subscription 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [],
+  "blocked_sources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -155,19 +155,16 @@ export const feedToFilters = async (
 
   // Split memberships by hide flag
   const membershipsByHide = memberships.reduce(
-    (
-      acc: { true: string[]; false: string[] },
-      value: { sourceId: SourceMember['sourceId']; hide: boolean },
-    ) => {
-      acc[value.hide ? 'true' : 'false'].push(value.sourceId);
+    (acc, value: { sourceId: SourceMember['sourceId']; hide: boolean }) => {
+      acc[value.hide ? 'hide' : 'show'].push(value.sourceId);
       return acc;
     },
-    { true: [], false: [] },
+    { hide: [], show: [] },
   );
 
   // If the user is not a member of the watercooler, hide it
-  if (!membershipsByHide.false.includes(WATERCOOLER_ID)) {
-    membershipsByHide.true.push(WATERCOOLER_ID);
+  if (!membershipsByHide.show.includes(WATERCOOLER_ID)) {
+    membershipsByHide.hide.push(WATERCOOLER_ID);
   }
 
   return {
@@ -175,8 +172,8 @@ export const feedToFilters = async (
     excludeTypes,
     excludeSources: excludeSources
       .map((sources: Source) => sources.id)
-      .concat(membershipsByHide.true),
-    sourceIds: membershipsByHide.false,
+      .concat(membershipsByHide.hide),
+    sourceIds: membershipsByHide.show,
   };
 };
 

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -28,6 +28,8 @@ import graphorm from '../graphorm';
 import { mapArrayToOjbect } from './object';
 import { runInSpan } from '../telemetry/opentelemetry';
 
+export const WATERCOOLER_ID = 'fd062672-63b7-4a10-87bd-96dcd10e9613';
+
 export const whereTags = (
   tags: string[],
   builder: SelectQueryBuilder<Post>,
@@ -100,7 +102,7 @@ export const feedToFilters = async (
   userId: string,
 ): Promise<AnonymousFeedFilters> => {
   const settings = await getExcludedAdvancedSettings(con, feedId);
-  const [tags, excludeSources, sourceIds] = await Promise.all([
+  const [tags, excludeSources, memberships] = await Promise.all([
     con.getRepository(FeedTag).find({ where: { feedId: feedId ?? '' } }),
     con
       .getRepository(Source)
@@ -125,10 +127,11 @@ export const feedToFilters = async (
           .getRepository(SourceMember)
           .createQueryBuilder('sm')
           .select('sm."sourceId"')
-          .where('sm."userId" = :userId', { userId })
-          .andWhere(
-            `COALESCE((flags->'hideFeedPosts')::boolean, FALSE) = FALSE`,
+          .addSelect(
+            "COALESCE((flags->'hideFeedPosts')::boolean, FALSE)",
+            'hide',
           )
+          .where('sm."userId" = :userId', { userId })
           .execute()
       : [],
   ]);
@@ -150,13 +153,30 @@ export const feedToFilters = async (
     )
     .map((setting) => setting.options.type);
 
+  // Split memberships by hide flag
+  const membershipsByHide = memberships.reduce(
+    (
+      acc: { true: string[]; false: string[] },
+      value: { sourceId: SourceMember['sourceId']; hide: boolean },
+    ) => {
+      acc[value.hide ? 'true' : 'false'].push(value.sourceId);
+      return acc;
+    },
+    { true: [], false: [] },
+  );
+
+  // If the user is not a member of the watercooler, hide it
+  if (!membershipsByHide.false.includes(WATERCOOLER_ID)) {
+    membershipsByHide.true.push(WATERCOOLER_ID);
+  }
+
   return {
     ...tagFilters,
     excludeTypes,
-    excludeSources: excludeSources.map((sources: Source) => sources.id),
-    sourceIds: sourceIds.map(
-      (member: Pick<SourceMember, 'sourceId'>) => member.sourceId,
-    ),
+    excludeSources: excludeSources
+      .map((sources: Source) => sources.id)
+      .concat(membershipsByHide.true),
+    sourceIds: membershipsByHide.false,
   };
 };
 


### PR DESCRIPTION
Make watercooler as opt-in even though it's a public feed. Watercooler mostly has memes which not all the users want, surfacing it as default to all users seems to be controversial.

I also fixed a bug that even though "show on my feed" was set to false there could be an edge case where we show the posts of the squad. Unrelated to the original task but I noticed it as I go.