### PR TITLE
feat: apply strict typescript rules to workers

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -141,7 +141,7 @@ it('should NOT add devcard unlocked notification if user has NOT reached the rep
       reputation: 15,
     },
   });
-  expect(actual).toEqual(undefined);
+  expect(actual).toBeUndefined();
 });
 
 it('should NOT add devcard unlocked notification if user had already reached the dev card threshold', async () => {
@@ -158,7 +158,7 @@ it('should NOT add devcard unlocked notification if user had already reached the
       reputation: 40,
     },
   });
-  expect(actual).toEqual(undefined);
+  expect(actual).toBeUndefined();
 });
 
 describe('source member role changed', () => {

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -141,7 +141,7 @@ it('should NOT add devcard unlocked notification if user has NOT reached the rep
       reputation: 15,
     },
   });
-  expect(actual).toEqual(null);
+  expect(actual).toEqual(undefined);
 });
 
 it('should NOT add devcard unlocked notification if user had already reached the dev card threshold', async () => {
@@ -158,7 +158,7 @@ it('should NOT add devcard unlocked notification if user had already reached the
       reputation: 40,
     },
   });
-  expect(actual).toEqual(null);
+  expect(actual).toEqual(undefined);
 });
 
 describe('source member role changed', () => {

--- a/src/entity/user/UserStreak.ts
+++ b/src/entity/user/UserStreak.ts
@@ -23,7 +23,7 @@ export class UserStreak {
   maxStreak: number;
 
   @Column({ type: 'timestamptz', default: null })
-  lastViewAt: Date;
+  lastViewAt: Date | null;
 
   @Column({ type: 'timestamptz', default: () => 'now()' })
   updatedAt: Date;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import { ApolloError } from 'apollo-server-errors';
+import { QueryFailedError } from 'typeorm';
 
 export enum UserFailErrorKeys {
   GenericError = 'GENERIC_ERROR',
@@ -107,9 +108,14 @@ export enum SourcePermissionErrorKeys {
 
 // Return 409 HTTP status code
 export class ConflictError extends ApolloError {
-  constructor(message) {
+  constructor(message: string) {
     super(message, 'CONFLICT');
 
     Object.defineProperty(this, 'name', { value: 'ConflictError' });
   }
 }
+
+export type TypeORMQueryFailedError = QueryFailedError & {
+  code?: string;
+  constraint?: string;
+};

--- a/src/workers/cdc/common.ts
+++ b/src/workers/cdc/common.ts
@@ -3,7 +3,7 @@ import {
   ContentQuality,
   ContentUpdatedMessage,
 } from '@dailydotdev/schema';
-import { DataSource } from 'typeorm';
+import { DataSource, ObjectLiteral } from 'typeorm';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
 import {
   ArticlePost,
@@ -20,7 +20,7 @@ import { JsonValue, Message } from '@bufbuild/protobuf';
 export const isChanged = <T>(before: T, after: T, property: keyof T): boolean =>
   before[property] != after[property];
 
-export const getTableName = <Entity>(
+export const getTableName = <Entity extends ObjectLiteral>(
   con: DataSource,
   target: EntityTarget<Entity>,
 ): string => con.getRepository(target).metadata.tableName;

--- a/src/workers/cdc/notifications.ts
+++ b/src/workers/cdc/notifications.ts
@@ -11,14 +11,14 @@ const onNotificationsChange = async (
   logger: FastifyBaseLogger,
   data: ChangeMessage<NotificationV2>,
 ): Promise<void> => {
-  if (data.payload.op === 'c') {
+  if (data.payload.op === 'c' && data.payload.after) {
     await notifyNewNotification(logger, data.payload.after);
   }
 };
 
 const worker: Worker = {
   subscription: 'api.cdc-notifications',
-  maxMessages: parseInt(process.env.CDC_WORKER_MAX_MESSAGES) || null,
+  maxMessages: parseInt(process.env.CDC_WORKER_MAX_MESSAGES) || undefined,
   handler: async (message, con, logger): Promise<void> => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/workers/commentCommentedSlackMessage.ts
+++ b/src/workers/commentCommentedSlackMessage.ts
@@ -1,6 +1,7 @@
 import { messageToJson, Worker } from './worker';
 import { Comment } from '../entity';
 import { notifyNewComment } from '../common';
+import { TypeORMQueryFailedError } from '../errors';
 
 interface Data {
   userId: string;
@@ -31,7 +32,9 @@ const worker: Worker = {
         },
         'Slack new comment message send',
       );
-    } catch (err) {
+    } catch (originalError) {
+      const err = originalError as TypeORMQueryFailedError;
+
       logger.error(
         {
           data,

--- a/src/workers/commentDownvotedRep.ts
+++ b/src/workers/commentDownvotedRep.ts
@@ -27,6 +27,10 @@ const worker: TypedWorker<'api.v1.comment-downvoted'> = {
           .getRepository(User)
           .findOneBy({ id: data.userId });
 
+        if (!grantBy) {
+          return;
+        }
+
         if (
           comment.userId === grantBy.id ||
           grantBy.reputation < REPUTATION_THRESHOLD

--- a/src/workers/commentDownvotedRep.ts
+++ b/src/workers/commentDownvotedRep.ts
@@ -28,6 +28,8 @@ const worker: TypedWorker<'api.v1.comment-downvoted'> = {
           .findOneBy({ id: data.userId });
 
         if (!grantBy) {
+          logger.info(logDetails, 'grantBy user does not exist');
+
           return;
         }
 

--- a/src/workers/commentUpvotedRep.ts
+++ b/src/workers/commentUpvotedRep.ts
@@ -27,6 +27,10 @@ const worker: TypedWorker<'comment-upvoted'> = {
           .getRepository(User)
           .findOneBy({ id: data.userId });
 
+        if (!grantBy) {
+          return;
+        }
+
         if (
           comment.userId === grantBy.id ||
           grantBy.reputation < REPUTATION_THRESHOLD

--- a/src/workers/commentUpvotedRep.ts
+++ b/src/workers/commentUpvotedRep.ts
@@ -28,6 +28,8 @@ const worker: TypedWorker<'comment-upvoted'> = {
           .findOneBy({ id: data.userId });
 
         if (!grantBy) {
+          logger.info(logDetails, 'grantBy user does not exist');
+
           return;
         }
 

--- a/src/workers/experimentAllocated.ts
+++ b/src/workers/experimentAllocated.ts
@@ -11,14 +11,17 @@ interface Data {
 const parseHash = (
   hash: Record<string, string>,
 ): Record<string, { variation: string; timestamp: Date }> => {
-  return Object.keys(hash).reduce((acc, key) => {
-    const [variation, timestamp] = hash[key].split(':');
-    acc[key] = {
-      variation,
-      timestamp: new Date(parseInt(timestamp)),
-    };
-    return acc;
-  }, {});
+  return Object.keys(hash).reduce(
+    (acc, key) => {
+      const [variation, timestamp] = hash[key].split(':');
+      acc[key] = {
+        variation,
+        timestamp: new Date(parseInt(timestamp)),
+      };
+      return acc;
+    },
+    {} as Record<string, { variation: string; timestamp: Date }>,
+  );
 };
 
 const keysToDrop = (

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -86,7 +86,8 @@ export const workers: Worker[] = [
   ...notificationWorkers,
 ];
 
-export const typedWorkers: BaseTypedWorker<unknown>[] = [
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const typedWorkers: BaseTypedWorker<any>[] = [
   sourceRequestApprovedRep,
   commentDownvotedRep,
   commentDownvoteCanceledRep,

--- a/src/workers/newNotificationV2RealTime.ts
+++ b/src/workers/newNotificationV2RealTime.ts
@@ -29,7 +29,7 @@ const worker: Worker = {
         await getNotificationV2AndChildren(con, id);
       if (notification) {
         const stream = await streamNotificationUsers(con, notification.id);
-        await processStream(
+        await processStream<{ userId: string }>(
           stream,
           ({ userId }) =>
             redisPubSub.publish(`events.notifications.${userId}.new`, {

--- a/src/workers/notifications/devCardUnlocked.ts
+++ b/src/workers/notifications/devCardUnlocked.ts
@@ -19,8 +19,9 @@ const worker: NotificationWorker = {
     if (
       data.user.reputation > DEFAULT_DEV_CARD_UNLOCKED_THRESHOLD ||
       data.userAfter.reputation < DEFAULT_DEV_CARD_UNLOCKED_THRESHOLD
-    )
-      return null;
+    ) {
+      return;
+    }
 
     const ctx: NotificationBaseContext = {
       userIds: [data.userAfter.id],

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -16,7 +16,7 @@ import postAdded from './postAdded';
 import memberJoinedSource from './squadMemberJoined';
 import sourceMemberRoleChanged from './sourceMemberRoleChanged';
 import squadPublicRequestNotification from './squadPublicRequestNotification';
-import { TypeOrmError } from '../../errors';
+import { TypeOrmError, TypeORMQueryFailedError } from '../../errors';
 import postMention from './postMention';
 import { collectionUpdated } from './collectionUpdated';
 import devCardUnlocked from './devCardUnlocked';
@@ -33,7 +33,9 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
         await con.transaction(async (entityManager) => {
           await generateAndStoreNotificationsV2(entityManager, args);
         });
-      } catch (err) {
+      } catch (originalError) {
+        const err = originalError as TypeORMQueryFailedError;
+
         if (err?.code === TypeOrmError.NULL_VIOLATION) {
           logger.error(
             { data: messageToJson(message) },

--- a/src/workers/notifications/postMention.ts
+++ b/src/workers/notifications/postMention.ts
@@ -30,7 +30,7 @@ const worker: NotificationWorker = {
       repo.findOneBy({ id: mentionedUserId }),
     ]);
 
-    if (!doneBy) {
+    if (!doneBy || !doneTo) {
       return;
     }
 

--- a/src/workers/notifications/sourceMemberRoleChanged.ts
+++ b/src/workers/notifications/sourceMemberRoleChanged.ts
@@ -42,6 +42,11 @@ const worker: NotificationWorker = {
     const source = await con
       .getRepository(Source)
       .findOneBy({ id: member.sourceId });
+
+    if (!source) {
+      return;
+    }
+
     const baseCtx: NotificationSourceContext = {
       userIds: [member.userId],
       source,

--- a/src/workers/notifications/sourceMemberRoleChanged.ts
+++ b/src/workers/notifications/sourceMemberRoleChanged.ts
@@ -36,14 +36,17 @@ const previousRoleToNewRole: Partial<
 
 const worker: NotificationWorker = {
   subscription: 'api.source-member-role-changed-notification',
-  handler: async (message, con) => {
+  handler: async (message, con, logger) => {
     const { previousRole, sourceMember: member }: Data = messageToJson(message);
+    const logDetails = { member, messageId: message.messageId };
 
     const source = await con
       .getRepository(Source)
       .findOneBy({ id: member.sourceId });
 
     if (!source) {
+      logger.info(logDetails, 'source does not exist');
+
       return;
     }
 
@@ -51,9 +54,6 @@ const worker: NotificationWorker = {
       userIds: [member.userId],
       source,
     };
-    if (!source) {
-      return;
-    }
 
     const roleToNotificationMap =
       previousRoleToNewRole[previousRole]?.[member.role];

--- a/src/workers/notifications/sourceRequest.ts
+++ b/src/workers/notifications/sourceRequest.ts
@@ -33,7 +33,7 @@ const worker: NotificationWorker = {
         return [{ type: NotificationType.SourceRejected, ctx }];
       }
       default:
-        return null;
+        return;
     }
   },
 };

--- a/src/workers/notifications/squadMemberJoined.ts
+++ b/src/workers/notifications/squadMemberJoined.ts
@@ -53,6 +53,11 @@ const worker: NotificationWorker = {
       con.getRepository(Source).findOneBy({ id: member.sourceId }),
       con.getRepository(WelcomePost).findOneBy({ sourceId: member.sourceId }),
     ]);
+
+    if (!source) {
+      return;
+    }
+
     if (!post || source.type !== SourceType.Squad) {
       return;
     }

--- a/src/workers/notifications/squadMemberJoined.ts
+++ b/src/workers/notifications/squadMemberJoined.ts
@@ -21,8 +21,9 @@ interface Data {
 
 const worker: NotificationWorker = {
   subscription: 'api.member-joined-source-notification',
-  handler: async (message, con) => {
+  handler: async (message, con, logger) => {
     const { sourceMember: member }: Data = messageToJson(message);
+    const logDetails = { member, messageId: message.messageId };
     const admins = await getSubscribedMembers(
       con,
       NotificationType.SquadMemberJoined,
@@ -39,6 +40,8 @@ const worker: NotificationWorker = {
       .findOneBy({ id: member.userId });
 
     if (!doneBy) {
+      logger.info(logDetails, 'doneBy user does not exist');
+
       return;
     }
 
@@ -55,6 +58,8 @@ const worker: NotificationWorker = {
     ]);
 
     if (!source) {
+      logger.info(logDetails, 'source does not exist');
+
       return;
     }
 

--- a/src/workers/notifications/squadPublicRequestNotification.ts
+++ b/src/workers/notifications/squadPublicRequestNotification.ts
@@ -24,12 +24,20 @@ const statusToTypeMap: Record<SquadPublicRequestStatus, NotificationType> = {
 
 const worker: NotificationWorker = {
   subscription: 'api.v1.squad-public-request-notification',
-  handler: async (message, con) => {
+  handler: async (message, con, logger) => {
     const data: Data = messageToJson(message);
     const { requestorId, status, sourceId } = data.request;
+    const logDetails = {
+      requestorId,
+      status,
+      sourceId,
+      messageId: message.messageId,
+    };
     const source = await con.getRepository(Source).findOneBy({ id: sourceId });
 
     if (!source) {
+      logger.info(logDetails, 'source does not exist');
+
       return [];
     }
 

--- a/src/workers/notifications/squadPublicRequestNotification.ts
+++ b/src/workers/notifications/squadPublicRequestNotification.ts
@@ -28,6 +28,11 @@ const worker: NotificationWorker = {
     const data: Data = messageToJson(message);
     const { requestorId, status, sourceId } = data.request;
     const source = await con.getRepository(Source).findOneBy({ id: sourceId });
+
+    if (!source) {
+      return [];
+    }
+
     const ctx: NotificationSquadRequestContext & NotificationSourceContext = {
       squadRequest: data.request,
       userIds: [requestorId],

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -30,7 +30,7 @@ export const uniquePostOwners = (
 ): string[] =>
   [...new Set([post.scoutId, post.authorId])].filter(
     (userId) => userId && !ignoreIds.includes(userId),
-  );
+  ) as string[];
 
 export const getSubscribedMembers = (
   con: DataSource,

--- a/src/workers/notifications/worker.ts
+++ b/src/workers/notifications/worker.ts
@@ -4,10 +4,12 @@ import { Message } from '../worker';
 import { NotificationBaseContext } from '../../notifications';
 import { NotificationType } from '../../notifications/common';
 
-export type NotificationHandlerReturn = {
-  type: NotificationType;
-  ctx: NotificationBaseContext;
-}[];
+export type NotificationHandlerReturn =
+  | {
+      type: NotificationType;
+      ctx: NotificationBaseContext;
+    }[]
+  | undefined;
 
 export interface NotificationWorker {
   subscription: string;

--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -49,7 +49,7 @@ const digestTypeToFunctionMap: Record<
     data: Data,
     con: DataSource,
     logger: FastifyBaseLogger,
-    allocationClient: ExperimentAllocationClient,
+    allocationClient?: ExperimentAllocationClient,
   ) => Promise<void>
 > = {
   [UserPersonalizedDigestType.Digest]: async (
@@ -83,8 +83,9 @@ const digestTypeToFunctionMap: Record<
     }
 
     const featureInstance =
-      sendTypeToFeatureMap[personalizedDigest.flags.sendType] ||
-      features.personalizedDigest;
+      sendTypeToFeatureMap[
+        personalizedDigest.flags.sendType as UserPersonalizedDigestSendType
+      ] || features.personalizedDigest;
     let featureValue: PersonalizedDigestFeatureConfig;
 
     if (config) {

--- a/src/workers/postCommentedSlackMessage.ts
+++ b/src/workers/postCommentedSlackMessage.ts
@@ -1,6 +1,7 @@
 import { messageToJson, Worker } from './worker';
 import { Comment } from '../entity';
 import { notifyNewComment } from '../common';
+import { TypeORMQueryFailedError } from '../errors';
 
 interface Data {
   userId: string;
@@ -31,7 +32,9 @@ const worker: Worker = {
         },
         'Slack new comment message send',
       );
-    } catch (err) {
+    } catch (originalError) {
+      const err = originalError as TypeORMQueryFailedError;
+
       logger.error(
         {
           data,

--- a/src/workers/postDownvotedRep.ts
+++ b/src/workers/postDownvotedRep.ts
@@ -27,6 +27,8 @@ const worker: TypedWorker<'api.v1.post-downvoted'> = {
           .findOneBy({ id: data.userId });
 
         if (!grantBy) {
+          logger.info(logDetails, 'grantBy user does not exist');
+
           return;
         }
 

--- a/src/workers/postDownvotedRep.ts
+++ b/src/workers/postDownvotedRep.ts
@@ -26,6 +26,10 @@ const worker: TypedWorker<'api.v1.post-downvoted'> = {
           .getRepository(User)
           .findOneBy({ id: data.userId });
 
+        if (!grantBy) {
+          return;
+        }
+
         if (grantBy.reputation < REPUTATION_THRESHOLD) {
           logger.info(
             logDetails,

--- a/src/workers/postUpvotedRep.ts
+++ b/src/workers/postUpvotedRep.ts
@@ -26,6 +26,8 @@ const worker: TypedWorker<'post-upvoted'> = {
           .findOneBy({ id: data.userId });
 
         if (!grantBy) {
+          logger.info(logDetails, 'grantBy user does not exist');
+
           return;
         }
 

--- a/src/workers/postUpvotedRep.ts
+++ b/src/workers/postUpvotedRep.ts
@@ -25,6 +25,10 @@ const worker: TypedWorker<'post-upvoted'> = {
           .getRepository(User)
           .findOneBy({ id: data.userId });
 
+        if (!grantBy) {
+          return;
+        }
+
         if (grantBy.reputation < REPUTATION_THRESHOLD) {
           logger.info(
             logDetails,

--- a/src/workers/updateComments.ts
+++ b/src/workers/updateComments.ts
@@ -1,3 +1,4 @@
+import { TypeORMQueryFailedError } from '../errors';
 import { updateMentions } from '../schema/comments';
 import { messageToJson, Worker } from './worker';
 
@@ -23,7 +24,9 @@ const worker: Worker = {
         },
         'updated username',
       );
-    } catch (err) {
+    } catch (originalError) {
+      const err = originalError as TypeORMQueryFailedError;
+
       logger.error(
         {
           data,

--- a/src/workers/usernameChanged.ts
+++ b/src/workers/usernameChanged.ts
@@ -1,3 +1,4 @@
+import { TypeORMQueryFailedError } from '../errors';
 import { notifyCommentsUpdate } from './../common/pubsub';
 import { CommentMention } from './../entity/CommentMention';
 import { messageToJson, Worker } from './worker';
@@ -38,7 +39,9 @@ const worker: Worker = {
         },
         'updated username',
       );
-    } catch (err) {
+    } catch (originalError) {
+      const err = originalError as TypeORMQueryFailedError;
+
       logger.error(
         {
           userId,


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on:
- error type handling
- workers
  - especially notification workers and their types