### PR TITLE
fix: pass image to content type update to avoid trigger failing

### DIFF
--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -279,7 +279,7 @@ const updatePost = async ({
     await entityManager
       .createQueryBuilder()
       .update(Post)
-      .set({ type: content_type })
+      .set({ type: content_type, image: data.image })
       .where('id = :id', { id })
       .execute();
 


### PR DESCRIPTION
After https://github.com/dailydotdev/daily-api/pull/1915 the prematurely visible post would still not update with error. It was due to trigger updating notification attachment image during type update.

When post ID was created through new create post endpoint its `type` is `article` which is default. Due to bug in https://github.com/dailydotdev/daily-api/pull/1915 this post became visible immediately which in turn scheduled a notification with attachment and other elements.

When next `content-published` message arrived with correct `type=video:youtube` it tried to update the type of post in separate query we do in the beginning of `updatePost` function call. The issue was that this call triggered a trigger which tried to update an image as well but due to post not having an image (and no image was provided in `UPDATE` call) the trigger failed which then failed the worker handling. When I setup the test I got the exactly the same error as [reported](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1715871951607159?thread_ts=1715867292.092599&cid=C01L0QXQJNB).

The separate update is only needed because typeorm `Repository` does not know how to resolve the type of child entity based on column automatically. :hidethepain:, we had this issue before see https://github.com/dailydotdev/daily-api/pull/1578

In this PR we:
- send `image` with that type update so that trigger is satisfied if image is just being set
- the above scenario of dispatching notification too early should not happen with the fix in https://github.com/dailydotdev/daily-api/pull/1915
- generally we should probably streamline and simplify all of the `postUpdated` logic since it is pretty hard to follow as is https://dailydotdev.atlassian.net/browse/WT-2020