### PR TITLE
fix: we emptied to many people

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -399,9 +399,9 @@ export const shouldResetStreak = (day: number, difference: number) => {
 };
 
 export const checkUserStreak = (streak: GQLUserStreakTz): boolean => {
-  const { lastViewAtTz: lastViewAt, timezone } = streak;
+  const { lastViewAtTz: lastViewAt, timezone, current } = streak;
 
-  if (!lastViewAt) {
+  if (!lastViewAt || current === 0) {
     return false;
   }
 
@@ -419,7 +419,7 @@ export const checkAndClearUserStreak = async (
   info: GraphQLResolveInfo,
   streak: GQLUserStreakTz,
 ): Promise<boolean> => {
-  if (checkUserStreak(streak)) {
+  if (strak.checkUserStreak(streak)) {
     const result = await clearUserStreak(con, [streak.userId]);
     return result > 0;
   }

--- a/src/cron/updateCurrentStreak.ts
+++ b/src/cron/updateCurrentStreak.ts
@@ -18,6 +18,7 @@ const cron: Cron = {
           .select(
             `us.*, (date_trunc('day', us."lastViewAt" at time zone COALESCE(u.timezone, 'utc'))::date) AS "lastViewAtTz", u.timezone`,
           )
+          .addSelect('us.currentStreak', 'current')
           .from(UserStreak, 'us')
           .innerJoin(User, 'u', 'u.id = us."userId"')
           .where(`us."currentStreak" != 0`)


### PR DESCRIPTION
The evaluation was missing the `current` !== 0 meaning we still spooled empty users