### PR TITLE
fix: notification worker cdc date value

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -330,7 +330,7 @@ describe('generateNotification', () => {
       'Click here if you wish to restore your streak',
     );
     expect(actual.notification.uniqueKey).toEqual(
-      format(ctx.streak.lastViewAt, 'dd-MM-yyyy'),
+      format(ctx.streak.lastViewAt as Date, 'dd-MM-yyyy'),
     );
   });
 

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3250,7 +3250,7 @@ describe('user streak change', () => {
   type ObjectType = UserStreak;
   const base: ChangeObject<ObjectType> = {
     userId: '1',
-    currentStreak: 2,
+    currentStreak: 3,
     totalStreak: 3,
     maxStreak: 4,
     lastViewAt: new Date().getTime(),
@@ -3292,8 +3292,8 @@ describe('user streak change', () => {
   describe('streak recovery', () => {
     const lastView = new Date('2024-06-24T12:00:00'); // Monday
     const dates = {
-      lastViewAt: lastView.getTime() * 1000,
-      updatedAt: lastView.getTime() * 1000,
+      lastViewAt: lastView.toISOString(),
+      updatedAt: lastView.toISOString(),
     };
 
     beforeEach(async () => {
@@ -3405,7 +3405,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString(),
         currentStreak: 0,
       };
       await con
@@ -3417,7 +3417,7 @@ describe('user streak change', () => {
           after,
           before: {
             ...base,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString(),
           },
           op: 'u',
           table: 'user_streak',
@@ -3446,7 +3446,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString(),
         currentStreak: 0,
       };
       await con
@@ -3458,7 +3458,7 @@ describe('user streak change', () => {
           after,
           before: {
             ...base,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString(),
           },
           op: 'u',
           table: 'user_streak',
@@ -3490,7 +3490,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-24T12:00:00'); // Monday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString(),
         currentStreak: 0,
       };
       await con.getRepository(UserStreakAction).save({
@@ -3507,7 +3507,7 @@ describe('user streak change', () => {
           after,
           before: {
             ...base,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString(),
           },
           op: 'u',
           table: 'user_streak',
@@ -3538,7 +3538,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString(),
         currentStreak: 0,
       };
       await con.getRepository(UserStreakAction).save({
@@ -3555,7 +3555,8 @@ describe('user streak change', () => {
           after,
           before: {
             ...base,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            currentStreak: 4,
+            lastViewAt: lastViewAt.toISOString(),
           },
           op: 'u',
           table: 'user_streak',
@@ -3572,7 +3573,7 @@ describe('user streak change', () => {
         'api.v1.user-streak-updated',
         { streak: after },
       ]);
-      expect(lastStreak).toEqual(base.currentStreak.toString());
+      expect(lastStreak).toEqual('4');
       const alert = await con.getRepository(Alerts).findOneBy({ userId: '1' });
       expect(alert.showRecoverStreak).toEqual(true);
     });

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -698,17 +698,16 @@ describe('streak reset restore', () => {
       StorageKey.Reset,
       streak.userId,
     );
-    const debeziumTime = streak.lastViewAt.getTime() * 1000;
     await setRedisObject(key, lastStreak.toString());
     const actual = await invokeNotificationWorker(worker.default, {
-      streak: { ...streak, lastViewAt: debeziumTime },
+      streak: { ...streak, lastViewAt: streak.lastViewAt.toISOString() },
     });
     expect(actual.length).toEqual(1);
     const bundle = actual[0];
     const ctx = bundle.ctx as NotificationStreakContext;
     expect(bundle.type).toEqual('streak_reset_restore');
     expect(ctx.streak.currentStreak).toEqual(lastStreak);
-    expect(ctx.streak.lastViewAt).toEqual(debeziumTime / 1000);
+    expect(ctx.streak.lastViewAt).toEqual(streak.lastViewAt.getTime());
   });
 
   it('should not add notification if the stored value has expired', async () => {

--- a/src/cio.ts
+++ b/src/cio.ts
@@ -81,9 +81,11 @@ export async function identifyUser(
     await cio.identify(id, {
       ...camelCaseToSnakeCase(dup),
       first_name: getFirstName(dup.name),
-      created_at: dateToCioTimestamp(debeziumTimeToDate(dup.createdAt)),
+      created_at: dateToCioTimestamp(
+        debeziumTimeToDate(dup.createdAt as number),
+      ),
       updated_at: dup.updatedAt
-        ? dateToCioTimestamp(debeziumTimeToDate(dup.updatedAt))
+        ? dateToCioTimestamp(debeziumTimeToDate(dup.updatedAt as number))
         : undefined,
       referral_link: genericInviteURL,
       cio_subscription_preferences: {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -9,11 +9,7 @@ import {
 import { differenceInDays, isSameDay, max } from 'date-fns';
 import { DataSource, EntityManager, In, Not } from 'typeorm';
 import { CommentMention, Comment, View, Source, SourceMember } from '../entity';
-import {
-  getTimezonedStartOfISOWeek,
-  getTimezonedEndOfISOWeek,
-  debeziumTimeToDate,
-} from './utils';
+import { getTimezonedStartOfISOWeek, getTimezonedEndOfISOWeek } from './utils';
 import { GraphQLResolveInfo } from 'graphql';
 import { utcToZonedTime } from 'date-fns-tz';
 import { sendAnalyticsEvent } from '../integrations/analytics';
@@ -567,7 +563,7 @@ export const shouldAllowRestore = async (
   const { userId, lastViewAt: lastViewAtDb } = streak;
   const user = await con.getRepository(DbUser).findOneBy({ id: userId });
   const today = new Date();
-  const lastView = debeziumTimeToDate(lastViewAtDb);
+  const lastView = new Date(lastViewAtDb);
   const lastRecovery = await getLastStreakRecoverDate(con, userId);
   const lastStreak = lastRecovery ? max([lastView, lastRecovery]) : lastView;
   const lastStreakDifference = differenceInDays(today, lastStreak);

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -560,10 +560,10 @@ export const shouldAllowRestore = async (
   con: DataSource,
   streak: ChangeObject<UserStreak>,
 ) => {
-  const { userId, lastViewAt: lastViewAtDb } = streak;
+  const { userId, lastViewAt: lastViewAtCdc } = streak;
   const user = await con.getRepository(DbUser).findOneBy({ id: userId });
   const today = new Date();
-  const lastView = new Date(lastViewAtDb);
+  const lastView = new Date(lastViewAtCdc);
   const lastRecovery = await getLastStreakRecoverDate(con, userId);
   const lastStreak = lastRecovery ? max([lastView, lastRecovery]) : lastView;
   const lastStreakDifference = differenceInDays(today, lastStreak);

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -151,7 +151,7 @@ export const generateNotificationMap: Record<
     builder
       .icon(NotificationIcon.Streak)
       .description('Click here if you wish to restore your streak')
-      .uniqueKey(format(ctx.streak.lastViewAt, 'dd-MM-yyyy'))
+      .uniqueKey(format(ctx.streak.lastViewAt as Date, 'dd-MM-yyyy'))
       .targetUrl(notificationsLink)
       .referenceStreak(ctx.streak)
       .setTargetUrlParameter([

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export type ChangeObject<Type> = {
   [Property in keyof Type as Exclude<
     Property,
     Required<Type>[Property] extends IgnoredTypes ? Property : never
-  >]: Required<Type>[Property] extends Date ? number : Type[Property];
+  >]: Required<Type>[Property] extends Date ? number | string : Type[Property];
 };
 
 export type ChangeSchema = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,13 @@ declare module 'fastify' {
 }
 
 type IgnoredTypes = Promise<unknown> | ((...args: unknown[]) => unknown);
+type CdcDate = number | string;
 
 export type ChangeObject<Type> = {
   [Property in keyof Type as Exclude<
     Property,
     Required<Type>[Property] extends IgnoredTypes ? Property : never
-  >]: Required<Type>[Property] extends Date ? number | string : Type[Property];
+  >]: Required<Type>[Property] extends Date ? CdcDate : Type[Property];
 };
 
 export type ChangeSchema = {

--- a/src/workers/bannerAdded.ts
+++ b/src/workers/bannerAdded.ts
@@ -15,7 +15,7 @@ const worker: Worker = {
     const { banner } = data;
 
     try {
-      const timestampMs = banner.timestamp / 1000; // createdAt comes as μs here
+      const timestampMs = (banner.timestamp as number) / 1000; // createdAt comes as μs here
 
       await setRedisObject(
         REDIS_BANNER_KEY,

--- a/src/workers/cdc/common.ts
+++ b/src/workers/cdc/common.ts
@@ -88,8 +88,8 @@ export const notifyPostContentUpdated = async ({
     postId: post.id,
     type: post.type,
     title: post.title,
-    createdAt: post.createdAt,
-    updatedAt: post.metadataChangedAt,
+    createdAt: post.createdAt as number,
+    updatedAt: post.metadataChangedAt as number,
     source: source
       ? {
           ...source,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -862,7 +862,9 @@ const onBookmarkChange = async (
   const getParams = (key: 'before' | 'after') => ({
     userId: data.payload[key]!.userId,
     postId: data.payload[key]!.postId,
-    remindAt: debeziumTimeToDate(data.payload[key]!.remindAt).getTime(),
+    remindAt: debeziumTimeToDate(
+      data.payload[key]!.remindAt as number,
+    ).getTime(),
   });
 
   if (data.payload.before?.remindAt) {


### PR DESCRIPTION
I was running into some issues while updating the tests due to the fact the `ChangeObject` always expects to receive a `number` for a `Date` column, when in fact, it can receive a `string` when the `Date` column is a `timestamptz`.

Have updated the `ChangeObject` to reflect the actual types that it may contain.

Also, I think having it explicitly defined whether the value is `as number` or `as string` safeguards us from mistakes as you will have to look first to verify which type to use based on the column date type.