### PR TITLE
fix: add experience level to required fields

### DIFF
--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -183,7 +183,7 @@ type AddNewUserResult =
   | { status: 'failed'; reason: UserFailErrorKeys; error?: Error };
 
 const checkRequiredFields = (data: AddUserData): boolean => {
-  return !!(data && data.id);
+  return !!(data && data.id && data.experienceLevel);
 };
 
 const checkEmail = async (


### PR DESCRIPTION
Just one small check for experience level, not sure if this covers all of our use cases like SSO but as a first step to not allowing registration with no experience level.

issue: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1719910800166109?thread_ts=1719910800.166109&cid=C01L0QXQJNB