### PR TITLE
fix: add new private feed by ids

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -110,6 +110,7 @@ const LOGGED_IN_BODY = {
     company: null,
     cover: null,
     experienceLevel: null,
+    isTeamMember: false,
   },
   marketingCta: null,
   feeds: [],
@@ -427,6 +428,20 @@ describe('logged in boot', () => {
           LOGGED_IN_BODY.user.reputation >= submitArticleThreshold,
       },
     });
+  });
+
+  it('should set team member to true if user is a team member', async () => {
+    await con.getRepository(Feature).save({
+      feature: FeatureType.Team,
+      userId: '1',
+      value: 1,
+    });
+    mockLoggedIn();
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('Cookie', 'ory_kratos_session=value;')
+      .expect(200);
+    expect(res.body.user.isTeamMember).toEqual(true);
   });
 });
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -430,6 +430,7 @@ const loggedInBoot = async (
         roles,
         permalink: `${process.env.COMMENTS_PREFIX}/${user.username || user.id}`,
         canSubmitArticle: user.reputation >= submitArticleThreshold,
+        isTeamMember: exp?.a?.team === 1,
       },
       visit,
       alerts: {

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -335,6 +335,31 @@ export const typeDefs = /* GraphQL */ `
     ): PostConnection! @auth
 
     """
+    Get feed by providing post ids
+    """
+    feedByIds(
+      """
+      Paginate after opaque cursor
+      """
+      after: String
+
+      """
+      Paginate first
+      """
+      first: Int
+
+      """
+      Array of post ids
+      """
+      postIds: [String!]!
+
+      """
+      Array of supported post types
+      """
+      supportedTypes: [String!]
+    ): PostConnection! @auth
+
+    """
     Get an adhoc feed using a provided config
     """
     feedByConfig(
@@ -1343,6 +1368,13 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
         info,
       );
     },
+    feedByIds: feedResolver(
+      (ctx, { postIds }: FeedArgs & { postIds: string[] }, builder, alias) =>
+        fixedIdsFeedBuilder(ctx, postIds, builder, alias),
+      feedPageGenerator,
+      applyFeedPaging,
+      {},
+    ),
     feedByConfig: (
       source,
       args: ConnectionArguments & { config: string },

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1,5 +1,7 @@
 import {
   BookmarkList,
+  Feature,
+  FeatureType,
   Feed,
   FeedAdvancedSettings,
   FeedFlagsPublic,
@@ -38,10 +40,10 @@ import { In, SelectQueryBuilder } from 'typeorm';
 import { ensureSourcePermissions, GQLSource } from './sources';
 import {
   feedCursorPageGenerator,
+  GQLEmptyResponse,
   offsetPageGenerator,
   Page,
   PageGenerator,
-  GQLEmptyResponse,
 } from './common';
 import { GQLPost } from './posts';
 import { Connection, ConnectionArguments } from 'graphql-relay';
@@ -62,7 +64,7 @@ import {
   ValidationError,
 } from 'apollo-server-errors';
 import { opentelemetry } from '../telemetry/opentelemetry';
-import { UserVote, maxFeedsPerUser } from '../types';
+import { maxFeedsPerUser, UserVote } from '../types';
 import { createDatePageGenerator } from '../common/datePageGenerator';
 import { generateShortId } from '../ids';
 import { SubmissionFailErrorMessage } from '../errors';
@@ -1371,9 +1373,21 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     feedByIds: feedResolver(
       (ctx, { postIds }: FeedArgs & { postIds: string[] }, builder, alias) =>
         fixedIdsFeedBuilder(ctx, postIds, builder, alias),
+
       feedPageGenerator,
       applyFeedPaging,
-      {},
+      {
+        fetchQueryParams: async (ctx): Promise<void> => {
+          const isTeamMember = await ctx.con
+            .getRepository(Feature)
+            .findOneByOrFail({ feature: FeatureType.Team, userId: ctx.userId });
+          if (!isTeamMember || isTeamMember.value !== 1) {
+            throw new ForbiddenError(
+              'Access denied! You need to be authorized to perform this action!',
+            );
+          }
+        },
+      },
     ),
     feedByConfig: (
       source,


### PR DESCRIPTION
Private feed for platform guys to play with.
I know it's not 100% secure on this side, but don't think it's exposing much realisticly.

The FE part is actually limited to team members (hence the boot addition)