### PR TITLE
feat(strict-ts): apply to markdown utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.5",
-        "@types/markdown-it": "14.0.1",
+        "@types/markdown-it": "14.1.1",
         "@types/node": "^20.14.2",
         "@types/node-fetch": "^2.6.11",
         "@types/retry": "^0.12.5",
@@ -3299,13 +3299,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.0.1.tgz",
-      "integrity": "sha512-6WfOG3jXR78DW8L5cTYCVVGAsIFZskRHCDo5tbqa+qtKVt4oDRVH7hyIWu1SpDQJlmIoEivNQZ5h+AGAOrgOtQ==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
       "dev": true,
       "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "node_modules/@types/mdurl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
         "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.5",
+        "@types/markdown-it": "14.0.1",
         "@types/node": "^20.14.2",
         "@types/node-fetch": "^2.6.11",
         "@types/retry": "^0.12.5",
@@ -3280,6 +3281,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
@@ -3290,6 +3297,22 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.0.1.tgz",
+      "integrity": "sha512-6WfOG3jXR78DW8L5cTYCVVGAsIFZskRHCDo5tbqa+qtKVt4oDRVH7hyIWu1SpDQJlmIoEivNQZ5h+AGAOrgOtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash": "^4.17.5",
-    "@types/markdown-it": "14.0.1",
+    "@types/markdown-it": "14.1.1",
     "@types/node": "^20.14.2",
     "@types/node-fetch": "^2.6.11",
     "@types/retry": "^0.12.5",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash": "^4.17.5",
+    "@types/markdown-it": "14.0.1",
     "@types/node": "^20.14.2",
     "@types/node-fetch": "^2.6.11",
     "@types/retry": "^0.12.5",

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -23,7 +23,7 @@ export const markdown: MarkdownIt = MarkdownIt({
 });
 
 export const getMentionLink = ({ id, username }: MarkdownMention): string => {
-  const href = getUserProfileUrl(username);
+  const href = getUserProfileUrl(username || '404');
 
   return `<a href="${href}" data-mention-id="${id}" data-mention-username="${username}">@${username}</a>`;
 };
@@ -50,9 +50,7 @@ const setTokenAttribute = (
 
 const defaultTextRender = markdown.renderer.rules.text as Renderer.RenderRule;
 
-type MarkdownMention = Pick<User, 'id'> & {
-  username: string;
-};
+type MarkdownMention = Pick<User, 'id' | 'username'>;
 
 export const mentionSpecialCharacters = new RegExp('[^a-zA-Z0-9_@-]', 'g');
 


### PR DESCRIPTION
daily.dev strict mode PR template

This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on:
- markdown
- utils