### PR TITLE
feat(strict-ts): apply to posts schema

### DIFF
--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -201,7 +201,9 @@ const MAX_CONTENT_LENGTH = 4000;
 
 type ValidatePostArgs = Pick<EditPostArgs, 'title' | 'content'>;
 
-export const validatePost = (args: ValidatePostArgs): ValidatePostArgs => {
+export const validatePost = (
+  args: ValidatePostArgs,
+): Required<ValidatePostArgs> => {
   const title = args.title?.trim() ?? '';
   const content = args.content?.trim() ?? '';
 

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -202,7 +202,7 @@ export const notifyView = (
   log: EventLogger,
   postId: string,
   userId: string,
-  referer: string,
+  referer: string | undefined,
   timestamp: Date,
   tags?: string[],
 ): Promise<void> =>

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -38,7 +38,7 @@ export type PostFlags = Partial<{
   private: boolean;
   visible: boolean;
   showOnFeed: boolean;
-  promoteToPublic: number;
+  promoteToPublic: number | null;
   deletedBy: string;
 }>;
 

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -590,7 +590,7 @@ export const resolvers: IResolvers<any, BaseContext> = {
     postComments: async (
       _,
       args: GQLPostCommentsArgs,
-      ctx: Context,
+      ctx: AuthContext,
       info,
     ): Promise<Connection<GQLComment>> => {
       const post = await ctx.con

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -82,7 +82,6 @@ import {
 import { GraphQLResolveInfo } from 'graphql';
 import { Roles } from '../roles';
 import { markdown, saveMentions } from '../common/markdown';
-// @ts-expect-error graphql-upload is not typed
 import { FileUpload } from 'graphql-upload/GraphQLUpload';
 import { insertOrIgnoreAction } from './actions';
 import { generateShortId, generateUUID } from '../ids';

--- a/src/workers/postCommentedRedis.ts
+++ b/src/workers/postCommentedRedis.ts
@@ -14,7 +14,10 @@ const worker: Worker = {
     const data: Data = messageToJson(message);
     try {
       const postNotificatiion = await getPostNotification(con, data.postId);
-      await redisPubSub.publish('events.posts.commented', postNotificatiion);
+
+      if (postNotificatiion) {
+        await redisPubSub.publish('events.posts.commented', postNotificatiion);
+      }
     } catch (err) {
       logger.error(
         {

--- a/src/workers/postUpvotedRedis.ts
+++ b/src/workers/postUpvotedRedis.ts
@@ -13,7 +13,10 @@ const worker: Worker = {
     const data: Data = messageToJson(message);
     try {
       const postNotificatiion = await getPostNotification(con, data.postId);
-      await redisPubSub.publish('events.posts.upvoted', postNotificatiion);
+
+      if (postNotificatiion) {
+        await redisPubSub.publish('events.posts.upvoted', postNotificatiion);
+      }
     } catch (err) {
       logger.error(
         {


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- posts schema
- minor fixes from past few PRs that were added to `main`
- almost half way there 💦 