### PR TITLE
feat: log when posts are lower then max

### DIFF
--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -230,6 +230,18 @@ export const getPersonalizedDigestEmailPayload = async ({
     return undefined;
   }
 
+  if (posts.length < feature.maxPosts) {
+    logger.warn(
+      {
+        personalizedDigest,
+        feedConfig: feedConfigPayload,
+        emailBatchId,
+        postsCount: posts.length,
+      },
+      'lower then max posts found for personalized digest',
+    );
+  }
+
   const variationProps = await getEmailVariation({
     personalizedDigest,
     posts,


### PR DESCRIPTION
We want to see if having small amount of posts in digest is more widespread.