### PR TITLE
fix: send blocked content curation to feed service

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`function feedToFilters should return filters for tags/sources based on the values from our data 1`] = `
 Object {
+  "blockedContentCuration": Array [],
   "blockedTags": Array [
     "golang",
   ],
@@ -19,8 +20,24 @@ Object {
 }
 `;
 
+exports[`function feedToFilters should return filters with blocked content types 1`] = `
+Object {
+  "blockedContentCuration": Array [
+    "listicle",
+  ],
+  "blockedTags": Array [],
+  "excludeSources": Array [
+    "fd062672-63b7-4a10-87bd-96dcd10e9613",
+  ],
+  "excludeTypes": Array [],
+  "includeTags": Array [],
+  "sourceIds": Array [],
+}
+`;
+
 exports[`function feedToFilters should return filters with source memberships 1`] = `
 Object {
+  "blockedContentCuration": Array [],
   "blockedTags": Array [],
   "excludeSources": Array [
     "fd062672-63b7-4a10-87bd-96dcd10e9613",

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1879,6 +1879,26 @@ describe('function feedToFilters', () => {
     expect(await feedToFilters(con, '1', '1')).toMatchSnapshot();
   });
 
+  it('should return filters with blocked content types', async () => {
+    loggedUser = '1';
+    await saveFixtures(con, User, [usersFixture[0]]);
+    await con.getRepository(AdvancedSettings).save({
+      id: 1,
+      title: 'test',
+      group: 'content_curation',
+      options: { type: 'listicle' },
+      description: '',
+      defaultEnabledState: true,
+    });
+    await con.getRepository(Feed).save({ id: '1', userId: '1' });
+    await con.getRepository(FeedAdvancedSettings).save({
+      feedId: '1',
+      advancedSettingsId: 1,
+      enabled: false,
+    });
+    expect(await feedToFilters(con, '1', '1')).toMatchSnapshot();
+  });
+
   it('should not return source in sourceIds if member set hideFeedPosts to true', async () => {
     loggedUser = '1';
     await con.getRepository(User).save(usersFixture[0]);

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -167,6 +167,13 @@ export const feedToFilters = async (
     membershipsByHide.hide.push(WATERCOOLER_ID);
   }
 
+  console.log(settings);
+  const blockedContentCuration = settings
+    .filter(
+      (setting) => setting.group === 'content_curation' && setting.options.type,
+    )
+    .map((setting) => setting.options.type);
+
   return {
     ...tagFilters,
     excludeTypes,
@@ -174,6 +181,7 @@ export const feedToFilters = async (
       .map((sources: Source) => sources.id)
       .concat(membershipsByHide.hide),
     sourceIds: membershipsByHide.show,
+    blockedContentCuration,
   };
 };
 
@@ -421,6 +429,7 @@ export interface AnonymousFeedFilters {
   includeTags?: string[];
   blockedTags?: string[];
   sourceIds?: string[];
+  blockedContentCuration?: string[];
 }
 
 export const anonymousFeedBuilder = (

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -167,7 +167,6 @@ export const feedToFilters = async (
     membershipsByHide.hide.push(WATERCOOLER_ID);
   }
 
-  console.log(settings);
   const blockedContentCuration = settings
     .filter(
       (setting) => setting.group === 'content_curation' && setting.options.type,

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -108,7 +108,10 @@ export const feedToFilters = async (
       .getRepository(Source)
       .createQueryBuilder('s')
       .select('s.id AS "id"')
-      .where((qb) => {
+      .where(`s.advancedSettings && ARRAY[:...settings]::integer[]`, {
+        settings: settings.map((setting) => setting.id),
+      })
+      .orWhere((qb) => {
         const subQuery = qb
           .subQuery()
           .select('fs."sourceId"')

--- a/src/entity/AdvancedSettings.ts
+++ b/src/entity/AdvancedSettings.ts
@@ -22,6 +22,6 @@ export class AdvancedSettings {
   @Column({ type: 'jsonb', default: {} })
   options: {
     source?: Pick<Source, 'id'>;
-    type?: PostType;
+    type?: PostType | string;
   };
 }

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -18,6 +18,7 @@ type Options = {
   includeBlockedSources?: boolean;
   includeSourceMemberships?: boolean;
   includePostTypes?: boolean;
+  includeBlockedContentCuration?: boolean;
 };
 
 type BaseConfig = Partial<Omit<FeedConfig, 'user_id' | 'page_size' | 'offset'>>;
@@ -86,6 +87,12 @@ export class FeedPreferencesConfigGenerator implements FeedConfigGenerator {
         config.allowed_post_types = (
           config.allowed_post_types || postTypes
         ).filter((x) => !filters.excludeTypes.includes(x));
+      }
+      if (
+        filters.blockedContentCuration?.length &&
+        this.opts.includeBlockedContentCuration
+      ) {
+        config.blocked_content_curations = filters.blockedContentCuration;
       }
       return { config };
     });

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -57,6 +57,7 @@ const opts = {
   includeBlockedSources: true,
   includeSourceMemberships: true,
   includePostTypes: true,
+  includeBlockedContentCuration: true,
 };
 
 export const baseFeedConfig: Partial<FeedConfig> = {
@@ -74,6 +75,7 @@ export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
           includePostTypes: true,
           includeBlockedSources: true,
           includeBlockedTags: true,
+          includeBlockedContentCuration: true,
         },
       ),
       'popular',

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -48,6 +48,7 @@ export type FeedConfig = {
   blocked_tags?: string[];
   blocked_sources?: string[];
   allowed_post_types?: string[];
+  blocked_content_curations?: string[];
   squad_ids?: string[];
   providers?: Record<string, FeedProvider>;
   source_types?: ('machine' | 'squad')[];

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -159,6 +159,11 @@ export const typeDefs = /* GraphQL */ `
     Posts must not include even one tag from this list
     """
     blockedTags: [String!]
+
+    """
+    Posts must comply with the advanced settings from this list
+    """
+    blockedContentCuration: [String!]
   }
 
   type FeedFlagsPublic {


### PR DESCRIPTION
Pass through the blocked_content_curation options to feed service.

@pnvasanth We send an example as such (this is correct?):
```
{
  user_id: '0c3TpWWzGYHbOOFp9k3av',
  page_size: 9,
  offset: 0,
  cursor: undefined,
  allowed_post_types: [ 'article', 'share', 'freeform', 'video:youtube', 'collection' ],
  total_pages: 1,
  fresh_page_size: '3',
  blocked_sources: [ 'community', 'fd062672-63b7-4a10-87bd-96dcd10e9613' ],
  blocked_content_curations: [ 'listicle' ]
}
```