### PR TITLE
fix: add missing jwt keys to adhoc deployments

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -231,6 +231,8 @@ if (isAdhocEnv) {
         'prometheus.io/scrape': 'true',
         'prometheus.io/port': '9464',
       },
+      env: [...jwtEnv],
+      ...jwtVols,
     },
   ];
 
@@ -253,6 +255,8 @@ if (isAdhocEnv) {
         'prometheus.io/scrape': 'true',
         'prometheus.io/port': '9464',
       },
+      env: [...jwtEnv],
+      ...jwtVols,
     });
   }
 } else {


### PR DESCRIPTION
Latest commits broke api-bg in adhoc, as it is unable to load JWT keys.