### PR TITLE
fix: sunday as start of week

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -473,6 +473,7 @@ describe('query userStreaks', () => {
     const fakeToday = new Date(2024, 0, 8); // Monday
     const lastViewAt = subDays(fakeToday, 3); // Friday
 
+    expect(lastViewAt.getDay()).toEqual(5); // Friday
     jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
     await expectStreak(5, 5, lastViewAt);
   });
@@ -486,6 +487,7 @@ describe('query userStreaks', () => {
       const fakeToday = new Date(2024, 0, 6, 12, 0, 0, 0); // Saturday
       const lastViewAt = subDays(fakeToday, 2); // Thursday
 
+      expect(lastViewAt.getDay()).toEqual(4); // Thursday
       jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
       await expectStreak(5, 5, lastViewAt);
     });
@@ -496,8 +498,9 @@ describe('query userStreaks', () => {
         .getRepository(User)
         .update({ id: loggedUser }, { weekStart: DayOfWeek.Sunday });
       const fakeToday = new Date(2024, 0, 7, 12, 0, 0, 0); // Sunday
-      const lastViewAt = subDays(fakeToday, 4); // Thursday
+      const lastViewAt = subDays(fakeToday, 3); // Thursday
 
+      expect(lastViewAt.getDay()).toEqual(4); // Thursday
       jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
       await expectStreak(5, 5, lastViewAt);
     });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -468,6 +468,20 @@ describe('query userStreaks', () => {
     await expectStreak(5, 5, lastViewAt);
   });
 
+  describe('Sunday as the start of the week', () => {
+    it('should not reset streak on Saturday when last read is Thursday', async () => {
+      loggedUser = '1';
+      await con
+        .getRepository(User)
+        .update({ id: loggedUser }, { weekStart: DayOfWeek.Sunday });
+      const fakeToday = new Date(2024, 0, 6); // Saturday
+      const lastViewAt = subDays(fakeToday, 2); // Thursday
+
+      jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+      await expectStreak(5, 5, lastViewAt);
+    });
+  });
+
   it('should reset streak on Monday when last read was Thursday', async () => {
     loggedUser = '1';
     const fakeToday = new Date(2024, 0, 8); // Monday

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -474,7 +474,7 @@ describe('query userStreaks', () => {
       await con
         .getRepository(User)
         .update({ id: loggedUser }, { weekStart: DayOfWeek.Sunday });
-      const fakeToday = new Date(2024, 0, 6); // Saturday
+      const fakeToday = new Date(2024, 0, 6, 12, 0, 0, 0); // Saturday
       const lastViewAt = subDays(fakeToday, 2); // Thursday
 
       jest.useFakeTimers({ advanceTimers: true, now: fakeToday });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -468,6 +468,15 @@ describe('query userStreaks', () => {
     await expectStreak(5, 5, lastViewAt);
   });
 
+  it('should not reset streak on Monday when last read is Friday', async () => {
+    loggedUser = '1';
+    const fakeToday = new Date(2024, 0, 8); // Monday
+    const lastViewAt = subDays(fakeToday, 3); // Friday
+
+    jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+    await expectStreak(5, 5, lastViewAt);
+  });
+
   describe('Sunday as the start of the week', () => {
     it('should not reset streak on Saturday when last read is Thursday', async () => {
       loggedUser = '1';
@@ -476,6 +485,18 @@ describe('query userStreaks', () => {
         .update({ id: loggedUser }, { weekStart: DayOfWeek.Sunday });
       const fakeToday = new Date(2024, 0, 6, 12, 0, 0, 0); // Saturday
       const lastViewAt = subDays(fakeToday, 2); // Thursday
+
+      jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
+      await expectStreak(5, 5, lastViewAt);
+    });
+
+    it('should not reset streak on Sunday when last read is Thursday', async () => {
+      loggedUser = '1';
+      await con
+        .getRepository(User)
+        .update({ id: loggedUser }, { weekStart: DayOfWeek.Sunday });
+      const fakeToday = new Date(2024, 0, 7, 12, 0, 0, 0); // Sunday
+      const lastViewAt = subDays(fakeToday, 4); // Thursday
 
       jest.useFakeTimers({ advanceTimers: true, now: fakeToday });
       await expectStreak(5, 5, lastViewAt);

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -419,12 +419,15 @@ export const shouldResetStreak = (
   const lastDayOfWeek =
     startOfWeek === DayOfWeek.Monday ? Day.Sunday : Day.Saturday;
 
-  return (
-    (day === lastDayOfWeek && difference > FREEZE_DAYS_IN_A_WEEK) ||
-    (day === firstDayOfWeek &&
-      difference > FREEZE_DAYS_IN_A_WEEK + MISSED_LIMIT) ||
-    (day > firstDayOfWeek && difference > MISSED_LIMIT)
-  );
+  if (day === lastDayOfWeek) {
+    return difference > FREEZE_DAYS_IN_A_WEEK;
+  }
+
+  if (day === firstDayOfWeek) {
+    return difference > FREEZE_DAYS_IN_A_WEEK + MISSED_LIMIT;
+  }
+
+  return day > firstDayOfWeek && difference > MISSED_LIMIT;
 };
 
 export const checkUserStreak = (streak: GQLUserStreakTz): boolean => {


### PR DESCRIPTION
When the start of the week is Sunday, the condition is not totally valid on all cases.

We now return early so if the condition doesn't apply, we won't have to unnecessarily check whether it would fit the second part of each remaining conditions.