### PR TITLE
fix: temporal workflow has already started

### DIFF
--- a/__tests__/temporal/notifications/activities.ts
+++ b/__tests__/temporal/notifications/activities.ts
@@ -1,0 +1,64 @@
+import {
+  BookmarkActivities,
+  createActivities,
+} from '../../../src/temporal/notifications/activities';
+import createOrGetConnection from '../../../src/db';
+import { DataSource } from 'typeorm';
+import { Bookmark, MachineSource, Post, User } from '../../../src/entity';
+import { saveFixtures } from '../../helpers';
+import { sourcesFixture, usersFixture } from '../../fixture';
+import { postsFixture } from '../../fixture/post';
+import { triggerTypedEvent } from '../../../src/common';
+import { MockActivityEnvironment } from '@temporalio/testing';
+
+let activities: BookmarkActivities;
+let con: DataSource;
+let env: MockActivityEnvironment;
+
+jest.mock('../../../src/common', () => ({
+  ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
+  triggerTypedEvent: jest.fn(),
+}));
+
+beforeEach(async () => {
+  con = await createOrGetConnection();
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, MachineSource, sourcesFixture);
+  await saveFixtures(con, Post, postsFixture);
+  env = new MockActivityEnvironment();
+  activities = createActivities({ con });
+});
+
+describe('validateBookmark activity', () => {
+  it('should return true if the bookmark still exists', async () => {
+    const bookmark = { userId: '1', postId: 'p1' };
+
+    await con.getRepository(Bookmark).save(bookmark);
+
+    const result = await env.run(activities.validateBookmark, bookmark);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false if the bookmark does not exists', async () => {
+    const bookmark = { userId: '1', postId: 'p1' };
+
+    const result = await env.run(activities.validateBookmark, bookmark);
+
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('sendBookmarkReminder activity', () => {
+  it('should send a pubsub event', async () => {
+    await env.run(activities.sendBookmarkReminder, {
+      userId: '1',
+      postId: 'p1',
+    });
+    expect(triggerTypedEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      'api.v1.post-bookmark-reminder',
+      { userId: '1', postId: 'p1' },
+    );
+  });
+});

--- a/__tests__/temporal/notifications/utils.ts
+++ b/__tests__/temporal/notifications/utils.ts
@@ -16,13 +16,13 @@ const mockActivities: BookmarkActivities = {
   sendBookmarkReminder,
 };
 
-afterAll(async () => {
-  await testEnv?.teardown();
-});
-
 let worker: Worker;
 
-beforeAll(async () => {
+jest.mock('../../../src/temporal/client', () => ({
+  getTemporalClient: () => testEnv.client,
+}));
+
+beforeEach(async () => {
   testEnv = await TestWorkflowEnvironment.createTimeSkipping();
   worker = await Worker.create({
     connection: testEnv.nativeConnection,
@@ -32,14 +32,11 @@ beforeAll(async () => {
       '../../../src/temporal/notifications/workflows',
     ),
   });
+  jest.clearAllMocks();
 });
 
-jest.mock('../../../src/temporal/client', () => ({
-  getTemporalClient: () => testEnv.client,
-}));
-
-beforeEach(async () => {
-  jest.clearAllMocks();
+afterEach(async () => {
+  await testEnv?.teardown();
 });
 
 describe('getReminderWorkflowId', () => {

--- a/__tests__/temporal/notifications/utils.ts
+++ b/__tests__/temporal/notifications/utils.ts
@@ -22,7 +22,7 @@ jest.mock('../../../src/temporal/client', () => ({
   getTemporalClient: () => testEnv.client,
 }));
 
-beforeEach(async () => {
+const setupTestEnv = async () => {
   testEnv = await TestWorkflowEnvironment.createTimeSkipping();
   worker = await Worker.create({
     connection: testEnv.nativeConnection,
@@ -32,11 +32,16 @@ beforeEach(async () => {
       '../../../src/temporal/notifications/workflows',
     ),
   });
-  jest.clearAllMocks();
-});
+};
 
-afterEach(async () => {
+const cleanupTestEnv = async () => {
   await testEnv?.teardown();
+  testEnv = null;
+  worker = null;
+};
+
+beforeEach(async () => {
+  jest.clearAllMocks();
 });
 
 describe('getReminderWorkflowId', () => {
@@ -54,6 +59,14 @@ describe('getReminderWorkflowId', () => {
 });
 
 describe('runReminderWorkflow', () => {
+  beforeEach(async () => {
+    await setupTestEnv();
+  });
+
+  afterEach(async () => {
+    await cleanupTestEnv();
+  });
+
   it('should start reminder workflow', async () => {
     const params = {
       postId: 'p1',
@@ -86,6 +99,14 @@ describe('runReminderWorkflow', () => {
 });
 
 describe('cancelReminderWorkflow', () => {
+  beforeEach(async () => {
+    await setupTestEnv();
+  });
+
+  afterEach(async () => {
+    await cleanupTestEnv();
+  });
+
   it('should cancel workflow', async () => {
     const params = {
       postId: 'p1',

--- a/__tests__/temporal/notifications/utils.ts
+++ b/__tests__/temporal/notifications/utils.ts
@@ -1,0 +1,123 @@
+import { BookmarkActivities } from '../../../src/temporal/notifications/activities';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import {
+  cancelReminderWorkflow,
+  getReminderWorkflowId,
+  runReminderWorkflow,
+} from '../../../src/temporal/notifications/utils';
+
+let testEnv: TestWorkflowEnvironment;
+
+const validateBookmark = jest.fn();
+const sendBookmarkReminder = jest.fn();
+const mockActivities: BookmarkActivities = {
+  validateBookmark,
+  sendBookmarkReminder,
+};
+
+afterAll(async () => {
+  await testEnv?.teardown();
+});
+
+let worker: Worker;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+  worker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: 'test',
+    activities: mockActivities,
+    workflowsPath: require.resolve(
+      '../../../src/temporal/notifications/workflows',
+    ),
+  });
+});
+
+jest.mock('../../../src/temporal/client', () => ({
+  getTemporalClient: () => testEnv.client,
+}));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+describe('getReminderWorkflowId', () => {
+  it('should generate reminder workflow id', () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: 12345,
+    };
+
+    expect(getReminderWorkflowId(params)).toBe(
+      'notification:bookmark:1:p1:12345',
+    );
+  });
+});
+
+describe('runReminderWorkflow', () => {
+  it('should start reminder workflow', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    const result = await worker.runUntil(runReminderWorkflow(params));
+    const description = await result.describe();
+
+    expect(description.status.name).toEqual('RUNNING');
+  });
+
+  it('should not start reminder workflow when workflow exists', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    const result = await worker.runUntil(runReminderWorkflow(params));
+    const description = await result.describe();
+
+    expect(description.status.name).toEqual('RUNNING');
+
+    const newWorkflow = await runReminderWorkflow(params);
+
+    expect(newWorkflow).not.toBeDefined();
+  });
+});
+
+describe('cancelReminderWorkflow', () => {
+  it('should cancel workflow', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    const result = await runReminderWorkflow(params);
+    const description = await result.describe();
+
+    expect(description.status.name).toEqual('RUNNING');
+
+    const cancelledResult = await worker.runUntil(
+      cancelReminderWorkflow(params),
+    );
+    const cancelled = await result.describe();
+    expect(cancelledResult).toBeDefined();
+    expect(cancelled.status.name).toEqual('TERMINATED');
+  });
+
+  it('should do nothing when workflow does not exist', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    const result = await worker.runUntil(cancelReminderWorkflow(params));
+
+    expect(result).not.toBeDefined();
+  });
+});

--- a/__tests__/temporal/notifications/workflows.ts
+++ b/__tests__/temporal/notifications/workflows.ts
@@ -69,13 +69,11 @@ describe('bookmarkReminderWorkflow workflow', () => {
 
     validateBookmark.mockReturnValueOnce(true);
 
-    await worker.runUntil(
-      testEnv.client.workflow.execute(bookmarkReminderWorkflow, {
-        workflowId: getReminderWorkflowId(params),
-        args: [params],
-        taskQueue: 'test',
-      }),
-    );
+    await testEnv.client.workflow.execute(bookmarkReminderWorkflow, {
+      workflowId: getReminderWorkflowId(params),
+      args: [params],
+      taskQueue: 'test',
+    });
 
     expect(mockActivities.sendBookmarkReminder).toHaveBeenCalledWith({
       postId: 'p1',

--- a/__tests__/temporal/notifications/workflows.ts
+++ b/__tests__/temporal/notifications/workflows.ts
@@ -1,0 +1,85 @@
+import { bookmarkReminderWorkflow } from '../../../src/temporal/notifications/workflows';
+import { BookmarkActivities } from '../../../src/temporal/notifications/activities';
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import { getReminderWorkflowId } from '../../../src/temporal/notifications/utils';
+
+let testEnv: TestWorkflowEnvironment;
+
+const validateBookmark = jest.fn();
+const sendBookmarkReminder = jest.fn();
+const mockActivities: BookmarkActivities = {
+  validateBookmark,
+  sendBookmarkReminder,
+};
+
+afterAll(async () => {
+  await testEnv?.teardown();
+});
+
+let worker: Worker;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+  worker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: 'test',
+    activities: mockActivities,
+    workflowsPath: require.resolve(
+      '../../../src/temporal/notifications/workflows',
+    ),
+  });
+});
+
+jest.mock('../../../src/temporal/client', () => ({
+  getTemporalClient: () => testEnv.client,
+}));
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+});
+
+describe('bookmarkReminderWorkflow workflow', () => {
+  it('should validate bookmark and do nothing if bookmark is not valid', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    validateBookmark.mockReturnValueOnce(false);
+
+    await worker.runUntil(
+      testEnv.client.workflow.execute(bookmarkReminderWorkflow, {
+        workflowId: getReminderWorkflowId(params),
+        args: [params],
+        taskQueue: 'test',
+      }),
+    );
+
+    expect(mockActivities.sendBookmarkReminder).not.toHaveBeenCalled();
+  });
+
+  it('should validate bookmark and send bookmark reminder', async () => {
+    const params = {
+      postId: 'p1',
+      userId: '1',
+      remindAt: Date.now() + 1000,
+    };
+
+    validateBookmark.mockReturnValueOnce(true);
+
+    await worker.runUntil(
+      testEnv.client.workflow.execute(bookmarkReminderWorkflow, {
+        workflowId: getReminderWorkflowId(params),
+        args: [params],
+        taskQueue: 'test',
+      }),
+    );
+
+    expect(mockActivities.sendBookmarkReminder).toHaveBeenCalledWith({
+      postId: 'p1',
+      userId: '1',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@temporalio/activity": "^1.10.1",
         "@temporalio/client": "^1.10.1",
         "@temporalio/common": "^1.10.1",
+        "@temporalio/testing": "^1.10.3",
         "@temporalio/worker": "^1.10.1",
         "@temporalio/workflow": "^1.10.1",
         "@types/he": "^1.2.3",
@@ -3144,22 +3145,22 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.10.1.tgz",
-      "integrity": "sha512-ZCUOq3pzIYuWeGCtY5cAbtjUqFr8qg6oQJ64gHqUlstk9mweeOtMhYUyBUNBeb+MlYn+YhtxyCaUc1HQlVXkHg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.10.3.tgz",
+      "integrity": "sha512-2wGEnH3lzfRkAPsM29Uih4jaXPjsRDCsXdSFJqmHz2fxcfodcjSjgTAJERFKRVOb9JfYmzsITRIrkKAfs3kvxA==",
       "dependencies": {
-        "@temporalio/common": "1.10.1",
+        "@temporalio/common": "1.10.3",
         "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.10.1.tgz",
-      "integrity": "sha512-j7ey7jvE9/2LPNggmItlvjugMbDIfN76wiQkxoXvS4Y4/6JHgcCAANJ5UpzkHR51LREkRBzDLVeRtxqrfgGMWw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.10.3.tgz",
+      "integrity": "sha512-0xGYlURFoHrWByIJB3vNCaY7p9lnUkvrlA4uVAG92AwI0z/kcXdkUwn+VTOBBJi83iX6NZ0QS47HA6sCr00OPw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.6",
-        "@temporalio/common": "1.10.1",
-        "@temporalio/proto": "1.10.1",
+        "@temporalio/common": "1.10.3",
+        "@temporalio/proto": "1.10.3",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
         "uuid": "^9.0.1"
@@ -3178,11 +3179,11 @@
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.10.1.tgz",
-      "integrity": "sha512-0l2XS2+4NW8y7zsCAMixAK0UEIEQLwx/f32j67VGT/DjJ1ri63W5ZTbZU7DoAB3yHjlfymblLQXgK46SzHgP3Q==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.10.3.tgz",
+      "integrity": "sha512-0LF4UZQomMy+K3dGR0PGkBAqBByavjldeUKyMONtDrVqtq4sO2+2NtLW9mvmXGCH15jsabye1pQZdZxlTGP/CQ==",
       "dependencies": {
-        "@temporalio/proto": "1.10.1",
+        "@temporalio/proto": "1.10.3",
         "long": "^5.2.3",
         "ms": "^3.0.0-canary.1",
         "proto3-json-serializer": "^2.0.0"
@@ -3197,12 +3198,12 @@
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.10.1.tgz",
-      "integrity": "sha512-HnyZ+6fcy0B5PjbzNaw+7ei51z86dQXYJMXx/B4p07Bmid1lSTqKzfd0WddjM+4u4kxiCBGXZ4A0OcfMRnjLRA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.10.3.tgz",
+      "integrity": "sha512-TJV8Th8h0pv6gwwEqcTUIbOZVqfKj/6qWgNBnZuHi3BYd1WKzvXGGg0r1gorwlfapaC3Mms/Rqed9Xlnl9xjDQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@temporalio/common": "1.10.1",
+        "@temporalio/common": "1.10.3",
         "arg": "^5.0.2",
         "cargo-cp-artifact": "^0.1.8",
         "which": "^4.0.0"
@@ -3236,26 +3237,41 @@
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.10.1.tgz",
-      "integrity": "sha512-kKe/B6yZU1iMmTQP161GLGHmWIhwhyn79rOFaurZ87kXswLmmss1TGO37H0GVqR1k4K8S8fewLPbayiYf+oksw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.10.3.tgz",
+      "integrity": "sha512-ugp04SpQFNmOa0+/kpg2vLfWMBPD2UW4s4XRaN23v9RREZ0HqV+DB+ZTT+03F9jeZlIFB0hxbF1Xd65tAF6fKg==",
       "dependencies": {
         "long": "^5.2.3",
         "protobufjs": "^7.2.5"
       }
     },
+    "node_modules/@temporalio/testing": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/testing/-/testing-1.10.3.tgz",
+      "integrity": "sha512-c88EapF8Y0wf2X/OjNX9LJH9loDJhMVbDqs1Lb99INbeYpyTHs1l4wttkAezhAnP5Ct6o6pzpyqKe20Uk0n7zw==",
+      "dependencies": {
+        "@temporalio/activity": "1.10.3",
+        "@temporalio/client": "1.10.3",
+        "@temporalio/common": "1.10.3",
+        "@temporalio/core-bridge": "1.10.3",
+        "@temporalio/proto": "1.10.3",
+        "@temporalio/worker": "1.10.3",
+        "@temporalio/workflow": "1.10.3",
+        "abort-controller": "^3.0.0"
+      }
+    },
     "node_modules/@temporalio/worker": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.10.1.tgz",
-      "integrity": "sha512-bGgA7ahVPc9OskeezYpkixQV4pCriEVm++M2wVxOz8wOygWokfqjpduE0sXmtKt7YNGM4oFTgs3ObQ3H9s7Ryg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.10.3.tgz",
+      "integrity": "sha512-IGHSpp9usFcn1kuYs234xOP2xjBJVyEtjborV8ZEFi9Eu01s7BfrNrVZUMQjs6dRTOCvvvkiFhU3MNuyk2qkWA==",
       "dependencies": {
         "@swc/core": "^1.3.102",
-        "@temporalio/activity": "1.10.1",
-        "@temporalio/client": "1.10.1",
-        "@temporalio/common": "1.10.1",
-        "@temporalio/core-bridge": "1.10.1",
-        "@temporalio/proto": "1.10.1",
-        "@temporalio/workflow": "1.10.1",
+        "@temporalio/activity": "1.10.3",
+        "@temporalio/client": "1.10.3",
+        "@temporalio/common": "1.10.3",
+        "@temporalio/core-bridge": "1.10.3",
+        "@temporalio/proto": "1.10.3",
+        "@temporalio/workflow": "1.10.3",
         "abort-controller": "^3.0.0",
         "heap-js": "^2.3.0",
         "memfs": "^4.6.0",
@@ -3294,12 +3310,12 @@
       }
     },
     "node_modules/@temporalio/workflow": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.10.1.tgz",
-      "integrity": "sha512-EaZEXxSjqcDI1PLo1RKU5eMAXzal98/bWw1pC71fN55AhW1YsxiS8upJQESp20Y+kkMmxJfBrpvinbFtMDgBvg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.10.3.tgz",
+      "integrity": "sha512-XnP1Srb4r1dhl4g5U/KDTSSJ9zixIeqBd5lfC0wol257ItjfJPJgXAYUNg0YqPg4HyE77OlG7Qh6qhyAU80ubg==",
       "dependencies": {
-        "@temporalio/common": "1.10.1",
-        "@temporalio/proto": "1.10.1"
+        "@temporalio/common": "1.10.3",
+        "@temporalio/proto": "1.10.3"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@temporalio/activity": "^1.10.1",
     "@temporalio/client": "^1.10.1",
     "@temporalio/common": "^1.10.1",
+    "@temporalio/testing": "^1.10.3",
     "@temporalio/worker": "^1.10.1",
     "@temporalio/workflow": "^1.10.1",
     "@types/he": "^1.2.3",

--- a/src/temporal/common.ts
+++ b/src/temporal/common.ts
@@ -37,9 +37,11 @@ export const getWorkflowHandle = async (
   return client.workflow.getHandle(workflowId);
 };
 
-export const getDescribeOrError = (handle: WorkflowHandle) => {
+export const getDescribeOrError = async (
+  handle: WorkflowHandle,
+): Promise<WorkflowExecutionDescription | undefined> => {
   try {
-    return handle.describe();
+    return await handle.describe();
   } catch (error) {
     if (error.name === TemporalError.NotFound) {
       return;
@@ -51,7 +53,7 @@ export const getDescribeOrError = (handle: WorkflowHandle) => {
 
 export const getWorkflowDescription = async (
   workflowId: string,
-): Promise<WorkflowExecutionDescription> => {
+): Promise<WorkflowExecutionDescription | undefined> => {
   const handle = await getWorkflowHandle(workflowId);
 
   return getDescribeOrError(handle);

--- a/src/temporal/common.ts
+++ b/src/temporal/common.ts
@@ -1,4 +1,7 @@
 import { DataSource } from 'typeorm';
+import { WorkflowHandle } from '@temporalio/client';
+import { WorkflowExecutionDescription } from '@temporalio/client/src/types';
+import { getTemporalClient } from './client';
 
 export enum WorkflowTopic {
   Notification = 'notification',
@@ -21,3 +24,35 @@ export const generateWorkflowId = (
 export interface InjectedProps {
   con: DataSource;
 }
+
+export enum TemporalError {
+  NotFound = 'WorkflowNotFoundError',
+}
+
+export const getWorkflowHandle = async (
+  workflowId: string,
+): Promise<WorkflowHandle> => {
+  const client = await getTemporalClient();
+
+  return client.workflow.getHandle(workflowId);
+};
+
+export const getDescribeOrError = (handle: WorkflowHandle) => {
+  try {
+    return handle.describe();
+  } catch (error) {
+    if (error.name === TemporalError.NotFound) {
+      return;
+    }
+
+    throw error;
+  }
+};
+
+export const getWorkflowDescription = async (
+  workflowId: string,
+): Promise<WorkflowExecutionDescription> => {
+  const handle = await getWorkflowHandle(workflowId);
+
+  return getDescribeOrError(handle);
+};

--- a/src/temporal/common.ts
+++ b/src/temporal/common.ts
@@ -31,7 +31,7 @@ export enum TemporalError {
 
 export const getWorkflowHandle = async (
   workflowId: string,
-): Promise<WorkflowHandle> => {
+): Promise<WorkflowHandle | undefined> => {
   const client = await getTemporalClient();
 
   return client.workflow.getHandle(workflowId);

--- a/src/temporal/config.ts
+++ b/src/temporal/config.ts
@@ -12,7 +12,7 @@ interface ServerOptions {
 }
 
 export const TEMPORAL_ADDRESS =
-  process.env.TEMPORAL_ADDRESS || 'host.docker.internal:7233';
+  process.env.TEMPORAL_ADDRESS || 'localhost:7233';
 export const TEMPORAL_NAMESPACE = process.env.TEMPORAL_NAMESPACE || 'default';
 
 let serverOptions: ServerOptions;

--- a/src/temporal/notifications/utils.ts
+++ b/src/temporal/notifications/utils.ts
@@ -56,6 +56,6 @@ export const cancelReminderWorkflow = async (
   const description = await getDescribeOrError(handle);
 
   if (description?.status.name === 'RUNNING') {
-    await handle.terminate();
+    return await handle.terminate();
   }
 };


### PR DESCRIPTION
- Create a function to catch errors that results to NotFound. As per documentation, running the `handle. describe` would result in a not found error rather than returning null.
- When the same workflow id is running, we should just ignore executing the same workflow.
- When workflow is not found and trying to cancel the id, we should just ignore it.
- Setup a test environment for Temporal. This involves worker registration in the test environment for integration testing.

~~TODO:~~
- [x] ~~Write tests for the whole Temporal integration.~~