### PR TITLE
fix: add canonical check on update aswell

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -167,6 +167,24 @@ it(`should not update if the post object doesn't have ID`, async () => {
   expect(post.metadataChangedAt).toEqual(new Date('2020-01-05T12:00:00.000Z'));
 });
 
+it(`should not update if the post changed URL already exists`, async () => {
+  await con.getRepository(ArticlePost).insert({
+    id: 'p3',
+    shortId: 'p3',
+    url: 'http://p3.com',
+    sourceId: 'a',
+  });
+  await expectSuccessfulBackground(worker, {
+    id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+    post_id: 'p1',
+    url: 'http://p3.com',
+    updated_at: new Date('01-05-2023 12:00:00'),
+  });
+  const post = await con.getRepository(ArticlePost).findOneBy({ id: 'p1' });
+  expect(post.url).toEqual('http://p1.com');
+  expect(post.metadataChangedAt).toEqual(new Date('2020-01-05T12:00:00.000Z'));
+});
+
 it('should update the post and keep it invisible if title is missing', async () => {
   await expectSuccessfulBackground(worker, {
     id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -200,7 +200,18 @@ type CheckExistingPostProps = {
   errorMsg: string;
   id?: string;
 };
-const checkExistingPost = async ({
+
+/**
+ * Function to check wheter an url/canonical url is already in use
+ *
+ * @param entityManager
+ * @param data
+ * @param counter
+ * @param logger
+ * @param errorMsg
+ * @param id - By passing the id we only search for other posts containing these URLs
+ */
+const checkExistingUrl = async ({
   entityManager,
   data,
   counter,
@@ -241,7 +252,7 @@ const createPost = async ({
   questions,
 }: CreatePostProps): Promise<Post | null> => {
   if (
-    await checkExistingPost({
+    await checkExistingUrl({
       entityManager,
       data,
       counter,
@@ -370,7 +381,7 @@ const updatePost = async ({
   }
 
   if (
-    await checkExistingPost({
+    await checkExistingUrl({
       entityManager,
       data,
       counter,

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -198,7 +198,7 @@ type CheckExistingPostProps = {
   counter: opentelemetry.Counter;
   logger: FastifyBaseLogger;
   errorMsg: string;
-  id?: string;
+  excludeId?: string;
 };
 
 /**
@@ -209,7 +209,7 @@ type CheckExistingPostProps = {
  * @param counter
  * @param logger
  * @param errorMsg
- * @param id - By passing the id we only search for other posts containing these URLs
+ * @param excludeId - By passing the id we only search for other posts containing these URLs
  */
 const checkExistingUrl = async ({
   entityManager,
@@ -217,7 +217,7 @@ const checkExistingUrl = async ({
   counter,
   logger,
   errorMsg,
-  id,
+  excludeId,
 }: CheckExistingPostProps): Promise<boolean> => {
   let builder = entityManager
     .getRepository(Post)
@@ -227,8 +227,8 @@ const checkExistingUrl = async ({
       '(url = :url or url = :canonicalUrl or "canonicalUrl" = :url or "canonicalUrl" = :canonicalUrl)',
       { url: data.url, canonicalUrl: data.canonicalUrl },
     );
-  if (id) {
-    builder = builder.andWhere('id != :id', { id });
+  if (excludeId) {
+    builder = builder.andWhere('id != :excludeId', { excludeId });
   }
   const existingPost = await builder.getRawOne();
   if (existingPost) {
@@ -387,7 +387,7 @@ const updatePost = async ({
       counter,
       logger,
       errorMsg: 'failed updating post because URL/canonical exists already',
-      id: databasePost?.id,
+      excludeId: databasePost?.id,
     })
   ) {
     return null;

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -213,7 +213,7 @@ const checkExistingPost = async ({
     .createQueryBuilder()
     .select('id')
     .where(
-      'url = :url or url = :canonicalUrl or "canonicalUrl" = :url or "canonicalUrl" = :canonicalUrl',
+      '(url = :url or url = :canonicalUrl or "canonicalUrl" = :url or "canonicalUrl" = :canonicalUrl)',
       { url: data.url, canonicalUrl: data.canonicalUrl },
     );
   if (id) {
@@ -376,7 +376,7 @@ const updatePost = async ({
       counter,
       logger,
       errorMsg: 'failed updating post because URL/canonical exists already',
-      id: databasePost.id,
+      id: databasePost?.id,
     })
   ) {
     return null;


### PR DESCRIPTION
The update hook didn't check if canonical/url already exists on the change causing catch errors.
Explicitly check now and uniform the check function