### PR TITLE
feat(slack): add source name and image for attachment

### DIFF
--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -148,8 +148,8 @@ describe('postAddedSlackChannelSend worker', () => {
       channel: '1',
       attachments: [
         {
-          author_icon: 'https://app.daily.dev/apple-touch-icon.png',
-          author_name: 'daily.dev',
+          author_icon: 'http://image.com/a',
+          author_name: 'A | daily.dev',
           image_url: 'https://daily.dev/image.jpg',
           title: 'P1',
           title_link:
@@ -191,8 +191,8 @@ describe('postAddedSlackChannelSend worker', () => {
       channel: '1',
       attachments: [
         {
-          author_icon: 'https://app.daily.dev/apple-touch-icon.png',
-          author_name: 'daily.dev',
+          author_icon: 'http//image.com/squadslackchannel',
+          author_name: 'Squad Slack Channel | daily.dev',
           image_url: 'https://daily.dev/image.jpg',
           title: 'Squad Channel Post 1',
           title_link:
@@ -242,8 +242,8 @@ describe('postAddedSlackChannelSend worker', () => {
       channel: '1',
       attachments: [
         {
-          author_icon: 'https://app.daily.dev/apple-touch-icon.png',
-          author_name: 'daily.dev',
+          author_icon: 'http//image.com/squadslackchannel',
+          author_name: 'Squad Slack Channel | daily.dev',
           image_url: 'https://daily.dev/image.jpg',
           title: 'Squad Channel Post 1',
           title_link:
@@ -309,8 +309,8 @@ describe('postAddedSlackChannelSend worker', () => {
       channel: '1',
       attachments: [
         {
-          author_icon: 'https://app.daily.dev/apple-touch-icon.png',
-          author_name: 'daily.dev',
+          author_icon: 'http//image.com/squadslackchannel',
+          author_name: 'Squad Slack Channel | daily.dev',
           image_url: 'https://daily.dev/image.jpg',
           title: 'Squad Channel Post 1',
           title_link:

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -69,9 +69,10 @@ export const getAttachmentForPostType = async <TPostType extends PostType>({
   postType: TPostType;
   postLink: string;
 }): Promise<MessageAttachment> => {
+  const source = await post.source;
   const attachment: MessageAttachment = {
-    author_name: 'daily.dev',
-    author_icon: 'https://app.daily.dev/apple-touch-icon.png',
+    author_name: `${source.name} | daily.dev`,
+    author_icon: source.image,
   };
 
   switch (postType) {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b469f6a5-bd03-4fba-9d4f-27176df813e1)

After:
![image](https://github.com/user-attachments/assets/22f62a51-74a3-4588-b727-107ec502869b)
