### PR TITLE
fix: remove gcp metrics exporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@fastify/helmet": "^11.1.1",
         "@fastify/rate-limit": "^9.1.0",
         "@fastify/websocket": "^10.0.1",
-        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.18.0",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.2.0",
         "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.18.0",
         "@google-cloud/opentelemetry-resource-util": "^2.2.0",
@@ -1194,26 +1193,6 @@
         "duplexify": "^4.1.2",
         "fastify-plugin": "^4.0.0",
         "ws": "^8.0.0"
-      }
-    },
-    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.18.0.tgz",
-      "integrity": "sha512-1IaZRGcrTlBaH/TjhGGt4UXwDZuklCjz3dMPQ4u0hjXOXAaIXrmnsamJEom6BSZtWB4OI/SwK0Uiiygl5irHOQ==",
-      "dependencies": {
-        "@google-cloud/opentelemetry-resource-util": "^2.2.0",
-        "@google-cloud/precise-date": "^4.0.0",
-        "google-auth-library": "^9.0.0",
-        "googleapis": "^137.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/sdk-metrics": "^1.0.0"
       }
     },
     "node_modules/@google-cloud/opentelemetry-cloud-trace-exporter": {
@@ -4423,6 +4402,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -6179,7 +6159,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/gaxios": {
       "version": "6.6.0",
@@ -6257,6 +6238,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6446,46 +6428,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/googleapis": {
-      "version": "137.1.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
-      "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
-      "dependencies": {
-        "google-auth-library": "^9.0.0",
-        "googleapis-common": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
-      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "gaxios": "^6.0.3",
-        "google-auth-library": "^9.7.0",
-        "qs": "^6.7.0",
-        "url-template": "^2.0.8",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6648,6 +6590,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6659,6 +6602,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8777,6 +8721,7 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9692,6 +9637,7 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -10209,6 +10155,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -11254,11 +11201,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@fastify/helmet": "^11.1.1",
     "@fastify/rate-limit": "^9.1.0",
     "@fastify/websocket": "^10.0.1",
-    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.18.0",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.2.0",
     "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.18.0",
     "@google-cloud/opentelemetry-resource-util": "^2.2.0",

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -2,13 +2,11 @@ import type { FastifyInstance } from 'fastify';
 import { api, resources, metrics } from '@opentelemetry/sdk-node';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
 import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
 
-import { isProd } from '../common/utils';
 import { logger } from '../logger';
 import {
   channel,
@@ -102,15 +100,6 @@ export const startMetrics = (serviceName: string): void => {
       }
     }),
   ];
-
-  if (isProd) {
-    readers.push(
-      new metrics.PeriodicExportingMetricReader({
-        exportIntervalMillis: 10_000,
-        exporter: new MetricExporter(),
-      }),
-    );
-  }
 
   const resource = new resources.Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: serviceName,


### PR DESCRIPTION
This removes the GCP metric exporter, now we only use prometheus metrics