### PR TITLE
feat: apply strict typescript rules to scripts

### DIFF
--- a/bin/addDisallowHandles.ts
+++ b/bin/addDisallowHandles.ts
@@ -5504,7 +5504,7 @@ const start = async (): Promise<void> => {
     disallowHandles.reduce((arr, handle) => {
       arr.push({ value: handle });
       return arr;
-    }, []),
+    }, [] as DisallowHandle[]),
   );
   await repo.save(createdResponse);
 };

--- a/bin/addWelcomePosts.ts
+++ b/bin/addWelcomePosts.ts
@@ -14,7 +14,7 @@ import { createSquadWelcomePost } from '../src/common';
 
   resStream.on('data', async (squadSource: SquadSource) => {
     // Fetch first admin based on created data
-    const { userId } = await con.getRepository(SourceMember).findOne({
+    const { userId } = await con.getRepository(SourceMember).findOneOrFail({
       where: { sourceId: squadSource.id, role: SourceMemberRoles.Admin },
       order: { createdAt: 'ASC' },
     });

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,7 +5,7 @@ import background from '../src/background';
 import cron from '../src/cron';
 import personalizedDigest from '../src/commands/personalizedDigest';
 
-async function run(positionals) {
+async function run(positionals: string[]) {
   switch (positionals[0]) {
     case 'api':
       tracer('api').start();

--- a/bin/notificationSubscribedUsers.ts
+++ b/bin/notificationSubscribedUsers.ts
@@ -5,7 +5,7 @@ import { parse } from 'csv-parse';
 
 (async () => {
   const con = await createOrGetConnection();
-  const subscribed = {};
+  const subscribed = {} as Record<string, boolean>;
 
   console.log('reading csv');
   const stream = fs

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,15 @@ import { Roles } from './roles';
 import { AccessToken } from './auth';
 import { opentelemetry } from './telemetry/opentelemetry';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface ProcessEnv {
+      PORT: string;
+    }
+  }
+}
+
 declare module 'fastify' {
   interface FastifyRequest {
     // Used for auth


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on:
- scripts
  - some global types