### PR TITLE
chore: adjust digest limits and ack count

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -385,10 +385,10 @@ if (isAdhocEnv) {
       args: ['dumb-init', 'node', 'bin/cli', 'personalized-digest'],
       minReplicas: 1,
       maxReplicas: 25,
-      limits: bgLimits,
+      limits: { memory: '512Mi' },
       requests: {
-        ...bgRequests,
         cpu: '500m',
+        memory: '256Mi',
       },
       metric: {
         type: 'pubsub',

--- a/src/commands/personalizedDigest.ts
+++ b/src/commands/personalizedDigest.ts
@@ -39,6 +39,7 @@ export default async function app(): Promise<void> {
           logger,
           pubsub,
         ),
+      25,
     ),
   );
 }


### PR DESCRIPTION
We also ack only single message per worker :hidethepain:

put it to 25 now because this was a ack/s ration for pods so I think each pod should be able to handle it
<img width="402" alt="image" src="https://github.com/user-attachments/assets/38f02f34-e423-4f74-ad26-3df370479f9f">
