### PR TITLE
feat: send weekly digest per timezone offset

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -42,7 +42,7 @@ export const crons: Cron[] = [
   },
   {
     name: 'personalized-digest',
-    schedule: '15 0 * * *',
+    schedule: '15 * * * *',
     limits: {
       memory: '1Gi',
     },

--- a/__tests__/cron/dailyDigest.ts
+++ b/__tests__/cron/dailyDigest.ts
@@ -1,5 +1,5 @@
 import cron from '../../src/cron/dailyDigest';
-import { expectSuccessfulCron, saveFixtures } from '../helpers';
+import { doNotFake, expectSuccessfulCron, saveFixtures } from '../helpers';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import {
@@ -51,22 +51,7 @@ describe('dailyDigest cron', () => {
 
     jest
       .useFakeTimers({
-        doNotFake: [
-          'hrtime',
-          'nextTick',
-          'performance',
-          'queueMicrotask',
-          'requestAnimationFrame',
-          'cancelAnimationFrame',
-          'requestIdleCallback',
-          'cancelIdleCallback',
-          'setImmediate',
-          'clearImmediate',
-          'setInterval',
-          'clearInterval',
-          'setTimeout',
-          'clearTimeout',
-        ],
+        doNotFake,
       })
       // set day to Tuesday to avoid weekend overlaps
       .setSystemTime(setDay(currentDate, 2));

--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -77,7 +77,7 @@ describe('personalizedDigest cron', () => {
     jest.useRealTimers();
   });
 
-  it('should schedule generation', async () => {
+  it('should schedule generation for interval', async () => {
     const usersToSchedule = usersFixture;
 
     await con.getRepository(UserPersonalizedDigest).save(

--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -12,7 +12,7 @@ import {
   digestPreferredHourOffset,
   notifyGeneratePersonalizedDigest,
 } from '../../src/common';
-import { format, setDay, startOfHour } from 'date-fns';
+import { addDays, format, setDay, setHours, startOfHour } from 'date-fns';
 import { logger } from '../../src/logger';
 import { getTimezoneOffset } from 'date-fns-tz';
 import { crons } from '../../src/cron/index';
@@ -125,11 +125,15 @@ describe('personalizedDigest cron', () => {
     const usersToSchedule = usersFixture;
 
     const fakePreferredDay = 3;
+    const fakeDate = setHours(
+      new Date('2024-09-11T10:32:42.680Z'),
+      fakePreferredHour - digestPreferredHourOffset,
+    );
     jest
       .useFakeTimers({
         doNotFake,
       })
-      .setSystemTime(new Date('2024-09-11T10:32:42.680Z'));
+      .setSystemTime(fakeDate);
 
     digestTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss');
 
@@ -174,14 +178,17 @@ describe('personalizedDigest cron', () => {
     const [, ...usersToSchedule] = usersFixture;
 
     const fakePreferredDay = 3;
+    const fakeDate = setHours(
+      new Date('2024-09-11T10:32:42.680Z'),
+      fakePreferredHour - digestPreferredHourOffset,
+    );
     jest
       .useFakeTimers({
         doNotFake,
       })
-      .setSystemTime(new Date('2024-09-11T10:32:42.680Z'));
+      .setSystemTime(fakeDate);
 
-    const fakeDate = new Date('2024-09-13T10:32:42.680Z');
-    digestTime = format(fakeDate, 'yyyy-MM-dd HH:mm:ss');
+    digestTime = format(addDays(new Date(), 2), 'yyyy-MM-dd HH:mm:ss');
 
     await con.getRepository(UserPersonalizedDigest).save(
       usersToSchedule.map((item) => ({

--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -8,8 +8,13 @@ import {
   UserPersonalizedDigestSendType,
 } from '../../src/entity';
 import { usersFixture } from '../fixture/user';
-import { notifyGeneratePersonalizedDigest } from '../../src/common';
+import {
+  digestPreferredHourOffset,
+  notifyGeneratePersonalizedDigest,
+} from '../../src/common';
+import { setDay, startOfHour } from 'date-fns';
 import { logger } from '../../src/logger';
+import { getTimezoneOffset } from 'date-fns-tz';
 
 let con: DataSource;
 
@@ -22,14 +27,54 @@ jest.mock('../../src/common/pubsub', () => ({
   notifyGeneratePersonalizedDigest: jest.fn(),
 }));
 
+function clampToHours(num: number): number {
+  return ((num % 24) + 24) % 24;
+}
+
 describe('personalizedDigest cron', () => {
-  const preferredDay = (new Date().getDay() + 1) % 7;
+  const sendType = UserPersonalizedDigestSendType.weekly;
+  const preferredDay = new Date().getDay();
+  let fakePreferredHour = 9;
 
   beforeEach(async () => {
     jest.resetAllMocks();
 
     await saveFixtures(con, User, usersFixture);
     await con.getRepository(UserPersonalizedDigest).clear();
+
+    const currentDate = new Date();
+    fakePreferredHour = clampToHours(
+      currentDate.getHours() + digestPreferredHourOffset,
+    );
+
+    jest
+      .useFakeTimers({
+        doNotFake: [
+          'hrtime',
+          'nextTick',
+          'performance',
+          'queueMicrotask',
+          'requestAnimationFrame',
+          'cancelAnimationFrame',
+          'requestIdleCallback',
+          'cancelIdleCallback',
+          'setImmediate',
+          'clearImmediate',
+          'setInterval',
+          'clearInterval',
+          'setTimeout',
+          'clearTimeout',
+        ],
+      })
+      // set day to Tuesday to avoid weekend overlaps
+      .setSystemTime(setDay(currentDate, 2));
+
+    await saveFixtures(con, User, usersFixture);
+    await con.getRepository(UserPersonalizedDigest).clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should schedule generation', async () => {
@@ -39,6 +84,7 @@ describe('personalizedDigest cron', () => {
       usersToSchedule.map((item) => ({
         userId: item.id,
         preferredDay,
+        preferredHour: fakePreferredHour,
       })),
     );
 
@@ -71,13 +117,15 @@ describe('personalizedDigest cron', () => {
     );
   });
 
-  it('should only schedule generation for next day subscriptions', async () => {
+  it('should not schedule generation for subscriptions with other preferredDay', async () => {
     const [, ...usersToSchedule] = usersFixture;
+    const sendDay = (preferredDay + 1) % 7;
 
     await con.getRepository(UserPersonalizedDigest).save(
       usersToSchedule.map((item) => ({
         userId: item.id,
-        preferredDay,
+        preferredDay: sendDay,
+        preferredHour: fakePreferredHour,
       })),
     );
 
@@ -86,28 +134,11 @@ describe('personalizedDigest cron', () => {
     const scheduledPersonalizedDigests = await con
       .getRepository(UserPersonalizedDigest)
       .findBy({
-        preferredDay,
+        preferredDay: sendDay,
       });
 
-    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(
-      usersToSchedule.length,
-    );
-    scheduledPersonalizedDigests.forEach((personalizedDigest) => {
-      expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledWith({
-        log: expect.anything(),
-        personalizedDigest,
-        emailSendTimestamp: expect.any(Number),
-        previousSendTimestamp: expect.any(Number),
-        emailBatchId: expect.any(String),
-      });
-    });
-    (notifyGeneratePersonalizedDigest as jest.Mock).mock.calls.forEach(
-      (call) => {
-        const { emailSendTimestamp, previousSendTimestamp } = call?.[0] || {};
-
-        expect(emailSendTimestamp).toBeGreaterThan(previousSendTimestamp);
-      },
-    );
+    expect(scheduledPersonalizedDigests.length).toBeGreaterThan(0);
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(0);
   });
 
   it('should log notify count', async () => {
@@ -117,6 +148,7 @@ describe('personalizedDigest cron', () => {
       usersToSchedule.map((item) => ({
         userId: item.id,
         preferredDay,
+        preferredHour: fakePreferredHour,
       })),
     );
 
@@ -127,7 +159,7 @@ describe('personalizedDigest cron', () => {
       {
         digestCount: usersToSchedule.length,
         emailBatchId: expect.any(String),
-        sendType: UserPersonalizedDigestSendType.weekly,
+        sendType,
       },
       'personalized digest sent',
     );
@@ -140,6 +172,7 @@ describe('personalizedDigest cron', () => {
       usersToSchedule.map((item) => ({
         userId: item.id,
         preferredDay,
+        preferredHour: fakePreferredHour,
         flags: {
           sendType: UserPersonalizedDigestSendType.workdays,
         },
@@ -165,8 +198,9 @@ describe('personalizedDigest cron', () => {
       usersToSchedule.map((item) => ({
         userId: item.id,
         preferredDay,
+        preferredHour: fakePreferredHour,
         flags: {
-          sendType: UserPersonalizedDigestSendType.weekly,
+          sendType,
         },
       })),
     );
@@ -181,5 +215,144 @@ describe('personalizedDigest cron', () => {
 
     expect(personalizedDigestRowsForDay).toHaveLength(usersToSchedule.length);
     expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(4);
+  });
+
+  it('should schedule generation for users with timezone behind UTC', async () => {
+    const currentDate = new Date();
+    const timezoneOffset =
+      getTimezoneOffset('America/Phoenix') / (60 * 60 * 1000);
+    const fakePreferredHourTimezone = clampToHours(
+      currentDate.getHours() + digestPreferredHourOffset + timezoneOffset,
+    );
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay,
+        preferredHour: fakePreferredHourTimezone,
+        flags: {
+          sendType,
+        },
+      })),
+    );
+    await con.getRepository(User).save(
+      usersToSchedule.map((item) => ({
+        id: item.id,
+        timezone: 'America/Phoenix',
+      })),
+    );
+
+    await expectSuccessfulCron(cron);
+
+    const scheduledPersonalizedDigests = await con
+      .getRepository(UserPersonalizedDigest)
+      .findBy({
+        preferredDay,
+      });
+
+    expect(scheduledPersonalizedDigests).toHaveLength(usersToSchedule.length);
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(4);
+  });
+
+  it('should schedule generation for users with timezone ahead UTC', async () => {
+    const currentDate = new Date();
+    const timezoneOffset = getTimezoneOffset('Asia/Tokyo') / (60 * 60 * 1000);
+    const fakePreferredHourTimezone = clampToHours(
+      currentDate.getHours() + digestPreferredHourOffset + timezoneOffset,
+    );
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay,
+        preferredHour: fakePreferredHourTimezone,
+        flags: {
+          sendType,
+        },
+      })),
+    );
+    await con.getRepository(User).save(
+      usersToSchedule.map((item) => ({
+        id: item.id,
+        timezone: 'Asia/Tokyo',
+      })),
+    );
+
+    await expectSuccessfulCron(cron);
+
+    const scheduledPersonalizedDigests = await con
+      .getRepository(UserPersonalizedDigest)
+      .findBy({
+        preferredDay,
+      });
+
+    expect(scheduledPersonalizedDigests).toHaveLength(usersToSchedule.length);
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(4);
+  });
+
+  it('should not schedule generation for users with prefferedHour in different timezone', async () => {
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay,
+        preferredHour: fakePreferredHour,
+        flags: {
+          sendType,
+        },
+      })),
+    );
+    await con.getRepository(User).save(
+      usersToSchedule.map((item) => ({
+        id: item.id,
+        timezone: 'America/New_York',
+      })),
+    );
+
+    await expectSuccessfulCron(cron);
+
+    const scheduledPersonalizedDigests = await con
+      .getRepository(UserPersonalizedDigest)
+      .findBy({
+        preferredDay,
+      });
+
+    expect(scheduledPersonalizedDigests).toHaveLength(usersToSchedule.length);
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(0);
+  });
+
+  it('should schedule send time in the future to match hours offset', async () => {
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay,
+        preferredHour: fakePreferredHour,
+        flags: {
+          sendType,
+        },
+      })),
+    );
+
+    const timestampBeforeCron = startOfHour(new Date()).getTime();
+
+    await expectSuccessfulCron(cron);
+
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(
+      usersToSchedule.length,
+    );
+    (notifyGeneratePersonalizedDigest as jest.Mock).mock.calls.forEach(
+      (call) => {
+        const { emailSendTimestamp } = call?.[0] || {};
+
+        expect(emailSendTimestamp).toBeGreaterThanOrEqual(
+          timestampBeforeCron + digestPreferredHourOffset * 60 * 60 * 1000,
+        );
+      },
+    );
   });
 });

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -407,3 +407,5 @@ export const dedupedSend = async (
     throw error;
   }
 };
+
+export const getDigestCronTime = (): string => 'NOW()';

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -27,7 +27,7 @@ const cron: Cron = {
       .from(UserPersonalizedDigest, 'upd')
       .leftJoin(User, 'u', 'u.id = upd."userId"')
       .where(
-        `(EXTRACT(DAY FROM NOW() AT TIME ZONE COALESCE(NULLIF(u.timezone, ''), '${DEFAULT_TIMEZONE}')) - 1) = upd."preferredDay"`,
+        `(EXTRACT(DOW FROM NOW() AT TIME ZONE COALESCE(NULLIF(u.timezone, ''), '${DEFAULT_TIMEZONE}'))) = upd."preferredDay"`,
         {
           defaultTimezone: DEFAULT_TIMEZONE,
         },


### PR DESCRIPTION
- send weekly digest per timezone offset same as daily digest
- should split the send over many batches throughout the day instead of single one at midnight
- should also increase weekly digest quality (article freshness) since generation is much closer to send
- currently weekly digest is still sent only on Wednesday (but this logic should support configuration change in the future)