### PR TITLE
fix: don't send slack integration notification if post is vordr flagged

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -53,6 +53,7 @@ import {
   postTagsFixture,
   sharedPostsFixture,
   videoPostsFixture,
+  vordrPostsFixture,
 } from './fixture/post';
 import nock from 'nock';
 import { deleteKeysByPattern } from '../src/redis';
@@ -1145,38 +1146,7 @@ describe('query sourceFeed', () => {
 
   describe('vordr', () => {
     beforeEach(async () => {
-      await saveFixtures(con, ArticlePost, [
-        {
-          id: 'vordr1',
-          shortId: 'svordr1',
-          title: 'vordr1',
-          url: 'http://vordr1.com',
-          image: 'https://daily.dev/image.jpg',
-          score: 10,
-          sourceId: 'b',
-          createdAt: new Date(new Date().getTime() - 4000),
-          tagsStr: 'html,javascript',
-          type: PostType.Article,
-          contentCuration: ['c1', 'c2'],
-          authorId: '2',
-          flags: { vordr: true },
-        },
-        {
-          id: 'vordr2',
-          shortId: 'svordr2',
-          title: 'vordr2',
-          url: 'http://vordr2.com',
-          image: 'https://daily.dev/image.jpg',
-          score: 10,
-          sourceId: 'b',
-          createdAt: new Date(new Date().getTime() - 4000),
-          tagsStr: 'html,javascript',
-          type: PostType.Article,
-          contentCuration: ['c1', 'c2'],
-          authorId: '2',
-          flags: { vordr: true },
-        },
-      ]);
+      await saveFixtures(con, ArticlePost, vordrPostsFixture);
     });
     it('should filter out posts that vordr has prevented', async () => {
       loggedUser = '1';

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -138,6 +138,39 @@ export const postsFixture: DeepPartial<ArticlePost | SharePost>[] = [
   },
 ];
 
+export const vordrPostsFixture: DeepPartial<ArticlePost>[] = [
+  {
+    id: 'vordr1',
+    shortId: 'svordr1',
+    title: 'vordr1',
+    url: 'http://vordr1.com',
+    image: 'https://daily.dev/image.jpg',
+    score: 10,
+    sourceId: 'b',
+    createdAt: new Date(new Date().getTime() - 4000),
+    tagsStr: 'html,javascript',
+    type: PostType.Article,
+    contentCuration: ['c1', 'c2'],
+    authorId: '2',
+    flags: { vordr: true },
+  },
+  {
+    id: 'vordr2',
+    shortId: 'svordr2',
+    title: 'vordr2',
+    url: 'http://vordr2.com',
+    image: 'https://daily.dev/image.jpg',
+    score: 10,
+    sourceId: 'b',
+    createdAt: new Date(new Date().getTime() - 4000),
+    tagsStr: 'html,javascript',
+    type: PostType.Article,
+    contentCuration: ['c1', 'c2'],
+    authorId: '2',
+    flags: { vordr: true },
+  },
+];
+
 export const sharedPostsFixture: DeepPartial<ArticlePost | SharePost>[] = [
   {
     id: 'squadP1',

--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -10,7 +10,7 @@ import {
   User,
 } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
-import { postsFixture } from '../fixture/post';
+import { postsFixture, vordrPostsFixture } from '../fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { typedWorkers } from '../../src/workers';
@@ -319,6 +319,24 @@ describe('postAddedSlackChannelSend worker', () => {
       ],
       text: 'Ido shared a new post: <http://localhost:5002/posts/squadslackchannelp1?utm_source=notification&utm_medium=slack&utm_campaign=new_post&jt=squadslackchanneltoken1&source=squadslackchannel&type=squad|http://localhost:5002/posts/squadslackchannelp1>',
       unfurl_links: false,
+    });
+  });
+
+  describe('vordr', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, ArticlePost, vordrPostsFixture);
+    });
+
+    it('should not send a message to the slack channel when the post is prevented by vordr', async () => {
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: 'vordr1',
+      });
+
+      const result = await expectSuccessfulTypedBackground(worker, {
+        post: post as unknown as ChangeObject<ArticlePost>,
+      });
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/__tests__/workers/vordrPostPrevented.ts
+++ b/__tests__/workers/vordrPostPrevented.ts
@@ -1,9 +1,9 @@
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
-import { ArticlePost, Post, PostType, Source, User } from '../../src/entity';
+import { ArticlePost, Post, Source, User } from '../../src/entity';
 import { vordrPostPrevented as worker } from '../../src/workers/vordrPostPrevented';
 import { badUsersFixture, sourcesFixture, usersFixture } from '../fixture';
-import { postsFixture } from '../fixture/post';
+import { postsFixture, vordrPostsFixture } from '../fixture/post';
 import { typedWorkers } from '../../src/workers';
 import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import { notifyNewVordrPost } from '../../src/common';
@@ -26,38 +26,7 @@ beforeEach(async () => {
   await saveFixtures(con, User, badUsersFixture);
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, Post, postsFixture);
-  await saveFixtures(con, ArticlePost, [
-    {
-      id: 'vordr1',
-      shortId: 'svordr1',
-      title: 'vordr1',
-      url: 'http://vordr1.com',
-      image: 'https://daily.dev/image.jpg',
-      score: 10,
-      sourceId: 'b',
-      createdAt: new Date(new Date().getTime() - 4000),
-      tagsStr: 'html,javascript',
-      type: PostType.Article,
-      contentCuration: ['c1', 'c2'],
-      authorId: '2',
-      flags: { vordr: true },
-    },
-    {
-      id: 'vordr2',
-      shortId: 'svordr2',
-      title: 'vordr2',
-      url: 'http://vordr2.com',
-      image: 'https://daily.dev/image.jpg',
-      score: 10,
-      sourceId: 'b',
-      createdAt: new Date(new Date().getTime() - 4000),
-      tagsStr: 'html,javascript',
-      type: PostType.Article,
-      contentCuration: ['c1', 'c2'],
-      authorId: '2',
-      flags: { vordr: true },
-    },
-  ]);
+  await saveFixtures(con, ArticlePost, vordrPostsFixture);
 });
 
 describe('vordrPostPrevented', () => {

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -37,6 +37,10 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
             },
           }),
         ]);
+        if (post.flags?.vordr) {
+          return;
+        }
+
         const source = await post.source;
         const sourceTypeName =
           source.type === SourceType.Squad ? 'Squad' : 'source';


### PR DESCRIPTION
New worker was added. Don't send messages via slack integration if posts is prevented by vordr.