### PR TITLE
fix: post suggestions query error when empty

### DIFF
--- a/__tests__/search.ts
+++ b/__tests__/search.ts
@@ -366,6 +366,24 @@ describe('query searchPostSuggestions', () => {
       },
     });
   });
+
+  it('should return empty search suggestion if no hits found', async () => {
+    nock.cleanAll();
+    mockMeili(
+      'q=p1&attributesToRetrieve=post_id,title',
+      JSON.stringify({
+        hits: [],
+      }),
+    );
+
+    const res = await client.query(QUERY('p1'));
+    expect(res.data).toEqual({
+      searchPostSuggestions: {
+        query: 'p1',
+        hits: [],
+      },
+    });
+  });
 });
 
 describe('query searchTagSuggestions', () => {

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -282,7 +282,9 @@ export const resolvers: IResolvers<unknown, Context> = traceResolvers({
           'source.id = post.sourceId AND source.private = false AND source.id != :sourceId',
           { sourceId: 'unknown' },
         )
-        .where('post.id IN (:...ids)', { ids: hits.map((x) => x.post_id) })
+        .where('post.id IN (:...ids)', {
+          ids: hits.length ? hits.map((x) => x.post_id) : ['nosuchid'],
+        })
         .orderBy(`array_position(array[${idsStr}], post.id)`);
       if (ctx.userId) {
         newBuilder = newBuilder


### PR DESCRIPTION
[Thread](https://dailydotdev.slack.com/archives/C03C3JZPRU4/p1722243021223849?thread_ts=1722242588.418389&cid=C03C3JZPRU4)

if no ids are passed so it gets empty `IN ()` which is syntax error