### PR TITLE
feat: download and store code snippets

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -951,62 +951,118 @@ describe('on post create', () => {
       expect(post.showOnFeed).toEqual(true);
       expect(post.flags.showOnFeed).toEqual(true);
     });
+  });
 
-    describe('post code snippets', () => {
-      it('should create post with code snippets', async () => {
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets: [
-            'while (true) {\n    /* remove this */\n}',
-            'const a = 1;\n\nconsole.log(a)',
-          ],
-        });
-
-        const uuid = randomUUID();
-
-        await expectSuccessfulBackground(worker, {
-          id: uuid,
-          title: `Title ${uuid}`,
-          url: `http://example.com/posts/${uuid}`,
-          source_id: 'a',
-          meta: {
-            stored_code_snippets: `gs://bucket/${uuid}.json`,
-          },
-        });
-
-        const post = await con.getRepository(ArticlePost).findOneByOrFail({
-          yggdrasilId: uuid,
-        });
-
-        const codeSnippets = await con.getRepository(PostCodeSnippet).find({
-          where: {
-            postId: post.id,
-          },
-          order: {
-            order: 'ASC',
-          },
-        });
-        expect(codeSnippets.length).toEqual(2);
-        expect(codeSnippets).toMatchObject([
-          {
-            content: 'while (true) {\n    /* remove this */\n}',
-            contentHash: 'ee1cdee8c96afc016935ccde191e021d3327ee79',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 0,
-            postId: post.id,
-          },
-          {
-            content: 'const a = 1;\n\nconsole.log(a)',
-            contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 1,
-            postId: post.id,
-          },
-        ]);
+  describe('post code snippets', () => {
+    it('should create post with code snippets', async () => {
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
       });
+
+      const uuid = randomUUID();
+
+      await expectSuccessfulBackground(worker, {
+        id: uuid,
+        title: `Title ${uuid}`,
+        url: `http://example.com/posts/${uuid}`,
+        source_id: 'a',
+        meta: {
+          stored_code_snippets: `gs://bucket/${uuid}.json`,
+        },
+      });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        yggdrasilId: uuid,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+      expect(codeSnippets.length).toEqual(2);
+      expect(codeSnippets).toMatchObject([
+        {
+          content: 'while (true) {\n    /* remove this */\n}',
+          contentHash: 'ee1cdee8c96afc016935ccde191e021d3327ee79',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 0,
+          postId: post.id,
+        },
+        {
+          content: 'const a = 1;\n\nconsole.log(a)',
+          contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 1,
+          postId: post.id,
+        },
+      ]);
+    });
+
+    it('should ignore duplicate code snippets', async () => {
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
+      });
+
+      const uuid = randomUUID();
+
+      await expectSuccessfulBackground(worker, {
+        id: uuid,
+        title: `Title ${uuid}`,
+        url: `http://example.com/posts/${uuid}`,
+        source_id: 'a',
+        meta: {
+          stored_code_snippets: `gs://bucket/${uuid}.json`,
+        },
+      });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        yggdrasilId: uuid,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+      expect(codeSnippets.length).toEqual(2);
+      expect(codeSnippets).toMatchObject([
+        {
+          content: 'while (true) {\n    /* remove this */\n}',
+          contentHash: 'ee1cdee8c96afc016935ccde191e021d3327ee79',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 0,
+          postId: post.id,
+        },
+        {
+          content: 'const a = 1;\n\nconsole.log(a)',
+          contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 1,
+          postId: post.id,
+        },
+      ]);
     });
   });
 });
@@ -1538,271 +1594,271 @@ describe('on post update', () => {
       expect(updatedPost.flags.showOnFeed).toEqual(true);
       expect(updatedPost.flags.promoteToPublic).toEqual(1);
     });
+  });
 
-    describe('post code snippets', () => {
-      const createPostWithCodeSnippets = async ({
+  describe('post code snippets', () => {
+    const createPostWithCodeSnippets = async ({
+      snippets,
+    }: Pick<PostCodeSnippetJsonFile, 'snippets'>) => {
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
         snippets,
-      }: Pick<PostCodeSnippetJsonFile, 'snippets'>) => {
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets,
-        });
-
-        const uuid = randomUUID();
-        const post = await con.getRepository(ArticlePost).save({
-          id: 'pcs1',
-          shortId: 'pcs1',
-          yggdrasilId: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
-          url: `http://example.com/posts/${uuid}`,
-          sourceId: 'a',
-        });
-        await insertCodeSnippetsFromUrl({
-          entityManager: con.manager,
-          post: {
-            id: post.id,
-          },
-          codeSnippetsUrl: `gs://bucket/${uuid}.json`,
-        });
-
-        return post;
-      };
-
-      it('should update post with code snippets', async () => {
-        const existingPost = await createPostWithCodeSnippets({
-          snippets: [
-            'while (true) {\n    /* remove this */\n}',
-            'const a = 1;\n\nconsole.log(a)',
-          ],
-        });
-        expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
-
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets: [
-            'while (false) {\n    /* remove that */\n}',
-            'const b = 1;\n\nconsole.log(b)',
-          ],
-        });
-
-        await expectSuccessfulBackground(worker, {
-          id: existingPost.yggdrasilId,
-          post_id: existingPost.id,
-          meta: {
-            stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
-          },
-        });
-
-        const post = await con.getRepository(ArticlePost).findOneByOrFail({
-          id: existingPost.id,
-        });
-
-        const codeSnippets = await con.getRepository(PostCodeSnippet).find({
-          where: {
-            postId: post.id,
-          },
-          order: {
-            order: 'ASC',
-          },
-        });
-        expect(codeSnippets.length).toEqual(2);
-        expect(codeSnippets).toMatchObject([
-          {
-            content: 'while (false) {\n    /* remove that */\n}',
-            contentHash: '1274ca65aa00681606f7894a55143607057bf209',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 0,
-            postId: post.id,
-          },
-          {
-            content: 'const b = 1;\n\nconsole.log(b)',
-            contentHash: '370e2729c7035b45c91b3f34fb76e3aafba4303f',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 1,
-            postId: post.id,
-          },
-        ]);
       });
 
-      it('should delete removed code snippets no and insert added ones', async () => {
-        const existingPost = await createPostWithCodeSnippets({
-          snippets: [
-            'while (true) {\n    /* remove this */\n}',
-            'const a = 1;\n\nconsole.log(a)',
-          ],
-        });
-        expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
-
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets: [
-            'const response = await fetch("https://example.com")',
-            'const a = 1;\n\nconsole.log(a)',
-            'const timer = setTimeout(console.log, 1000)',
-            'const interval = setInterval(console.log, 200)',
-          ],
-        });
-
-        await expectSuccessfulBackground(worker, {
-          id: existingPost.yggdrasilId,
-          post_id: existingPost.id,
-          meta: {
-            stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
-          },
-        });
-
-        const post = await con.getRepository(ArticlePost).findOneByOrFail({
-          id: existingPost.id,
-        });
-
-        const codeSnippets = await con.getRepository(PostCodeSnippet).find({
-          where: {
-            postId: post.id,
-          },
-          order: {
-            order: 'ASC',
-          },
-        });
-
-        expect(codeSnippets.length).toEqual(4);
-        expect(codeSnippets).toMatchObject([
-          {
-            content: 'const response = await fetch("https://example.com")',
-            contentHash: '4b261b65a7d507fe8effedc225cbdb63af8e234e',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 0,
-            postId: post.id,
-          },
-          {
-            content: 'const a = 1;\n\nconsole.log(a)',
-            contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 1,
-            postId: post.id,
-          },
-          {
-            content: 'const timer = setTimeout(console.log, 1000)',
-            contentHash: 'af7d49e07a60a5ac7d4727ce997ab845086b72bb',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 2,
-            postId: post.id,
-          },
-          {
-            content: 'const interval = setInterval(console.log, 200)',
-            contentHash: 'b48a89bf7863a66a5aa62970b3485880d896419a',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 3,
-            postId: post.id,
-          },
-        ]);
+      const uuid = randomUUID();
+      const post = await con.getRepository(ArticlePost).save({
+        id: 'pcs1',
+        shortId: 'pcs1',
+        yggdrasilId: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+        url: `http://example.com/posts/${uuid}`,
+        sourceId: 'a',
+      });
+      await insertCodeSnippetsFromUrl({
+        entityManager: con.manager,
+        post: {
+          id: post.id,
+        },
+        codeSnippetsUrl: `gs://bucket/${uuid}.json`,
       });
 
-      it('should delete all snippets if all are removed', async () => {
-        const existingPost = await createPostWithCodeSnippets({
-          snippets: [
-            'while (true) {\n    /* remove this */\n}',
-            'const a = 1;\n\nconsole.log(a)',
-          ],
-        });
-        expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
+      return post;
+    };
 
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets: [],
-        });
+    it('should update post with code snippets', async () => {
+      const existingPost = await createPostWithCodeSnippets({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
+      });
+      expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
 
-        await expectSuccessfulBackground(worker, {
-          id: existingPost.yggdrasilId,
-          post_id: existingPost.id,
-          meta: {
-            stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
-          },
-        });
-
-        const post = await con.getRepository(ArticlePost).findOneByOrFail({
-          id: existingPost.id,
-        });
-
-        const codeSnippets = await con.getRepository(PostCodeSnippet).find({
-          where: {
-            postId: post.id,
-          },
-          order: {
-            order: 'ASC',
-          },
-        });
-
-        expect(codeSnippets.length).toEqual(0);
-        expect(codeSnippets).toMatchObject([]);
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [
+          'while (false) {\n    /* remove that */\n}',
+          'const b = 1;\n\nconsole.log(b)',
+        ],
       });
 
-      it('should update snippets when order is changed', async () => {
-        const existingPost = await createPostWithCodeSnippets({
-          snippets: [
-            'while (true) {\n    /* remove this */\n}',
-            'const a = 1;\n\nconsole.log(a)',
-          ],
-        });
-        expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
-
-        (
-          downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
-        ).mockResolvedValueOnce({
-          snippets: [
-            'const a = 1;\n\nconsole.log(a)',
-            'while (true) {\n    /* remove this */\n}',
-          ],
-        });
-
-        await expectSuccessfulBackground(worker, {
-          id: existingPost.yggdrasilId,
-          post_id: existingPost.id,
-          meta: {
-            stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
-          },
-        });
-
-        const post = await con.getRepository(ArticlePost).findOneByOrFail({
-          id: existingPost.id,
-        });
-
-        const codeSnippets = await con.getRepository(PostCodeSnippet).find({
-          where: {
-            postId: post.id,
-          },
-          order: {
-            order: 'ASC',
-          },
-        });
-        expect(codeSnippets.length).toEqual(2);
-        expect(codeSnippets).toMatchObject([
-          {
-            content: 'const a = 1;\n\nconsole.log(a)',
-            contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 0,
-            postId: post.id,
-          },
-          {
-            content: 'while (true) {\n    /* remove this */\n}',
-            contentHash: 'ee1cdee8c96afc016935ccde191e021d3327ee79',
-            createdAt: expect.any(Date),
-            language: PostCodeSnippetLanguage.Plain,
-            order: 1,
-            postId: post.id,
-          },
-        ]);
+      await expectSuccessfulBackground(worker, {
+        id: existingPost.yggdrasilId,
+        post_id: existingPost.id,
+        meta: {
+          stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
+        },
       });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: existingPost.id,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+      expect(codeSnippets.length).toEqual(2);
+      expect(codeSnippets).toMatchObject([
+        {
+          content: 'while (false) {\n    /* remove that */\n}',
+          contentHash: '1274ca65aa00681606f7894a55143607057bf209',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 0,
+          postId: post.id,
+        },
+        {
+          content: 'const b = 1;\n\nconsole.log(b)',
+          contentHash: '370e2729c7035b45c91b3f34fb76e3aafba4303f',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 1,
+          postId: post.id,
+        },
+      ]);
+    });
+
+    it('should delete removed code snippets no and insert added ones', async () => {
+      const existingPost = await createPostWithCodeSnippets({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
+      });
+      expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
+
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [
+          'const response = await fetch("https://example.com")',
+          'const a = 1;\n\nconsole.log(a)',
+          'const timer = setTimeout(console.log, 1000)',
+          'const interval = setInterval(console.log, 200)',
+        ],
+      });
+
+      await expectSuccessfulBackground(worker, {
+        id: existingPost.yggdrasilId,
+        post_id: existingPost.id,
+        meta: {
+          stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
+        },
+      });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: existingPost.id,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+
+      expect(codeSnippets.length).toEqual(4);
+      expect(codeSnippets).toMatchObject([
+        {
+          content: 'const response = await fetch("https://example.com")',
+          contentHash: '4b261b65a7d507fe8effedc225cbdb63af8e234e',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 0,
+          postId: post.id,
+        },
+        {
+          content: 'const a = 1;\n\nconsole.log(a)',
+          contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 1,
+          postId: post.id,
+        },
+        {
+          content: 'const timer = setTimeout(console.log, 1000)',
+          contentHash: 'af7d49e07a60a5ac7d4727ce997ab845086b72bb',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 2,
+          postId: post.id,
+        },
+        {
+          content: 'const interval = setInterval(console.log, 200)',
+          contentHash: 'b48a89bf7863a66a5aa62970b3485880d896419a',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 3,
+          postId: post.id,
+        },
+      ]);
+    });
+
+    it('should delete all snippets if all are removed', async () => {
+      const existingPost = await createPostWithCodeSnippets({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
+      });
+      expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
+
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [],
+      });
+
+      await expectSuccessfulBackground(worker, {
+        id: existingPost.yggdrasilId,
+        post_id: existingPost.id,
+        meta: {
+          stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
+        },
+      });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: existingPost.id,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+
+      expect(codeSnippets.length).toEqual(0);
+      expect(codeSnippets).toMatchObject([]);
+    });
+
+    it('should update snippets when order is changed', async () => {
+      const existingPost = await createPostWithCodeSnippets({
+        snippets: [
+          'while (true) {\n    /* remove this */\n}',
+          'const a = 1;\n\nconsole.log(a)',
+        ],
+      });
+      expect(await con.getRepository(PostCodeSnippet).count()).toBe(2);
+
+      (
+        downloadJsonFile as jest.MockedFunction<typeof downloadJsonFile>
+      ).mockResolvedValueOnce({
+        snippets: [
+          'const a = 1;\n\nconsole.log(a)',
+          'while (true) {\n    /* remove this */\n}',
+        ],
+      });
+
+      await expectSuccessfulBackground(worker, {
+        id: existingPost.yggdrasilId,
+        post_id: existingPost.id,
+        meta: {
+          stored_code_snippets: `gs://bucket/${existingPost.yggdrasilId}.json`,
+        },
+      });
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: existingPost.id,
+      });
+
+      const codeSnippets = await con.getRepository(PostCodeSnippet).find({
+        where: {
+          postId: post.id,
+        },
+        order: {
+          order: 'ASC',
+        },
+      });
+      expect(codeSnippets.length).toEqual(2);
+      expect(codeSnippets).toMatchObject([
+        {
+          content: 'const a = 1;\n\nconsole.log(a)',
+          contentHash: 'c1d469fbdc2d504110e247b6f754075d1cda2cce',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 0,
+          postId: post.id,
+        },
+        {
+          content: 'while (true) {\n    /* remove this */\n}',
+          contentHash: 'ee1cdee8c96afc016935ccde191e021d3327ee79',
+          createdAt: expect.any(Date),
+          language: PostCodeSnippetLanguage.Plain,
+          order: 1,
+          postId: post.id,
+        },
+      ]);
     });
   });
 });

--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -37,7 +37,7 @@ import {
   PostCodeSnippetJsonFile,
   PostCodeSnippetLanguage,
 } from '../../src/types';
-import { insertCodeSnippets } from '../../src/common';
+import { insertCodeSnippetsFromUrl } from '../../src/common/post';
 
 jest.mock('../../src/common/googleCloud', () => ({
   ...(jest.requireActual('../../src/common/googleCloud') as Record<
@@ -1557,7 +1557,7 @@ describe('on post update', () => {
           url: `http://example.com/posts/${uuid}`,
           sourceId: 'a',
         });
-        await insertCodeSnippets({
+        await insertCodeSnippetsFromUrl({
           entityManager: con.manager,
           post: {
             id: post.id,

--- a/bin/insertCodeSnippets.ts
+++ b/bin/insertCodeSnippets.ts
@@ -1,0 +1,51 @@
+import fastq from 'fastq';
+import '../src/config';
+import createOrGetConnection from '../src/db';
+import { Post } from '../src/entity';
+import { insertCodeSnippets } from '../src/common/post';
+
+type SnippetRow = { postId: string; filePath: string };
+
+const main = async () => {
+  const queueConcurrency = +process.env.QUEUE_CONCURRENCY || 1;
+  const con = await createOrGetConnection();
+
+  const stream = await con
+    .getRepository(Post)
+    .createQueryBuilder()
+    .select('id', 'postId')
+    .addSelect(`"contentMeta"->>'stored_code_snippets'`, 'filePath')
+    .where(`("contentMeta"->>'stored_code_snippets') is not null`)
+    .stream();
+
+  let insertCount = 0;
+  const insertQueue = fastq.promise(
+    async ({ postId, filePath }: SnippetRow) => {
+      await insertCodeSnippets({
+        entityManager: con.manager,
+        post: {
+          id: postId,
+        },
+        codeSnippetsUrl: filePath,
+      });
+
+      insertCount += 1;
+    },
+    queueConcurrency,
+  );
+
+  stream.on('data', ({ postId, filePath }: SnippetRow) => {
+    insertQueue.push({ postId, filePath });
+  });
+
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  await insertQueue.drained();
+
+  console.log('insertion finished with a total of: ', insertCount);
+  process.exit();
+};
+
+main();

--- a/bin/insertCodeSnippets.ts
+++ b/bin/insertCodeSnippets.ts
@@ -1,33 +1,94 @@
 import fastq from 'fastq';
 import '../src/config';
-import createOrGetConnection from '../src/db';
 import { Post } from '../src/entity';
+import { downloadFile } from '../src/common/googleCloud';
+import { readdir, readFile, writeFile } from 'fs/promises';
+import createOrGetConnection from '../src/db';
+import path from 'path';
+import { PostCodeSnippetJsonFile } from '../src/types';
 import { insertCodeSnippets } from '../src/common/post';
 
 type SnippetRow = { postId: string; filePath: string };
 
+enum BinInsertCodeSnippetOperation {
+  Download = 'download',
+  Insert = 'insert',
+}
+
 const main = async () => {
   const queueConcurrency = +process.env.QUEUE_CONCURRENCY || 1;
+  const operation = process.argv[2];
+  const savePath = process.argv[3];
+
+  if (
+    !Object.values(BinInsertCodeSnippetOperation).includes(
+      operation as BinInsertCodeSnippetOperation,
+    )
+  ) {
+    throw new Error(`Invalid operation: ${operation}`);
+  }
+
+  if (!savePath) {
+    throw new Error('Path is required');
+  }
+
   const con = await createOrGetConnection();
 
-  const stream = await con
-    .getRepository(Post)
-    .createQueryBuilder()
-    .select('id', 'postId')
-    .addSelect(`"contentMeta"->>'stored_code_snippets'`, 'filePath')
-    .where(`("contentMeta"->>'stored_code_snippets') is not null`)
-    .stream();
+  if (operation === BinInsertCodeSnippetOperation.Download) {
+    const stream = await con
+      .getRepository(Post)
+      .createQueryBuilder()
+      .select('id', 'postId')
+      .addSelect(`"contentMeta"->>'stored_code_snippets'`, 'filePath')
+      .where(`("contentMeta"->>'stored_code_snippets') is not null`)
+      .stream();
+
+    let downloadCount = 0;
+
+    const downloadQueue = fastq.promise(
+      async ({ postId, filePath }: SnippetRow) => {
+        const result = await downloadFile({ url: filePath });
+        await writeFile(path.join(savePath, `${postId}.json`), result);
+
+        downloadCount += 1;
+      },
+      queueConcurrency,
+    );
+
+    stream.on('data', ({ postId, filePath }: SnippetRow) => {
+      downloadQueue.push({ postId, filePath });
+    });
+
+    await new Promise((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+    await downloadQueue.drained();
+
+    console.log('download finished with a total of: ', downloadCount);
+    process.exit();
+  }
+
+  const dirList = await readdir(savePath, { withFileTypes: true });
+  const files = dirList
+    .filter((dirent) => dirent.isFile())
+    .map((dirent) => dirent.name);
 
   let insertCount = 0;
 
   const insertQueue = fastq.promise(
     async ({ postId, filePath }: SnippetRow) => {
+      const fileContent = await readFile(filePath, 'utf-8');
+      const codeSnippetsJson = JSON.parse(
+        fileContent,
+      ) as PostCodeSnippetJsonFile;
+
       await insertCodeSnippets({
         entityManager: con.manager,
         post: {
           id: postId,
         },
-        codeSnippetsUrl: filePath,
+        codeSnippetsJson,
       });
 
       insertCount += 1;
@@ -35,14 +96,12 @@ const main = async () => {
     queueConcurrency,
   );
 
-  stream.on('data', ({ postId, filePath }: SnippetRow) => {
-    insertQueue.push({ postId, filePath });
+  files.forEach((file) => {
+    const [postId] = file.split('.');
+
+    insertQueue.push({ postId, filePath: path.join(savePath, file) });
   });
 
-  await new Promise((resolve, reject) => {
-    stream.on('error', reject);
-    stream.on('end', resolve);
-  });
   await insertQueue.drained();
 
   console.log('insertion finished with a total of: ', insertCount);

--- a/bin/insertCodeSnippets.ts
+++ b/bin/insertCodeSnippets.ts
@@ -19,6 +19,7 @@ const main = async () => {
     .stream();
 
   let insertCount = 0;
+
   const insertQueue = fastq.promise(
     async ({ postId, filePath }: SnippetRow) => {
       await insertCodeSnippets({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.19.0",
         "@google-cloud/opentelemetry-resource-util": "^2.3.0",
         "@google-cloud/pubsub": "^4.5.0",
+        "@google-cloud/storage": "^7.12.1",
         "@graphql-tools/schema": "^10.0.4",
         "@graphql-tools/utils": "^10.3.3",
         "@growthbook/growthbook": "^1.1.0",
@@ -1369,6 +1370,39 @@
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.12.1.tgz",
+      "integrity": "sha512-Z3ZzOnF3YKLuvpkvF+TjQ6lztxcAyTILp+FjKonmVpEwPa9vFvxpZjubLR4sB6bf19i/8HL2AXRjA0YFgHFRmQ==",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^4.4.1",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@graphql-tools/merge": {
@@ -4517,6 +4551,14 @@
         "safe-stable-stringify": "^2.4.3"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5702,14 +5744,14 @@
       }
     },
     "node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
+        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6438,6 +6480,27 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
       "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA=="
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastify": {
       "version": "4.28.1",
@@ -7367,6 +7430,21 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -9585,7 +9663,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -11330,6 +11407,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -12508,7 +12590,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.19.0",
     "@google-cloud/opentelemetry-resource-util": "^2.3.0",
     "@google-cloud/pubsub": "^4.5.0",
+    "@google-cloud/storage": "^7.12.1",
     "@graphql-tools/schema": "^10.0.4",
     "@graphql-tools/utils": "^10.3.3",
     "@growthbook/growthbook": "^1.1.0",

--- a/src/common/googleCloud.ts
+++ b/src/common/googleCloud.ts
@@ -1,19 +1,16 @@
 import { Storage, DownloadOptions } from '@google-cloud/storage';
 import { PropsParameters } from '../types';
-
-export enum StorageBucket {
-  CodeSnippets = 'daily-dev-yggdrasil-code-snippets',
-}
+import path from 'path';
 
 export const downloadFile = async ({
-  bucket,
-  fileName,
+  url,
   options,
 }: {
-  bucket: StorageBucket;
-  fileName: string;
+  url: string;
   options?: DownloadOptions;
 }): Promise<string> => {
+  const bucket = path.dirname(url);
+  const fileName = path.basename(url);
   const storage = new Storage();
 
   const [result] = await storage
@@ -25,10 +22,10 @@ export const downloadFile = async ({
 };
 
 export const downloadJsonFile = async <T>({
-  bucket,
-  fileName,
+  url,
+  options,
 }: PropsParameters<typeof downloadFile>): Promise<T> => {
-  const result = await downloadFile({ bucket, fileName });
+  const result = await downloadFile({ url, options });
 
   return JSON.parse(result);
 };

--- a/src/common/googleCloud.ts
+++ b/src/common/googleCloud.ts
@@ -1,0 +1,34 @@
+import { Storage, DownloadOptions } from '@google-cloud/storage';
+import { PropsParameters } from '../types';
+
+export enum StorageBucket {
+  CodeSnippets = 'daily-dev-yggdrasil-code-snippets',
+}
+
+export const downloadFile = async ({
+  bucket,
+  fileName,
+  options,
+}: {
+  bucket: StorageBucket;
+  fileName: string;
+  options?: DownloadOptions;
+}): Promise<string> => {
+  const storage = new Storage();
+
+  const [result] = await storage
+    .bucket(bucket)
+    .file(fileName)
+    .download(options);
+
+  return result.toString();
+};
+
+export const downloadJsonFile = async <T>({
+  bucket,
+  fileName,
+}: PropsParameters<typeof downloadFile>): Promise<T> => {
+  const result = await downloadFile({ bucket, fileName });
+
+  return JSON.parse(result);
+};

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -22,7 +22,7 @@ import { createHash } from 'node:crypto';
 import { PostCodeSnippet } from '../entity/posts/PostCodeSnippet';
 import { logger } from '../logger';
 import { downloadJsonFile } from './googleCloud';
-import { PostCodeSnippetJsonFile } from '../types';
+import type { PostCodeSnippetJsonFile } from '../types';
 
 export const defaultImage = {
   urls: process.env.DEFAULT_IMAGE_URL?.split?.(',') ?? [],

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -54,6 +54,39 @@ export const uniqueifyArray = <T>(array: T[]): T[] => {
   return [...new Set(array)];
 };
 
+export /**
+ * Remove duplicate values from an array of objects per unique key
+ *
+ * @template T
+ * @template R
+ * @param {T[]} array Array of objects
+ * @param {(item: T) => string} uniqueKey Function to get the unique key from the item
+ * @param {(item: T, index: number, uniqueKey: string) => R} [processItem] Optional function to process the item before adding it to the result array
+ * @return {*}  {R[]}
+ */
+const uniqueifyObjectArray = <T, R = T>(
+  array: T[],
+  uniqueKey: (item: T) => string,
+  processItem?: (item: T, index: number, uniqueKey: string) => R,
+): R[] => {
+  const uniqueMap = array.reduce((acc, item, index) => {
+    const itemKey = uniqueKey(item);
+
+    if (!acc.has(itemKey)) {
+      const newItem =
+        typeof processItem === 'function'
+          ? processItem(item, index, itemKey)
+          : item;
+
+      acc.set(itemKey, newItem as unknown as R);
+    }
+
+    return acc;
+  }, new Map<string, R>());
+
+  return Array.from(uniqueMap.values());
+};
+
 /**
  * Remove empty values from an array
  *

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -12,6 +12,7 @@ import { PostTag } from '../PostTag';
 import { PostKeyword } from '../PostKeyword';
 import { User } from '../user';
 import { PostRelation } from './PostRelation';
+import type { PostCodeSnippet } from './PostCodeSnippet';
 
 export enum PostType {
   Article = 'article',
@@ -261,4 +262,13 @@ export class Post {
 
   @Column({ type: 'jsonb', default: {} })
   contentQuality: PostContentQuality;
+
+  @OneToMany(
+    'PostCodeSnippet',
+    (postCodeSnippet: PostCodeSnippet) => postCodeSnippet.post,
+    {
+      lazy: true,
+    },
+  )
+  public codeSnippets: Promise<PostCodeSnippet[]>;
 }

--- a/src/entity/posts/PostCodeSnippet.ts
+++ b/src/entity/posts/PostCodeSnippet.ts
@@ -21,7 +21,7 @@ export class PostCodeSnippet {
   @Column({ type: 'integer' })
   order: number;
 
-  @PrimaryColumn({ type: 'text', default: PostCodeSnippetLanguage.Plain })
+  @Column({ type: 'text', default: PostCodeSnippetLanguage.Plain })
   language: PostCodeSnippetLanguage;
 
   @CreateDateColumn()

--- a/src/entity/posts/PostCodeSnippet.ts
+++ b/src/entity/posts/PostCodeSnippet.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { PostCodeSnippetLanguage } from '../../types';
+import type { Post } from './Post';
+
+@Entity()
+export class PostCodeSnippet {
+  @PrimaryColumn({ type: 'text' })
+  postId: string;
+
+  @PrimaryColumn({ type: 'text' })
+  contentHash: string;
+
+  @Index()
+  @Column({ type: 'integer' })
+  order: number;
+
+  @PrimaryColumn({ type: 'text', default: PostCodeSnippetLanguage.Plain })
+  language: PostCodeSnippetLanguage;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @ManyToOne('Post', {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  post: Promise<Post>;
+}

--- a/src/migration/1724929128486-PostCodeSnippets.ts
+++ b/src/migration/1724929128486-PostCodeSnippets.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostCodeSnippets1724929128486 implements MigrationInterface {
+  name = 'PostCodeSnippets1724929128486';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "post_code_snippet" ("postId" text NOT NULL, "contentHash" text NOT NULL, "order" integer NOT NULL, "language" text NOT NULL DEFAULT 'plain', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "content" text NOT NULL, CONSTRAINT "PK_3e5fe344bf86e8d31d32a7440bb" PRIMARY KEY ("postId", "contentHash"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3e0dbd7a7243bddd0740b4589b" ON "post_code_snippet" ("order") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post_code_snippet" ADD CONSTRAINT "FK_41925c29ce7a2820e87ff8d22fd" FOREIGN KEY ("postId") REFERENCES "post"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "post_code_snippet" DROP CONSTRAINT "FK_41925c29ce7a2820e87ff8d22fd"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_3e0dbd7a7243bddd0740b4589b"`,
+    );
+    await queryRunner.query(`DROP TABLE "post_code_snippet"`);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,3 +143,7 @@ export type PropsParameters<T extends (props: object) => unknown> = T extends (
 ) => unknown
   ? P
   : never;
+
+export enum PostCodeSnippetLanguage {
+  Plain = 'plain',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,3 +147,7 @@ export type PropsParameters<T extends (props: object) => unknown> = T extends (
 export enum PostCodeSnippetLanguage {
   Plain = 'plain',
 }
+
+export type PostCodeSnippetJsonFile = {
+  snippets: string[];
+};

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -32,10 +32,11 @@ import { SubmissionFailErrorKeys, SubmissionFailErrorMessage } from '../errors';
 import { generateShortId } from '../ids';
 import { FastifyBaseLogger } from 'fastify';
 import { EntityManager } from 'typeorm';
-import { insertCodeSnippets, parseDate, updateFlagsStatement } from '../common';
+import { parseDate, updateFlagsStatement } from '../common';
 import { markdown } from '../common/markdown';
 import { counters } from '../telemetry';
 import { I18nRecord } from '../types';
+import { insertCodeSnippetsFromUrl } from '../common/post';
 
 interface Data {
   id: string;
@@ -739,7 +740,7 @@ const worker: Worker = {
               },
               originalData: data,
             }),
-            insertCodeSnippets({
+            insertCodeSnippetsFromUrl({
               entityManager,
               post: {
                 id: postId,

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -729,6 +729,29 @@ const worker: Worker = {
           });
         }
 
+        // temp wrapper to avoid any issue with post processing
+        // while we test code snippets insertion
+        const safeInsertCodeSnippets = async () => {
+          try {
+            await insertCodeSnippetsFromUrl({
+              entityManager,
+              post: {
+                id: postId,
+              },
+              codeSnippetsUrl: data?.meta?.stored_code_snippets,
+            });
+          } catch (err) {
+            logger.error(
+              {
+                postId,
+                codeSnippetsUrl: data?.meta?.stored_code_snippets,
+                err,
+              },
+              'failed to save code snippets for post',
+            );
+          }
+        };
+
         if (postId) {
           await Promise.all([
             handleCollectionRelations({
@@ -740,13 +763,7 @@ const worker: Worker = {
               },
               originalData: data,
             }),
-            insertCodeSnippetsFromUrl({
-              entityManager,
-              post: {
-                id: postId,
-              },
-              codeSnippetsUrl: data?.meta?.stored_code_snippets,
-            }),
+            safeInsertCodeSnippets(),
           ]);
         }
       });


### PR DESCRIPTION
- [x] download and insert code snippets inside the postUpdated worker
- [x] script to backfill code snippets into PostCodeSnippets entity
- [x] migrations
- [x] tests

Will add query for snippets in following PR.

Verified locally by pulling few snippets from prod. Need to merge this so I can back import with created script.

AS-496