### PR TITLE
fix: correct copy for high rate squads

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -809,6 +809,7 @@ describe('mutation commentOnPost', () => {
         client,
         { mutation: MUTATION, variables },
         'RATE_LIMITED',
+        'Take a break. You already commented enough in the last hour',
       );
 
       // Check expiry, to not cause it to be flaky, we check if it is within 10 seconds
@@ -993,6 +994,7 @@ describe('mutation commentOnComment', () => {
         client,
         { mutation: MUTATION, variables },
         'RATE_LIMITED',
+        'Take a break. You already commented enough in the last hour',
       );
 
       // Check expiry, to not cause it to be flaky, we check if it is within 10 seconds

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -134,10 +134,14 @@ export const testMutationErrorCode = async (
   client: GraphQLTestClient,
   mutation: Mutation,
   code: string,
+  message?: string,
 ): Promise<void> =>
   testMutationError(client, mutation, (errors) => {
     expect(errors.length).toEqual(1);
     expect(errors[0].extensions?.code).toEqual(code);
+    if (message) {
+      expect(errors[0].message).toEqual(message);
+    }
   });
 
 export type Query = {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2591,11 +2591,11 @@ describe('mutation checkLinkPreview', () => {
       expect(res.errors).toBeFalsy();
     }
 
-    return testMutationErrorCode(
+    await testMutationErrorCode(
       client,
       { mutation: MUTATION, variables },
       'RATE_LIMITED',
-      'Take a break. You already posted enough in the last ten minutes',
+      'Too many requests, please try again in 60s',
     );
   });
 

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1883,6 +1883,7 @@ describe('mutation sharePost', () => {
         client,
         { mutation: MUTATION, variables: variables },
         'RATE_LIMITED',
+        'Take a break. You already posted enough in the last hour',
       );
 
       // Check expiry, to not cause it to be flaky, we check if it is within 10 seconds
@@ -1925,6 +1926,7 @@ describe('mutation sharePost', () => {
             variables: { ...variables, sourceId: WATERCOOLER_ID },
           },
           'RATE_LIMITED',
+          'Take a break. You already posted enough in the last ten minutes',
         );
       });
     });
@@ -2462,6 +2464,7 @@ describe('mutation submitExternalLink', () => {
         client,
         { mutation: MUTATION, variables: variables },
         'RATE_LIMITED',
+        'Take a break. You already posted enough in the last hour',
       );
 
       // Check expiry, to not cause it to be flaky, we check if it is within 10 seconds
@@ -2512,6 +2515,7 @@ describe('mutation submitExternalLink', () => {
             },
           },
           'RATE_LIMITED',
+          'Take a break. You already posted enough in the last ten minutes',
         );
       });
     });
@@ -2591,6 +2595,7 @@ describe('mutation checkLinkPreview', () => {
       client,
       { mutation: MUTATION, variables },
       'RATE_LIMITED',
+      'Take a break. You already posted enough in the last ten minutes',
     );
   });
 
@@ -2945,6 +2950,7 @@ describe('mutation createFreeformPost', () => {
         client,
         { mutation: MUTATION, variables: params },
         'RATE_LIMITED',
+        'Take a break. You already posted enough in the last hour',
       );
 
       // Check expiry, to not cause it to be flaky, we check if it is within 10 seconds
@@ -2987,6 +2993,7 @@ describe('mutation createFreeformPost', () => {
             variables: { ...params, sourceId: WATERCOOLER_ID },
           },
           'RATE_LIMITED',
+          'Take a break. You already posted enough in the last ten minutes',
         );
       });
     });


### PR DESCRIPTION
The error message for high rate squad, like Watercooler, should say `last ten minutes` instead of `last hour`.