### PR TITLE
feat(cio): webhook move to delete path instead of method

### DIFF
--- a/__tests__/webhooks.ts
+++ b/__tests__/webhooks.ts
@@ -264,7 +264,7 @@ describe('POST /webhooks/customerio/marketing_cta', () => {
       });
 
       const { body } = await request(app.server)
-        .delete('/webhooks/customerio/marketing_cta')
+        .post('/webhooks/customerio/marketing_cta/delete')
         .set('x-cio-timestamp', timestamp.toString())
         .set('x-cio-signature', hash)
         .send(payload)
@@ -289,7 +289,7 @@ describe('POST /webhooks/customerio/marketing_cta', () => {
       ).toHaveLength(2);
 
       const { body } = await request(app.server)
-        .delete('/webhooks/customerio/marketing_cta')
+        .post('/webhooks/customerio/marketing_cta/delete')
         .set('x-cio-timestamp', timestamp.toString())
         .set('x-cio-signature', hash)
         .send(payload)

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -98,7 +98,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
         },
       });
 
-      fastify.delete<MarketingCtaPayload>('/', {
+      fastify.post<MarketingCtaPayload>('/delete', {
         config: {
           rawBody: true,
         },


### PR DESCRIPTION
AS-369

cio does not support `DELETE` method so opted for `/delete` path. Alternative to use custom header can be limited by header size (because we will be sending JSON) so I think this is easier and in the future we can easily switch back the method if cio supports it. 