### PR TITLE
feat(slack): send post metric

### DIFF
--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -78,6 +78,10 @@ const counterMap = {
       name: 'cdc_trigger',
       description: 'How many times the cdc trigger was called',
     },
+    postSentSlack: {
+      name: 'post_sent_slack',
+      description: 'How many posts were sent to slack workspaces',
+    },
   },
   cron: {
     streakUpdate: {

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -9,6 +9,7 @@ import {
 import { addNotificationUtm, addPrivateSourceJoinParams } from '../common';
 import { SourceMemberRoles } from '../roles';
 import { SlackApiError, SlackApiErrorCode } from '../errors';
+import { counters } from '../telemetry/metrics';
 
 const sendQueueConcurrency = 10;
 
@@ -131,6 +132,10 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 text: messageText,
                 attachments: [attachment],
                 unfurl_links: false,
+              });
+
+              counters?.background?.postSentSlack?.add(1, {
+                source: source.id,
               });
             } catch (originalError) {
               const error = originalError as Error;


### PR DESCRIPTION
Add metric for slack post sends so we can see how many posts where sent to different channels/workspaces.