### PR TITLE
fix: decrypt slack user token and error handling

### DIFF
--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -67,10 +67,13 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
 
               logger.error(
                 {
-                  integrationId: userIntegration.id,
-                  sourceId: data.post.sourceId,
-                  channelId,
-                  error: error.message,
+                  data: {
+                    integrationId: userIntegration.id,
+                    sourceId: data.post.sourceId,
+                    channelId,
+                  },
+                  messageId: message.messageId,
+                  err: error,
                 },
                 'failed to send slack message',
               );


### PR DESCRIPTION
Forgot to decrypt token in worker which resulted in failed auth on slack. Also added error handling so we can catch future errors in message handler. 