### PR TITLE
chore: adjust digest pod limits

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -385,10 +385,10 @@ if (isAdhocEnv) {
       args: ['dumb-init', 'node', 'bin/cli', 'personalized-digest'],
       minReplicas: 1,
       maxReplicas: 25,
-      limits: { memory: '512Mi' },
+      limits: bgLimits,
       requests: {
-        cpu: '100m',
-        memory: '256Mi',
+        ...bgRequests,
+        cpu: '500m',
       },
       metric: {
         type: 'pubsub',


### PR DESCRIPTION
looks like memory is not an issue but a cpu usage, so verticaly scaling that a bit further to see how it goes

reverting memory to standard bg limits