### PR TITLE
feat: add keyword synonym field

### DIFF
--- a/__tests__/__snapshots__/keywords.ts.snap
+++ b/__tests__/__snapshots__/keywords.ts.snap
@@ -173,6 +173,7 @@ Object {
   "keyword": Object {
     "occurrences": 200,
     "status": "allow",
+    "synonym": null,
     "value": "nodejs",
   },
 }
@@ -181,6 +182,17 @@ Object {
 exports[`query keyword should return null when keyword does not exist 1`] = `
 Object {
   "keyword": null,
+}
+`;
+
+exports[`query keyword should return synonym 1`] = `
+Object {
+  "keyword": Object {
+    "occurrences": 20,
+    "status": "synonym",
+    "synonym": "javascript",
+    "value": "js",
+  },
 }
 `;
 

--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -143,7 +143,7 @@ describe('query keyword', () => {
   const QUERY = `
   query Keyword($value: String!) {
     keyword(value: $value) {
-      value, status, occurrences
+      value, status, occurrences, synonym
     }
   }`;
 
@@ -167,6 +167,24 @@ describe('query keyword', () => {
       { value: 'react', occurrences: 300 },
     ]);
     const res = await client.query(QUERY, { variables: { value: 'go' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it('should return synonym', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save([
+      { value: 'nodejs', status: 'allow', occurrences: 200 },
+      { value: 'react', occurrences: 300 },
+      {
+        value: 'js',
+        occurrences: 20,
+        status: 'synonym',
+        synonym: 'javascript',
+      },
+    ]);
+    const res = await client.query(QUERY, { variables: { value: 'js' } });
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchSnapshot();
   });

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -18,6 +18,7 @@ export interface GQLKeyword {
   occurrences: number;
   flags?: KeywordFlagsPublic;
   createdAt?: Date;
+  synonym?: string;
 }
 
 interface GQLKeywordSearchResults {
@@ -71,6 +72,10 @@ export const typeDefs = /* GraphQL */ `
     Date when the keyword was created
     """
     createdAt: DateTime
+    """
+    Keyword synonym
+    """
+    synonym: String
   }
 
   """


### PR DESCRIPTION
I need the field for upcoming roadmap integration so I can link tag to its synonym if exists.