### PR TITLE
refactor: use different slack channels

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -121,6 +121,8 @@ config:
     sendgridApiKey: placeholder
     sendgridWebhookAnalyticsKey:
       secure: AAABAN93rTdOaHRB0LdcCsxtW0iEDhqNeUQaldjnx44gUVu2xjn0lR9bW1MgPZ8v6KBfAG8k8Uf2tqg2zWKiP9Dk1eDH7TR5v2XmKnvnP/rzCwhz0eZ0Yd3qoSJ8NUBhxcB/somueTshRZI2xfjtQf2aKyZ9KKIoPPs1U8D1fiyQPeQm2e7in0CouLbEGkS/FUpyHVLS6l2mUlq4
+    slackCommentsWebhook:
+      secure: AAABAG7/pYJ5ygBQmCdyiDR0DwOV9KrJxvVHSXNUqK2bTjFygyCUnr10RZD6wedYdBKkxJ1bPZeYD/uqSAj/NVkl69yPaURJYtb99G+O11Sjj/rKptKWWx+NLBkGW6GQjlApc3Zk1yykF7dKpooeoaM=
     slackWebhook:
       secure: AAABANMRr419hiCx/eBF5NJvKB8LDGb8GffeQzg5PxXoD5A9iQn7cPM30aB0jl3cWTKX65VrDShNl+GO86zvRIq4nXvwpjSdi/ToCHDBxyg7sIIQvngrlJuPQ9da+fj426VWkg5fFnwg02QuxMoHqrM=
     snotraOrigin:

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -2,9 +2,15 @@ import { IncomingWebhook } from '@slack/webhook';
 import { Post, Comment } from '../entity';
 import { getDiscussionLink } from './links';
 
-export const webhook = process.env.SLACK_WEBHOOK
-  ? new IncomingWebhook(process.env.SLACK_WEBHOOK)
-  : { send: (): Promise<void> => Promise.resolve() };
+const nullWebhook = { send: (): Promise<void> => Promise.resolve() };
+export const webhooks = Object.freeze({
+  content: process.env.SLACK_WEBHOOK
+    ? new IncomingWebhook(process.env.SLACK_WEBHOOK)
+    : nullWebhook,
+  comments: process.env.SLACK_WEBHOOK
+    ? new IncomingWebhook(process.env.SLACK_COMMENTS_WEBHOOK)
+    : nullWebhook,
+});
 
 export const notifyNewComment = async (
   post: Post,
@@ -12,7 +18,7 @@ export const notifyNewComment = async (
   comment: string,
   commentId: string,
 ): Promise<void> => {
-  await webhook.send({
+  await webhooks.comments.send({
     text: 'New comment',
     attachments: [
       {
@@ -41,7 +47,7 @@ export const notifyPostReport = async (
   comment?: string,
   tags?: string[],
 ): Promise<void> => {
-  await webhook.send({
+  await webhooks.content.send({
     text: 'Post was just reported!',
     attachments: [
       {
@@ -77,7 +83,7 @@ export const notifyCommentReport = async (
   reason: string,
   note?: string,
 ): Promise<void> => {
-  await webhook.send({
+  await webhooks.content.send({
     text: 'Comment was just reported!',
     attachments: [
       {

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -7,7 +7,7 @@ export const webhooks = Object.freeze({
   content: process.env.SLACK_WEBHOOK
     ? new IncomingWebhook(process.env.SLACK_WEBHOOK)
     : nullWebhook,
-  comments: process.env.SLACK_WEBHOOK
+  comments: process.env.SLACK_COMMENTS_WEBHOOK
     ? new IncomingWebhook(process.env.SLACK_COMMENTS_WEBHOOK)
     : nullWebhook,
 });

--- a/src/workers/postScoutMatchedSlack.ts
+++ b/src/workers/postScoutMatchedSlack.ts
@@ -1,6 +1,6 @@
 import { messageToJson, Worker } from './worker';
 import { Post } from '../entity';
-import { getDiscussionLink, webhook } from '../common';
+import { getDiscussionLink, webhooks } from '../common';
 import { ChangeObject } from '../types';
 
 interface Data {
@@ -16,7 +16,7 @@ const worker: Worker = {
       return;
     }
     try {
-      await webhook.send({
+      await webhooks.content.send({
         text: 'New community link!',
         attachments: [
           {


### PR DESCRIPTION
Separate comments to the rest within Slack to make it easier to moderate