### PR TITLE
feat: set scout during post update

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -1078,6 +1078,107 @@ describe('on post update', () => {
       is_ai_probability: 0.52,
     });
   });
+
+  it('should update post with the relevant scout id and update submission', async () => {
+    const uuid = randomUUID();
+    await saveFixtures(con, Source, [
+      {
+        id: COMMUNITY_PICKS_SOURCE,
+        name: 'Community recommendations',
+        image: 'sample.image.com',
+      },
+    ]);
+    await createDefaultUser();
+    await createDefaultSubmission(uuid);
+    await con.getRepository(ArticlePost).save({
+      id: 'scp1',
+      shortId: 'scp1',
+      url: 'https://post.com/scp1',
+      title: 'Scouted title',
+      visible: false,
+      yggdrasilId: 'e0ea497b-fd69-4e55-b4e9-2df9ec42b91c',
+      sourceId: COMMUNITY_PICKS_SOURCE,
+    });
+
+    await expectSuccessfulBackground(worker, {
+      id: 'e0ea497b-fd69-4e55-b4e9-2df9ec42b91c',
+      title: 'Title',
+      url: 'https://post.com/scp1',
+      source_id: COMMUNITY_PICKS_SOURCE,
+      submission_id: uuid,
+    });
+
+    const post = await con
+      .getRepository(ArticlePost)
+      .findOneBy({ url: 'https://post.com/scp1' });
+    expect(post).toBeTruthy();
+    expect(post!.scoutId).toEqual('1');
+    const submissions = await con.getRepository(Submission).find();
+    const [submission] = submissions;
+    expect(submissions.length).toEqual(1);
+    expect(submission.id).toEqual(uuid);
+    expect(submission.status).toEqual(SubmissionStatus.Accepted);
+  });
+
+  it('should not set scout id when post is already scouted', async () => {
+    const uuid = randomUUID();
+    await saveFixtures(con, Source, [
+      {
+        id: COMMUNITY_PICKS_SOURCE,
+        name: 'Community recommendations',
+        image: 'sample.image.com',
+      },
+    ]);
+    await createDefaultUser();
+    await createDefaultSubmission(uuid);
+    await con.getRepository(ArticlePost).save({
+      id: 'scp1',
+      shortId: 'scp1',
+      url: 'https://post.com/scp1',
+      title: 'Scouted title',
+      visible: false,
+      yggdrasilId: 'e0ea497b-fd69-4e55-b4e9-2df9ec42b91c',
+      sourceId: COMMUNITY_PICKS_SOURCE,
+    });
+
+    await expectSuccessfulBackground(worker, {
+      id: 'e0ea497b-fd69-4e55-b4e9-2df9ec42b91c',
+      title: 'Title',
+      url: 'https://post.com/scp1',
+      source_id: COMMUNITY_PICKS_SOURCE,
+      submission_id: uuid,
+    });
+
+    const post = await con
+      .getRepository(ArticlePost)
+      .findOneBy({ url: 'https://post.com/scp1' });
+    expect(post).toBeTruthy();
+    expect(post!.scoutId).toEqual('1');
+
+    await con.getRepository(User).save({ ...usersFixture[1] });
+    const uuid2 = randomUUID();
+    await con.getRepository(Submission).save(
+      con.getRepository(Submission).create({
+        id: uuid2,
+        url: 'http://sample.article/test',
+        userId: '2',
+      }),
+    );
+
+    await expectSuccessfulBackground(worker, {
+      id: 'e0ea497b-fd69-4e55-b4e9-2df9ec42b91c',
+      title: 'Title',
+      url: 'https://post.com/scp1',
+      source_id: COMMUNITY_PICKS_SOURCE,
+      submission_id: uuid2,
+    });
+
+    const post2 = await con
+      .getRepository(ArticlePost)
+      .findOneBy({ url: 'https://post.com/scp1' });
+    expect(post2).toBeTruthy();
+    expect(post2!.scoutId).toEqual('1');
+  });
 });
 
 describe('on youtube post', () => {


### PR DESCRIPTION
After introduction of #1915 all post get created on API first to reserve post id. 

Our scout assignment logic runs only on `createPost` so it would miss attributing scouts for these new posts.

This PR adds the logic in `updatePost` as well and `scoutId` is set if it was not set before.

For more info see [thread](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1715872489501549)