### PR TITLE
fix: trying to fix some flaky tests

### DIFF
--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -377,7 +377,7 @@ describe('mutation setKeywordAsSynonym', () => {
   });
 });
 
-describe('flags field', () => {
+describe('keywords flags field', () => {
   const QUERY = `{
     keyword(value: "react") {
       flags {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3690,7 +3690,7 @@ describe('downvoted field', () => {
   });
 });
 
-describe('flags field', () => {
+describe('posts flags field', () => {
   const QUERY = `{
     post(id: "p1") {
       flags {

--- a/__tests__/workers/notifications/collectionUpdated.ts
+++ b/__tests__/workers/notifications/collectionUpdated.ts
@@ -150,7 +150,6 @@ beforeEach(async () => {
       type: PostRelationType.Collection,
     },
   ]);
-
   await saveFixtures(con, NotificationPreferencePost, [
     {
       userId: '1',
@@ -188,7 +187,7 @@ describe('collectionUpdated worker', () => {
     expect(registeredWorker).toBeDefined();
   });
 
-  it('should notifiy when a collection is updated', async () => {
+  it('should notify when a collection is updated', async () => {
     const actual = await invokeNotificationWorker(worker, {
       post: {
         id: 'c1',


### PR DESCRIPTION
It doesn't fix the main one we have :( (can't find what could cause the source id to change, maybe the parralism? although this shouldn't be affected from what I can read per suite)

Does fix some other flaky tests we had (same named tests basically is never a good idea)

Tried some random flaky test package and it didn't even find the main one. (So makes me wonder it's really due to parralism :))

Others found though:
![Screenshot 2024-06-21 at 15 33 19](https://github.com/dailydotdev/daily-api/assets/554874/0bd032bc-ed0a-4e4f-933f-155b5ec35c62)