### PR TITLE
fix: streak reset time calculation

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3403,8 +3403,8 @@ describe('user streak change', () => {
     it('should set cache of previous streak even when weekend had passed if it has only been 2 valid days', async () => {
       jest
         .useFakeTimers({ doNotFake })
-        .setSystemTime(new Date('2024-06-24T12:00:00')); // Monday
-      const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
+        .setSystemTime(new Date('2024-09-02T12:00:00')); // Monday
+      const lastViewAt = new Date('2024-08-29T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
         lastViewAt: lastViewAt.getTime() * 1000,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3259,8 +3259,8 @@ describe('user streak change', () => {
     currentStreak: 2,
     totalStreak: 3,
     maxStreak: 4,
-    lastViewAt: new Date().getTime(),
-    updatedAt: new Date().getTime(),
+    lastViewAt: new Date().toISOString() as never,
+    updatedAt: new Date().toISOString() as never,
   };
 
   it('should not notify on creation', async () => {
@@ -3296,10 +3296,9 @@ describe('user streak change', () => {
   });
 
   describe('streak recovery', () => {
-    const lastView = new Date('2024-06-24T12:00:00'); // Monday
-    const dates = {
-      lastViewAt: lastView.getTime() * 1000,
-      updatedAt: lastView.getTime() * 1000,
+    const dates: Record<string, unknown> = {
+      lastViewAt: '2024-06-24T12:00:00',
+      updatedAt: '2024-06-24T12:00:00',
     };
 
     beforeEach(async () => {
@@ -3307,7 +3306,7 @@ describe('user streak change', () => {
       await saveFixtures(con, User, [usersFixture[0]]);
       await con.getRepository(UserStreak).save({
         ...base,
-        lastViewAt: new Date(base.lastViewAt),
+        lastViewAt: new Date(base.lastViewAt as never),
         updatedAt: new Date(base.updatedAt),
       });
 
@@ -3407,7 +3406,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-08-29T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString() as never,
         currentStreak: 0,
       };
       await con
@@ -3420,7 +3419,7 @@ describe('user streak change', () => {
           before: {
             ...base,
             currentStreak: 3,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString() as never,
           },
           op: 'u',
           table: 'user_streak',
@@ -3444,7 +3443,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString() as never,
         currentStreak: 0,
       };
       await con
@@ -3457,7 +3456,7 @@ describe('user streak change', () => {
           before: {
             ...base,
             currentStreak: 3,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString() as never,
           },
           op: 'u',
           table: 'user_streak',
@@ -3484,7 +3483,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-24T12:00:00'); // Monday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString() as never,
         currentStreak: 0,
       };
       await con.getRepository(UserStreakAction).save({
@@ -3502,7 +3501,7 @@ describe('user streak change', () => {
           before: {
             ...base,
             currentStreak: 3,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString() as never,
           },
           op: 'u',
           table: 'user_streak',
@@ -3528,7 +3527,7 @@ describe('user streak change', () => {
       const lastViewAt = new Date('2024-06-20T12:00:00'); // previous Thursday
       const after: ChangeObject<ObjectType> = {
         ...base,
-        lastViewAt: lastViewAt.getTime() * 1000,
+        lastViewAt: lastViewAt.toISOString() as never,
         currentStreak: 0,
       };
       await con.getRepository(UserStreakAction).save({
@@ -3546,7 +3545,7 @@ describe('user streak change', () => {
           before: {
             ...base,
             currentStreak: 3,
-            lastViewAt: lastViewAt.getTime() * 1000,
+            lastViewAt: lastViewAt.toISOString() as never,
           },
           op: 'u',
           table: 'user_streak',

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -698,7 +698,7 @@ describe('streak reset restore', () => {
       StorageKey.Reset,
       streak.userId,
     );
-    const debeziumTime = streak.lastViewAt.getTime() * 1000;
+    const debeziumTime = streak.lastViewAt.getTime();
     await setRedisObject(key, lastStreak.toString());
     const actual = await invokeNotificationWorker(worker.default, {
       streak: { ...streak, lastViewAt: debeziumTime },
@@ -708,7 +708,7 @@ describe('streak reset restore', () => {
     const ctx = bundle.ctx as NotificationStreakContext;
     expect(bundle.type).toEqual('streak_reset_restore');
     expect(ctx.streak.currentStreak).toEqual(lastStreak);
-    expect(ctx.streak.lastViewAt).toEqual(debeziumTime / 1000);
+    expect(ctx.streak.lastViewAt).toEqual(debeziumTime);
   });
 
   it('should not add notification if the stored value has expired', async () => {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -15,7 +15,6 @@ import { utcToZonedTime } from 'date-fns-tz';
 import { sendAnalyticsEvent } from '../integrations/analytics';
 import { DayOfWeek, DEFAULT_WEEK_START } from './date';
 import { ChangeObject, ContentLanguage } from '../types';
-import { logger } from '../logger';
 
 export interface User {
   id: string;

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -9,16 +9,13 @@ import {
 import { differenceInDays, isSameDay, max } from 'date-fns';
 import { DataSource, EntityManager, In, Not } from 'typeorm';
 import { CommentMention, Comment, View, Source, SourceMember } from '../entity';
-import {
-  getTimezonedStartOfISOWeek,
-  getTimezonedEndOfISOWeek,
-  debeziumTimeToDate,
-} from './utils';
+import { getTimezonedStartOfISOWeek, getTimezonedEndOfISOWeek } from './utils';
 import { GraphQLResolveInfo } from 'graphql';
 import { utcToZonedTime } from 'date-fns-tz';
 import { sendAnalyticsEvent } from '../integrations/analytics';
 import { DayOfWeek, DEFAULT_WEEK_START } from './date';
 import { ChangeObject, ContentLanguage } from '../types';
+import { logger } from '../logger';
 
 export interface User {
   id: string;
@@ -573,7 +570,7 @@ export const shouldAllowRestore = async (
   const { userId, lastViewAt: lastViewAtDb } = streak;
   const user = await con.getRepository(DbUser).findOneBy({ id: userId });
   const today = new Date();
-  const lastView = debeziumTimeToDate(lastViewAtDb);
+  const lastView = new Date(lastViewAtDb);
   const lastRecovery = await getLastStreakRecoverDate(con, userId);
   const lastStreak = lastRecovery ? max([lastView, lastRecovery]) : lastView;
   const lastStreakDifference = differenceInDays(today, lastStreak);

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -833,7 +833,7 @@ const setRestoreStreakCache = async (
   const key = generateStorageKey(StorageTopic.Streak, StorageKey.Reset, userId);
   const now = today.getTime();
   const nextDay = addDays(now, 1).setHours(0, 0, 0, 0);
-  const differenceInSeconds = (nextDay - now) * 1000;
+  const differenceInSeconds = (nextDay - now) / 1000;
 
   await Promise.all([
     setRedisObjectWithExpiry(key, previousStreak, differenceInSeconds),

--- a/src/workers/notifications/userStreakResetNotification.ts
+++ b/src/workers/notifications/userStreakResetNotification.ts
@@ -3,7 +3,7 @@ import { generateTypedNotificationWorker } from './worker';
 import { NotificationStreakContext } from '../../notifications';
 import { generateStorageKey, StorageKey, StorageTopic } from '../../config';
 import { getRedisObject } from '../../redis';
-import { debeziumTimeToDate, isNumber } from '../../common';
+import { isNumber } from '../../common';
 
 const worker = generateTypedNotificationWorker<'api.v1.user-streak-updated'>({
   subscription: 'api.user-streak-reset-notification',
@@ -26,7 +26,7 @@ const worker = generateTypedNotificationWorker<'api.v1.user-streak-updated'>({
       streak: {
         ...streak,
         currentStreak: parseInt(lastStreak, 10),
-        lastViewAt: debeziumTimeToDate(streak.lastViewAt).getTime(),
+        lastViewAt: new Date(streak.lastViewAt).getTime(),
       },
     };
 


### PR DESCRIPTION
Root cause: the column was `timestamptz`, so we should not use the debezium time function. Returned value was string.

Still added some logging for debugging purposes. This should only log when the user streak was greater than 2 and turned to 0.