### PR TITLE
feat(strict-ts): apply to integrations

### DIFF
--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -6,6 +6,7 @@ import { DataSource } from 'typeorm';
 import { UserIntegrationSlack } from '../entity/UserIntegration';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { FastifyRequest } from 'fastify';
+import { PropsParameters } from '../types';
 
 const nullWebhook = { send: (): Promise<void> => Promise.resolve() };
 export const webhooks = Object.freeze({
@@ -248,9 +249,9 @@ export const getSlackIntegrationOrFail = async ({
   id,
   userId,
   con,
-}: Parameters<
+}: PropsParameters<
   typeof getSlackIntegration
->[0]): Promise<UserIntegrationSlack> => {
+>): Promise<UserIntegrationSlack> => {
   const slackIntegration = await getSlackIntegration({ id, userId, con });
 
   if (!slackIntegration) {

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -244,11 +244,13 @@ export const getSlackIntegration = async ({
   return slackIntegration;
 };
 
-export const getSlackIntegrationOrFail: typeof getSlackIntegration = async ({
+export const getSlackIntegrationOrFail = async ({
   id,
   userId,
   con,
-}) => {
+}: Parameters<
+  typeof getSlackIntegration
+>[0]): Promise<UserIntegrationSlack> => {
   const slackIntegration = await getSlackIntegration({ id, userId, con });
 
   if (!slackIntegration) {

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -1,7 +1,7 @@
 import { generateUUID } from '../ids';
 import { retryFetch } from './retry';
 
-const generateEventId = (now) => {
+const generateEventId = (now: Date) => {
   const randomStr = (Math.random() + 1).toString(36).substring(8);
   const timePart = (now.getTime() / 1000).toFixed(0);
   return `${timePart}${randomStr}`;

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -2,7 +2,7 @@ import { Context } from '../../Context';
 import { GenericMetadata } from '../lofn';
 
 export type FeedResponse = {
-  data: [postId: string, metadata: string | undefined][];
+  data: [postId: string, metadata: string | null][];
   cursor?: string;
 };
 

--- a/src/integrations/networkError.ts
+++ b/src/integrations/networkError.ts
@@ -2,7 +2,8 @@
 
 const objectToString = Object.prototype.toString;
 
-const isError = (value) => objectToString.call(value) === '[object Error]';
+const isError = (value: Error) =>
+  objectToString.call(value) === '[object Error]';
 
 const errorMessages = new Set([
   'Failed to fetch', // Chrome
@@ -13,7 +14,7 @@ const errorMessages = new Set([
   'fetch failed', // Undici (Node.js)
 ]);
 
-export default function isNetworkError(error) {
+export default function isNetworkError(error: Error) {
   const isValid =
     error &&
     isError(error) &&

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -6,7 +6,7 @@ import { runInSpan, TelemetrySemanticAttributes } from '../telemetry';
 export class AbortError extends Error {
   public originalError: Error;
 
-  constructor(message) {
+  constructor(message: Error | string) {
     super();
 
     if (message instanceof Error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,3 +137,9 @@ export enum ContentLanguage {
 export type I18nRecord = Partial<Record<ContentLanguage, string>>;
 
 export const validLanguages = Object.values(ContentLanguage);
+
+export type PropsParameters<T extends (props: object) => unknown> = T extends (
+  props: infer P,
+) => unknown
+  ? P
+  : never;


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- integrations (mainly feed)