### PR TITLE
feat: add SquadPublicRequest entity and DB migration

### DIFF
--- a/src/entity/SquadPublicRequest.ts
+++ b/src/entity/SquadPublicRequest.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { Source } from './Source';
+import { User } from './user';
+
+enum SquadPublicRequestStatus {
+  Pending = 'pending',
+  Approved = 'approved',
+  Rejected = 'rejected',
+}
+
+@Entity()
+@Index('IDX_squad_public_request_sourceId', ['sourceId'])
+@Unique('source_id_status_unique_constraint', ['sourceId', 'status'])
+export class SquadPublicRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  @Index('IDX_squad_public_request_sourceId')
+  sourceId: string;
+
+  @ManyToOne(() => Source, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  source: Promise<Source>;
+
+  @Column({ type: 'text' })
+  requestorId: string;
+
+  @ManyToOne(() => User, {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  requestor: Promise<User>;
+
+  @Column({ default: () => 'now()', type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ default: () => 'now()', type: 'timestamptz' })
+  updatedAt: Date;
+
+  @Column({ type: 'text' })
+  status: SquadPublicRequestStatus;
+}

--- a/src/migration/1715795499542-SquadPublicRequest.ts
+++ b/src/migration/1715795499542-SquadPublicRequest.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SquadPublicRequest1715795499542 implements MigrationInterface {
+    name = 'SquadPublicRequest1715795499542'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "squad_public_request" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "sourceId" text NOT NULL, "requestorId" character varying NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "status" text NOT NULL, CONSTRAINT "source_id_status_unique_constraint" UNIQUE ("sourceId", "status"), CONSTRAINT "PK_61c2c7bbc7b36a21c36f1b2f46a" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_squad_public_request_sourceId" ON "squad_public_request" ("sourceId") `);
+        await queryRunner.query(`ALTER TABLE "squad_public_request" ADD CONSTRAINT "FK_588b9bbf0415aba1e4fed23b8f7" FOREIGN KEY ("sourceId") REFERENCES "source"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "squad_public_request" ADD CONSTRAINT "FK_cb822e7eeeb23bf497848d081fb" FOREIGN KEY ("requestorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "squad_public_request" DROP CONSTRAINT "FK_cb822e7eeeb23bf497848d081fb"`);
+        await queryRunner.query(`ALTER TABLE "squad_public_request" DROP CONSTRAINT "FK_588b9bbf0415aba1e4fed23b8f7"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_squad_public_request_sourceId"`);
+        await queryRunner.query(`DROP TABLE "squad_public_request"`);
+    }
+
+}


### PR DESCRIPTION
## Description

Adding entity for storing squad public requests.

[RFC reference here](https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/866254882/RFC-031+-+Public+Squads#API-changes.3).

Added a unique constraint to make sure only 1 request per squad can be in the same state.

Index added on the `sourceId` column to make retrieval by `sourceId` faster. Right now I'm not sure if we need to add more indexes, depending on the functionality we will implement later. We can always add more indexes :)

### Changes from the RFC

- Renamed column `requestedById` to `requestorId`, I think it reads better.
- Renamed column `reivewStatus` to `status`, I think it is descriptive enough.
- Supplied default value of `now()` to the `createdAt` and `updatedAt` columns.
- Since we have problems with `timestamp` columns in graphorm, I preemptively changed the type to `timestamptz`, it hurts no one to have the timezone stored as well.
- Added autogenerated `id` column, as per [discussion on the RFC](https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/866254882/RFC-031+-+Public+Squads?focusedCommentId=894730272).