### PR TITLE
feat(slack): adjust message format after testing

### DIFF
--- a/__tests__/integrations.ts
+++ b/__tests__/integrations.ts
@@ -453,6 +453,22 @@ describe('slack integration', () => {
       expect(resUpdate.errors).toBeFalsy();
       expect(slackPostMessage).toHaveBeenCalledTimes(1);
     });
+
+    it('should return error if integration is not found', async () => {
+      loggedUser = '1';
+
+      await testMutationErrorCode(
+        client,
+        {
+          mutation: MUTATION({
+            integrationId: '4a51defd-a083-4967-82a8-edb009d57d05',
+            channelId: '1',
+            sourceId: 'squadslack',
+          }),
+        },
+        'NOT_FOUND',
+      );
+    });
   });
 
   describe('query sourceIntegration', () => {

--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -103,7 +103,16 @@ describe('postAddedSlackChannelSend worker', () => {
     });
     expect(chatPostMessage).toHaveBeenCalledWith({
       channel: '1',
-      text: expect.any(String),
+      attachments: [
+        {
+          author_icon: 'https://app.daily.dev/apple-touch-icon.png',
+          author_name: 'daily.dev',
+          image_url: 'https://daily.dev/image.jpg',
+          title: 'P1',
+          title_link: 'http://localhost:5002/posts/p1',
+        },
+      ],
+      text: 'New post on "A" source. http://localhost:5002/posts/p1',
     });
   });
 

--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -109,10 +109,12 @@ describe('postAddedSlackChannelSend worker', () => {
           author_name: 'daily.dev',
           image_url: 'https://daily.dev/image.jpg',
           title: 'P1',
-          title_link: 'http://localhost:5002/posts/p1',
+          title_link:
+            'http://localhost:5002/posts/p1?utm_source=notification&utm_medium=slack&utm_campaign=new_post',
         },
       ],
-      text: 'New post on "A" source. http://localhost:5002/posts/p1',
+      text: 'New post on "A" source. <http://localhost:5002/posts/p1?utm_source=notification&utm_medium=slack&utm_campaign=new_post|http://localhost:5002/posts/p1>',
+      unfurl_links: false,
     });
   });
 

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -62,16 +62,17 @@ export const getAttachmentForPostType = async <TPostType extends PostType>({
   con,
   post,
   postType,
+  postLink,
 }: {
   con: DataSource;
   post: Post;
   postType: TPostType;
+  postLink: string;
 }): Promise<MessageAttachment> => {
   const attachment: MessageAttachment = {
     author_name: 'daily.dev',
     author_icon: 'https://app.daily.dev/apple-touch-icon.png',
   };
-  const postLink = `${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
 
   switch (postType) {
     case PostType.Article:

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -1,15 +1,13 @@
 import { LogLevel, MessageAttachment, WebClient } from '@slack/web-api';
 import { DataSource } from 'typeorm';
-import {
-  PostType,
-  Post,
-  ArticlePost,
-  FreeformPost,
-  SharePost,
-  WelcomePost,
-  CollectionPost,
-  YouTubePost,
-} from '../entity';
+import { Post, PostType } from '../entity/posts/Post';
+import { ArticlePost } from '../entity/posts/ArticlePost';
+import { FreeformPost } from '../entity/posts/FreeformPost';
+import { SharePost } from '../entity/posts/SharePost';
+import { WelcomePost } from '../entity/posts/WelcomePost';
+import { CollectionPost } from '../entity/posts/CollectionPost';
+import { YouTubePost } from '../entity/posts/YouTubePost';
+
 import {
   UserIntegration,
   UserIntegrationSlack,

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -1,12 +1,5 @@
 import { LogLevel, MessageAttachment, WebClient } from '@slack/web-api';
 import { DataSource } from 'typeorm';
-import { Post, PostType } from '../entity/posts/Post';
-import { ArticlePost } from '../entity/posts/ArticlePost';
-import { FreeformPost } from '../entity/posts/FreeformPost';
-import { SharePost } from '../entity/posts/SharePost';
-import { WelcomePost } from '../entity/posts/WelcomePost';
-import { CollectionPost } from '../entity/posts/CollectionPost';
-import { YouTubePost } from '../entity/posts/YouTubePost';
 
 import {
   UserIntegration,
@@ -15,6 +8,16 @@ import {
 } from '../entity/UserIntegration';
 import { decrypt } from './crypto';
 import { isProd } from './utils';
+import {
+  PostType,
+  Post,
+  ArticlePost,
+  CollectionPost,
+  YouTubePost,
+  FreeformPost,
+  WelcomePost,
+  SharePost,
+} from '../entity/posts';
 
 export type GQLUserIntegration = {
   id: string;
@@ -53,15 +56,6 @@ export const getSlackClient = async ({
   return new WebClient(await getIntegrationToken({ integration }), {
     logLevel: isProd ? LogLevel.ERROR : LogLevel.WARN,
   });
-};
-
-export const contentTypeFromPostType: Record<PostType, typeof Post> = {
-  [PostType.Article]: ArticlePost,
-  [PostType.Freeform]: FreeformPost,
-  [PostType.Share]: SharePost,
-  [PostType.Welcome]: WelcomePost,
-  [PostType.Collection]: CollectionPost,
-  [PostType.VideoYouTube]: YouTubePost,
 };
 
 export const getAttachmentForPostType = async <TPostType extends PostType>({

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -1,9 +1,22 @@
+import { LogLevel, MessageAttachment, WebClient } from '@slack/web-api';
+import { DataSource } from 'typeorm';
+import {
+  PostType,
+  Post,
+  ArticlePost,
+  FreeformPost,
+  SharePost,
+  WelcomePost,
+  CollectionPost,
+  YouTubePost,
+} from '../entity';
 import {
   UserIntegration,
   UserIntegrationSlack,
   UserIntegrationType,
 } from '../entity/UserIntegration';
 import { decrypt } from './crypto';
+import { isProd } from './utils';
 
 export type GQLUserIntegration = {
   id: string;
@@ -32,4 +45,102 @@ export const getIntegrationToken = async <
     default:
       throw new Error('unsupported integration type');
   }
+};
+
+export const getSlackClient = async ({
+  integration,
+}: {
+  integration: UserIntegration;
+}): Promise<WebClient> => {
+  return new WebClient(await getIntegrationToken({ integration }), {
+    logLevel: isProd ? LogLevel.ERROR : LogLevel.WARN,
+  });
+};
+
+export const contentTypeFromPostType: Record<PostType, typeof Post> = {
+  [PostType.Article]: ArticlePost,
+  [PostType.Freeform]: FreeformPost,
+  [PostType.Share]: SharePost,
+  [PostType.Welcome]: WelcomePost,
+  [PostType.Collection]: CollectionPost,
+  [PostType.VideoYouTube]: YouTubePost,
+};
+
+export const getAttachmentForPostType = async <TPostType extends PostType>({
+  con,
+  post,
+  postType,
+}: {
+  con: DataSource;
+  post: Post;
+  postType: TPostType;
+}): Promise<MessageAttachment> => {
+  const attachment: MessageAttachment = {
+    author_name: 'daily.dev',
+    author_icon: 'https://app.daily.dev/apple-touch-icon.png',
+  };
+  const postLink = `${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
+
+  switch (postType) {
+    case PostType.Article:
+    case PostType.Collection:
+    case PostType.VideoYouTube: {
+      const articlePost = post as ArticlePost & CollectionPost & YouTubePost;
+
+      if (articlePost.title) {
+        attachment.title = articlePost.title;
+        attachment.title_link = postLink;
+      }
+
+      if (articlePost.summary) {
+        attachment.text = articlePost.summary;
+      }
+
+      if (articlePost.image) {
+        attachment.image_url = articlePost.image;
+      }
+
+      break;
+    }
+    case PostType.Freeform:
+    case PostType.Welcome: {
+      const freeformPost = post as FreeformPost & WelcomePost;
+
+      attachment.title = freeformPost.title;
+      attachment.title_link = postLink;
+
+      if (freeformPost.image) {
+        attachment.image_url = freeformPost.image;
+      }
+
+      break;
+    }
+    case PostType.Share: {
+      const sharePost = post as SharePost;
+      let title = sharePost.title;
+
+      const sharedPost = (await con.getRepository(Post).findOneBy({
+        id: sharePost.sharedPostId,
+      })) as ArticlePost;
+
+      if (!title) {
+        title = sharedPost?.title;
+      }
+
+      if (sharedPost?.image) {
+        attachment.image_url = sharedPost.image;
+      }
+
+      if (title) {
+        attachment.title = title;
+        attachment.title_link = postLink;
+      }
+
+      break;
+    }
+    default:
+      throw new Error(`unsupported post type ${postType}`);
+  }
+
+  return attachment;
 };

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -6,6 +6,7 @@ import {
   getAttachmentForPostType,
   getSlackClient,
 } from '../common/userIntegration';
+import { addNotificationUtm } from '../common';
 
 const sendQueueConcurrency = 10;
 
@@ -61,7 +62,13 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 channel: channelId,
               });
 
-              let message = `New post on "${source.name}" ${sourceTypeName}. ${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
+              const postLinkPlain = `${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
+              const postLink = addNotificationUtm(
+                postLinkPlain,
+                'slack',
+                'new_post',
+              );
+              let message = `New post on "${source.name}" ${sourceTypeName}. <${postLink}|${postLinkPlain}>`;
               const author = await post.author;
               const authorName = author?.name || author?.username;
 
@@ -73,6 +80,7 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 con,
                 post,
                 postType: data.post.type,
+                postLink,
               });
 
               await slackClient.chat.postMessage({

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -1,9 +1,12 @@
-import { WebClient } from '@slack/web-api';
 import { UserSourceIntegrationSlack } from '../entity/UserSourceIntegration';
 import { TypedWorker } from './worker';
 import fastq from 'fastq';
 import { Post, SourceType } from '../entity';
-import { getIntegrationToken } from '../common';
+import {
+  contentTypeFromPostType,
+  getAttachmentForPostType,
+  getSlackClient,
+} from '../common/userIntegration';
 
 const sendQueueConcurrency = 10;
 
@@ -13,14 +16,17 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
     handler: async (message, con, logger): Promise<void> => {
       const { data } = message;
 
+      const postType = contentTypeFromPostType[data.post.type] || Post;
+
       try {
         const [post, integrations] = await Promise.all([
-          con.getRepository(Post).findOneOrFail({
+          con.getRepository(postType).findOneOrFail({
             where: {
               id: data.post.id,
             },
             relations: {
               source: true,
+              author: true,
             },
           }),
           con.getRepository(UserSourceIntegrationSlack).find({
@@ -35,7 +41,7 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
         const source = await post.source;
 
         const sourceTypeName =
-          source.type === SourceType.Squad ? 'squad' : 'source';
+          source.type === SourceType.Squad ? 'Squad' : 'source';
 
         const sendQueue = fastq.promise(
           async ({
@@ -48,9 +54,9 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
             const userIntegration = await integration.userIntegration;
 
             try {
-              const slackClient = new WebClient(
-                await getIntegrationToken({ integration: userIntegration }),
-              );
+              const slackClient = await getSlackClient({
+                integration: userIntegration,
+              });
 
               // channel should already be joined when the integration is connected
               // but just in case
@@ -58,9 +64,24 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 channel: channelId,
               });
 
+              let message = `New post on "${source.name}" ${sourceTypeName}. ${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
+              const author = await post.author;
+              const authorName = author?.name || author?.username;
+
+              if (sourceTypeName === 'Squad' && authorName) {
+                message = `${authorName} shared a new post on "${source.name}" ${sourceTypeName}. ${process.env.COMMENTS_PREFIX}/posts/${post.id}`;
+              }
+
+              const attachment = await getAttachmentForPostType({
+                con,
+                post,
+                postType: data.post.type,
+              });
+
               await slackClient.chat.postMessage({
                 channel: channelId,
-                text: `New post added to ${sourceTypeName} "${source.name}" ${process.env.COMMENTS_PREFIX}/posts/${post.id}`,
+                text: message,
+                attachments: [attachment],
               });
             } catch (originalError) {
               const error = originalError as Error;

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -82,6 +82,7 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 channel: channelId,
                 text: message,
                 attachments: [attachment],
+                unfurl_links: false,
               });
             } catch (originalError) {
               const error = originalError as Error;

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -3,7 +3,6 @@ import { TypedWorker } from './worker';
 import fastq from 'fastq';
 import { Post, SourceType } from '../entity';
 import {
-  contentTypeFromPostType,
   getAttachmentForPostType,
   getSlackClient,
 } from '../common/userIntegration';
@@ -16,11 +15,9 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
     handler: async (message, con, logger): Promise<void> => {
       const { data } = message;
 
-      const postType = contentTypeFromPostType[data.post.type] || Post;
-
       try {
         const [post, integrations] = await Promise.all([
-          con.getRepository(postType).findOneOrFail({
+          con.getRepository(Post).findOneOrFail({
             where: {
               id: data.post.id,
             },


### PR DESCRIPTION
- now supports private posts as well (since we no longer depend on slack link embeds)
- also refactored WebClient to single place so we can set appropriate log level
- add utm params to links