### PR TITLE
chore: bin script for missing feed_source follows

### DIFF
--- a/bin/insertMissingSourceFollows.ts
+++ b/bin/insertMissingSourceFollows.ts
@@ -1,0 +1,29 @@
+import '../src/config';
+import createOrGetConnection from '../src/db';
+
+/**
+ * Bin script to retroactively insert missing follows for users who previously where subscribed to a source but didn't explicitly follow it.
+ */
+
+(async () => {
+  const con = await createOrGetConnection();
+
+  await con.query(
+    `
+      ALTER TABLE feed_source DISABLE TRIGGER unsubscribe_notification_source_post_added_trigger;
+
+      INSERT INTO feed_source ("feedId", "sourceId", "blocked")
+      SELECT  notification_preference."userId" as "feedId", notification_preference."sourceId", false as "blocked" FROM notification_preference
+      WHERE
+        NOT EXISTS (SELECT *
+                    FROM feed_source
+                    WHERE feed_source."sourceId" = notification_preference."sourceId" AND feed_source."feedId" = notification_preference."userId")
+        AND "type" = 'source' AND "status" = 'subscribed';
+
+      ALTER TABLE feed_source ENABLE TRIGGER unsubscribe_notification_source_post_added_trigger;
+    `,
+  );
+  console.log('inserted feed_source records');
+
+  process.exit();
+})();


### PR DESCRIPTION
When we migrated from subscribe to follow-notify we missed the fact we need to retro make anyone that's currently subscribed also auto-follow that source.

This script inserts records into `feed_source` if they don't exist, but are subscribed to a source.
(We need to bypass the trigger, else it will auto remove the records from `notification_preference`)

Discussion here:
https://dailydotdev.slack.com/archives/C01473UNK9C/p1724134356244039