### PR TITLE
fix: don't show non visible community picks

### DIFF
--- a/__tests__/submissions.ts
+++ b/__tests__/submissions.ts
@@ -300,6 +300,37 @@ describe('mutation submitArticle', () => {
     });
   });
 
+  it('should reject if the post exist but not visible', async () => {
+    loggedUser = '1';
+    const request = 'http://p8.com';
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, ArticlePost, [
+      {
+        id: 'pdeleted',
+        shortId: 'spdeleted',
+        title: 'PDeleted',
+        url: request,
+        canonicalUrl: request,
+        score: 0,
+        sourceId: 'a',
+        createdAt: new Date('2021-09-22T07:15:51.247Z'),
+        tagsStr: 'javascript,webdev',
+        visible: false,
+      },
+    ]);
+
+    const res = await client.mutate(MUTATION, { variables: { url: request } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      submitArticle: {
+        result: 'rejected',
+        reason: SubmissionFailErrorMessage.POST_DELETED,
+        post: null,
+        submission: null,
+      },
+    });
+  });
+
   it('should not allow invalid urls', async () => {
     loggedUser = '1';
     const request = 'test/sample/url';

--- a/src/schema/submissions.ts
+++ b/src/schema/submissions.ts
@@ -173,7 +173,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         .getRepository(ArticlePost)
         .findOneBy([{ url }, { canonicalUrl: url }]);
       if (existingPost) {
-        if (existingPost.deleted) {
+        if (existingPost.deleted || !existingPost.visible) {
           return {
             result: 'rejected',
             reason: SubmissionFailErrorMessage.POST_DELETED,


### PR DESCRIPTION
Currently community picks on already added but private/non visible fields would show it exists, on clicking result in 404.
So now we simply show it got added before, and cannot be re-added (as per deleted guidelines)

![image](https://github.com/user-attachments/assets/e790a1e8-7b33-4af4-b452-df4ec44d3d19)

AS-502 #done 