### PR TITLE
feat(strict-ts): apply to gql schemas 3

### DIFF
--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -72,7 +72,7 @@ export const whereKeyword = (
 
 export const getExcludedAdvancedSettings = async (
   con: DataSource,
-  feedId: string,
+  feedId?: string,
 ): Promise<Partial<AdvancedSettings>[]> => {
   if (!feedId) {
     return [];
@@ -103,8 +103,8 @@ export const getExcludedAdvancedSettings = async (
 
 export const feedToFilters = async (
   con: DataSource,
-  feedId: string,
-  userId: string,
+  feedId?: string,
+  userId?: string,
 ): Promise<AnonymousFeedFilters> => {
   const settings = await getExcludedAdvancedSettings(con, feedId);
   const [tags, excludeSources, memberships] = await Promise.all([
@@ -444,7 +444,7 @@ export interface AnonymousFeedFilters {
 
 export const anonymousFeedBuilder = (
   ctx: Context,
-  filters: AnonymousFeedFilters,
+  filters: AnonymousFeedFilters | undefined,
   builder: SelectQueryBuilder<Post>,
   alias: string,
 ): SelectQueryBuilder<Post> => {
@@ -479,11 +479,11 @@ export const anonymousFeedBuilder = (
 
 export const configuredFeedBuilder = (
   ctx: Context,
-  feedId: string,
+  feedId: string | undefined,
   unreadOnly: boolean,
   builder: SelectQueryBuilder<Post>,
   alias: string,
-  filters: AnonymousFeedFilters,
+  filters: AnonymousFeedFilters | undefined,
 ): SelectQueryBuilder<Post> => {
   let newBuilder = anonymousFeedBuilder(ctx, filters, builder, alias);
   if (unreadOnly) {

--- a/src/schema/actions.ts
+++ b/src/schema/actions.ts
@@ -62,8 +62,7 @@ export const insertOrIgnoreAction = (
     .orIgnore()
     .execute();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   unknown,
   BaseContext
 >({

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -221,8 +221,7 @@ export const getAlerts = async (
   return ALERTS_DEFAULT as Alerts;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   unknown,
   BaseContext
 >({

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -268,8 +268,7 @@ const searchResolver = feedResolver(
   { removeHiddenPosts: true, removeBannedPosts: false },
 );
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   unknown,
   BaseContext
 >({

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -3,7 +3,7 @@ import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { IResolvers } from '@graphql-tools/utils';
 import { DataSource, EntityManager, In, Not } from 'typeorm';
 import { AuthContext, BaseContext, Context } from '../Context';
-import { traceResolverObject } from './trace';
+import { traceResolvers } from './trace';
 import {
   getDiscussionLink,
   recommendUsersByQuery,
@@ -558,10 +558,11 @@ const validateComment = (ctx: Context, content: string): void => {
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Query: traceResolverObject<any, any, any>({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
+  Query: {
     commentFeed: async (
       _,
       args: ConnectionArguments,
@@ -767,9 +768,8 @@ export const resolvers: IResolvers<any, BaseContext> = {
 
       return comment;
     },
-  }),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Mutation: traceResolverObject<any, any, any>({
+  },
+  Mutation: {
     commentOnPost: async (
       source,
       { postId, content }: GQLPostCommentArgs,
@@ -970,9 +970,9 @@ export const resolvers: IResolvers<any, BaseContext> = {
 
       return { _: true };
     },
-  }),
+  },
   Comment: {
     permalink: (comment: GQLComment): string =>
       getDiscussionLink(comment.postId, comment.id),
   },
-};
+});

--- a/src/schema/compatibility.ts
+++ b/src/schema/compatibility.ts
@@ -1,6 +1,6 @@
 import { IFieldResolver, IResolvers } from '@graphql-tools/utils';
-import { Context } from '../Context';
-import { traceResolverObject } from './trace';
+import { BaseContext, Context } from '../Context';
+import { traceResolvers } from './trace';
 import { GQLPost } from './posts';
 import {
   anonymousFeedBuilder,
@@ -171,9 +171,11 @@ const orderFeed = (
     'DESC',
   );
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, Context> = {
-  Query: traceResolverObject({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
+  Query: {
     latest: compatFeedResolver(
       (
         ctx,
@@ -228,5 +230,5 @@ export const resolvers: IResolvers<any, Context> = {
           alias,
         ),
     ),
-  }),
-};
+  },
+});

--- a/src/schema/integrations.ts
+++ b/src/schema/integrations.ts
@@ -195,7 +195,10 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
-export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
   Query: {
     slackChannels: async (
       _,
@@ -236,7 +239,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers({
       }
 
       return {
-        data: result.channels.map((channel) => {
+        data: result.channels!.map((channel) => {
           return {
             id: channel.id,
             name: channel.name,
@@ -392,7 +395,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers({
         await ctx.con.getRepository(UserSourceIntegrationSlack).update(
           {
             sourceId: args.sourceId,
-            userIntegrationId: existingUserIntegration.id,
+            userIntegrationId: existingUserIntegration!.id,
           },
           record,
         );

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -1,5 +1,5 @@
 import { IResolvers } from '@graphql-tools/utils';
-import { Context } from '../Context';
+import { AuthContext, BaseContext, Context } from '../Context';
 import { traceResolvers } from './trace';
 import {
   Keyword,
@@ -138,13 +138,15 @@ export const typeDefs = /* GraphQL */ `
 
 const PENDING_THRESHOLD = 25;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, Context> = traceResolvers({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
   Query: {
     randomPendingKeyword: async (
       source,
       args,
-      ctx,
+      ctx: AuthContext,
       info,
     ): Promise<GQLKeyword | null> => {
       const res = await graphorm.query<GQLKeyword>(ctx, info, (builder) => {
@@ -160,7 +162,11 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
       }
       return null;
     },
-    countPendingKeywords: async (source, args, ctx): Promise<number> => {
+    countPendingKeywords: async (
+      source,
+      args,
+      ctx: AuthContext,
+    ): Promise<number> => {
       return ctx.con.getRepository(Keyword).count({
         where: {
           occurrences: MoreThanOrEqual(PENDING_THRESHOLD),
@@ -171,7 +177,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     searchKeywords: async (
       source,
       { query }: { query: string },
-      ctx,
+      ctx: AuthContext,
       info,
     ): Promise<GQLKeywordSearchResults> => {
       const parsedInfo = parseResolveInfo(info) as ResolveTree;
@@ -197,7 +203,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     keyword: async (
       source,
       { value }: { value: string },
-      ctx,
+      ctx: Context,
       info,
     ): Promise<GQLKeyword | null> => {
       const res = await graphorm.query<GQLKeyword>(ctx, info, (builder) => {
@@ -213,7 +219,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     allowKeyword: async (
       source,
       { keyword }: GQLKeywordArgs,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
         await entityManager.getRepository(Keyword).save({
@@ -226,7 +232,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     denyKeyword: async (
       source,
       { keyword }: GQLKeywordArgs,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
         await entityManager.getRepository(Keyword).save({
@@ -239,7 +245,7 @@ export const resolvers: IResolvers<any, Context> = traceResolvers({
     setKeywordAsSynonym: async (
       source,
       { keywordToUpdate, originalKeyword }: GQLSynonymKeywordArgs,
-      ctx,
+      ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
         const repo = entityManager.getRepository(Keyword);

--- a/src/schema/leaderboard.ts
+++ b/src/schema/leaderboard.ts
@@ -1,5 +1,5 @@
 import { IResolvers } from '@graphql-tools/utils';
-import { Context } from '../Context';
+import { BaseContext } from '../Context';
 import { traceResolvers } from './trace';
 import { GQLUser } from './users';
 import { User, UserStats, UserStreak } from '../entity';
@@ -113,7 +113,10 @@ const getUserLeaderboardForStat = async ({
   });
 };
 
-export const resolvers: IResolvers<unknown, Context> = traceResolvers({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
   Query: {
     highestReputation: async (_, args, ctx): Promise<GQLUserLeaderboard[]> => {
       const users = await ctx.con.getRepository(User).find({

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -296,8 +296,7 @@ export const getSettings = async (
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   unknown,
   BaseContext
 >({

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -126,8 +126,7 @@ const getFormattedTags = async (
   return tags.map(({ tag }) => ({ name: tag }));
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = traceResolvers<
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   unknown,
   BaseContext
 >({

--- a/src/schema/urlShortener.ts
+++ b/src/schema/urlShortener.ts
@@ -1,7 +1,7 @@
 import { IResolvers } from '@graphql-tools/utils';
 
-import { Context } from '../Context';
-import { traceResolverObject } from './trace';
+import { AuthContext, BaseContext } from '../Context';
+import { traceResolvers } from './trace';
 import { getShortUrl, isValidHttpUrl } from '../common';
 import { ValidationError } from 'apollo-server-errors';
 
@@ -19,13 +19,15 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, Context> = {
-  Query: traceResolverObject({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
+  Query: {
     getShortUrl: async (
       source,
       { url }: { url: string },
-      ctx: Context,
+      ctx: AuthContext,
     ): Promise<string> => {
       if (
         !isValidHttpUrl(url) ||
@@ -37,5 +39,5 @@ export const resolvers: IResolvers<any, Context> = {
       const result = await getShortUrl(url, ctx.log);
       return result;
     },
-  }),
-};
+  },
+});

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -31,7 +31,7 @@ import {
 import { IResolvers } from '@graphql-tools/utils';
 import { FileUpload } from 'graphql-upload/GraphQLUpload.js';
 import { AuthContext, BaseContext, Context } from '../Context';
-import { traceResolverObject } from './trace';
+import { traceResolvers } from './trace';
 import {
   GQLDatePageGeneratorConfig,
   queryPaginatedByDate,
@@ -983,10 +983,11 @@ const getUserStreakQuery = async (
   }));
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolvers: IResolvers<any, BaseContext> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Query: traceResolverObject<any, any, any>({
+export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
+  unknown,
+  BaseContext
+>({
+  Query: {
     whoami: async (_, __, ctx: AuthContext, info: GraphQLResolveInfo) => {
       const res = await graphorm.query<GQLUser>(ctx, info, (builder) => {
         builder.queryBuilder = builder.queryBuilder
@@ -1172,7 +1173,7 @@ export const resolvers: IResolvers<any, BaseContext> = {
     searchReadingHistorySuggestions: async (
       source,
       { query }: { query: string },
-      ctx,
+      ctx: Context,
     ) => {
       const hits: { title: string }[] = await ctx.con.query(
         `
@@ -1199,7 +1200,7 @@ export const resolvers: IResolvers<any, BaseContext> = {
     searchReadingHistory: async (
       source,
       args: ConnectionArguments & { query: string },
-      ctx,
+      ctx: AuthContext,
       info,
     ): Promise<Connection<GQLView>> => readHistoryResolver(args, ctx, info),
     readHistory: async (
@@ -1372,9 +1373,8 @@ export const resolvers: IResolvers<any, BaseContext> = {
         },
       );
     },
-  }),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Mutation: traceResolverObject<any, any, any>({
+  },
+  Mutation: {
     updateUserProfile: async (
       _,
       { data, upload }: GQLUserParameters,
@@ -1710,7 +1710,7 @@ export const resolvers: IResolvers<any, BaseContext> = {
         weekStart,
       };
     },
-  }),
+  },
   User: {
     permalink: getUserPermalink,
   },
@@ -1729,4 +1729,4 @@ export const resolvers: IResolvers<any, BaseContext> = {
       }
     },
   },
-};
+});


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- feeds schema
- devcard schema
- notifications schema
- common schema
- some retro fixes for code that was added in the meantime
- remove `any` eslint-disable rules from all schemas (now that context is standardized)

This one concludes work on schemas.