### PR TITLE
feat: handle lofn extra field

### DIFF
--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -442,4 +442,52 @@ describe('FeedLofnConfigGenerator', () => {
       },
     });
   });
+
+  it('should generate config through lofn and include extra in the request', async () => {
+    const mockClient = mock<ILofnClient>();
+    const mockedValue = {
+      user_id: '1',
+      config: {
+        page_size: 20,
+        total_pages: 10,
+        providers: {},
+      },
+      tyr_metadata: {
+        test: 'da',
+      },
+      extra: {
+        aigc_threshold: 'none',
+      },
+    };
+    mockClient.fetchConfig.mockResolvedValueOnce(mockedValue);
+    const generator: FeedConfigGenerator = new FeedLofnConfigGenerator(
+      {
+        total_pages: 1,
+      },
+      mockClient,
+      {
+        feed_version: '30',
+      },
+    );
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 10,
+      offset: 3,
+    });
+    expect(actual).toMatchObject({
+      config: {
+        user_id: '1',
+        total_pages: 1,
+        page_size: 10,
+        fresh_page_size: '4',
+        aigc_threshold: 'none',
+        config: {
+          providers: {},
+        },
+      },
+      extraMetadata: {
+        mab: mockedValue.tyr_metadata,
+      },
+    });
+  });
 });

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -165,6 +165,7 @@ export class FeedLofnConfigGenerator implements FeedConfigGenerator {
 
         const config = {
           config: lofnConfig.config,
+          ...lofnConfig.extra,
           ...preferencesConfig.config,
         };
 

--- a/src/integrations/lofn/types.ts
+++ b/src/integrations/lofn/types.ts
@@ -10,6 +10,7 @@ export type LofnFeedConfigResponse = {
   user_id: string;
   config: FeedConfig;
   tyr_metadata?: GenericMetadata;
+  extra?: GenericMetadata;
 };
 
 export type LofnFeedConfigPayload = {


### PR DESCRIPTION
Some feed experiments are not part of the inner config but the request itself. Something we will probably have to fix in the future but for now we need it for the AIGC experiment.