### PR TITLE
fix(create-post): make sure url is saved as null if missing

### DIFF
--- a/__tests__/privateRpc.ts
+++ b/__tests__/privateRpc.ts
@@ -264,5 +264,6 @@ describe('PostService', () => {
       .findOneBy({ id: result.postId });
     expect(post).toBeTruthy();
     expect(post!.yggdrasilId).toEqual('95ba892c-d641-4b94-ba47-be03c4c6cc8b');
+    expect(post!.url).toBeNull();
   });
 });

--- a/src/routes/privateRpc.ts
+++ b/src/routes/privateRpc.ts
@@ -67,6 +67,7 @@ export default function (router: ConnectRouter) {
       throw new ConnectError('unauthenticated', Code.Unauthenticated);
     }
 
+    const originalReq = req.clone();
     const con = await createOrGetConnection();
 
     try {
@@ -91,7 +92,7 @@ export default function (router: ConnectRouter) {
       };
     } catch (error) {
       logger.error(
-        { err: error, data: req.toJson() },
+        { err: error, data: originalReq.toJson() },
         'error while creating post',
       );
 

--- a/src/routes/privateRpc.ts
+++ b/src/routes/privateRpc.ts
@@ -77,6 +77,7 @@ export default function (router: ConnectRouter) {
       const postId = await generateShortId();
       const postEntity = con.getRepository(ArticlePost).create({
         ...req,
+        url: req.url || null,
         id: postId,
         shortId: postId,
         visible: false,
@@ -89,7 +90,10 @@ export default function (router: ConnectRouter) {
         url: req.url,
       };
     } catch (error) {
-      logger.error({ err: error }, 'error while creating post');
+      logger.error(
+        { err: error, data: req.toJson() },
+        'error while creating post',
+      );
 
       if (error instanceof ConnectError) {
         throw error;


### PR DESCRIPTION
- url could be saved as `undefined | ''` and we want `null` value for the row (to avoid duplicate constraint)
- also added logging so on error we can see the payload for create post