### PR TITLE
fix: update to queries to avoid writes

### DIFF
--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -162,8 +162,8 @@ describe('reading streaks', () => {
     const streak = await con.getRepository(UserStreak).findOne({
       where: {
         userId: 'u1',
-        lastViewAt: new Date(currentDate),
       },
+      order: { lastViewAt: 'DESC' },
     });
     for (const key in expectedStreak) {
       expect(streak?.[key]).toEqual(expectedStreak[key]);
@@ -315,7 +315,7 @@ describe('reading streaks', () => {
   it('should not increment a reading streak if lastViewAt is the same day', async () => {
     await runTest(
       '2024-01-26T17:23Z',
-      '2024-01-26T17:23Z',
+      '2024-01-26T15:23Z',
       defaultStreak,
       defaultStreak,
     );

--- a/__tests__/workers/newView.ts
+++ b/__tests__/workers/newView.ts
@@ -313,10 +313,12 @@ describe('reading streaks', () => {
   });
 
   it('should not increment a reading streak if lastViewAt is the same day', async () => {
-    await runTest('2024-01-26T19:17Z', '2024-01-26T17:23Z', defaultStreak, {
-      ...defaultStreak,
-      lastViewAt: new Date('2024-01-26T19:17Z'),
-    });
+    await runTest(
+      '2024-01-26T17:23Z',
+      '2024-01-26T17:23Z',
+      defaultStreak,
+      defaultStreak,
+    );
   });
 
   describe('showMilestone is set correctly', () => {
@@ -408,7 +410,7 @@ describe('reading streaks', () => {
 
     it('should not set showStreakMilestone if lastViewAt is the same day', async () => {
       await runTest(
-        '2024-01-26T19:17Z',
+        '2024-01-26T17:23Z',
         '2024-01-26T17:23Z',
         {
           ...defaultStreak,
@@ -417,7 +419,6 @@ describe('reading streaks', () => {
         {
           ...defaultStreak,
           currentStreak: 5,
-          lastViewAt: new Date('2024-01-26T19:17Z'),
         },
       );
 


### PR DESCRIPTION
We detected that in the current streak system we always update each row in `user_streak` with a new `lastViewAt` and `updatedAt` this has heavy implications on the writes on this table.

In general it's not that bad, but when we add debezium to this table/cdc it overloads that system.

We decided to do two separate queries
- Query if streak should be updated
- If yes: Run update

This results in only 1 write per user a day.

Once approved I'll adjust the CDC flow again to bring it back.

For reference the old PR has notes around what's implemented already:
https://github.com/dailydotdev/daily-api/pull/1653