### PR TITLE
feat(strict-ts): apply to source schemas

### DIFF
--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -121,7 +121,7 @@ We hope you will find ${name} useful!`;
 
 export const createSquadWelcomePost = async (
   con: DataSource | EntityManager,
-  source: SquadSource,
+  source: Pick<SquadSource, 'id' | 'name'>,
   adminId: string,
   args: Partial<FreeformPost> = {},
 ) => {

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -140,8 +140,8 @@ export class MachineSource extends Source {
 @ChildEntity(SourceType.Squad)
 export class SquadSource extends Source {
   @Column({ default: 0 })
-  memberPostingRank?: number;
+  memberPostingRank: number;
 
   @Column({ default: 0 })
-  memberInviteRank?: number;
+  memberInviteRank: number;
 }

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1415,8 +1415,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       return paginateSourceMembers(
         (queryBuilder, alias) => {
-          queryBuilder = queryBuilder.andWhere(`${alias}."userId" = :user`, {
-            user: ctx.userId,
+          queryBuilder = queryBuilder.andWhere(`${alias}."userId" = :userId`, {
+            userId: ctx.userId,
           });
 
           if (
@@ -1455,8 +1455,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     ): Promise<Connection<GQLSourceMember>> => {
       return paginateSourceMembers(
         (queryBuilder, alias) => {
-          queryBuilder = queryBuilder.andWhere(`${alias}."userId" = :user`, {
-            user: userId,
+          queryBuilder = queryBuilder.andWhere(`${alias}."userId" = :userId`, {
+            userId,
           });
 
           if (


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- source schema
- sourceRequest schema