### PR TITLE
chore: add metric to see which table spools how many req

### DIFF
--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -60,6 +60,10 @@ const counterMap = {
       name: 'cio_events',
       description: 'How many customerio events were sent to analytics',
     },
+    cdcTrigger: {
+      name: 'cdc_trigger',
+      description: 'How many times the cdc trigger was called',
+    },
   },
   background: {
     postError: {

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -60,10 +60,6 @@ const counterMap = {
       name: 'cio_events',
       description: 'How many customerio events were sent to analytics',
     },
-    cdcTrigger: {
-      name: 'cdc_trigger',
-      description: 'How many times the cdc trigger was called',
-    },
   },
   background: {
     postError: {
@@ -74,6 +70,10 @@ const counterMap = {
       name: 'notification_failed',
       description:
         'Number of notifications failed to be sent via different channels',
+    },
+    cdcTrigger: {
+      name: 'cdc_trigger',
+      description: 'How many times the cdc trigger was called',
     },
   },
   cron: {

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -88,6 +88,7 @@ import { getTableName, isChanged, notifyPostContentUpdated } from './common';
 import { UserComment } from '../../entity/user/UserComment';
 import { StorageKey, StorageTopic, generateStorageKey } from '../../config';
 import { deleteRedisKey } from '../../redis';
+import { counters } from '../../telemetry';
 
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,
@@ -813,6 +814,7 @@ const worker: Worker = {
       ) {
         return;
       }
+      counters?.api?.cdcTrigger?.add(1, { table: data.payload.source.table });
       switch (data.payload.source.table) {
         case getTableName(con, Banner):
           await onBannerChange(con, logger, data);

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -814,7 +814,9 @@ const worker: Worker = {
       ) {
         return;
       }
-      counters?.api?.cdcTrigger?.add(1, { table: data.payload.source.table });
+      counters?.background?.cdcTrigger?.add(1, {
+        table: data.payload.source.table,
+      });
       switch (data.payload.source.table) {
         case getTableName(con, Banner):
           await onBannerChange(con, logger, data);


### PR DESCRIPTION
Would be nice to know...
I see sometimes the CDC still gets overworked and kind of want to see which tables cause these spikes.

Do let me know if anyone thinks it's too much 😅