### PR TITLE
feat: add feeds to logged boot

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -4,6 +4,7 @@ import {
   GraphQLTestingState,
   initializeGraphQLTesting,
   MockContext,
+  saveFixtures,
   TEST_UA,
 } from './helpers';
 import createOrGetConnection from '../src/db';
@@ -15,6 +16,7 @@ import {
   Banner,
   Feature,
   FeatureType,
+  Feed,
   MachineSource,
   MarketingCta,
   MarketingCtaStatus,
@@ -107,6 +109,7 @@ const LOGGED_IN_BODY = {
     experienceLevel: null,
   },
   marketingCta: null,
+  feeds: [],
 };
 
 const ANONYMOUS_BODY = {
@@ -971,6 +974,66 @@ describe('boot misc', () => {
         currentMember: {
           permissions: [SourcePermissions.Post],
         },
+      },
+    ]);
+  });
+
+  it('should return the user feeds', async () => {
+    mockLoggedIn();
+    const feeds = [
+      {
+        id: '1',
+        userId: '1',
+
+        slug: '1',
+      },
+      {
+        id: 'cf1',
+        userId: '1',
+        flags: {
+          name: 'Cool feed',
+        },
+        slug: 'cool-feed-cf1',
+      },
+      {
+        id: 'cf2',
+        userId: '1',
+        flags: {
+          name: 'PHP feed',
+        },
+        slug: 'php-feed-cf2',
+      },
+      {
+        id: 'cf3',
+        userId: '2',
+        flags: {
+          name: 'Awful feed',
+        },
+        slug: 'awful-feed-cf3',
+      },
+    ];
+    await saveFixtures(con, User, usersFixture);
+    await con.getRepository(Feed).save(feeds);
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('Cookie', 'ory_kratos_session=value;')
+      .expect(200);
+    expect(res.body.feeds).toMatchObject([
+      {
+        id: 'cf1',
+        userId: '1',
+        flags: {
+          name: 'Cool feed',
+        },
+        slug: 'cool-feed-cf1',
+      },
+      {
+        id: 'cf2',
+        userId: '1',
+        flags: {
+          name: 'PHP feed',
+        },
+        slug: 'php-feed-cf2',
       },
     ]);
   });

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import createOrGetConnection from '../db';
-import { DataSource, EntityManager } from 'typeorm';
+import { DataSource, EntityManager, Not } from 'typeorm';
 import { clearAuthentication, dispatchWhoami } from '../kratos';
 import { generateUUID } from '../ids';
 import { generateSessionId, setTrackingId } from '../tracking';
@@ -10,6 +10,7 @@ import {
   ALERTS_DEFAULT,
   Banner,
   Feature,
+  Feed,
   MarketingCta,
   Settings,
   SETTINGS_DEFAULT,
@@ -44,6 +45,7 @@ import { getEncryptedFeatures } from '../growthbook';
 import { differenceInMinutes, isSameDay } from 'date-fns';
 import { runInSpan } from '../telemetry/opentelemetry';
 import { getUnreadNotificationsCount } from '../notifications/common';
+import { maxFeedsPerUser } from '../types';
 
 export type BootSquadSource = Omit<GQLSource, 'currentMember'> & {
   permalink: string;
@@ -176,6 +178,24 @@ const getSquads = async (
       };
     });
   });
+
+const getFeeds = async ({
+  con,
+  userId,
+}: {
+  con: DataSource;
+  userId: string;
+}): Promise<Feed[]> => {
+  const feeds = con.getRepository(Feed).find({
+    where: {
+      id: Not(userId),
+      userId,
+    },
+    take: maxFeedsPerUser,
+  });
+
+  return feeds;
+};
 
 const moderators = [
   '1d339aa5b85c4e0ba85fdedb523c48d4',
@@ -351,6 +371,7 @@ const loggedInBoot = async (
       exp,
       marketingCta,
       extra,
+      feeds,
     ] = await Promise.all([
       visitSection(req, res),
       getUser(con, userId),
@@ -363,6 +384,7 @@ const loggedInBoot = async (
       getExperimentation(userId, con),
       getMarketingCta(con, log, userId),
       middleware ? middleware(con, req, res) : {},
+      getFeeds({ con, userId }),
     ]);
     if (!user) {
       return handleNonExistentUser(con, req, res, middleware);
@@ -406,6 +428,7 @@ const loggedInBoot = async (
       accessToken,
       exp,
       marketingCta,
+      feeds,
       ...extra,
     };
   });


### PR DESCRIPTION
Our sidebar is prone to layout shifts so feeds have to go to boot. 😞 

It will be preloaded into `useFeeds` query on frontend during boot fetch see https://github.com/dailydotdev/apps/pull/3106/commits/4ca6cdf6ac7a935b0ce718b4e6be303b66a895c1