### PR TITLE
feat: add fetch/undici instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@opentelemetry/instrumentation-ioredis": "^0.42.0",
         "@opentelemetry/instrumentation-pg": "^0.43.0",
         "@opentelemetry/instrumentation-pino": "^0.41.0",
+        "@opentelemetry/instrumentation-undici": "^0.4.0",
         "@opentelemetry/resource-detector-container": "^0.3.11",
         "@opentelemetry/resource-detector-gcp": "^0.29.10",
         "@opentelemetry/sdk-node": "^0.52.1",
@@ -2515,6 +2516,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.4.0.tgz",
+      "integrity": "sha512-UdMQBpz11SqtWlmDnk5SoqF5QDom4VmW8SVDt9Q2xuMWVh8lc0kVROfoo2pl7zU6H6gFR8eudb3eFXIdrFn0ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.52.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@opentelemetry/instrumentation-ioredis": "^0.42.0",
     "@opentelemetry/instrumentation-pg": "^0.43.0",
     "@opentelemetry/instrumentation-pino": "^0.41.0",
+    "@opentelemetry/instrumentation-undici": "^0.4.0",
     "@opentelemetry/resource-detector-container": "^0.3.11",
     "@opentelemetry/resource-detector-gcp": "^0.29.10",
     "@opentelemetry/sdk-node": "^0.52.1",

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -8,6 +8,7 @@ import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
 import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
 import { TypeormInstrumentation } from 'opentelemetry-instrumentation-typeorm';
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 
 import { NodeSDK, logs, node, api, resources } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
@@ -87,6 +88,7 @@ const instrumentations = [
   new TypeormInstrumentation({
     suppressInternalInstrumentation: true,
   }),
+  new UndiciInstrumentation(),
 ];
 
 api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.INFO);


### PR DESCRIPTION
Can now trace `fetch` requests too

```ts
await fetch('https://webhook.site/50afac16-4d86-4ae1-921e-73a40aa29cf3');
```
![image](https://github.com/user-attachments/assets/beb66900-e4b8-47f7-9d76-576ff561efca)