### PR TITLE
fix: add node_modules bin directory to path

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,5 +13,7 @@ RUN npm i
 
 COPY . .
 
+ENV PATH /opt/app/node_modules/.bin:$PATH
+
 CMD ["npm", "run", "dev"]
 


### PR DESCRIPTION
This is just a minor DX improvement when working with scripts locally. Instead of doing `./node_modules/.bin/ts-node`, you can now just do `ts-node` directly.