### PR TITLE
chore: fix the correct sending of last_view_at

### DIFF
--- a/__tests__/workers/userStreakUpdatedCio.ts
+++ b/__tests__/workers/userStreakUpdatedCio.ts
@@ -59,8 +59,8 @@ describe('userStreakUpdatedCio worker', () => {
     currentStreak: 2,
     totalStreak: 3,
     maxStreak: 4,
-    lastViewAt: 1714577744717000,
-    updatedAt: 1714577744717000,
+    lastViewAt: new Date('2024-01-26T17:17Z').getTime(),
+    updatedAt: new Date('2024-01-26T17:17Z').getTime(),
   };
 
   beforeEach(async () => {
@@ -93,7 +93,7 @@ describe('userStreakUpdatedCio worker', () => {
         { day: 'Tu', read: false },
         { day: 'We', read: false },
       ],
-      last_view_at: 1714577744,
+      last_view_at: 1706289420,
     });
   });
 
@@ -134,7 +134,7 @@ describe('userStreakUpdatedCio worker', () => {
         { day: 'Tu', read: true },
         { day: 'We', read: false },
       ],
-      last_view_at: 1714577744,
+      last_view_at: 1706289420,
     });
   });
 });

--- a/src/cio.ts
+++ b/src/cio.ts
@@ -46,25 +46,13 @@ export async function identifyUserStreak(
     lastViewAt,
   } = data;
 
-  log.info(
-    {
-      userId,
-      currentStreak,
-      totalStreak,
-      maxStreak,
-      lastViewAt,
-      lastSevenDays,
-    },
-    'Identifying user streak',
-  );
-
   try {
     await cio.identify(userId, {
       current_streak: currentStreak,
       total_streak: totalStreak,
       max_streak: maxStreak,
       last_view_at: lastViewAt
-        ? dateToCioTimestamp(debeziumTimeToDate(lastViewAt))
+        ? dateToCioTimestamp(new Date(lastViewAt))
         : undefined,
       last_seven_days_streak: lastSevenDays,
     });


### PR DESCRIPTION
Remove the temporary log
Fix the actual sending of the last_view_at (at UTC - so we can quicker compare it inside CIO)