### PR TITLE
chore: adjust digest limits and processing

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -386,10 +386,10 @@ if (isAdhocEnv) {
       args: ['dumb-init', 'node', 'bin/cli', 'personalized-digest'],
       minReplicas: 1,
       maxReplicas: 1,
-      limits: { memory: '2Gi' },
+      limits: { memory: '1Gi' },
       requests: {
         cpu: '1',
-        memory: '1Gi',
+        memory: '512Mi',
       },
       metric: {
         type: 'pubsub',

--- a/src/commands/personalizedDigest.ts
+++ b/src/commands/personalizedDigest.ts
@@ -39,7 +39,7 @@ export default async function app(): Promise<void> {
           logger,
           pubsub,
         ),
-      50,
+      100,
     ),
   );
 }

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -172,8 +172,8 @@ const personalizedDigestFeedClient = new FeedClient(
       minimumRps: 1,
     },
     limits: {
-      maxRequests: 50,
-      queuedRequests: 50,
+      maxRequests: 150,
+      queuedRequests: 100,
     },
     retryOpts: {
       maxAttempts: 0,


### PR DESCRIPTION
- lower memory (we were nowhere close to 2Gi)
- increase parallel processing to 100 messages on worker
  - adjust garmr to match