### PR TITLE
feat: always send join message when channel is changed for source

### DIFF
--- a/src/schema/integrations.ts
+++ b/src/schema/integrations.ts
@@ -358,7 +358,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers({
         await client.conversations.join({
           channel: args.channelId,
         });
+      }
 
+      const channelChanged = existing?.channelIds?.[0] !== args.channelId;
+
+      if (channelChanged) {
         const sourceTypeName =
           source.type === SourceType.Squad ? 'squad' : 'source';
 


### PR DESCRIPTION
- with last change it was not sending if bot was part of slack channel already