### PR TITLE
feat: add missing fk to user relations

### DIFF
--- a/__tests__/actions.ts
+++ b/__tests__/actions.ts
@@ -1,5 +1,5 @@
 import { DataSource } from 'typeorm';
-import { UserAction, UserActionType } from '../src/entity';
+import { User, UserAction, UserActionType } from '../src/entity';
 import createOrGetConnection from '../src/db';
 import {
   disposeGraphQLTesting,
@@ -7,9 +7,11 @@ import {
   GraphQLTestingState,
   initializeGraphQLTesting,
   MockContext,
+  saveFixtures,
   testMutationErrorCode,
   testQueryErrorCode,
 } from './helpers';
+import { usersFixture } from './fixture/user';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -28,6 +30,8 @@ afterAll(() => disposeGraphQLTesting(state));
 
 beforeEach(async () => {
   loggedUser = null;
+
+  await saveFixtures(con, User, usersFixture);
 });
 
 describe('query actions', () => {

--- a/__tests__/bookmarks.ts
+++ b/__tests__/bookmarks.ts
@@ -16,11 +16,13 @@ import {
   View,
   BookmarkList,
   ArticlePost,
+  User,
 } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { postsFixture, postTagsFixture } from './fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
+import { usersFixture } from './fixture/user';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -62,6 +64,7 @@ beforeEach(async () => {
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, ArticlePost, postsFixture);
   await saveFixtures(con, PostTag, postTagsFixture);
+  await saveFixtures(con, User, usersFixture);
 });
 
 afterAll(() => disposeGraphQLTesting(state));

--- a/__tests__/compatibility.ts
+++ b/__tests__/compatibility.ts
@@ -12,11 +12,13 @@ import {
   Post,
   PostKeyword,
   Source,
+  User,
 } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { postKeywordsFixture, postsFixture } from './fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
+import { usersFixture } from './fixture/user';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -123,6 +125,10 @@ describe('query bookmarks', () => {
       ${feedFields}
     }
   }`;
+
+  beforeEach(async () => {
+    await saveFixtures(con, User, usersFixture);
+  });
 
   it('should return bookmarks ordered by time', async () => {
     const latest = new Date().toISOString();

--- a/__tests__/rss.ts
+++ b/__tests__/rss.ts
@@ -108,6 +108,7 @@ beforeAll(async () => {
 afterAll(() => app.close());
 
 beforeEach(async () => {
+  await saveFixtures(con, User, usersFixture);
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, ArticlePost, postsFixture);
   await saveFixtures(con, PostKeyword, postKeywordsFixture);
@@ -120,6 +121,7 @@ describe('GET /rss/b/:slug', () => {
 
   it('should fail when user does not exist', async () => {
     await con.getRepository(Settings).save({ userId: '1', bookmarkSlug: slug });
+    await con.getRepository(User).delete({});
     return request(app.server).get(path).expect(404);
   });
 

--- a/__tests__/settings.ts
+++ b/__tests__/settings.ts
@@ -8,13 +8,15 @@ import {
   GraphQLTestingState,
   initializeGraphQLTesting,
   MockContext,
+  saveFixtures,
   testMutationErrorCode,
   testQueryError,
   testQueryErrorCode,
 } from './helpers';
-import { CampaignCtaPlacement, Settings } from '../src/entity';
+import { CampaignCtaPlacement, Settings, User } from '../src/entity';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
+import { usersFixture } from './fixture/user';
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -33,6 +35,8 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   loggedUser = null;
+
+  await saveFixtures(con, User, usersFixture);
 });
 
 afterAll(() => disposeGraphQLTesting(state));

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -651,6 +651,10 @@ describe('user', () => {
   type ObjectType = Omit<User, 'createdAt'>;
   const base: ChangeObject<ObjectType> = { ...defaultUser };
 
+  beforeEach(async () => {
+    await saveFixtures(con, User, usersFixture);
+  });
+
   it('should notify on user created', async () => {
     await expectSuccessfulBackground(
       worker,
@@ -1575,6 +1579,11 @@ describe('feed', () => {
     userId: '1',
     id: '1',
   };
+
+  beforeEach(async () => {
+    await saveFixtures(con, User, usersFixture);
+  });
+
   it('should update alerts when feed is created', async () => {
     const repo = con.getRepository(Alerts);
     await repo.save({ userId: base.userId, myFeed: null });
@@ -2615,6 +2624,10 @@ describe('marketing cta', () => {
   });
 
   describe('on user assign', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, User, usersFixture);
+    });
+
     it('should clear boot cache for the user when they are assigned to the campaign', async () => {
       expect(
         await getRedisObject(

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, OneToOne, PrimaryColumn } from 'typeorm';
 import { User } from './user';
 
 export type AlertsFlags = Partial<{
@@ -54,7 +54,7 @@ export class Alerts {
 
   bootPopup?: boolean;
 
-  @ManyToOne(() => User, {
+  @OneToOne(() => User, {
     lazy: true,
     onDelete: 'CASCADE',
   })

--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from './user';
 
 export type AlertsFlags = Partial<{
   lastReferralReminder: Date | null;
@@ -52,9 +53,15 @@ export class Alerts {
   banner?: boolean;
 
   bootPopup?: boolean;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
 }
 
-export const ALERTS_DEFAULT: Omit<Alerts, 'userId' | 'flags'> = {
+export const ALERTS_DEFAULT: Omit<Alerts, 'userId' | 'flags' | 'user'> = {
   filter: true,
   rankLastSeen: null,
   myFeed: null,

--- a/src/entity/Bookmark.ts
+++ b/src/entity/Bookmark.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import { BookmarkList } from './BookmarkList';
 import { Post } from './posts';
+import { User } from './user';
 
 @Entity()
 @Index('IDX_bookmark_userId_createdAt', { synchronize: false })
@@ -30,4 +31,10 @@ export class Bookmark {
   @Column({ default: () => 'now()' })
   @Index('IDX_bookmark_createdAt', { synchronize: false })
   createdAt: Date;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
 }

--- a/src/entity/Settings.ts
+++ b/src/entity/Settings.ts
@@ -2,9 +2,11 @@ import {
   Column,
   Entity,
   Index,
+  ManyToOne,
   PrimaryColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { User } from './user';
 
 export enum CampaignCtaPlacement {
   Header = 'header',
@@ -64,6 +66,12 @@ export class Settings {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
 }
 
 export const SETTINGS_DEFAULT = {

--- a/src/entity/Settings.ts
+++ b/src/entity/Settings.ts
@@ -2,7 +2,7 @@ import {
   Column,
   Entity,
   Index,
-  ManyToOne,
+  OneToOne,
   PrimaryColumn,
   UpdateDateColumn,
 } from 'typeorm';
@@ -67,7 +67,7 @@ export class Settings {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @ManyToOne(() => User, {
+  @OneToOne(() => User, {
     lazy: true,
     onDelete: 'CASCADE',
   })

--- a/src/entity/user/UserAction.ts
+++ b/src/entity/user/UserAction.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from './User';
 
 export enum UserActionType {
   EnableNotification = 'enable_notification',
@@ -22,4 +23,10 @@ export class UserAction {
 
   @Column({ type: 'timestamp without time zone', default: () => 'now()' })
   completedAt: Date;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
 }

--- a/src/entity/user/UserState.ts
+++ b/src/entity/user/UserState.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from './User';
 
 export enum UserStateKey {
   CommunityLinkAccess = 'community_link_access',
@@ -14,4 +15,10 @@ export class UserState {
 
   @Column({ default: false })
   value: boolean;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  user: Promise<User>;
 }

--- a/src/migration/1715095164142-AddUserRelationFK.ts
+++ b/src/migration/1715095164142-AddUserRelationFK.ts
@@ -1,0 +1,75 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddUserRelationFK1715095164142 implements MigrationInterface {
+    name = 'AddUserRelationFK1715095164142'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // UserAction
+        await queryRunner.query(`
+            DELETE FROM user_action WHERE "userId" IN (
+                SELECT DISTINCT rt."userId" FROM user_action rt
+                LEFT JOIN public.user u ON rt."userId" = u.id
+                WHERE u.id IS NULL
+            )
+        `);
+        await queryRunner.query(`ALTER TABLE "user_action" ADD CONSTRAINT "FK_c025478b45e60017ed10c77f99c" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+
+        // Alerts
+        await queryRunner.query(`
+            DELETE FROM alerts WHERE "userId" IN (
+                SELECT DISTINCT rt."userId" FROM alerts rt
+                LEFT JOIN public.user u ON rt."userId" = u.id
+                WHERE u.id IS NULL
+            )
+        `);
+        await queryRunner.query(`ALTER TABLE "alerts" ADD CONSTRAINT "FK_f2678f7b11e5128abbbc4511906" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+
+        // - Bookmark
+        await queryRunner.query(`
+            DELETE FROM bookmark WHERE "userId" IN (
+                SELECT DISTINCT rt."userId" FROM bookmark rt
+                LEFT JOIN public.user u ON rt."userId" = u.id
+                WHERE u.id IS NULL
+            )
+        `);
+        await queryRunner.query(`ALTER TABLE "bookmark" ADD CONSTRAINT "FK_e389fc192c59bdce0847ef9ef8b" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+
+        // - Settings
+        await queryRunner.query(`
+            DELETE FROM settings WHERE "userId" IN (
+                SELECT DISTINCT rt."userId" FROM settings rt
+                LEFT JOIN public.user u ON rt."userId" = u.id
+                WHERE u.id IS NULL
+            )
+        `);
+        await queryRunner.query(`ALTER TABLE "settings" ADD CONSTRAINT "FK_9175e059b0a720536f7726a88c7" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+
+        // - UserState
+        await queryRunner.query(`
+            DELETE FROM user_state WHERE "userId" IN (
+                SELECT DISTINCT rt."userId" FROM user_state rt
+                LEFT JOIN public.user u ON rt."userId" = u.id
+                WHERE u.id IS NULL
+            )
+        `);
+        await queryRunner.query(`ALTER TABLE "user_state" ADD CONSTRAINT "FK_b35c67d61943214aff1e7c94abd" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // UserAction
+        await queryRunner.query(`ALTER TABLE "user_action" DROP CONSTRAINT "FK_c025478b45e60017ed10c77f99c"`);
+
+        // Alerts
+        await queryRunner.query(`ALTER TABLE "alerts" DROP CONSTRAINT "FK_f2678f7b11e5128abbbc4511906"`);
+
+        // - Bookmark
+        await queryRunner.query(`ALTER TABLE "bookmark" DROP CONSTRAINT "FK_e389fc192c59bdce0847ef9ef8b"`);
+
+        // - Settings
+        await queryRunner.query(`ALTER TABLE "settings" DROP CONSTRAINT "FK_9175e059b0a720536f7726a88c7"`);
+
+        // - UserState
+        await queryRunner.query(`ALTER TABLE "user_state" DROP CONSTRAINT "FK_b35c67d61943214aff1e7c94abd"`);
+    }
+
+}

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -60,8 +60,8 @@ export type Experimentation = {
 
 export type BaseBoot = {
   visit: { visitId: string; sessionId: string };
-  alerts: Omit<Alerts, 'userId' | 'flags'>;
-  settings: Omit<Settings, 'userId' | 'updatedAt'>;
+  alerts: Omit<Alerts, 'userId' | 'flags' | 'user'>;
+  settings: Omit<Settings, 'userId' | 'updatedAt' | 'user'>;
   notifications: { unreadNotificationsCount: number };
   squads: BootSquadSource[];
   exp?: Experimentation;

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -254,7 +254,7 @@ type PartialBookmarkSharing = Pick<GQLBookmarksSharing, 'slug'>;
 export const getSettings = async (
   con: DataSource,
   userId: string,
-): Promise<Settings> => {
+): Promise<Omit<Settings, 'user'>> => {
   try {
     const repo = con.getRepository(Settings);
     const settings = await repo.findOneBy({ userId });

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -34,7 +34,7 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
         });
       } catch (err) {
         if (err?.code === TypeOrmError.NULL_VIOLATION) {
-          logger.warn(
+          logger.error(
             { data: messageToJson(message) },
             'null violation when creating a notification',
           );
@@ -44,7 +44,7 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
           err?.code === TypeOrmError.FOREIGN_KEY &&
           err?.constraint === TypeOrmError.USER_CONSTRAINT
         ) {
-          logger.warn(
+          logger.error(
             { data: messageToJson(message) },
             'user constraint failed when creating a notification',
           );


### PR DESCRIPTION
In addition to https://github.com/dailydotdev/daily-api/pull/1878, fixing other cases where FK was missing on `userId` column.

- adding 1:1 and M:1 relations depending on PK
- migration file each has `DELETE` statement to delete leftover entries from relation tables for deleted users, eg. leftover alerts, bookmarks, settings from those deleted users
- tests updates are mostly due to users fixture missing now that we added FK

this will delete:
- user_action - 6,596 rows
- alerts - 33,347 rows
- bookmark - 4,278 rows
- settings - 74,233 rows
- user_state - 9 rows