### PR TITLE
feat(strict-ts): apply to gql schemas 2

### DIFF
--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -1,7 +1,7 @@
 import { Alerts, ALERTS_DEFAULT, UserActionType } from '../entity';
 import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
-import { Context } from '../Context';
+import { AuthContext, BaseContext } from '../Context';
 import { DataSource } from 'typeorm';
 import { insertOrIgnoreAction } from './actions';
 import { GQLEmptyResponse } from './common';
@@ -154,7 +154,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get the alerts for user
     """
-    userAlerts: Alerts!
+    userAlerts: Alerts! @auth
   }
 `;
 
@@ -219,17 +219,20 @@ export const getAlerts = async (
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, Context> = traceResolvers({
+export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
   Mutation: {
     updateUserAlerts: async (
       _,
       { data }: { data: GQLUpdateAlertsInput },
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLAlerts> => updateAlerts(ctx.con, ctx.userId, data),
     updateLastReferralReminder: async (
       _,
       __,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await updateAlerts(
         ctx.con,
@@ -241,23 +244,27 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       );
       return { _: true };
     },
-    updateLastBootPopup: async (_, __, ctx): Promise<GQLEmptyResponse> => {
+    updateLastBootPopup: async (
+      _,
+      __,
+      ctx: AuthContext,
+    ): Promise<GQLEmptyResponse> => {
       await updateAlerts(ctx.con, ctx.userId, { lastBootPopup: new Date() });
       return { _: true };
     },
     updateFeedFeedbackReminder: async (
       _,
       __,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await updateAlerts(ctx.con, ctx.userId, {
         lastFeedSettingsFeedback: new Date(),
       });
-      return { _: null };
+      return { _: true };
     },
   },
   Query: {
-    userAlerts: (_, __, ctx): Promise<GQLAlerts> | GQLAlerts =>
+    userAlerts: (_, __, ctx: AuthContext): Promise<GQLAlerts> | GQLAlerts =>
       getAlerts(ctx.con, ctx.userId),
   },
 });

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -1,7 +1,7 @@
 import { Alerts, ALERTS_DEFAULT, UserActionType } from '../entity';
 import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
-import { AuthContext, BaseContext } from '../Context';
+import { AuthContext, BaseContext, Context } from '../Context';
 import { DataSource } from 'typeorm';
 import { insertOrIgnoreAction } from './actions';
 import { GQLEmptyResponse } from './common';
@@ -154,7 +154,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get the alerts for user
     """
-    userAlerts: Alerts! @auth
+    userAlerts: Alerts!
   }
 `;
 
@@ -207,11 +207,14 @@ export const updateAlerts = async (
 
 export const getAlerts = async (
   con: DataSource,
-  userId: string,
+  userId?: string,
 ): Promise<Omit<Alerts, 'flags'>> => {
-  const alerts = await con.getRepository(Alerts).findOneBy({
-    userId,
-  });
+  const alerts = userId
+    ? await con.getRepository(Alerts).findOneBy({
+        userId,
+      })
+    : undefined;
+
   if (alerts) {
     return saveReturnAlerts(alerts);
   }
@@ -264,7 +267,7 @@ export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
     },
   },
   Query: {
-    userAlerts: (_, __, ctx: AuthContext): Promise<GQLAlerts> | GQLAlerts =>
+    userAlerts: (_, __, ctx: Context): Promise<GQLAlerts> | GQLAlerts =>
       getAlerts(ctx.con, ctx.userId),
   },
 });


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- actions schema
- alerts schema
- bookmarks schema
- comments schema