### PR TITLE
feat: add circuit breaker for feed client

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -385,11 +385,11 @@ if (isAdhocEnv) {
       env: [...jwtEnv],
       args: ['dumb-init', 'node', 'bin/cli', 'personalized-digest'],
       minReplicas: 1,
-      maxReplicas: 25,
-      limits: { memory: '512Mi' },
+      maxReplicas: 1,
+      limits: { memory: '2Gi' },
       requests: {
-        cpu: '500m',
-        memory: '256Mi',
+        cpu: '1',
+        memory: '1Gi',
       },
       metric: {
         type: 'pubsub',

--- a/.infra/workers.ts
+++ b/.infra/workers.ts
@@ -11,7 +11,7 @@ export { workers, digestDeadLetter };
 
 const digestWorkersArgsMap: Record<string, WorkerArgs> = {
   'api.personalized-digest-email': {
-    ackDeadlineSeconds: 60,
+    ackDeadlineSeconds: 120,
     deadLetterPolicy: {
       deadLetterTopic: `projects/${gcp.config.project}/topics/${digestDeadLetter}`,
       maxDeliveryAttempts: 5,

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "apollo-server-errors": "^3.3.0",
         "apollo-server-types": "^3.8.0",
         "cloudinary": "^1.41.3",
+        "cockatiel": "^3.2.1",
         "csv-parse": "^5.5.6",
         "customerio-node": "^4.1.1",
         "dataloader": "^2.2.2",
@@ -5218,6 +5219,14 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/collect-v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "apollo-server-errors": "^3.3.0",
     "apollo-server-types": "^3.8.0",
     "cloudinary": "^1.41.3",
+    "cockatiel": "^3.2.1",
     "csv-parse": "^5.5.6",
     "customerio-node": "^4.1.1",
     "dataloader": "^2.2.2",

--- a/src/commands/personalizedDigest.ts
+++ b/src/commands/personalizedDigest.ts
@@ -39,7 +39,7 @@ export default async function app(): Promise<void> {
           logger,
           pubsub,
         ),
-      25,
+      50,
     ),
   );
 }

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -160,6 +160,7 @@ const personalizedDigestFeedClient = new FeedClient(
   process.env.PERSONALIZED_DIGEST_FEED,
   {
     ...fetchOptions,
+    timeout: 10 * 1000,
     retries: 0,
   },
   new GarmrService({

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -164,7 +164,7 @@ const personalizedDigestFeedClient = new FeedClient(
     retries: 0,
   },
   new GarmrService({
-    service: FeedClient.name,
+    service: 'feed-client-digest',
     breakerOpts: {
       halfOpenAfter: 5 * 1000,
       threshold: 0.1,

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -22,6 +22,7 @@ import { SendEmailRequestWithTemplate } from 'customerio-node/dist/lib/api/reque
 import { v4 as uuidv4 } from 'uuid';
 import { DayOfWeek } from './date';
 import { fetchOptions } from '../http';
+import { GarmrService } from '../integrations/garmr';
 
 type TemplatePostData = Pick<
   ArticlePost,
@@ -155,6 +156,30 @@ const getEmailVariation = async ({
   };
 };
 
+const personalizedDigestFeedClient = new FeedClient(
+  process.env.PERSONALIZED_DIGEST_FEED,
+  {
+    ...fetchOptions,
+    retries: 0,
+  },
+  new GarmrService({
+    service: FeedClient.name,
+    breakerOpts: {
+      halfOpenAfter: 5 * 1000,
+      threshold: 0.1,
+      duration: 10 * 1000,
+      minimumRps: 1,
+    },
+    limits: {
+      maxRequests: 50,
+      queuedRequests: 50,
+    },
+    retryOpts: {
+      maxAttempts: 0,
+    },
+  }),
+);
+
 export const getPersonalizedDigestEmailPayload = async ({
   con,
   logger,
@@ -180,13 +205,6 @@ export const getPersonalizedDigestEmailPayload = async ({
     con,
     personalizedDigest.userId,
     personalizedDigest.userId,
-  );
-  const personalizedDigestFeedClient = new FeedClient(
-    process.env.PERSONALIZED_DIGEST_FEED,
-    {
-      ...fetchOptions,
-      retries: 1,
-    },
   );
 
   const feedConfigPayload = {

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -10,7 +10,7 @@ import {
 import { format, isSameDay, nextDay, previousDay } from 'date-fns';
 import { PersonalizedDigestFeatureConfig } from '../growthbook';
 import { feedToFilters, fixedIdsFeedBuilder } from './feedGenerator';
-import { FeedClient } from '../integrations/feed';
+import { FeedClient } from '../integrations/feed/clients';
 import { addNotificationUtm, baseNotificationEmailData } from './mailing';
 import { pickImageUrl } from './post';
 import { getDiscussionLink } from './links';

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -101,6 +101,8 @@ export const removeEmptyValues = <T>(array: T[]): T[] => array.filter(Boolean);
  */
 export const isProd = process.env.NODE_ENV === 'production';
 
+export const isTest = process.env.NODE_ENV === 'test';
+
 export const parseDate = (date: string | Date): Date | undefined => {
   if (!date) {
     return undefined;

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -3,7 +3,7 @@ import { RequestInit } from 'node-fetch';
 import { fetchOptions as globalFetchOptions } from '../../http';
 import { retryFetchParse } from '../retry';
 import { GenericMetadata } from '../lofn';
-import { GarmrService, IGarmrClient } from '../garmr';
+import { GarmrNoopService, IGarmrClient, IGarmrService } from '../garmr';
 
 type RawFeedServiceResponse = {
   data: { post_id: string; metadata: Record<string, string> }[];
@@ -20,25 +20,16 @@ type FeedFetchOptions = RequestInit & {
 export class FeedClient implements IFeedClient, IGarmrClient {
   private readonly url: string;
   private readonly fetchOptions: FeedFetchOptions;
-  private static readonly garmr = new GarmrService({
-    service: FeedClient.name,
-    breakerOpts: {
-      halfOpenAfter: 3 * 1000,
-      threshold: 0.1,
-      duration: 30 * 1000,
-    },
-  });
-
-  get garmr() {
-    return FeedClient.garmr;
-  }
+  readonly garmr: IGarmrService;
 
   constructor(
     url = process.env.INTERNAL_FEED,
     fetchOptions: FeedFetchOptions = globalFetchOptions,
+    garmr: IGarmrService = new GarmrNoopService(),
   ) {
     this.url = url;
     this.fetchOptions = fetchOptions;
+    this.garmr = garmr;
   }
 
   async fetchFeed(

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -21,6 +21,7 @@ export class FeedClient implements IFeedClient, IGarmrClient {
   private readonly url: string;
   private readonly fetchOptions: FeedFetchOptions;
   private static readonly garmr = new GarmrService({
+    service: FeedClient.name,
     breakerOpts: {
       halfOpenAfter: 3 * 1000,
       threshold: 0.1,

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -46,7 +46,7 @@ export class FeedClient implements IFeedClient, IGarmrClient {
           method: 'POST',
           body: JSON.stringify(config),
         },
-        { retries: 0 },
+        { retries: this.fetchOptions.retries ?? 5 },
       );
     });
 

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -3,6 +3,7 @@ import { RequestInit } from 'node-fetch';
 import { fetchOptions as globalFetchOptions } from '../../http';
 import { retryFetchParse } from '../retry';
 import { GenericMetadata } from '../lofn';
+import { GarmrService, IGarmrClient } from '../garmr';
 
 type RawFeedServiceResponse = {
   data: { post_id: string; metadata: Record<string, string> }[];
@@ -16,9 +17,20 @@ type FeedFetchOptions = RequestInit & {
 /**
  * Naive implementation of a feed client that fetches the feed from the feed service
  */
-export class FeedClient implements IFeedClient {
+export class FeedClient implements IFeedClient, IGarmrClient {
   private readonly url: string;
   private readonly fetchOptions: FeedFetchOptions;
+  private static readonly garmr = new GarmrService({
+    breakerOpts: {
+      halfOpenAfter: 3 * 1000,
+      threshold: 0.1,
+      duration: 30 * 1000,
+    },
+  });
+
+  get garmr() {
+    return FeedClient.garmr;
+  }
 
   constructor(
     url = process.env.INTERNAL_FEED,
@@ -34,15 +46,18 @@ export class FeedClient implements IFeedClient {
     config,
     extraMetadata: GenericMetadata = undefined,
   ): Promise<FeedResponse> {
-    const res = await retryFetchParse<RawFeedServiceResponse>(
-      this.url,
-      {
-        ...this.fetchOptions,
-        method: 'POST',
-        body: JSON.stringify(config),
-      },
-      { retries: this.fetchOptions.retries ?? 5 },
-    );
+    const res = await this.garmr.execute(() => {
+      return retryFetchParse<RawFeedServiceResponse>(
+        this.url,
+        {
+          ...this.fetchOptions,
+          method: 'POST',
+          body: JSON.stringify(config),
+        },
+        { retries: 0 },
+      );
+    });
+
     if (!res?.data?.length) {
       return { data: [] };
     }

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -50,6 +50,7 @@ export class FeedGenerator {
 export const snotraClient = new SnotraClient();
 export const feedClient = new FeedClient();
 export const lofnClient = new LofnClient();
+export const popularFeedClient = new FeedClient(process.env.POPULAR_FEED);
 
 const opts = {
   includeBlockedTags: true,
@@ -68,7 +69,7 @@ export const baseFeedConfig: Partial<FeedConfig> = {
 export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
   Object.freeze({
     popular: new FeedGenerator(
-      new FeedClient(process.env.POPULAR_FEED),
+      popularFeedClient,
       new FeedPreferencesConfigGenerator(
         {},
         {

--- a/src/integrations/garmr.ts
+++ b/src/integrations/garmr.ts
@@ -31,6 +31,7 @@ export class GarmrService {
       halfOpenAfter: number;
       threshold: number;
       duration: number;
+      minimumRps?: number;
     };
     retryOpts?: {
       maxAttempts: number;
@@ -67,6 +68,7 @@ export class GarmrService {
       breaker: new SamplingBreaker({
         threshold: breakerOpts.threshold,
         duration: breakerOpts.duration,
+        minimumRps: breakerOpts.minimumRps ?? 5,
       }),
     });
     circuitBreakerPolicy.onBreak((event: FailureReason<Error>) => {

--- a/src/integrations/garmr.ts
+++ b/src/integrations/garmr.ts
@@ -2,24 +2,30 @@ import {
   bulkhead,
   circuitBreaker,
   ConstantBackoff,
+  FailureReason,
   handleAll,
   IDefaultPolicyContext,
   IPolicy,
+  noop,
   Policy,
   retry,
   SamplingBreaker,
   wrap,
 } from 'cockatiel';
+import { logger } from '../logger';
+import { isTest } from '../common';
 
 export class GarmrService {
   instance: IPolicy;
 
   constructor({
+    service,
     handler,
     breakerOpts,
     retryOpts,
     limits,
   }: {
+    service: string;
     handler?: Policy;
     breakerOpts: {
       halfOpenAfter: number;
@@ -35,6 +41,13 @@ export class GarmrService {
       queuedRequests?: number;
     };
   }) {
+    // in testing we avoid the circuit breaker logic due to repeatable nature
+    if (isTest) {
+      this.instance = noop;
+
+      return;
+    }
+
     const retryPolicy = retry(handleAll, {
       maxAttempts: retryOpts?.maxAttempts ?? 2,
       backoff: new ConstantBackoff(retryOpts?.timeout ?? 100),
@@ -45,12 +58,31 @@ export class GarmrService {
       limits?.queuedRequests ?? 0,
     );
 
+    const commonLoggerData = {
+      service,
+    };
+
     const circuitBreakerPolicy = circuitBreaker(handler ?? handleAll, {
       halfOpenAfter: breakerOpts.halfOpenAfter,
       breaker: new SamplingBreaker({
         threshold: breakerOpts.threshold,
         duration: breakerOpts.duration,
       }),
+    });
+    circuitBreakerPolicy.onBreak((event: FailureReason<Error>) => {
+      logger.warn(
+        {
+          ...commonLoggerData,
+          event,
+        },
+        'circuit breaker opened',
+      );
+    });
+    circuitBreakerPolicy.onHalfOpen(() => {
+      logger.info(commonLoggerData, 'circuit breaker half-opened');
+    });
+    circuitBreakerPolicy.onReset(() => {
+      logger.info(commonLoggerData, 'circuit breaker reset');
     });
 
     this.instance = wrap(retryPolicy, circuitBreakerPolicy, bulkheadPolicy);

--- a/src/integrations/garmr.ts
+++ b/src/integrations/garmr.ts
@@ -13,7 +13,7 @@ import {
   wrap,
 } from 'cockatiel';
 import { logger } from '../logger';
-import { isTest } from '../common';
+import { isTest } from '../common/utils';
 import { counters } from '../telemetry/metrics';
 
 export interface IGarmrService {

--- a/src/integrations/garmr.ts
+++ b/src/integrations/garmr.ts
@@ -1,0 +1,69 @@
+import {
+  bulkhead,
+  circuitBreaker,
+  ConstantBackoff,
+  handleAll,
+  IDefaultPolicyContext,
+  IPolicy,
+  Policy,
+  retry,
+  SamplingBreaker,
+  wrap,
+} from 'cockatiel';
+
+export class GarmrService {
+  instance: IPolicy;
+
+  constructor({
+    handler,
+    breakerOpts,
+    retryOpts,
+    limits,
+  }: {
+    handler?: Policy;
+    breakerOpts: {
+      halfOpenAfter: number;
+      threshold: number;
+      duration: number;
+    };
+    retryOpts?: {
+      maxAttempts: number;
+      timeout: number;
+    };
+    limits?: {
+      maxRequests: number;
+      queuedRequests?: number;
+    };
+  }) {
+    const retryPolicy = retry(handleAll, {
+      maxAttempts: retryOpts?.maxAttempts ?? 2,
+      backoff: new ConstantBackoff(retryOpts?.timeout ?? 100),
+    });
+
+    const bulkheadPolicy = bulkhead(
+      limits?.maxRequests ?? 1000,
+      limits?.queuedRequests ?? 0,
+    );
+
+    const circuitBreakerPolicy = circuitBreaker(handler ?? handleAll, {
+      halfOpenAfter: breakerOpts.halfOpenAfter,
+      breaker: new SamplingBreaker({
+        threshold: breakerOpts.threshold,
+        duration: breakerOpts.duration,
+      }),
+    });
+
+    this.instance = wrap(retryPolicy, circuitBreakerPolicy, bulkheadPolicy);
+  }
+
+  execute<T>(
+    fn: (context: IDefaultPolicyContext) => PromiseLike<T> | T,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    return this.instance.execute(fn, signal);
+  }
+}
+
+export interface IGarmrClient {
+  garmr: GarmrService;
+}

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -50,7 +50,6 @@ import { GQLPost } from './posts';
 import { Connection, ConnectionArguments } from 'graphql-relay';
 import graphorm from '../graphorm';
 import {
-  FeedClient,
   feedClient,
   FeedConfigName,
   FeedGenerator,
@@ -75,6 +74,7 @@ import {
 } from '../common/feed';
 import { FeedLocalConfigGenerator } from '../integrations/feed/configs';
 import { counters } from '../telemetry';
+import { popularFeedClient } from '../integrations/feed/generators';
 
 interface GQLTagsCategory {
   id: string;
@@ -1306,7 +1306,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         ctx.userId
       ) {
         const feedGenerator = new FeedGenerator(
-          new FeedClient(process.env.POPULAR_FEED),
+          popularFeedClient,
           new FeedPreferencesConfigGenerator(
             {},
             {
@@ -1354,7 +1354,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       const feedGenerator = filters
         ? new FeedGenerator(
-            new FeedClient(process.env.POPULAR_FEED),
+            popularFeedClient,
             new FeedLocalConfigGenerator(
               {},
               {

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -89,6 +89,24 @@ const counterMap = {
       description: 'How many streaks get updated',
     },
   },
+  'personalized-digest': {
+    garmrBreak: {
+      name: 'garmr_break',
+      description: 'How many times breaker has been triggered',
+    },
+    garmrHalfOpen: {
+      name: 'garm_half_open',
+      description: 'How many times breaker has been half opened',
+    },
+    garmrReset: {
+      name: 'garmr_reset',
+      description: 'How many times breaker has been reset',
+    },
+    garmrRetry: {
+      name: 'garmr_retry',
+      description: 'How many times a request has been retried',
+    },
+  },
 };
 
 export const counters: Partial<{


### PR DESCRIPTION
- circuit breaker implementation for FeedClient
- can be injected into other feed services like Lofn
- can also be used outside of classes/clients as regular instance/singleton
- possibly we can expose more options and different types of [breaker strategies](https://github.com/connor4312/cockatiel?tab=readme-ov-file#circuitbreakerpolicy--halfopenafter-breaker-initialstate-)

TODO
- [x] check tests (disable breaker in tests)
- [x] return specific error when circuit is broken
- [x] adjust options to match volume expected for feed service