### PR TITLE
fix: remove `table.include.list` from `Pulumi.prod.yaml`

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -7,7 +7,6 @@ config:
   api:clickhouseSync:
     keys:
       slot.name: "clickhouse_sync"
-      table.include.list: "public.post"
     vars:
       clickhouse_database:
         secure: AAABAFXhGil+ZGIYbGEIU71Q2eQslzMjGAkeeW0LumXI3GA=


### PR DESCRIPTION
It always detected changes in the yaml file, but because the pulumi value was set the `table.include.list: "public.post"`, it always used that value, instead of the one in the yaml file 🙈 