### PR TITLE
chore: add ordering on search users

### DIFF
--- a/__tests__/search.ts
+++ b/__tests__/search.ts
@@ -579,6 +579,33 @@ describe('query searchUserSuggestions', () => {
     ]);
   });
 
+  it('should order by reputation', async () => {
+    await con
+      .getRepository(User)
+      .update({ id: '2' }, { name: 'Ido test 2', reputation: 100 });
+    const res = await client.query(QUERY('ido'));
+    expect(res.data.searchUserSuggestions).toBeTruthy();
+
+    const result = res.data.searchUserSuggestions;
+
+    expect(result.query).toBe('ido');
+    expect(result.hits).toHaveLength(2);
+    expect(result.hits).toMatchObject([
+      {
+        id: '2',
+        image: 'https://daily.dev/tsahi.jpg',
+        subtitle: 'tsahidaily',
+        title: 'Ido test 2',
+      },
+      {
+        id: '1',
+        image: 'https://daily.dev/ido.jpg',
+        subtitle: 'idoshamun',
+        title: 'Ido',
+      },
+    ]);
+  });
+
   it('should only return infoConfirmed users', async () => {
     await con.getRepository(User).update({ id: '1' }, { infoConfirmed: false });
     await con.getRepository(User).update({ id: '2' }, { name: 'Ido test 2' });

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -456,6 +456,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               });
           }),
         )
+        .orderBy('u.reputation', 'DESC')
         .andWhere(whereVordrFilter('u'))
         .limit(getSearchLimit({ limit }));
       const hits = await searchQuery.getRawMany();


### PR DESCRIPTION
In order to enfore using the right indexes we need a ordering by (choose reputation as it makes a lot of sense)