### PR TITLE
chore: adjust digest max messages

### DIFF
--- a/src/commands/personalizedDigest.ts
+++ b/src/commands/personalizedDigest.ts
@@ -39,7 +39,7 @@ export default async function app(): Promise<void> {
           logger,
           pubsub,
         ),
-      25,
+      50,
     ),
   );
 }


### PR DESCRIPTION
Aside from initial worker which gets overloaded until we scale pods we have a bit of legroom on the pods so I would try to increase the maxMessages to `50` so its parallelized a bit more. 

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/fa274a3a-3379-461e-872f-0c7393d09388">

Oldest ack message is already much lower and not triggering alerts

<img width="463" alt="image" src="https://github.com/user-attachments/assets/3abb17e9-2de9-4d05-8955-7b37220c1dad">
