### PR TITLE
feat: add search tags suggestions query

### DIFF
--- a/__tests__/common/search.ts
+++ b/__tests__/common/search.ts
@@ -1,0 +1,19 @@
+import { defaultSearchLimit, getSearchLimit } from '../../src/common/search';
+
+describe('getSearchLimit', () => {
+  it('should return default limit', () => {
+    expect(getSearchLimit({ limit: undefined })).toBe(defaultSearchLimit);
+  });
+
+  it('should return custom search limit', () => {
+    expect(getSearchLimit({ limit: 20 })).toBe(20);
+  });
+
+  it('should return max search limit', () => {
+    expect(getSearchLimit({ limit: 200 })).toBe(100);
+  });
+
+  it('should return min search limit', () => {
+    expect(getSearchLimit({ limit: 0 })).toBe(1);
+  });
+});

--- a/__tests__/common/search.ts
+++ b/__tests__/common/search.ts
@@ -1,4 +1,8 @@
-import { defaultSearchLimit, getSearchLimit } from '../../src/common/search';
+import {
+  defaultSearchLimit,
+  getSearchLimit,
+  maxSearchLimit,
+} from '../../src/common/search';
 
 describe('getSearchLimit', () => {
   it('should return default limit', () => {
@@ -10,10 +14,11 @@ describe('getSearchLimit', () => {
   });
 
   it('should return max search limit', () => {
-    expect(getSearchLimit({ limit: 200 })).toBe(100);
+    expect(getSearchLimit({ limit: 200 })).toBe(maxSearchLimit);
   });
 
   it('should return min search limit', () => {
     expect(getSearchLimit({ limit: 0 })).toBe(1);
+    expect(getSearchLimit({ limit: -5 })).toBe(1);
   });
 });

--- a/src/common/search.ts
+++ b/src/common/search.ts
@@ -10,13 +10,5 @@ export const maxSearchLimit = 100;
 export const getSearchLimit = ({
   limit,
 }: Pick<SearchSuggestionArgs, 'limit'>) => {
-  if (limit > maxSearchLimit) {
-    return maxSearchLimit;
-  }
-
-  if (limit < 1) {
-    return 1;
-  }
-
-  return limit ?? defaultSearchLimit;
+  return Math.max(Math.min(limit ?? defaultSearchLimit, maxSearchLimit), 1);
 };

--- a/src/common/search.ts
+++ b/src/common/search.ts
@@ -1,0 +1,22 @@
+export type SearchSuggestionArgs = {
+  query: string;
+  version: number;
+  limit?: number;
+};
+
+export const defaultSearchLimit = 3;
+export const maxSearchLimit = 100;
+
+export const getSearchLimit = ({
+  limit,
+}: Pick<SearchSuggestionArgs, 'limit'>) => {
+  if (limit > maxSearchLimit) {
+    return maxSearchLimit;
+  }
+
+  if (limit < 1) {
+    return 1;
+  }
+
+  return limit ?? defaultSearchLimit;
+};


### PR DESCRIPTION
AS-281

Add query to use in search panel. https://github.com/dailydotdev/apps/pull/3067

Similar query is in `schema/keywords` but it is only for moderators and I wanted to expose this one from`schema/search` to match specific format we return for all of our search providers.