### PR TITLE
fix: set HPA to trigger at 130% of requested memory (~80% of limit)

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -269,7 +269,7 @@ if (isAdhocEnv) {
       requests: apiRequests,
       readinessProbe,
       livenessProbe,
-      metric: { type: 'memory_cpu', cpu: 80 },
+      metric: { type: 'memory_cpu', cpu: 80, memory: 130 },
       createService: true,
       enableCdn: true,
       disableLifecycle: true,


### PR DESCRIPTION
After we adjusted requests and limits, the HPA has scaled up a bit more. The pods now idle around 80% of requested, where the HPA kicks in and scales up deployment.

This change sets the HPA to trigger at 130% usage of requested memory, which is 81.25% of limit.