### PR TITLE
feat(strict-ts): apply to gql schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@temporalio/workflow": "^1.10.1",
         "@types/he": "^1.2.3",
         "@types/shortid": "0.0.32",
+        "@types/uuid": "^10.0.0",
         "apollo-server-errors": "^3.3.0",
         "apollo-server-types": "^3.8.0",
         "cloudinary": "^1.41.3",
@@ -3744,6 +3745,11 @@
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
       "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.28",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@temporalio/workflow": "^1.10.1",
     "@types/he": "^1.2.3",
     "@types/shortid": "0.0.32",
+    "@types/uuid": "^10.0.0",
     "apollo-server-errors": "^3.3.0",
     "apollo-server-types": "^3.8.0",
     "cloudinary": "^1.41.3",

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -1,6 +1,6 @@
 import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
-import { Context } from '../Context';
+import { AuthContext, BaseContext, Context } from '../Context';
 import {
   getSessions,
   postFeedback,
@@ -237,12 +237,15 @@ const meiliSearchResolver = feedResolver(
   },
 );
 
-export const resolvers: IResolvers<unknown, Context> = traceResolvers({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
   Query: {
     searchSessionHistory: async (
       _,
       args: ConnectionArguments,
-      ctx,
+      ctx: AuthContext,
     ): Promise<ConnectionRelay<GQLSearchSession>> => {
       const { first, after } = args;
 
@@ -250,15 +253,22 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
         () => !!after,
         (nodeSize) => nodeSize === first,
         (node) => node.id,
-        () => getSessions(ctx.userId, { limit: first, lastId: after }),
+        () =>
+          getSessions(ctx.userId, {
+            limit: first || undefined,
+            lastId: after || undefined,
+          }),
       );
     },
-    searchSession: async (_, { id }: { id: string }, ctx): Promise<Search> =>
-      getSession(ctx.userId, id),
+    searchSession: async (
+      _,
+      { id }: { id: string },
+      ctx: AuthContext,
+    ): Promise<Search> => getSession(ctx.userId, id),
     searchPostSuggestions: async (
       source,
       { query, version }: { query: string; version: number },
-      ctx,
+      ctx: Context,
     ): Promise<GQLSearchSuggestionsResults> => {
       const searchParams = new URLSearchParams({
         q: query,
@@ -309,7 +319,7 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
         first: number;
         after: string;
       },
-      ctx,
+      ctx: Context,
       info,
     ): Promise<ConnectionRelay<GQLPost> & { query: string }> => {
       const limit = Math.min(args.first || 10);
@@ -386,7 +396,7 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
     searchResultFeedback: async (
       _,
       { chunkId, value }: SearchResultFeedback,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       if (value > 1 || value < -1) {
         throw new ValidationError('Invalid value');


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- search schema
- settings schema
- submissions schema
- tags schema
- uuid package types added