### PR TITLE
refactor: squad posting to increment squad total posts

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3630,8 +3630,7 @@ describe('mutation votePost', () => {
     );
   });
 
-  it('should upvote', async () => {
-    loggedUser = '1';
+  const testUpvote = async () => {
     await con.getRepository(Post).save({
       id: 'p1',
       upvotes: 3,
@@ -3652,6 +3651,32 @@ describe('mutation votePost', () => {
     });
     const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
     expect(post?.upvotes).toEqual(4);
+  };
+
+  it('should upvote', async () => {
+    loggedUser = '1';
+    const source = await con.getRepository(Source).findOneByOrFail({ id: 'a' });
+    expect(source.flags.totalUpvotes).toEqual(undefined);
+
+    await testUpvote();
+
+    const updatedSource = await con
+      .getRepository(Source)
+      .findOneByOrFail({ id: 'a' });
+    expect(updatedSource.flags.totalUpvotes).toEqual(undefined);
+  });
+
+  it('should upvote and increment squad total upvotes', async () => {
+    loggedUser = '1';
+    const repo = con.getRepository(Source);
+    await repo.update({ id: 'a' }, { type: SourceType.Squad });
+    const source = await repo.findOneByOrFail({ id: 'a' });
+    expect(source.flags.totalUpvotes).toEqual(undefined);
+
+    await testUpvote();
+
+    const updatedSource = await repo.findOneByOrFail({ id: 'a' });
+    expect(updatedSource.flags.totalUpvotes).toEqual(1);
   });
 
   it('should downvote', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3797,7 +3797,7 @@ describe('mutation votePost', () => {
 
     await testDownvote();
 
-    // should not be affected since this is not a squad
+    // should not be affected since the existing vote was a downvote
     const updatedSource = await con
       .getRepository(Source)
       .findOneByOrFail({ id: 'a' });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1225,6 +1225,9 @@ describe('mutation deletePost', () => {
       sharedPostId: 'p1',
       authorId,
     });
+    await con
+      .getRepository(Source)
+      .update({ id: 'a' }, { flags: { totalPosts: 1 } });
   };
 
   it('should not authorize when not logged in', () =>
@@ -1289,6 +1292,19 @@ describe('mutation deletePost', () => {
     const id = 'sp1';
     await createSharedPost(id);
     await verifyPostDeleted(id, loggedUser);
+  });
+
+  it('should allow member to delete their own shared post and reduce squads flags total posts', async () => {
+    loggedUser = '2';
+    const id = 'sp1';
+    await createSharedPost(id);
+    const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+    expect(source.flags.totalPosts).toEqual(1);
+    await verifyPostDeleted(id, loggedUser);
+    const updatedSource = await con
+      .getRepository(Source)
+      .findOneBy({ id: 'a' });
+    expect(updatedSource.flags.totalPosts).toEqual(0);
   });
 
   const verifyPostDeleted = async (id: string, user: string) => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -715,6 +715,7 @@ describe('welcomePost type', () => {
 
   it('should add welcome post and increment squad total posts', async () => {
     const repo = con.getRepository(Source);
+    await repo.update({ id: 'a' }, { type: SourceType.Squad });
     const source = await repo.findOneBy({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '1');
     expect(post.showOnFeed).toEqual(false);
@@ -1297,8 +1298,10 @@ describe('mutation deletePost', () => {
   it('should allow member to delete their own shared post and reduce squads flags total posts', async () => {
     loggedUser = '2';
     const id = 'sp1';
+    const repo = con.getRepository(Source);
+    await repo.update({ id: 'a' }, { type: SourceType.Squad });
     await createSharedPost(id);
-    const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+    const source = await repo.findOneBy({ id: 'a' });
     expect(source.flags.totalPosts).toEqual(1);
     await verifyPostDeleted(id, loggedUser);
     const updatedSource = await con

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3685,9 +3685,7 @@ describe('mutation votePost', () => {
     await testUpvote();
 
     const updatedSource = await repo.findOneByOrFail({ id: 'a' });
-    // the reason this will become 2 is we touched the post.upvotes twice.
-    // first was through the manual update, second was through the mutation
-    expect(updatedSource.flags.totalUpvotes).toEqual(2);
+    expect(updatedSource.flags.totalUpvotes).toEqual(4);
   });
 
   const testDownvote = async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2036,6 +2036,7 @@ describe('mutation viewPost', () => {
   });
 
   it('should submit view event', async () => {
+    loggedUser = '1';
     await con
       .getRepository(Post)
       .update({ id: 'p1' }, { type: PostType.Share });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -724,6 +724,17 @@ describe('welcomePost type', () => {
     const updatedSource = await repo.findOneBy({ id: 'a' });
     expect(updatedSource.flags.totalPosts).toEqual(1);
   });
+
+  it('should add a post and NOT increment source total posts', async () => {
+    const repo = con.getRepository(Source);
+    const source = await repo.findOneBy({ id: 'a' });
+    const post = await createSquadWelcomePost(con, source, '1');
+    expect(post.showOnFeed).toEqual(false);
+    expect(post.flags.showOnFeed).toEqual(false);
+
+    const updatedSource = await repo.findOneBy({ id: 'a' });
+    expect(updatedSource.flags.totalPosts).toEqual(undefined);
+  });
 });
 
 describe('query post', () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2038,31 +2038,6 @@ describe('mutation viewPost', () => {
   });
 });
 
-describe('trigger increment_squad_views_count', () => {
-  it('should NOT update source total views', async () => {
-    const repo = con.getRepository(Source);
-    const source = await repo.findOneByOrFail({ id: 'a' });
-    expect(source.flags.totalViews).toEqual(undefined);
-
-    await con.getRepository(Post).update({ id: 'p1' }, { views: 1 });
-
-    const updatedSource = await repo.findOneByOrFail({ id: 'a' });
-    expect(updatedSource.flags.totalViews).toEqual(undefined);
-  });
-
-  it('should update squad total views', async () => {
-    const repo = con.getRepository(Source);
-    await repo.update({ id: 'a' }, { type: SourceType.Squad });
-    const source = await repo.findOneByOrFail({ id: 'a' });
-    expect(source.flags.totalViews).toEqual(undefined);
-
-    await con.getRepository(Post).update({ id: 'p1' }, { views: 1 });
-
-    const updatedSource = await repo.findOneByOrFail({ id: 'a' });
-    expect(updatedSource.flags.totalViews).toEqual(1);
-  });
-});
-
 describe('mutation submitExternalLink', () => {
   const MUTATION = `
   mutation SubmitExternalLink($sourceId: ID!, $url: String!, $commentary: String, $title: String, $image: String) {
@@ -3662,6 +3637,12 @@ describe('mutation votePost', () => {
     expect(post?.upvotes).toEqual(4);
   };
 
+  it('should upvote', async () => {
+    loggedUser = '1';
+
+    await testUpvote();
+  });
+
   it('should upvote and NOT update source flags upvotes count', async () => {
     loggedUser = '1';
     const source = await con.getRepository(Source).findOneByOrFail({ id: 'a' });
@@ -3710,6 +3691,12 @@ describe('mutation votePost', () => {
     const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
     expect(post?.downvotes).toEqual(4);
   };
+
+  it('should downvote', async () => {
+    loggedUser = '1';
+
+    await testDownvote();
+  });
 
   it('should downvote and NOT update source flags upvotes count', async () => {
     loggedUser = '1';
@@ -3762,6 +3749,11 @@ describe('mutation votePost', () => {
       hidden: false,
     });
   };
+
+  it('should cancel vote', async () => {
+    loggedUser = '1';
+    await testCancelVote();
+  });
 
   it('should cancel vote and NOT update source flags upvotes count', async () => {
     loggedUser = '1';

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3676,7 +3676,9 @@ describe('mutation votePost', () => {
     await testUpvote();
 
     const updatedSource = await repo.findOneByOrFail({ id: 'a' });
-    expect(updatedSource.flags.totalUpvotes).toEqual(1);
+    // the reason this will become 2 is we touched the post.upvotes twice.
+    // first was through the manual update, second was through the mutation
+    expect(updatedSource.flags.totalUpvotes).toEqual(2);
   });
 
   it('should downvote', async () => {

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -3,7 +3,6 @@ import {
   Comment,
   ExternalLinkPreview,
   FreeformPost,
-  Post,
   PostOrigin,
   savePost,
   SquadSource,

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -5,6 +5,7 @@ import {
   FreeformPost,
   Post,
   PostOrigin,
+  savePost,
   SquadSource,
   User,
   WelcomePost,
@@ -126,33 +127,37 @@ export const createSquadWelcomePost = async (
   args: Partial<FreeformPost> = {},
 ) => {
   const content = getWelcomeContent(source);
-  const repo = con.getRepository(WelcomePost);
   const id = await generateShortId();
 
-  return repo.save({
-    ...args,
-    id,
-    shortId: id,
-    title: WELCOME_POST_TITLE,
-    sourceId: source.id,
-    authorId: adminId,
-    content,
-    contentHtml: markdown.render(content),
-    image: defaultImage.welcomePost,
-    banned: true,
-    flags: {
+  return savePost({
+    con,
+    type: WelcomePost,
+    shouldUpdateFlags: true,
+    post: {
+      ...args,
+      id,
+      shortId: id,
+      title: WELCOME_POST_TITLE,
+      sourceId: source.id,
+      authorId: adminId,
+      content,
+      contentHtml: markdown.render(content),
+      image: defaultImage.welcomePost,
       banned: true,
-      private: true,
+      flags: {
+        banned: true,
+        private: true,
+        visible: true,
+        showOnFeed: false,
+      },
       visible: true,
+      private: true,
+      pinnedAt: new Date(),
+      visibleAt: new Date(),
+      origin: PostOrigin.UserGenerated,
       showOnFeed: false,
     },
-    visible: true,
-    private: true,
-    pinnedAt: new Date(),
-    visibleAt: new Date(),
-    origin: PostOrigin.UserGenerated,
-    showOnFeed: false,
-  } as Partial<Post>);
+  });
 };
 
 export type EditablePost = Pick<
@@ -173,16 +178,21 @@ export const createFreeformPost = async (
     .getRepository(SquadSource)
     .findOneBy({ id: args.sourceId });
 
-  return con.getRepository(FreeformPost).save({
-    ...args,
-    shortId: args.id,
-    visible: true,
-    private: privacy,
-    visibleAt: new Date(),
-    origin: PostOrigin.UserGenerated,
-    flags: {
+  return savePost({
+    con,
+    type: FreeformPost,
+    shouldUpdateFlags: true,
+    post: {
+      ...args,
+      shortId: args.id,
       visible: true,
       private: privacy,
+      visibleAt: new Date(),
+      origin: PostOrigin.UserGenerated,
+      flags: {
+        visible: true,
+        private: privacy,
+      },
     },
   });
 };

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -3,8 +3,8 @@ import {
   Comment,
   ExternalLinkPreview,
   FreeformPost,
+  Post,
   PostOrigin,
-  savePost,
   SquadSource,
   User,
   WelcomePost,
@@ -128,35 +128,30 @@ export const createSquadWelcomePost = async (
   const content = getWelcomeContent(source);
   const id = await generateShortId();
 
-  return savePost({
-    con,
-    type: WelcomePost,
-    shouldUpdateFlags: true,
-    post: {
-      ...args,
-      id,
-      shortId: id,
-      title: WELCOME_POST_TITLE,
-      sourceId: source.id,
-      authorId: adminId,
-      content,
-      contentHtml: markdown.render(content),
-      image: defaultImage.welcomePost,
+  return con.getRepository(WelcomePost).save({
+    ...args,
+    id,
+    shortId: id,
+    title: WELCOME_POST_TITLE,
+    sourceId: source.id,
+    authorId: adminId,
+    content,
+    contentHtml: markdown.render(content),
+    image: defaultImage.welcomePost,
+    banned: true,
+    flags: {
       banned: true,
-      flags: {
-        banned: true,
-        private: true,
-        visible: true,
-        showOnFeed: false,
-      },
-      visible: true,
       private: true,
-      pinnedAt: new Date(),
-      visibleAt: new Date(),
-      origin: PostOrigin.UserGenerated,
+      visible: true,
       showOnFeed: false,
     },
-  });
+    visible: true,
+    private: true,
+    pinnedAt: new Date(),
+    visibleAt: new Date(),
+    origin: PostOrigin.UserGenerated,
+    showOnFeed: false,
+  } as Partial<Post>);
 };
 
 export type EditablePost = Pick<
@@ -177,21 +172,16 @@ export const createFreeformPost = async (
     .getRepository(SquadSource)
     .findOneBy({ id: args.sourceId });
 
-  return savePost({
-    con,
-    type: FreeformPost,
-    shouldUpdateFlags: true,
-    post: {
-      ...args,
-      shortId: args.id,
+  return con.getRepository(FreeformPost).save({
+    ...args,
+    shortId: args.id,
+    visible: true,
+    private: privacy,
+    visibleAt: new Date(),
+    origin: PostOrigin.UserGenerated,
+    flags: {
       visible: true,
       private: privacy,
-      visibleAt: new Date(),
-      origin: PostOrigin.UserGenerated,
-      flags: {
-        visible: true,
-        private: privacy,
-      },
     },
   });
 };

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -43,9 +43,8 @@ interface DeletePostProps {
   userId?: string;
 }
 
-export const deletePost = async ({ con, id, userId }: DeletePostProps) => {
-  const postRepo = con.getRepository(Post);
-  const res = await postRepo.update(
+export const deletePost = async ({ con, id, userId }: DeletePostProps) =>
+  con.getRepository(Post).update(
     { id },
     {
       deleted: true,
@@ -55,25 +54,6 @@ export const deletePost = async ({ con, id, userId }: DeletePostProps) => {
       }),
     },
   );
-
-  if (res.affected === 0) {
-    return res;
-  }
-
-  const post = await postRepo.findOneBy({ id });
-  const source = await post.source;
-
-  await con.getRepository(Source).update(
-    { id: source.id },
-    {
-      flags: updateFlagsStatement({
-        totalPosts: source.flags.totalPosts - 1,
-      }),
-    },
-  );
-
-  return res;
-};
 
 export const getAuthorPostStats = async (
   con: DataSource,

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -25,8 +25,6 @@ import { PostMention } from './PostMention';
 import { PostQuestion } from './PostQuestion';
 import { PostRelation, PostRelationType } from './PostRelation';
 import { CollectionPost } from './CollectionPost';
-import { EntityTarget } from 'typeorm/common/EntityTarget';
-import { DeepPartial } from 'typeorm/common/DeepPartial';
 
 export type PostStats = {
   numPosts: number;
@@ -37,37 +35,6 @@ export type PostStats = {
 
 type StringPostStats = {
   [Property in keyof PostStats]: string;
-};
-
-interface SavePostProps<T extends Post> {
-  con: DataSource | EntityManager;
-  type: EntityTarget<T>;
-  post: DeepPartial<T>;
-  shouldUpdateFlags?: boolean;
-}
-
-export const savePost = async <T extends Post>({
-  con,
-  type,
-  post,
-  shouldUpdateFlags,
-}: SavePostProps<T>) => {
-  const res = await con.getRepository(type).save(post);
-
-  if (shouldUpdateFlags) {
-    const source = await con
-      .getRepository(Source)
-      .findOneBy({ id: res.sourceId });
-
-    const currentTotalPosts = source.flags?.totalPosts || 0;
-    const flags = updateFlagsStatement({
-      totalPosts: currentTotalPosts + 1,
-    });
-
-    await con.getRepository(Source).update({ id: source.id }, { flags });
-  }
-
-  return res;
 };
 
 interface DeletePostProps {
@@ -372,29 +339,24 @@ export const createSharePost = async (
 
     const id = await generateShortId();
 
-    const post = await savePost<SharePost>({
-      con,
-      type: SharePost,
-      shouldUpdateFlags: true,
-      post: {
-        id,
-        shortId: id,
-        createdAt: new Date(),
-        sourceId,
-        authorId: userId,
-        sharedPostId: postId,
-        title: strippedCommentary,
-        titleHtml,
+    const post = await con.getRepository(SharePost).save({
+      id,
+      shortId: id,
+      createdAt: new Date(),
+      sourceId,
+      authorId: userId,
+      sharedPostId: postId,
+      title: strippedCommentary,
+      titleHtml,
+      sentAnalyticsReport: true,
+      private: privacy,
+      origin: PostOrigin.UserGenerated,
+      visible,
+      visibleAt: visible ? new Date() : null,
+      flags: {
         sentAnalyticsReport: true,
         private: privacy,
-        origin: PostOrigin.UserGenerated,
         visible,
-        visibleAt: visible ? new Date() : null,
-        flags: {
-          sentAnalyticsReport: true,
-          private: privacy,
-          visible,
-        },
       },
     });
 

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -89,6 +89,10 @@ export const deletePost = async ({ con, id, userId }: DeletePostProps) => {
     },
   );
 
+  if (res.affected === 0) {
+    return res;
+  }
+
   const post = await postRepo.findOneBy({ id });
   const source = await post.source;
 

--- a/src/migration/1714633817175-SquadTotalPostsTrigger.ts
+++ b/src/migration/1714633817175-SquadTotalPostsTrigger.ts
@@ -10,15 +10,11 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
           LANGUAGE PLPGSQL
           AS
         $$
-        DECLARE
-          s public.source;
         BEGIN
-          SELECT * INTO s FROM public.source WHERE id = NEW."sourceId";
-          IF s.type = 'squad' THEN
-            UPDATE source
-            SET flags = jsonb_set(flags, array['totalPosts'], to_jsonb(COALESCE(CAST(flags->>'totalPosts' AS INTEGER), 0) + 1))
-            WHERE id = s.id;
-          END IF;
+          UPDATE  source
+          SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(COALESCE(CAST(flags->>'totalPosts' AS INTEGER), 0) + 1))
+          WHERE   id = NEW."sourceId"
+          AND     type = 'squad';
           RETURN NEW;
         END;
         $$
@@ -33,18 +29,14 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
           LANGUAGE PLPGSQL
           AS
         $$
-        DECLARE
-          s public.source;
         BEGIN
           IF OLD.deleted = false AND NEW.deleted = true THEN
-            SELECT * INTO s FROM public.source WHERE id = OLD."sourceId";
-            IF s.type = 'squad' THEN
-              UPDATE source
-              SET flags = jsonb_set(flags, array['totalPosts'], to_jsonb(CAST(flags->>'totalPosts' AS INTEGER) - 1))
-              WHERE id = s.id;
-            END IF;
+            UPDATE  source
+            SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(CAST(flags->>'totalPosts' AS INTEGER) - 1))
+            WHERE   id = NEW."sourceId"
+            AND     type = 'squad';
           END IF;
-          RETURN OLD;
+          RETURN NEW;
         END;
         $$
       `);

--- a/src/migration/1714633817175-SquadTotalPostsTrigger.ts
+++ b/src/migration/1714633817175-SquadTotalPostsTrigger.ts
@@ -20,43 +20,16 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
         $$
       `);
     queryRunner.query(
-      `CREATE TRIGGER increment_squad_posts_count AFTER INSERT ON "post" FOR EACH ROW EXECUTE PROCEDURE increment_squad_posts_count()`,
-    );
-
-    queryRunner.query(`
-        CREATE OR REPLACE FUNCTION deduct_squad_stats()
-          RETURNS TRIGGER
-          LANGUAGE PLPGSQL
-          AS
-        $$
-        BEGIN
-          IF OLD.deleted = false AND NEW.deleted = true THEN
-            UPDATE  source
-            SET     flags = jsonb_set(
-                              jsonb_set(
-                                flags,
-                                '{totalPosts}',
-                                to_jsonb(GREATEST(0, CAST(flags->>'totalPosts' AS INTEGER) - 1))
-                              ),
-                              '{totalViews}',
-                              to_jsonb(GREATEST(0, CAST(flags->>'totalViews' AS INTEGER) - OLD.views))
-                            )
-            WHERE   id = NEW."sourceId"
-            AND     type = 'squad';
-          END IF;
-          RETURN NEW;
-        END;
-        $$
-      `);
-    queryRunner.query(
-      `CREATE TRIGGER deduct_squad_stats AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE deduct_squad_stats()`,
+      `
+        CREATE TRIGGER increment_squad_posts_count
+        AFTER INSERT ON "post"
+        FOR EACH ROW
+        EXECUTE PROCEDURE increment_squad_posts_count()
+      `,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.query('DROP TRIGGER IF EXISTS deduct_squad_stats ON post');
-    queryRunner.query('DROP FUNCTION IF EXISTS deduct_squad_stats');
-
     queryRunner.query(
       'DROP TRIGGER IF EXISTS increment_squad_posts_count ON post',
     );

--- a/src/migration/1714633817175-SquadTotalPostsTrigger.ts
+++ b/src/migration/1714633817175-SquadTotalPostsTrigger.ts
@@ -32,7 +32,7 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
         BEGIN
           IF OLD.deleted = false AND NEW.deleted = true THEN
             UPDATE  source
-            SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(CAST(flags->>'totalPosts' AS INTEGER) - 1))
+            SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(GREATEST(0, COALESCE(CAST(flags->>'totalPosts' AS INTEGER), 0) - 1)))
             WHERE   id = NEW."sourceId"
             AND     type = 'squad';
           END IF;

--- a/src/migration/1714633817175-SquadTotalPostsTrigger.ts
+++ b/src/migration/1714633817175-SquadTotalPostsTrigger.ts
@@ -12,7 +12,7 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
         $$
         BEGIN
           UPDATE  source
-          SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(COALESCE(flags->>'totalPosts'::int , 0) + 1))
+          SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(COALESCE(CAST(flags->>'totalPosts' AS INTEGER) , 0) + 1))
           WHERE   id = NEW."sourceId"
           AND     type = 'squad';
           RETURN NEW;
@@ -24,7 +24,7 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
     );
 
     queryRunner.query(`
-        CREATE OR REPLACE FUNCTION decrement_squad_stats()
+        CREATE OR REPLACE FUNCTION deduct_squad_stats()
           RETURNS TRIGGER
           LANGUAGE PLPGSQL
           AS
@@ -32,7 +32,15 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
         BEGIN
           IF OLD.deleted = false AND NEW.deleted = true THEN
             UPDATE  source
-            SET     flags = jsonb_set(flags, '{totalPosts}', to_jsonb(GREATEST(0, flags->>'totalPosts'::int - 1))),
+            SET     flags = jsonb_set(
+                              jsonb_set(
+                                flags,
+                                '{totalPosts}',
+                                to_jsonb(GREATEST(0, CAST(flags->>'totalPosts' AS INTEGER) - 1))
+                              ),
+                              '{totalViews}',
+                              to_jsonb(GREATEST(0, CAST(flags->>'totalViews' AS INTEGER) - OLD.views))
+                            )
             WHERE   id = NEW."sourceId"
             AND     type = 'squad';
           END IF;
@@ -41,13 +49,13 @@ export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
         $$
       `);
     queryRunner.query(
-      `CREATE TRIGGER decrement_squad_stats AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE decrement_squad_stats()`,
+      `CREATE TRIGGER deduct_squad_stats AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE deduct_squad_stats()`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.query('DROP TRIGGER IF EXISTS decrement_squad_stats ON post');
-    queryRunner.query('DROP FUNCTION IF EXISTS decrement_squad_stats');
+    queryRunner.query('DROP TRIGGER IF EXISTS deduct_squad_stats ON post');
+    queryRunner.query('DROP FUNCTION IF EXISTS deduct_squad_stats');
 
     queryRunner.query(
       'DROP TRIGGER IF EXISTS increment_squad_posts_count ON post',

--- a/src/migration/1714633817175-SquadTotalPostsTrigger.ts
+++ b/src/migration/1714633817175-SquadTotalPostsTrigger.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SquadTotalPostsTrigger1714633817175 implements MigrationInterface {
+  name = 'SquadTotalPostsTrigger1714633817175';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+        CREATE OR REPLACE FUNCTION update_squad_posts_count()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        DECLARE
+          s public.source;
+        BEGIN
+          SELECT * INTO s FROM public.source WHERE id = NEW."sourceId";
+          IF s.type = 'squad' THEN
+            UPDATE source
+            SET flags = jsonb_set(flags, array['totalPosts'], to_jsonb(COALESCE(CAST(flags->>'totalPosts' AS INTEGER), 0) + 1))
+            WHERE id = s.id;
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    queryRunner.query(
+      `CREATE TRIGGER update_squad_posts_count AFTER INSERT ON "post" FOR EACH ROW EXECUTE PROCEDURE update_squad_posts_count()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(
+      'DROP TRIGGER IF EXISTS update_squad_posts_count ON post',
+    );
+    queryRunner.query('DROP FUNCTION IF EXISTS update_squad_posts_count');
+  }
+}

--- a/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
+++ b/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
@@ -19,8 +19,11 @@ export class SquadTotalUpvotesTrigger1714662136871
                               flags,
                               '{totalUpvotes}',
                               to_jsonb(
-                                COALESCE(CAST(flags->>'totalUpvotes' AS INTEGER), 0) +
-                                (CASE WHEN NEW.upvotes > OLD.upvotes THEN 1 ELSE -1 END)
+                                GREATEST(
+                                  0,
+                                  COALESCE(CAST(flags->>'totalUpvotes' AS INTEGER), 0) +
+                                  (CASE WHEN NEW.upvotes > OLD.upvotes THEN 1 ELSE -1 END)
+                                )
                               )
                             )
             WHERE   id = NEW."sourceId"

--- a/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
+++ b/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
@@ -21,7 +21,7 @@ export class SquadTotalUpvotesTrigger1714662136871
                               to_jsonb(
                                 GREATEST(
                                   0,
-                                  COALESCE(CAST(flags->>'totalUpvotes' AS INTEGER), 0) +
+                                  COALESCE(flags->>'totalUpvotes'::int, 0) +
                                   (CASE WHEN NEW.upvotes > OLD.upvotes THEN 1 ELSE -1 END)
                                 )
                               )

--- a/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
+++ b/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SquadTotalUpvotesTrigger1714662136871
+  implements MigrationInterface
+{
+  name = 'SquadTotalUpvotesTrigger1714662136871';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+        CREATE OR REPLACE FUNCTION update_squad_upvotes_count()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          IF NEW.upvotes <> OLD.upvotes THEN
+            UPDATE  source
+            SET     flags = jsonb_set(
+                              flags,
+                              '{totalUpvotes}',
+                              to_jsonb(
+                                COALESCE(CAST(flags->>'totalUpvotes' AS INTEGER), 0) +
+                                (CASE WHEN NEW.upvotes > OLD.upvotes THEN 1 ELSE -1 END)
+                              )
+                            )
+            WHERE   id = NEW."sourceId"
+            AND     type = 'squad';
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    queryRunner.query(
+      `CREATE TRIGGER update_squad_upvotes_count AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE update_squad_upvotes_count()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(
+      'DROP TRIGGER IF EXISTS update_squad_upvotes_count ON post',
+    );
+    queryRunner.query('DROP FUNCTION IF EXISTS update_squad_upvotes_count');
+  }
+}

--- a/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
+++ b/src/migration/1714662136871-SquadTotalUpvotesTrigger.ts
@@ -21,7 +21,7 @@ export class SquadTotalUpvotesTrigger1714662136871
                               to_jsonb(
                                 GREATEST(
                                   0,
-                                  COALESCE(flags->>'totalUpvotes'::int, 0) +
+                                  COALESCE(CAST(flags->>'totalUpvotes' AS INTEGER), 0) +
                                   (CASE WHEN NEW.upvotes > OLD.upvotes THEN 1 ELSE -1 END)
                                 )
                               )

--- a/src/migration/1714667947050-SquadTotalViewsTrigger.ts
+++ b/src/migration/1714667947050-SquadTotalViewsTrigger.ts
@@ -11,22 +11,26 @@ export class SquadTotalViewsTrigger1714667947050 implements MigrationInterface {
           AS
         $$
         BEGIN
-          IF NEW.views > OLD.views THEN
-            UPDATE  source
-            SET     flags = jsonb_set(
-                              flags,
-                              '{totalViews}',
-                              to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
-                            )
-            WHERE   id = NEW."sourceId"
-            AND     type = 'squad';
-          END IF;
+          UPDATE  source
+          SET     flags = jsonb_set(
+                            flags,
+                            '{totalViews}',
+                            to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
+                          )
+          WHERE   id = NEW."sourceId"
+          AND     type = 'squad';
           RETURN NEW;
         END;
         $$
       `);
     queryRunner.query(
-      `CREATE TRIGGER increment_squad_views_count AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE increment_squad_views_count()`,
+      `
+        CREATE TRIGGER increment_squad_views_count
+        AFTER UPDATE ON "post"
+        FOR EACH ROW
+        WHEN (NEW.views > OLD.views)
+        EXECUTE PROCEDURE increment_squad_views_count()
+      `,
     );
   }
 

--- a/src/migration/1714667947050-SquadTotalViewsTrigger.ts
+++ b/src/migration/1714667947050-SquadTotalViewsTrigger.ts
@@ -16,7 +16,7 @@ export class SquadTotalViewsTrigger1714667947050 implements MigrationInterface {
             SET     flags = jsonb_set(
                               flags,
                               '{totalViews}',
-                              to_jsonb(COALESCE(flags->>'totalViews'::int, 0) + 1)
+                              to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
                             )
             WHERE   id = NEW."sourceId"
             AND     type = 'squad';

--- a/src/migration/1714667947050-SquadTotalViewsTrigger.ts
+++ b/src/migration/1714667947050-SquadTotalViewsTrigger.ts
@@ -16,7 +16,7 @@ export class SquadTotalViewsTrigger1714667947050 implements MigrationInterface {
             SET     flags = jsonb_set(
                               flags,
                               '{totalViews}',
-                              to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
+                              to_jsonb(COALESCE(flags->>'totalViews'::int, 0) + 1)
                             )
             WHERE   id = NEW."sourceId"
             AND     type = 'squad';

--- a/src/migration/1714667947050-SquadTotalViewsTrigger.ts
+++ b/src/migration/1714667947050-SquadTotalViewsTrigger.ts
@@ -15,7 +15,7 @@ export class SquadTotalViewsTrigger1714667947050 implements MigrationInterface {
           SET     flags = jsonb_set(
                             flags,
                             '{totalViews}',
-                            to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
+                            to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + (NEW.views - OLD.views))
                           )
           WHERE   id = NEW."sourceId"
           AND     type = 'squad';

--- a/src/migration/1714667947050-SquadTotalViewsTrigger.ts
+++ b/src/migration/1714667947050-SquadTotalViewsTrigger.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SquadTotalViewsTrigger1714667947050 implements MigrationInterface {
+  name = 'SquadTotalViewsTrigger1714667947050';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+        CREATE OR REPLACE FUNCTION increment_squad_views_count()
+          RETURNS TRIGGER
+          LANGUAGE PLPGSQL
+          AS
+        $$
+        BEGIN
+          IF NEW.views > OLD.views THEN
+            UPDATE  source
+            SET     flags = jsonb_set(
+                              flags,
+                              '{totalViews}',
+                              to_jsonb(COALESCE(CAST(flags->>'totalViews' AS INTEGER), 0) + 1)
+                            )
+            WHERE   id = NEW."sourceId"
+            AND     type = 'squad';
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+    queryRunner.query(
+      `CREATE TRIGGER increment_squad_views_count AFTER UPDATE ON "post" FOR EACH ROW EXECUTE PROCEDURE increment_squad_views_count()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(
+      'DROP TRIGGER IF EXISTS increment_squad_views_count ON post',
+    );
+    queryRunner.query('DROP FUNCTION IF EXISTS increment_squad_views_count');
+  }
+}

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -57,6 +57,7 @@ import {
   User,
   PostRelationType,
   PostRelation,
+  deletePost,
 } from '../entity';
 import { GQLEmptyResponse } from './common';
 import {
@@ -1363,16 +1364,7 @@ export const resolvers: IResolvers<any, Context> = {
       ctx: Context,
     ): Promise<GQLEmptyResponse> => {
       if (ctx.roles.includes(Roles.Moderator)) {
-        await ctx.getRepository(Post).update(
-          { id },
-          {
-            deleted: true,
-            flags: updateFlagsStatement<Post>({
-              deleted: true,
-              deletedBy: ctx.userId,
-            }),
-          },
-        );
+        await deletePost({ con: ctx.con, id, userId: ctx.userId });
         return { _: true };
       }
 
@@ -1386,16 +1378,7 @@ export const resolvers: IResolvers<any, Context> = {
             SourcePermissions.PostDelete,
           );
         }
-        await repo.update(
-          { id },
-          {
-            deleted: true,
-            flags: updateFlagsStatement<Post>({
-              deleted: true,
-              deletedBy: ctx.userId,
-            }),
-          },
-        );
+        await deletePost({ con: manager, id, userId: ctx.userId });
       });
 
       return { _: true };


### PR DESCRIPTION
As the RFC has mentioned, we should update the mutation for creating new posts related to Squad.

There was no mention of deleting posts, but I assumed we should reduce the count by 1. Feel free to mention if we should not make any changes to it.

Notable changes here:
- Created a generic function for saving changes to posts, this is to allow us to streamline the updating of flags (maybe we could have done the increment on the new post worker, but I might have missed the discussion around it).
- Created a generic function for deleting a post, to do the same above.

MI-322 #done