### PR TITLE
fix: switching back to private mode

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -1513,6 +1513,21 @@ describe('mutation editSquad', () => {
     );
   });
 
+  it('should ignore null private value and edit squad', async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, {
+      variables: { ...variables, name: 'test', isPrivate: null },
+    });
+
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource.name).toEqual('test');
+    expect(editSource.private).toBeTruthy();
+  });
+
   it("should not change squad's private status if variable is not found", async () => {
     loggedUser = '1';
 

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -19,6 +19,8 @@ import {
   SourceFeed,
   SourceMember,
   SourceType,
+  SquadPublicRequest,
+  SquadPublicRequestStatus,
   SquadSource,
   User,
   WelcomePost,
@@ -1451,8 +1453,8 @@ describe('mutation createSquad', () => {
 
 describe('mutation editSquad', () => {
   const MUTATION = `
-  mutation EditSquad($sourceId: ID!, $name: String!, $handle: String!, $description: String, $memberPostingRole: String, $memberInviteRole: String) {
-  editSquad(sourceId: $sourceId, name: $name, handle: $handle, description: $description, memberPostingRole: $memberPostingRole, memberInviteRole: $memberInviteRole) {
+  mutation EditSquad($sourceId: ID!, $name: String!, $handle: String!, $description: String, $memberPostingRole: String, $memberInviteRole: String, $isPrivate: Boolean) {
+  editSquad(sourceId: $sourceId, name: $name, handle: $handle, description: $description, memberPostingRole: $memberPostingRole, memberInviteRole: $memberInviteRole, isPrivate: $isPrivate) {
     id
   }
 }`;
@@ -1499,6 +1501,52 @@ describe('mutation editSquad', () => {
       .getRepository(SquadSource)
       .findOneBy({ id: variables.sourceId });
     expect(editSource.name).toEqual('test');
+  });
+
+  it('should not edit squad to public if no request was approved', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { ...variables, isPrivate: false } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it("should not change squad's private status if variable is not found", async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource.private).toBeTruthy();
+  });
+
+  it('should edit squad privacy status if the user has been approved before', async () => {
+    loggedUser = '1';
+
+    await con
+      .getRepository(SquadSource)
+      .update({ id: variables.sourceId }, { private: true });
+    await con.getRepository(SquadPublicRequest).save({
+      sourceId: variables.sourceId,
+      requestorId: '1',
+      status: SquadPublicRequestStatus.Approved,
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { ...variables, isPrivate: false },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const editSource = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(editSource.private).toBeFalsy();
   });
 
   it('should edit squad description with new lines', async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -68,12 +68,15 @@ export const SubmissionFailErrorMessage: Record<
 
 export enum SourceRequestErrorKeys {
   AccessDenied = 'ACCESS_DENIED',
+  SquadIneligible = 'SQUAD_INELIGIBLE',
 }
 
 export const SourceRequestErrorMessage: Record<SourceRequestErrorKeys, string> =
   {
     [SourceRequestErrorKeys.AccessDenied]:
       'You do not have sufficient permissions and or reputation to submit a source request yet.',
+    [SourceRequestErrorKeys.SquadIneligible]:
+      'Squad has not been approved yet of becoming public',
   };
 
 export class NotFoundError extends ApolloError {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1495,6 +1495,14 @@ export const resolvers: IResolvers<any, Context> = {
         inputHandle !== current.handle,
       );
 
+      const updates: Partial<SquadSource> = {
+        name,
+        handle,
+        description,
+        memberPostingRank: sourceRoleRank[memberPostingRole],
+        memberInviteRank: sourceRoleRank[memberInviteRole],
+      };
+
       if (!isNullOrUndefined(isPrivate) && current.private !== isPrivate) {
         const approved = await ctx.con
           .getRepository(SquadPublicRequest)
@@ -1505,23 +1513,14 @@ export const resolvers: IResolvers<any, Context> = {
         if (!approved) {
           throw new ValidationError(SourceRequestErrorMessage.SQUAD_INELIGIBLE);
         }
+
+        updates.private = isPrivate;
       }
 
       try {
         const editedSourceId = await ctx.con.transaction(
           async (entityManager) => {
             const repo = entityManager.getRepository(SquadSource);
-            const updates: Partial<SquadSource> = {
-              name,
-              handle,
-              description,
-              memberPostingRank: sourceRoleRank[memberPostingRole],
-              memberInviteRank: sourceRoleRank[memberInviteRole],
-            };
-
-            if (!isNullOrUndefined(isPrivate)) {
-              updates.private = isPrivate;
-            }
 
             // Update existing squad
             await repo.update({ id: sourceId }, updates);


### PR DESCRIPTION
Allow admins to make their public Squad go private (vice-versa) once approval has been received.

Something we missed on the RFC: https://dailydotdev.slack.com/archives/C069XNYMDGV/p1715851833290429?thread_ts=1715851745.713089&cid=C069XNYMDGV