### PR TITLE
fix: add allowed_content_curation flag to feed config

### DIFF
--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -179,6 +179,13 @@ describe('FeedPreferencesConfigGenerator', () => {
         defaultEnabledState: true,
         options: { type: PostType.Article },
       },
+      {
+        title: 'News',
+        group: 'content_curation',
+        description: '',
+        defaultEnabledState: true,
+        options: { type: 'news' },
+      },
     ]);
     await con.getRepository(FeedAdvancedSettings).save([
       { feedId: '1', advancedSettingsId: 1, enabled: false },
@@ -216,6 +223,44 @@ describe('FeedPreferencesConfigGenerator', () => {
         offset: 3,
         page_size: 2,
         squad_ids: expect.arrayContaining(['a', 'b']),
+        total_pages: 20,
+        user_id: '1',
+      },
+    });
+  });
+
+  it('should generate feed config with blocked content curation', async () => {
+    await con
+      .getRepository(FeedAdvancedSettings)
+      .save([{ feedId: '1', advancedSettingsId: 3, enabled: false }]);
+    const generator: FeedConfigGenerator = new FeedPreferencesConfigGenerator(
+      config,
+      {
+        includeBlockedContentCuration: true,
+      },
+    );
+
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
+    expect(actual).toEqual({
+      config: {
+        allowed_content_curations: [
+          'release',
+          'opinion',
+          'listicle',
+          'comparison',
+          'tutorial',
+          'story',
+          'meme',
+        ],
+        blocked_content_curations: ['news'],
+        feed_config_name: FeedConfigName.Personalise,
+        fresh_page_size: '1',
+        offset: 3,
+        page_size: 2,
         total_pages: 20,
         user_id: '1',
       },

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -23,6 +23,16 @@ type Options = {
 };
 
 type BaseConfig = Partial<Omit<FeedConfig, 'user_id' | 'page_size' | 'offset'>>;
+const AllowedContentCurationTypes = [
+  'news',
+  'release',
+  'opinion',
+  'listicle',
+  'comparison',
+  'tutorial',
+  'story',
+  'meme',
+] as const;
 
 function getDefaultConfig(
   baseConfig: BaseConfig,
@@ -88,6 +98,9 @@ const addFiltersToConfig = ({
     opts.includeBlockedContentCuration
   ) {
     baseConfig.blocked_content_curations = filters.blockedContentCuration;
+    baseConfig.allowed_content_curations = AllowedContentCurationTypes.filter(
+      (type) => !filters.blockedContentCuration.includes(type),
+    );
   }
 
   return baseConfig;

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -49,6 +49,7 @@ export type FeedConfig = {
   blocked_sources?: string[];
   allowed_post_types?: string[];
   blocked_content_curations?: string[];
+  allowed_content_curations?: string[];
   squad_ids?: string[];
   providers?: Record<string, FeedProvider>;
   source_types?: ('machine' | 'squad')[];


### PR DESCRIPTION
Add `allowed_content_curations` config if user has any blocked items.
Also noticed we didn't even have a test for blocked_content_curations so added one that covers both cases now.

AS-505 #done 