### PR TITLE
feat: send company verification email

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1193,6 +1193,7 @@ describe('user company', () => {
       expect(sendEmail).toHaveBeenCalledTimes(1);
       expect(sendEmail).toHaveBeenCalledWith({
         to: 'u1@com4.com',
+        send_to_unsubscribed: true,
         message_data: {
           code: expect.any(String),
         },

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -46,6 +46,7 @@ import {
 } from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import {
+  CioTransactionalMessageTemplateId,
   codepenSocialUrlMatch,
   DayOfWeek,
   encrypt,
@@ -1198,7 +1199,8 @@ describe('user company', () => {
         identifiers: {
           id: loggedUser,
         },
-        transactional_message_id: '51',
+        transactional_message_id:
+          CioTransactionalMessageTemplateId.VerifyCompany,
       });
     });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1117,7 +1117,7 @@ describe('user company', () => {
         client,
         { query: QUERY, variables: { email: 'u2@com4.com' } },
         (errors) => {
-          expect(errors[0].extensions.code).toEqual(
+          expect(errors[0].extensions!.code).toEqual(
             'GRAPHQL_VALIDATION_FAILED',
           );
           expect(errors[0].message).toEqual(
@@ -1200,6 +1200,30 @@ describe('user company', () => {
         },
         transactional_message_id: '51',
       });
+    });
+
+    it('should not send verification email to user if email is verified', async () => {
+      loggedUser = '1';
+      await con.getRepository(UserCompany).save({
+        verified: true,
+        email: 'u1@com3.com',
+        code: '654321',
+        userId: loggedUser,
+      });
+      return testQueryError(
+        client,
+        { query: QUERY, variables: { email: 'u1@com3.com' } },
+        (errors) => {
+          expect(errors[0].extensions!.code).toEqual(
+            'GRAPHQL_VALIDATION_FAILED',
+          );
+          expect(errors[0].message).toEqual(
+            'This email has already been verified',
+          );
+
+          expect(sendEmail).not.toHaveBeenCalled();
+        },
+      );
     });
   });
 

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -21,6 +21,10 @@ export enum CioUnsubscribeTopic {
   Digest = '8',
 }
 
+export enum CioTransactionalMessageTemplateId {
+  VerifyCompany = '51',
+}
+
 export const cioApi = new APIClient(process.env.CIO_APP_KEY);
 
 export const addNotificationUtm = (

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -55,6 +55,8 @@ import {
   VALID_WEEK_STARTS,
   GQLUserIntegration,
   GQLUserCompany,
+  sendEmail,
+  CioTransactionalMessageTemplateId,
 } from '../common';
 import { getSearchQuery, GQLEmptyResponse, processSearchQuery } from './common';
 import { ActiveView } from '../entity/ActiveView';
@@ -1758,6 +1760,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           companyId: company?.id ?? null,
         });
       }
+
+      await sendEmail({
+        transactional_message_id:
+          CioTransactionalMessageTemplateId.VerifyCompany,
+        message_data: {
+          code,
+        },
+        identifiers: {
+          id: ctx.userId,
+        },
+        to: email,
+      });
 
       return { _: true };
     },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1766,6 +1766,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       }
 
       await sendEmail({
+        send_to_unsubscribed: true,
         transactional_message_id:
           CioTransactionalMessageTemplateId.VerifyCompany,
         message_data: {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1750,6 +1750,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           );
         }
 
+        if (existingUserCompanyEmail.verified === true) {
+          throw new ValidationError('This email has already been verified');
+        }
+
         const updatedRecord = { ...existingUserCompanyEmail, code };
         await ctx.con.getRepository(UserCompany).save(updatedRecord);
       } else {


### PR DESCRIPTION
Send email verification.
Also added a check to see if the email is already verified, to not generate new codes and sending emails. Edge case, but could be if user has verification open in two windows, verifies in one, then clicks re-send code in another windows.

Required to be merged before https://github.com/dailydotdev/apps/pull/3478

AS-536