### PR TITLE
feat: add team member output

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -640,6 +640,46 @@ describe('query user', () => {
   });
 });
 
+describe('query team members', () => {
+  const QUERY = `query User($id: ID!) {
+    user(id: $id) {
+      name
+      username
+      image
+      isTeamMember
+    }
+  }`;
+
+  it('should return team member as false', async () => {
+    const requestUserId = '1';
+    const res = await client.query(QUERY, { variables: { id: requestUserId } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.user).toMatchObject({
+      name: 'Ido',
+      username: null,
+      image: 'https://daily.dev/ido.jpg',
+      isTeamMember: false,
+    });
+  });
+
+  it('should return team member as true', async () => {
+    await con.getRepository(Feature).insert({
+      feature: FeatureType.Team,
+      userId: '1',
+      value: 1,
+    });
+    const requestUserId = '1';
+    const res = await client.query(QUERY, { variables: { id: requestUserId } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.user).toMatchObject({
+      name: 'Ido',
+      username: null,
+      image: 'https://daily.dev/ido.jpg',
+      isTeamMember: true,
+    });
+  });
+});
+
 describe('query userReadingRank', () => {
   const QUERY = `query UserReadingRank($id: ID!, $version: Int, $limit: Int){
     userReadingRank(id: $id, version: $version, limit: $limit) {

--- a/src/entity/Feature.ts
+++ b/src/entity/Feature.ts
@@ -2,6 +2,7 @@ import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import { User } from './user';
 
 export enum FeatureType {
+  Team = 'team',
   Squad = 'squad',
   Search = 'search',
 }

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -77,12 +77,15 @@ const obj = new GraphORM({
         transform: nullIfNotSameUser,
       },
       isTeamMember: {
-        select: (_, alias, qb) =>
-          qb
-            .select('count(*)')
+        select: (_, alias, qb) => {
+          const query = qb
+            .select('1')
             .from(Feature, 'f')
             .where(`f."userId" = ${alias}.id`)
-            .andWhere(`f."feature" = :feature`, { feature: FeatureType.Team }),
+            .andWhere(`f."feature" = :feature`, { feature: FeatureType.Team });
+
+          return `EXISTS${query.getQuery()}`;
+        },
         transform: (value: number): boolean => value > 0,
       },
     },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -14,6 +14,8 @@ import {
   defaultPublicSourceFlags,
   UserPersonalizedDigestFlagsPublic,
   UserPersonalizedDigestSendType,
+  Feature,
+  FeatureType,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -73,6 +75,15 @@ const obj = new GraphORM({
       },
       notificationEmail: {
         transform: nullIfNotSameUser,
+      },
+      isTeamMember: {
+        select: (_, alias, qb) =>
+          qb
+            .select('count(*)')
+            .from(Feature, 'f')
+            .where(`f."userId" = ${alias}.id`)
+            .andWhere(`f."feature" = :feature`, { feature: FeatureType.Team }),
+        transform: (value: number): boolean => value > 0,
       },
     },
   },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -264,6 +264,10 @@ export const typeDefs = /* GraphQL */ `
     Experience level of the user
     """
     experienceLevel: String
+    """
+    Whether the user is a team member
+    """
+    isTeamMember: Boolean
   }
 
   """


### PR DESCRIPTION
Ole-Martin's favorite feature enablement.
This way we can simply add it to each user fragment wherever we want to know it :) 