### PR TITLE
fix: temporarily disable pino telemetry instrumentation

### DIFF
--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -6,7 +6,6 @@ import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
-// import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
 import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
 import { TypeormInstrumentation } from 'opentelemetry-instrumentation-typeorm';
 
@@ -77,13 +76,6 @@ const instrumentations = [
     mergeItems: true,
     ignoreTrivialResolveSpans: true,
   }),
-  // new PinoInstrumentation({
-  //   logKeys: {
-  //     traceId: 'trace',
-  //     spanId: 'spanId',
-  //     traceFlags: 'traceSampled',
-  //   },
-  // }),
   // Did not really get anything from IORedis
   new IORedisInstrumentation(),
   // TODO: remove this once pubsub has implemented the new tracing methods

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -6,7 +6,7 @@ import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
-import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
+// import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
 import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
 import { TypeormInstrumentation } from 'opentelemetry-instrumentation-typeorm';
 
@@ -77,13 +77,13 @@ const instrumentations = [
     mergeItems: true,
     ignoreTrivialResolveSpans: true,
   }),
-  new PinoInstrumentation({
-    logKeys: {
-      traceId: 'trace',
-      spanId: 'spanId',
-      traceFlags: 'traceSampled',
-    },
-  }),
+  // new PinoInstrumentation({
+  //   logKeys: {
+  //     traceId: 'trace',
+  //     spanId: 'spanId',
+  //     traceFlags: 'traceSampled',
+  //   },
+  // }),
   // Did not really get anything from IORedis
   new IORedisInstrumentation(),
   // TODO: remove this once pubsub has implemented the new tracing methods


### PR DESCRIPTION
Temporarily disables the pino telemetry instrumentation, as I noticed the logs appears twice, once as a single line, the once output on multiple lines.
Will come back later to this to look at why it happens, but in the meantime, not much value is lost.