### PR TITLE
As 393 double notifications

### DIFF
--- a/__tests__/workers/newNotificationV2Mail.ts
+++ b/__tests__/workers/newNotificationV2Mail.ts
@@ -739,6 +739,60 @@ it('should set parameters for squad_post_added email', async () => {
   expect(args.transactional_message_id).toEqual('17');
 });
 
+it('should set parameters for post_mention email', async () => {
+  const sharedPost = await con.getRepository(ArticlePost).save(postsFixture[0]);
+  await con
+    .getRepository(Source)
+    .update({ id: 'a' }, { type: SourceType.Squad });
+  const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+  const post = await con.getRepository(SharePost).save({
+    id: 'ps',
+    shortId: 'ps',
+    sourceId: 'a',
+    title: 'Shared post',
+    sharedPostId: 'p1',
+    authorId: '2',
+  });
+  const doneBy = await con.getRepository(User).findOneBy({ id: '2' });
+  const doneTo = await con.getRepository(User).findOneBy({ id: '1' });
+  const ctx: NotificationPostContext & NotificationDoneByContext = {
+    userIds: ['1'],
+    post,
+    sharedPost,
+    source,
+    doneBy,
+    doneTo,
+  };
+
+  const notificationId = await saveNotificationV2Fixture(
+    con,
+    NotificationType.PostMention,
+    ctx,
+  );
+  await expectSuccessfulBackground(worker, {
+    notification: {
+      id: notificationId,
+      userId: '1',
+    },
+  });
+  expect(sendEmail).toHaveBeenCalledTimes(1);
+  const args = jest.mocked(sendEmail).mock
+    .calls[0][0] as SendEmailRequestWithTemplate;
+  expect(args.message_data).toEqual({
+    commentary: 'Shared post',
+    full_name: 'Tsahi',
+    post_image: 'https://daily.dev/image.jpg',
+    post_link:
+      'http://localhost:5002/posts/ps?utm_source=notification&utm_medium=email&utm_campaign=post_mention',
+    post_title: 'P1',
+    profile_image: 'https://daily.dev/tsahi.jpg',
+    squad_image: 'http://image.com/a',
+    squad_name: 'A',
+    user_reputation: '10',
+  });
+  expect(args.transactional_message_id).toEqual('54');
+});
+
 it('should set parameters for squad_member_joined email', async () => {
   await con
     .getRepository(Source)


### PR DESCRIPTION
No longer sending new post notification if you where mentioned on set post.
Adds email for post_mention notification.

Open question to product if we can fix that freeform also sends email.
https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1723715298467949?thread_ts=1718870031.393249&cid=C01L0QXQJNB