### PR TITLE
fix: actually send post_id as prop

### DIFF
--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -46,6 +46,7 @@ import { ConnectionArguments } from 'graphql-relay';
 import graphorm from '../graphorm';
 import {
   feedClient,
+  FeedConfigName,
   FeedGenerator,
   feedGenerators,
   SimpleFeedConfigGenerator,
@@ -1250,11 +1251,18 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       ctx,
       info,
     ) => {
+      const generator = new FeedGenerator(
+        feedClient,
+        new SimpleFeedConfigGenerator({
+          feed_config_name: FeedConfigName.PostSimilarity,
+          ...args,
+        }),
+      );
       return feedResolverCursor(
         source,
         {
           ...(args as FeedArgs & { post_id: string }),
-          generator: feedGenerators['post_similarity'],
+          generator,
         },
         ctx,
         info,


### PR DESCRIPTION
After tedious debugging I realized our `feedResolverCursor` doesn't allow post_id by default, thus a manual generator setting is needed to actually add the `post_id`.