### PR TITLE
fix: expose prometheus ports internally in cluster

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -258,7 +258,6 @@ if (isAdhocEnv) {
 } else {
   appsArgs = [
     {
-      port: 3000,
       env: [nodeOptions(memory), ...jwtEnv],
       minReplicas: 3,
       maxReplicas: 25,
@@ -271,11 +270,18 @@ if (isAdhocEnv) {
       enableCdn: true,
       disableLifecycle: true,
       serviceTimeout: 60,
+      ports: [
+        { containerPort: 3000, name: 'http' },
+        { containerPort: 9464, name: 'metrics' },
+      ],
+      servicePorts: [
+        { targetPort: 3000, port: 80, name: 'http' },
+        { targetPort: 9464, port: 9464, name: 'metrics' },
+      ],
       ...jwtVols,
     },
     {
       nameSuffix: 'ws',
-      port: 3000,
       env: [
         nodeOptions(wsMemory),
         { name: 'ENABLE_SUBSCRIPTIONS', value: 'true' },
@@ -288,6 +294,8 @@ if (isAdhocEnv) {
       livenessProbe,
       metric: { type: 'memory_cpu', cpu: 85 },
       disableLifecycle: true,
+      ports: [{ containerPort: 9464, name: 'metrics' }],
+      servicePorts: [{ targetPort: 9464, port: 9464, name: 'metrics' }],
       ...jwtVols,
     },
     {
@@ -302,10 +310,11 @@ if (isAdhocEnv) {
         labels: { app: name },
         targetAverageValue: 100,
       },
+      ports: [{ containerPort: 9464, name: 'metrics' }],
+      servicePorts: [{ targetPort: 9464, port: 9464, name: 'metrics' }],
     },
     {
       nameSuffix: 'private',
-      port: 3000,
       env: [{ name: 'ENABLE_PRIVATE_ROUTES', value: 'true' }, ...jwtEnv],
       minReplicas: 2,
       maxReplicas: 2,
@@ -319,6 +328,14 @@ if (isAdhocEnv) {
       createService: true,
       serviceType: 'ClusterIP',
       disableLifecycle: true,
+      ports: [
+        { containerPort: 3000, name: 'http' },
+        { containerPort: 9464, name: 'metrics' },
+      ],
+      servicePorts: [
+        { targetPort: 3000, port: 80, name: 'http' },
+        { targetPort: 9464, port: 9464, name: 'metrics' },
+      ],
       ...jwtVols,
     },
   ];
@@ -336,6 +353,8 @@ if (isAdhocEnv) {
         labels: { app: name, subapp: 'personalized-digest' },
         targetAverageValue: 100,
       },
+      ports: [{ containerPort: 9464, name: 'metrics' }],
+      servicePorts: [{ targetPort: 9464, port: 9464, name: 'metrics' }],
     });
   }
 }


### PR DESCRIPTION
For the prometheus scraper to find the metrics, we need to expose the metrics endpoint.

NOTE: This is a temporary change, will move it to pulumi-common if prometheus works out great