### PR TITLE
fix: validate timezone input

### DIFF
--- a/__tests__/__snapshots__/users.ts.snap
+++ b/__tests__/__snapshots__/users.ts.snap
@@ -51,7 +51,7 @@ Object {
   "name": "Ido",
   "notificationEmail": true,
   "permalink": "http://localhost:5002/aaa1",
-  "timezone": "Asia/Manila",
+  "timezone": "Europe/London",
   "twitter": null,
   "username": "aaa1",
 }

--- a/__tests__/common/timezone.ts
+++ b/__tests__/common/timezone.ts
@@ -1,4 +1,4 @@
-import { validateValidTimeZone } from '../../src/common';
+import { validateValidTimeZone } from '../../src/common/timezone';
 
 describe('validateValidTimeZone tests', () => {
   it('should return true for valid time zones', () => {

--- a/__tests__/common/timezone.ts
+++ b/__tests__/common/timezone.ts
@@ -1,0 +1,41 @@
+import { validateValidTimeZone } from '../../src/common';
+
+describe('validateValidTimeZone tests', () => {
+  it('should return true for valid time zones', () => {
+    const timeZones = [
+      'Pacific/Bougainville',
+      'Asia/Srednekolymsk',
+      'Asia/Magadan',
+      'Pacific/Norfolk',
+      'Asia/Sakhalin',
+      'Pacific/Guadalcanal',
+      'Asia/Anadyr',
+      'Pacific/Auckland',
+      'Pacific/Fiji',
+      'Pacific/Chatham',
+      'Pacific/Tongatapu',
+      'Pacific/Apia',
+      'Pacific/Kiritimati',
+      'Etc/UTC',
+    ];
+    timeZones.forEach((tz) => {
+      expect(validateValidTimeZone(tz)).toBeTruthy();
+    });
+  });
+
+  it('should return false for invalid time zones', () => {
+    const invalidTimeZones = [
+      'Pacific/Invalid',
+      'Asia/Invalid',
+      'Etc/Invalid',
+      'Invalid/Invalid',
+      'Invalid/Asia',
+      'Invalid/Pacific',
+      'Invalid/Etc',
+    ];
+
+    invalidTimeZones.forEach((tz) => {
+      expect(validateValidTimeZone(tz)).toBeFalsy();
+    });
+  });
+});

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1855,6 +1855,19 @@ describe('mutation updateUserProfile', () => {
     );
   });
 
+  it('should not allow invalid timezone', async () => {
+    loggedUser = '1';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { data: { timezone: 'Europe/Trondheim' } },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should update user profile', async () => {
     loggedUser = '1';
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1860,7 +1860,7 @@ describe('mutation updateUserProfile', () => {
 
     const repo = con.getRepository(User);
     const user = await repo.findOneBy({ id: loggedUser });
-    const timezone = 'Asia/Manila';
+    const timezone = 'Europe/London';
     const res = await client.mutate(MUTATION, {
       variables: { data: { timezone, username: 'aaa1', name: 'Ido' } },
     });

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -18,3 +18,4 @@ export * from './personalizedDigest';
 export * from './vote';
 export * from './feed';
 export * from './constants';
+export * from './timezone';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -18,4 +18,3 @@ export * from './personalizedDigest';
 export * from './vote';
 export * from './feed';
 export * from './constants';
-export * from './timezone';

--- a/src/common/timezone.ts
+++ b/src/common/timezone.ts
@@ -1,0 +1,508 @@
+export interface TimeZoneItem {
+  value: string;
+  label: string;
+  offset?: number;
+}
+
+export const TIME_ZONES: TimeZoneItem[] = [
+  {
+    value: 'Pacific/Midway',
+    label: 'Midway Island, American Samoa',
+  },
+  {
+    value: 'America/Adak',
+    label: 'Aleutian Islands',
+  },
+  {
+    value: 'Pacific/Honolulu',
+    label: 'Hawaii',
+  },
+  {
+    value: 'Pacific/Marquesas',
+    label: 'Marquesas Islands',
+  },
+  {
+    value: 'America/Anchorage',
+    label: 'Alaska',
+  },
+  {
+    value: 'America/Tijuana',
+    label: 'Baja California',
+  },
+  {
+    value: 'America/Los_Angeles',
+    label: 'Pacific Time (US and Canada)',
+  },
+  {
+    value: 'America/Phoenix',
+    label: 'Arizona',
+  },
+  {
+    value: 'America/Chihuahua',
+    label: 'Chihuahua, La Paz, Mazatlan',
+  },
+  {
+    value: 'America/Denver',
+    label: 'Mountain Time (US and Canada), Navajo Nation',
+  },
+  {
+    value: 'America/Belize',
+    label: 'Central America',
+  },
+  {
+    value: 'America/Chicago',
+    label: 'Central Time (US and Canada)',
+  },
+  {
+    value: 'Pacific/Easter',
+    label: 'Easter Island',
+  },
+  {
+    value: 'America/Mexico_City',
+    label: 'Guadalajara, Mexico City, Monterrey',
+  },
+  {
+    value: 'America/Regina',
+    label: 'Saskatchewan',
+  },
+  {
+    value: 'America/Bogota',
+    label: 'Bogota, Lima, Quito',
+  },
+  {
+    value: 'America/Cancun',
+    label: 'Chetumal',
+  },
+  {
+    value: 'America/New_York',
+    label: 'Eastern Time (US and Canada)',
+  },
+  {
+    value: 'America/Port-au-Prince',
+    label: 'Haiti',
+  },
+  {
+    value: 'America/Havana',
+    label: 'Havana',
+  },
+  {
+    value: 'America/Indiana/Indianapolis',
+    label: 'Indiana (East)',
+  },
+  {
+    value: 'America/Asuncion',
+    label: 'Asuncion',
+  },
+  {
+    value: 'America/Halifax',
+    label: 'Atlantic Time (Canada)',
+  },
+  {
+    value: 'America/Caracas',
+    label: 'Caracas',
+  },
+  {
+    value: 'America/Cuiaba',
+    label: 'Cuiaba',
+  },
+  {
+    value: 'America/Manaus',
+    label: 'Georgetown, La Paz, Manaus, San Juan',
+  },
+  {
+    value: 'America/Santiago',
+    label: 'Santiago',
+  },
+  {
+    value: 'America/Grand_Turk',
+    label: 'Turks and Caicos',
+  },
+  {
+    value: 'America/St_Johns',
+    label: 'Newfoundland',
+  },
+  {
+    value: 'America/Fortaleza',
+    label: 'Araguaina',
+  },
+  {
+    value: 'America/Sao_Paulo',
+    label: 'Brasilia',
+  },
+  {
+    value: 'America/Cayenne',
+    label: 'Cayenne, Fortaleza',
+  },
+  {
+    value: 'America/Buenos_Aires',
+    label: 'City of Buenos Aires',
+  },
+  {
+    value: 'America/Godthab',
+    label: 'Greenland',
+  },
+  {
+    value: 'America/Montevideo',
+    label: 'Montevideo',
+  },
+  {
+    value: 'America/Miquelon',
+    label: 'Saint Pierre and Miquelon',
+  },
+  {
+    value: 'America/Bahia',
+    label: 'Salvador',
+  },
+  {
+    value: 'America/Noronha',
+    label: 'Fernando de Noronha',
+  },
+  {
+    value: 'Atlantic/Azores',
+    label: 'Azores',
+  },
+  {
+    value: 'Atlantic/Cape_Verde',
+    label: 'Cabo Verde Islands',
+  },
+  {
+    value: 'Europe/London',
+    label: 'Dublin, Edinburgh, Lisbon, London',
+  },
+  {
+    value: 'Africa/Monrovia',
+    label: 'Monrovia, Reykjavik',
+  },
+  {
+    value: 'Europe/Amsterdam',
+    label: 'Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna',
+  },
+  {
+    value: 'Europe/Belgrade',
+    label: 'Belgrade, Bratislava, Budapest, Ljubljana, Prague',
+  },
+  {
+    value: 'Europe/Brussels',
+    label: 'Brussels, Copenhagen, Madrid, Paris',
+  },
+  {
+    value: 'Europe/Warsaw',
+    label: 'Sarajevo, Skopje, Warsaw, Zagreb',
+  },
+  {
+    value: 'Africa/Algiers',
+    label: 'West Central Africa',
+  },
+  {
+    value: 'Africa/Casablanca',
+    label: 'Casablanca',
+  },
+  {
+    value: 'Africa/Windhoek',
+    label: 'Windhoek',
+  },
+  {
+    value: 'Asia/Amman',
+    label: 'Amman',
+  },
+  {
+    value: 'Europe/Athens',
+    label: 'Athens, Bucharest',
+  },
+  {
+    value: 'Asia/Beirut',
+    label: 'Beirut',
+  },
+  {
+    value: 'Africa/Cairo',
+    label: 'Cairo',
+  },
+  {
+    value: 'Asia/Damascus',
+    label: 'Damascus',
+  },
+  {
+    value: 'Asia/Gaza',
+    label: 'Gaza, Hebron',
+  },
+  {
+    value: 'Africa/Harare',
+    label: 'Harare, Pretoria',
+  },
+  {
+    value: 'Europe/Helsinki',
+    label: 'Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
+  },
+  {
+    value: 'Asia/Jerusalem',
+    label: 'Jerusalem',
+  },
+  {
+    value: 'Europe/Kaliningrad',
+    label: 'Kaliningrad',
+  },
+  {
+    value: 'Africa/Tripoli',
+    label: 'Tripoli',
+  },
+  {
+    value: 'Asia/Baghdad',
+    label: 'Baghdad',
+  },
+  {
+    value: 'Asia/Istanbul',
+    label: 'Istanbul',
+  },
+  {
+    value: 'Asia/Kuwait',
+    label: 'Kuwait, Riyadh',
+  },
+  {
+    value: 'Europe/Minsk',
+    label: 'Minsk',
+  },
+  {
+    value: 'Europe/Moscow',
+    label: 'Moscow, St. Petersburg',
+  },
+  {
+    value: 'Africa/Nairobi',
+    label: 'Nairobi',
+  },
+  {
+    value: 'Asia/Tehran',
+    label: 'Tehran',
+  },
+  {
+    value: 'Asia/Muscat',
+    label: 'Abu Dhabi, Muscat',
+  },
+  {
+    value: 'Europe/Astrakhan',
+    label: 'Astrakhan, Ulyanovsk, Volgograd',
+  },
+  {
+    value: 'Asia/Baku',
+    label: 'Baku',
+  },
+  {
+    value: 'Europe/Samara',
+    label: 'Izhevsk, Samara',
+  },
+  {
+    value: 'Indian/Mauritius',
+    label: 'Port Louis',
+  },
+  {
+    value: 'Asia/Tbilisi',
+    label: 'Tbilisi',
+  },
+  {
+    value: 'Asia/Yerevan',
+    label: 'Yerevan',
+  },
+  {
+    value: 'Asia/Kabul',
+    label: 'Kabul',
+  },
+  {
+    value: 'Asia/Tashkent',
+    label: 'Tashkent, Ashgabat',
+  },
+  {
+    value: 'Asia/Yekaterinburg',
+    label: 'Ekaterinburg',
+  },
+  {
+    value: 'Asia/Karachi',
+    label: 'Islamabad, Karachi',
+  },
+  {
+    value: 'Asia/Kolkata',
+    label: 'Chennai, Kolkata, Mumbai, New Delhi',
+  },
+  {
+    value: 'Asia/Colombo',
+    label: 'Sri Jayawardenepura',
+  },
+  {
+    value: 'Asia/Katmandu',
+    label: 'Kathmandu',
+  },
+  {
+    value: 'Asia/Almaty',
+    label: 'Astana',
+  },
+  {
+    value: 'Asia/Dhaka',
+    label: 'Dhaka',
+  },
+  {
+    value: 'Asia/Rangoon',
+    label: 'Yangon (Rangoon)',
+  },
+  {
+    value: 'Asia/Novosibirsk',
+    label: 'Novosibirsk',
+  },
+  {
+    value: 'Asia/Bangkok',
+    label: 'Bangkok, Hanoi, Jakarta',
+  },
+  {
+    value: 'Asia/Barnaul',
+    label: 'Barnaul, Gorno-Altaysk',
+  },
+  {
+    value: 'Asia/Hovd',
+    label: 'Hovd',
+  },
+  {
+    value: 'Asia/Krasnoyarsk',
+    label: 'Krasnoyarsk',
+  },
+  {
+    value: 'Asia/Tomsk',
+    label: 'Tomsk',
+  },
+  {
+    value: 'Asia/Chongqing',
+    label: 'Beijing, Chongqing, Hong Kong SAR, Urumqi',
+  },
+  {
+    value: 'Asia/Irkutsk',
+    label: 'Irkutsk',
+  },
+  {
+    value: 'Asia/Kuala_Lumpur',
+    label: 'Kuala Lumpur, Singapore',
+  },
+  {
+    value: 'Australia/Perth',
+    label: 'Perth',
+  },
+  {
+    value: 'Asia/Taipei',
+    label: 'Taipei',
+  },
+  {
+    value: 'Asia/Ulaanbaatar',
+    label: 'Ulaanbaatar',
+  },
+  {
+    value: 'Asia/Pyongyang',
+    label: 'Pyongyang',
+  },
+  {
+    value: 'Australia/Eucla',
+    label: 'Eucla',
+  },
+  {
+    value: 'Asia/Chita',
+    label: 'Chita',
+  },
+  {
+    value: 'Asia/Tokyo',
+    label: 'Osaka, Sapporo, Tokyo',
+  },
+  {
+    value: 'Asia/Seoul',
+    label: 'Seoul',
+  },
+  {
+    value: 'Asia/Yakutsk',
+    label: 'Yakutsk',
+  },
+  {
+    value: 'Australia/Adelaide',
+    label: 'Adelaide',
+  },
+  {
+    value: 'Australia/Darwin',
+    label: 'Darwin',
+  },
+  {
+    value: 'Australia/Brisbane',
+    label: 'Brisbane',
+  },
+  {
+    value: 'Australia/Canberra',
+    label: 'Canberra, Melbourne, Sydney',
+  },
+  {
+    value: 'Pacific/Guam',
+    label: 'Guam, Port Moresby',
+  },
+  {
+    value: 'Australia/Hobart',
+    label: 'Hobart',
+  },
+  {
+    value: 'Asia/Vladivostok',
+    label: 'Vladivostok',
+  },
+  {
+    value: 'Australia/Lord_Howe',
+    label: 'Lord Howe Island',
+  },
+  {
+    value: 'Pacific/Bougainville',
+    label: 'Bougainville Island',
+  },
+  {
+    value: 'Asia/Srednekolymsk',
+    label: 'Chokurdakh',
+  },
+  {
+    value: 'Asia/Magadan',
+    label: 'Magadan',
+  },
+  {
+    value: 'Pacific/Norfolk',
+    label: 'Norfolk Island',
+  },
+  {
+    value: 'Asia/Sakhalin',
+    label: 'Sakhalin',
+  },
+  {
+    value: 'Pacific/Guadalcanal',
+    label: 'Solomon Islands, New Caledonia',
+  },
+  {
+    value: 'Asia/Anadyr',
+    label: 'Anadyr, Petropavlovsk-Kamchatsky',
+  },
+  {
+    value: 'Pacific/Auckland',
+    label: 'Auckland, Wellington',
+  },
+  {
+    value: 'Pacific/Fiji',
+    label: 'Fiji Islands',
+  },
+  {
+    value: 'Pacific/Chatham',
+    label: 'Chatham Islands',
+  },
+  {
+    value: 'Pacific/Tongatapu',
+    label: "Nuku'alofa",
+  },
+  {
+    value: 'Pacific/Apia',
+    label: 'Samoa',
+  },
+  {
+    value: 'Pacific/Kiritimati',
+    label: 'Kiritimati Island',
+  },
+  {
+    value: 'Etc/UTC',
+    label: 'Universal Time Coordinated',
+  },
+];
+
+export const validateValidTimeZone = (timeZone: string): boolean => {
+  return TIME_ZONES.some((tz) => tz.value === timeZone);
+};

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -32,6 +32,7 @@ import {
 import { generateTrackingId } from '../../ids';
 import { UserStreak } from './UserStreak';
 import { DEFAULT_TIMEZONE } from '../../types';
+import { validateValidTimeZone } from '../../common';
 
 @Entity()
 @Index('IDX_user_lowerusername_username', { synchronize: false })
@@ -396,6 +397,15 @@ export const validateUserUpdate = async (
       'username',
       entityManager,
     );
+  }
+
+  if ('timezone' in data) {
+    const isValidTimeZone = validateValidTimeZone(data.timezone);
+    if (!isValidTimeZone) {
+      throw new ValidationError(
+        JSON.stringify({ timezone: 'invalid timezone' }),
+      );
+    }
   }
 
   ['name', 'twitter', 'github', 'hashnode'].forEach((key) => {

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -32,7 +32,7 @@ import {
 import { generateTrackingId } from '../../ids';
 import { UserStreak } from './UserStreak';
 import { DEFAULT_TIMEZONE } from '../../types';
-import { validateValidTimeZone } from '../../common';
+import { validateValidTimeZone } from '../../common/timezone';
 
 @Entity()
 @Index('IDX_user_lowerusername_username', { synchronize: false })

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -84,6 +84,7 @@ export interface GQLUpdateUserInput {
   portfolio?: string;
   acceptedMarketing?: boolean;
   notificationEmail?: boolean;
+  timezone?: string;
   infoConfirmed?: boolean;
   experienceLevel?: string;
 }


### PR DESCRIPTION
Adds validation for timezones. Users are now able to send in their own value, with would break the digest cron jobs as postgres expects valid timezones.

AS-394