### PR TITLE
feat: filter mySourceMemberships by type

### DIFF
--- a/__tests__/__snapshots__/sources.ts.snap
+++ b/__tests__/__snapshots__/sources.ts.snap
@@ -98,68 +98,6 @@ Object {
 }
 `;
 
-exports[`query mySourceMemberships should not return source memberships in user is blocked 1`] = `
-Object {
-  "mySourceMemberships": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "role": "admin",
-          "roleRank": 10,
-          "source": Object {
-            "id": "b",
-          },
-          "user": Object {
-            "id": "2",
-          },
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "dGltZToxNjcxNDA4MDAwMDAw",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
-
-exports[`query mySourceMemberships should return source memberships 1`] = `
-Object {
-  "mySourceMemberships": Object {
-    "edges": Array [
-      Object {
-        "node": Object {
-          "role": "member",
-          "roleRank": 0,
-          "source": Object {
-            "id": "a",
-          },
-          "user": Object {
-            "id": "2",
-          },
-        },
-      },
-      Object {
-        "node": Object {
-          "role": "admin",
-          "roleRank": 10,
-          "source": Object {
-            "id": "b",
-          },
-          "user": Object {
-            "id": "2",
-          },
-        },
-      },
-    ],
-    "pageInfo": Object {
-      "endCursor": "dGltZToxNjcxNDA4MDAwMDAw",
-      "hasNextPage": false,
-    },
-  },
-}
-`;
-
 exports[`query source current member should return current member as admin 1`] = `
 Object {
   "source": Object {

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -123,7 +123,7 @@ describe('query sources', () => {
 }`;
 
   it('should return only public sources', async () => {
-    const res = await client.query(QUERY());
+    const res = await client.query(QUERY(10, true));
     const isPublic = res.data.sources.edges.every(({ node }) => !!node.public);
     expect(isPublic).toBeTruthy();
   });
@@ -1141,8 +1141,8 @@ describe('mutation createSquad', () => {
 }`;
 
   const variables = {
-    name: 'Squad',
-    handle: 'squad',
+    name: 'Squad Create Test',
+    handle: 'squadcreatetest',
     postId: 'p1',
     commentary: 'My comment',
   };
@@ -1166,8 +1166,8 @@ describe('mutation createSquad', () => {
     const newSource = await con
       .getRepository(SquadSource)
       .findOneBy({ id: newId });
-    expect(newSource.name).toEqual('Squad');
-    expect(newSource.handle).toEqual('squad');
+    expect(newSource.name).toEqual(variables.name);
+    expect(newSource.handle).toEqual(variables.handle);
     expect(newSource.active).toEqual(true);
     expect(newSource.private).toEqual(true);
     expect(newSource?.memberPostingRank).toEqual(
@@ -1323,8 +1323,8 @@ describe('mutation createSquad', () => {
     const newSource = await con
       .getRepository(SquadSource)
       .findOneBy({ id: newId });
-    expect(newSource.name).toEqual('Squad');
-    expect(newSource.handle).toEqual('squad');
+    expect(newSource.name).toEqual(variables.name);
+    expect(newSource.handle).toEqual(variables.handle);
     expect(newSource.active).toEqual(true);
     expect(newSource.private).toEqual(true);
     expect(newSource?.memberPostingRank).toEqual(
@@ -1386,8 +1386,8 @@ describe('mutation createSquad', () => {
     const newSource = await con
       .getRepository(SquadSource)
       .findOneBy({ id: newId });
-    expect(newSource.name).toEqual('Squad');
-    expect(newSource.handle).toEqual('squad');
+    expect(newSource.name).toEqual(variables.name);
+    expect(newSource.handle).toEqual(variables.handle);
     expect(newSource.active).toEqual(true);
     expect(newSource.private).toEqual(true);
     expect(newSource?.memberInviteRank).toEqual(

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -875,9 +875,9 @@ describe('query mySourceMemberships', () => {
       );
   });
 
-  const createQuery = (type?: string) => `
+  const createQuery = (type?: SourceType) => `
     query SourceMemberships {
-      mySourceMemberships${type ? `(type: "${type}")` : ''} {
+      mySourceMemberships${type ? `(type: ${type})` : ''} {
         pageInfo {
           endCursor
           hasNextPage
@@ -928,7 +928,7 @@ describe('query mySourceMemberships', () => {
 
   it('should only return squad type memberships if specified', async () => {
     loggedUser = '1';
-    const res = await client.query(createQuery('squad'));
+    const res = await client.query(createQuery(SourceType.Squad));
     expect(res.errors).toBeFalsy();
     expect(res.data.mySourceMemberships).toBeDefined();
     expect(res.data.mySourceMemberships.edges).toHaveLength(1);

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -11,10 +11,10 @@ import {
   SourceFlagsPublic,
   SourceMember,
   SourceMemberFlagsPublic,
-  SourceType,
   SquadSource,
   User,
 } from '../entity';
+import { SourceType } from '../entity/Source';
 import {
   SourceMemberRoles,
   sourceRoleRank,
@@ -39,10 +39,10 @@ import { randomUUID } from 'crypto';
 import {
   createSquadWelcomePost,
   getSourceLink,
-  toGQLEnum,
   updateFlagsStatement,
   uploadSquadImage,
 } from '../common';
+import { toGQLEnum } from '../common/utils';
 import { GraphQLResolveInfo } from 'graphql';
 import { SourcePermissionErrorKeys, TypeOrmError } from '../errors';
 import {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -39,6 +39,7 @@ import { randomUUID } from 'crypto';
 import {
   createSquadWelcomePost,
   getSourceLink,
+  toGQLEnum,
   updateFlagsStatement,
   uploadSquadImage,
 } from '../common';
@@ -285,6 +286,8 @@ export const typeDefs = /* GraphQL */ `
     hits: [Tag]!
   }
 
+  ${toGQLEnum(SourceType, 'SourceType')}
+
   extend type Query {
     """
     Get all available sources
@@ -413,7 +416,7 @@ export const typeDefs = /* GraphQL */ `
       """
       Source type (machine/squad)
       """
-      type: String
+      type: SourceType
     ): SourceMemberConnection! @auth
 
     """
@@ -1272,7 +1275,7 @@ export const resolvers: IResolvers<any, Context> = {
             .addOrderBy(`${alias}."createdAt"`, 'DESC');
 
           if (type) {
-            queryBuilder = queryBuilder
+            queryBuilder
               .innerJoin(Source, 's', `${alias}."sourceId" = s.id`)
               .andWhere(`s."type" = :type`, {
                 type,


### PR DESCRIPTION
For successfully querying squads that the user belongs to, we need to be able to filter the sources by type. 

Changed the unit tests not to depend on snapshots as well, AFAIK that's the new practice.

Related issue: 
- https://dailydotdev.atlassian.net/browse/MI-324

Related PR for the UI changes:
- https://github.com/dailydotdev/apps/pull/3084