### PR TITLE
feat: typed notification worker

### DIFF
--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -69,6 +69,10 @@ export type PubSubSchema = {
   'api.v1.user-streak-updated': {
     streak: ChangeObject<UserStreak>;
   };
+  'api.v1.post-bookmark-reminder': {
+    postId: string;
+    userId: string;
+  };
 };
 
 export async function triggerTypedEvent<T extends keyof PubSubSchema>(

--- a/src/workers/notifications/postBookmarkReminder.ts
+++ b/src/workers/notifications/postBookmarkReminder.ts
@@ -1,18 +1,11 @@
-import { messageToJson } from '../worker';
 import { Bookmark } from '../../entity';
 import { NotificationType } from '../../notifications/common';
-import { NotificationWorker } from './worker';
+import { generateTypedNotificationWorker } from './worker';
 import { buildPostContext } from './utils';
 
-interface Data {
-  postId: string;
-  userId: string;
-}
-
-const worker: NotificationWorker = {
-  subscription: 'api.post-bookmark-reminder-notification',
-  handler: async (message, con) => {
-    const { postId, userId }: Data = messageToJson(message);
+const worker = generateTypedNotificationWorker({
+  subscription: 'api.v1.post-bookmark-reminder',
+  handler: async ({ postId, userId }, con) => {
     const postCtx = await buildPostContext(con, postId);
 
     if (!postCtx) {
@@ -34,6 +27,6 @@ const worker: NotificationWorker = {
       },
     ];
   },
-};
+});
 
 export default worker;

--- a/src/workers/notifications/worker.ts
+++ b/src/workers/notifications/worker.ts
@@ -1,8 +1,9 @@
 import { DataSource } from 'typeorm';
 import { FastifyBaseLogger } from 'fastify';
-import { Message } from '../worker';
+import { Message, messageToJson } from '../worker';
 import { NotificationBaseContext } from '../../notifications';
 import { NotificationType } from '../../notifications/common';
+import { PubSubSchema } from '../../common';
 
 export type NotificationHandlerReturn =
   | {
@@ -11,12 +12,48 @@ export type NotificationHandlerReturn =
     }[]
   | undefined;
 
+export type NotificationWorkerHandler = (
+  message: Message,
+  con: DataSource,
+  logger: FastifyBaseLogger,
+) => Promise<NotificationHandlerReturn>;
+
 export interface NotificationWorker {
   subscription: string;
+  handler: NotificationWorkerHandler;
+  maxMessages?: number;
+}
+
+interface TypedNotificationWorkerProps<
+  T extends keyof PubSubSchema,
+  D extends PubSubSchema[T],
+> {
+  subscription: T;
   handler: (
-    message: Message,
+    data: D,
     con: DataSource,
     logger: FastifyBaseLogger,
   ) => Promise<NotificationHandlerReturn>;
-  maxMessages?: number;
 }
+
+interface GenerateTypeWorkerResult<T extends keyof PubSubSchema> {
+  subscription: T;
+  handler: NotificationWorkerHandler;
+}
+
+export const generateTypedNotificationWorker = <
+  T extends keyof PubSubSchema,
+  D extends PubSubSchema[T],
+>({
+  subscription,
+  handler,
+}: TypedNotificationWorkerProps<T, D>): GenerateTypeWorkerResult<T> => {
+  return {
+    subscription,
+    handler: (message, ...props) => {
+      const data: D = messageToJson(message);
+
+      return handler(data, ...props);
+    },
+  };
+};


### PR DESCRIPTION
- Introduce a typed notification worker.
- Removes the necessity of having to use `messageToJson` by introducing a worker generator.
- Typed data based on the topic.
- See the error below if I try to deconstruct an unknown property to what was defined.

![Screenshot 2024-07-12 at 1 45 45 PM](https://github.com/user-attachments/assets/f69c9268-787c-4c7a-92d8-9fa626150dea)
