### PR TITLE
fix: hide alert if streak recover no longer available;

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -28,6 +28,7 @@ import {
   UserStreakActionType,
   getAuthorPostStats,
   streakRecoverCost,
+  Alerts,
 } from '../entity';
 import {
   AuthenticationError,
@@ -1983,6 +1984,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       const oldStreakLength = await getRestoreStreakCache({ userId });
       if (!oldStreakLength) {
+        await ctx.con
+          .getRepository(Alerts)
+          .update({ userId }, { showRecoverStreak: false });
         throw new ValidationError('No streak to recover');
       }
 


### PR DESCRIPTION
As is, we hide the alert only when the user pass from 0 -> 1 in streak length. 
But if user keep not reading the banner will showing forever at every reload even if he keep click on "Recover my streak" on frontend. This will fix this issue.