### PR TITLE
fix: fetch sources using our best practices

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -299,7 +299,7 @@ describe('query trendingSources', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchObject({
       trendingSources: [
-        { id: 'a', name: 'A', image: 'http://image.com/a', public: null },
+        { id: 'a', name: 'A', image: 'http://image.com/a', public: true },
       ],
     });
   });
@@ -351,7 +351,7 @@ describe('query popularSources', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchObject({
       popularSources: [
-        { id: 'a', name: 'A', image: 'http://image.com/a', public: null },
+        { id: 'a', name: 'A', image: 'http://image.com/a', public: true },
       ],
     });
   });
@@ -404,7 +404,7 @@ describe('query topVideoSources', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data).toMatchObject({
       topVideoSources: [
-        { id: 'a', name: 'A', image: 'http://image.com/a', public: null },
+        { id: 'a', name: 'A', image: 'http://image.com/a', public: true },
       ],
     });
   });

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1091,7 +1091,6 @@ const getFormattedSources = async <Entity>(
         'ts',
         `ts."sourceId" = ${builder.alias}.id`,
       )
-      .where({ active: true, type: SourceType.Machine })
       .orderBy('r', 'DESC')
       .limit(limit);
     return builder;

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -65,6 +65,7 @@ import { SourceTagView } from '../entity/SourceTagView';
 import { TrendingSource } from '../entity/TrendingSource';
 import { PopularSource } from '../entity/PopularSource';
 import { PopularVideoSource } from '../entity/PopularVideoSource';
+import { EntityTarget } from 'typeorm/common/EntityTarget';
 
 export interface GQLSource {
   id: string;
@@ -1075,20 +1076,26 @@ const togglePinnedPosts = async (
   return { _: true };
 };
 
-const getFormattedSources = async (entity, args, ctx): Promise<GQLSource[]> => {
+const getFormattedSources = async <Entity>(
+  entity: EntityTarget<Entity>,
+  args: { limit?: number },
+  ctx: Context,
+  info: GraphQLResolveInfo,
+): Promise<GQLSource[]> => {
   const { limit = 10 } = args;
-  /*
-   * This is not best practice, but due to missing join/basetable support for graphORM we decided to leave it like this to ship faster
-   * If you ever need child entities/graphORM magic this needs to change
-   */
-  return await ctx.con
-    .createQueryBuilder()
-    .select('s.*')
-    .from(entity, 'ts')
-    .innerJoin(Source, 's', 'ts."sourceId" = s.id')
-    .orderBy('r', 'DESC')
-    .limit(limit)
-    .getRawMany();
+
+  return await graphorm.query(ctx, info, (builder) => {
+    builder.queryBuilder
+      .innerJoin(
+        ctx.con.getMetadata(entity).tableName,
+        'ts',
+        `ts."sourceId" = ${builder.alias}.id`,
+      )
+      .where({ active: true, type: SourceType.Machine })
+      .orderBy('r', 'DESC')
+      .limit(limit);
+    return builder;
+  });
 };
 
 const paginateSourceMembers = (
@@ -1268,12 +1275,12 @@ export const resolvers: IResolvers<any, Context> = {
         return builder;
       });
     },
-    trendingSources: async (_, args, ctx): Promise<GQLSource[]> =>
-      getFormattedSources(TrendingSource, args, ctx),
-    popularSources: async (_, args, ctx): Promise<GQLSource[]> =>
-      getFormattedSources(PopularSource, args, ctx),
-    topVideoSources: async (_, args, ctx): Promise<GQLSource[]> =>
-      getFormattedSources(PopularVideoSource, args, ctx),
+    trendingSources: async (_, args, ctx, info): Promise<GQLSource[]> =>
+      getFormattedSources(TrendingSource, args, ctx, info),
+    popularSources: async (_, args, ctx, info): Promise<GQLSource[]> =>
+      getFormattedSources(PopularSource, args, ctx, info),
+    topVideoSources: async (_, args, ctx, info): Promise<GQLSource[]> =>
+      getFormattedSources(PopularVideoSource, args, ctx, info),
     sourceByFeed: async (
       _,
       { feed }: { feed: string },


### PR DESCRIPTION
When we introduced the source directory, we did a workaround to overcome graphorm issue. But now I fixed the queries to follow our best practices