### PR TITLE
feat: add generic notification webhook endpoint

### DIFF
--- a/__tests__/webhooks.ts
+++ b/__tests__/webhooks.ts
@@ -512,6 +512,29 @@ describe('POST /webhooks/customerio/notification', () => {
     });
   });
 
+  it('should remove duplicate userIds', async () => {
+    const { body } = await request(app.server)
+      .post('/webhooks/customerio/notification')
+      .send({ ...payload, userIds: ['u1', 'u1', 'u2', 'u3'] })
+      .use(withSignature)
+      .expect(200);
+
+    expect(body.success).toEqual(true);
+
+    expect(sendGenericPush).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(sendGenericPush).mock.calls[0][0]).toMatchObject([
+      'u1',
+      'u2',
+      'u3',
+    ]);
+    expect(jest.mocked(sendGenericPush).mock.calls[0][1]).toMatchObject({
+      body: 'body',
+      title: 'title',
+      url: 'url',
+      utm_campaign: 'utm_campaign',
+    });
+  });
+
   it('should return 400 when the payload is invalid', async () => {
     const { body } = await request(app.server)
       .post('/webhooks/customerio/notification')

--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -117,3 +117,37 @@ export async function sendStreakReminderPush(
 
   await client.createNotification(push);
 }
+
+export type GenericPushPayload = {
+  title: string;
+  body: string;
+  url?: string;
+  utm_campaign?: string;
+};
+
+export const sendGenericPush = async (
+  userIds: string[],
+  notification: GenericPushPayload,
+) => {
+  if (!appId || !apiKey) return null;
+  const push = new OneSignal.Notification();
+  push.app_id = appId;
+  push.include_external_user_ids = userIds;
+  push.contents = {
+    en: notification.body,
+  };
+  push.headings = {
+    en: notification.title,
+  };
+
+  push.chrome_web_badge = chromeWebBadge;
+  push.chrome_web_icon = chromeWebIcon;
+
+  if (notification.url) {
+    push.url = notification.utm_campaign
+      ? addNotificationUtm(notification.url, 'push', notification.utm_campaign)
+      : notification.url;
+  }
+
+  return client.createNotification(push);
+};

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -53,24 +53,22 @@ type NotificationPayload = {
 };
 
 type ReportingEvent = {
-  Body: {
-    data: {
-      action_id?: number;
-      broadcast_id?: number;
-      customer_id: string;
-      identifiers: {
-        id: string;
-      };
-      delivery_id: string;
-      recipient?: string;
-      email_address?: string;
+  data: {
+    action_id?: number;
+    broadcast_id?: number;
+    customer_id: string;
+    identifiers: {
+      id: string;
     };
-    event_id: string;
-    trigger_event_id?: string;
-    object_type: string;
-    metric: string;
-    timestamp: number;
+    delivery_id: string;
+    recipient?: string;
+    email_address?: string;
   };
+  event_id: string;
+  trigger_event_id?: string;
+  object_type: string;
+  metric: string;
+  timestamp: number;
 };
 
 const subscriptionMetrics = [
@@ -79,7 +77,7 @@ const subscriptionMetrics = [
   'unsubscribed',
 ];
 
-async function trackCioEvent(payload: ReportingEvent['Body']): Promise<void> {
+async function trackCioEvent(payload: ReportingEvent): Promise<void> {
   const dupPayload = { ...payload, data: { ...payload.data } };
   const userId = dupPayload.data.identifiers.id;
   // Delete personal data
@@ -236,7 +234,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
     },
   });
 
-  fastify.post<ReportingEvent>('/reporting', {
+  fastify.post<WebhookPayload<ReportingEvent>>('/reporting', {
     config: {
       rawBody: true,
     },

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -97,6 +97,9 @@ async function trackCioEvent(payload: ReportingEvent): Promise<void> {
   await sendAnalyticsEvent([event]);
 }
 
+/**
+ * Validate the required fields in the notification payload
+ */
 const validateNotificationPayload = (payload: NotificationPayload): boolean => {
   return (
     payload &&

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -38,17 +38,13 @@ const verifyCIOSignature = (
 };
 
 type MarketingCtaPayload = {
-  Body: {
-    userId: string;
-    marketingCtaId: string;
-  };
+  userId: string;
+  marketingCtaId: string;
 };
 
 type PromotedPostPayload = {
-  Body: {
-    userId: string;
-    postId: string;
-  };
+  userId: string;
+  postId: string;
 };
 
 type NotificationPayload = {
@@ -117,7 +113,7 @@ const validateNotificationPayload = (payload: NotificationPayload): boolean => {
 export const customerio = async (fastify: FastifyInstance): Promise<void> => {
   fastify.register(
     async (fastify: FastifyInstance): Promise<void> => {
-      fastify.addHook<MarketingCtaPayload>(
+      fastify.addHook<WebhookPayload<MarketingCtaPayload>>(
         'preValidation',
         async (req, res) => {
           const valid = verifyCIOSignature(process.env.CIO_WEBHOOK_SECRET, req);
@@ -127,7 +123,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
         },
       );
 
-      fastify.post<MarketingCtaPayload>('/', {
+      fastify.post<WebhookPayload<MarketingCtaPayload>>('/', {
         config: {
           rawBody: true,
         },
@@ -154,7 +150,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
         },
       });
 
-      fastify.post<MarketingCtaPayload>('/delete', {
+      fastify.post<WebhookPayload<MarketingCtaPayload>>('/delete', {
         config: {
           rawBody: true,
         },
@@ -181,7 +177,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
     { prefix: '/marketing_cta' },
   );
 
-  fastify.post<PromotedPostPayload>('/promote_post', {
+  fastify.post<WebhookPayload<PromotedPostPayload>>('/promote_post', {
     config: {
       rawBody: true,
     },

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -47,7 +47,7 @@ type PromotedPostPayload = {
   postId: string;
 };
 
-type NotificationPayload = {
+export type NotificationPayload = {
   userIds: string[];
   notification: GenericPushPayload;
 };

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -225,7 +225,10 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
       }
 
       try {
-        await sendGenericPush(payload.userIds, payload.notification);
+        await sendGenericPush(
+          [...new Set(payload.userIds)],
+          payload.notification,
+        );
         return res.send({ success: true });
       } catch (error) {
         logger.error({ error }, 'Error sending generic push');

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -210,10 +210,7 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
       rawBody: true,
     },
     handler: async (req, res) => {
-      const valid = verifyCIOSignature(
-        process.env.CIO_REPORTING_WEBHOOK_SECRET,
-        req,
-      );
+      const valid = verifyCIOSignature(process.env.CIO_WEBHOOK_SECRET, req);
       if (!valid) {
         req.log.warn('cio notifcations webhook invalid signature');
         return res.status(403).send({ error: 'Invalid signature' });

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -103,11 +103,11 @@ async function trackCioEvent(payload: ReportingEvent): Promise<void> {
 const validateNotificationPayload = (payload: NotificationPayload): boolean => {
   return (
     payload &&
-    payload.notification &&
-    payload.notification.title &&
-    payload.notification.body &&
-    payload.userIds &&
-    payload.userIds.length > 0
+    payload?.notification &&
+    payload?.notification?.title &&
+    payload?.notification?.body &&
+    payload?.userIds &&
+    payload?.userIds.length > 0
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,10 @@ export type ChangeMessage<T> = {
   };
 };
 
+export type WebhookPayload<T> = {
+  Body: T;
+};
+
 export enum DayOfWeek {
   Sunday = 0,
   Monday = 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export type ChangeMessage<T> = {
 };
 
 export type WebhookPayload<T> = {
-  Body: T;
+  Body?: T;
 };
 
 export enum DayOfWeek {


### PR DESCRIPTION
Adds a new webhook endpoint that allows us to send notifications via OneSignal from customer.io
Also cleaned up the webhook tests to simplify the generation of signatures.

Expected JSON payload is
```json
{
	"userIds": ["u1", "u2"],
	"notification": {
		"title": "Notification title",
		"body": "Notification message"
	}
}
```

And the `notification` can be extended like this. Where both `url` and `utm_campaign` are both optional. `utm_campaign` has no effect if no `url` is set.
```json
{
	"userIds": ["u1", "u2"],
	"notification": {
		"title": "Notification title",
		"body": "Notification message",
		"url": "https://website.com",
		"utm_campaign": "utm_campaign"
	}
}
```

AS-412