### PR TITLE
feat: store last view data in CIO

### DIFF
--- a/__tests__/workers/userStreakUpdatedCio.ts
+++ b/__tests__/workers/userStreakUpdatedCio.ts
@@ -59,8 +59,8 @@ describe('userStreakUpdatedCio worker', () => {
     currentStreak: 2,
     totalStreak: 3,
     maxStreak: 4,
-    lastViewAt: new Date().getTime(),
-    updatedAt: new Date().getTime(),
+    lastViewAt: 1714577744717000,
+    updatedAt: 1714577744717000,
   };
 
   beforeEach(async () => {
@@ -93,6 +93,7 @@ describe('userStreakUpdatedCio worker', () => {
         { day: 'Tu', read: false },
         { day: 'We', read: false },
       ],
+      last_view_at: 1714577744,
     });
   });
 
@@ -133,6 +134,7 @@ describe('userStreakUpdatedCio worker', () => {
         { day: 'Tu', read: true },
         { day: 'We', read: false },
       ],
+      last_view_at: 1714577744,
     });
   });
 });

--- a/src/cio.ts
+++ b/src/cio.ts
@@ -37,13 +37,21 @@ export async function identifyUserStreak(
     lastSevenDays: { [key: string]: boolean };
   },
 ): Promise<void> {
-  const { userId, currentStreak, totalStreak, maxStreak, lastSevenDays } = data;
+  const {
+    userId,
+    currentStreak,
+    totalStreak,
+    maxStreak,
+    lastSevenDays,
+    lastViewAt,
+  } = data;
 
   try {
     await cio.identify(userId, {
       current_streak: currentStreak,
       total_streak: totalStreak,
       max_streak: maxStreak,
+      last_view_at: dateToCioTimestamp(debeziumTimeToDate(lastViewAt)),
       last_seven_days_streak: lastSevenDays,
     });
   } catch (err) {


### PR DESCRIPTION
Store the last view at column in CIO so we can calculate when your last read was.
It doesn't support timezone, but since we work day-day basis I think the edge-case is ok.