### PR TITLE
hotfix: unique select merge

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -222,7 +222,9 @@ const obj = new GraphORM({
           isMany: false,
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
-              .where(`${childAlias}."userId" = :userId`, { userId: ctx.userId })
+              .where(`${childAlias}."userId" = :voteUserId`, {
+                voteUserId: ctx.userId,
+              })
               .andWhere(`${childAlias}."postId" = "${parentAlias}".id`);
           },
         },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -449,7 +449,9 @@ const obj = new GraphORM({
           isMany: false,
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
-              .where(`${childAlias}."userId" = :userId`, { userId: ctx.userId })
+              .where(`${childAlias}."userId" = :voteUserId`, {
+                voteUserId: ctx.userId,
+              })
               .andWhere(`${childAlias}."commentId" = "${parentAlias}".id`);
           },
         },


### PR DESCRIPTION
Super big edge case...

But when viewing any of the comment feeds votes on comments would show as those from THAT user not your logged in user.

This was caused by the innerJoins on graphorm using the same parameter property basically.
EG:
Top level
![image](https://github.com/user-attachments/assets/72ba1797-9698-4a8f-9ed4-f7ac7300baad)

Sub level (graphorm)
![Screenshot 2024-07-12 at 15 59 58](https://github.com/user-attachments/assets/b48efc37-ea56-4fa6-bccd-d6d9e919f782)

Resulting in sub level alone:
```
res [
  '(SELECT "user_comment_pw4"."vote" AS "vote", user_comment_pw4."votedAt" AS "votedAt" FROM "public"."user_comment" "user_comment_pw4" WHERE user_comment_pw4."userId" = $1 AND user_comment_pw4."commentId" = comment_z2m."id" LIMIT 1)',
  [ 'TPKCfSC2rYrYNShi8Ynxs' ]
]
```

But because the parameters are shared inside a bigger query the end result combination is:
```
'SELECT "comment_fny"."id" AS "id", "comment_fny"."contentHtml" AS "contentHtml", "comment_fny"."createdAt" AS "createdAt", "comment_fny"."lastUpdatedAt" AS "lastUpdatedAt", "comment_fny"."upvotes" AS "numUpvotes", (SELECT to_jsonb(res) AS "children" FROM (SELECT "user_xmw"."id" AS "id", "user_xmw"."name" AS "name", "user_xmw"."image" AS "image", "user_xmw"."username" AS "username", "user_xmw"."bio" AS "bio", "user_xmw"."createdAt" AS "createdAt", "user_xmw"."reputation" AS "reputation", user_xmw."id" AS "id", user_xmw."username" AS "username", user_xmw."createdAt" AS "createdAt" FROM "public"."user" "user_xmw" WHERE "user_xmw"."id" = "comment_fny"."userId" LIMIT 1) "res") AS "author", (SELECT to_jsonb(res) AS "children" FROM (SELECT "user_comment_qbh"."vote" AS "vote", user_comment_qbh."votedAt" AS "votedAt" FROM "public"."user_comment" "user_comment_qbh" WHERE user_comment_qbh."userId" = $1 AND user_comment_qbh."commentId" = comment_fny."id" LIMIT 1) "res") AS "userState", (SELECT to_jsonb(res) AS "children" FROM (SELECT "post_zzo"."id" AS "id", "post_zzo"."title" AS "title", post_zzo."id" AS "id", post_zzo."shortId" AS "shortId", post_zzo."createdAt" AS "createdAt", post_zzo."pinnedAt" AS "pinnedAt", post_zzo."authorId" AS "authorId", post_zzo."scoutId" AS "scoutId", post_zzo."private" AS "private", post_zzo."type" AS "type", post_zzo."slug" AS "slug" FROM "public"."post" "post_zzo" WHERE "post_zzo"."id" = "comment_fny"."postId" LIMIT 1) "res") AS "post", comment_fny."id" AS "id", comment_fny."postId" AS "postId", comment_fny."createdAt" AS "createdAt" FROM "public"."comment" "comment_fny" INNER JOIN "public"."post" "p" ON "comment_fny"."postId" = "p"."id"  INNER JOIN "public"."source" "s" ON "p"."sourceId" = "s"."id" WHERE comment_fny."userId" = $1 AND "s"."private" = false AND "p"."visible" = true AND "p"."deleted" = false ORDER BY comment_fny."createdAt" DESC LIMIT 20',
  [ '53N9PlSnVUwKkDlpv2hMS' ]
```

This fix ensures the parameter for subQuery is unique 🤯

Raised by:
https://github.com/dailydotdev/daily/issues/1270