### PR TITLE
fix: remove `api:image` from adhoc

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -83,7 +83,6 @@ config:
     tz: UTC
     urlPrefix: http://api.local.com
     vordrIps: ""
-  api:image: api-image:tilt-c7aebcf8065ef69d
   api:k8s:
     namespace: local
   api:temporal:


### PR DESCRIPTION
Accidentally added in #2070