### PR TITLE
feat: allow contentMeta update in freeform post

### DIFF
--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -324,6 +324,7 @@ const allowedFieldsMapping = {
     'readTime',
     'summary',
     'tagsStr',
+    'contentMeta',
   ],
 };
 


### PR DESCRIPTION
@denisb0 backfills and also translates freeform post titles after creation so we want to save `contentMeta` for freeform posts as well. 