### PR TITLE
fix: reputation event for restoring streak

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -6,6 +6,7 @@ import {
   addDays,
   addHours,
   addSeconds,
+  format,
   startOfDay,
   startOfISOWeek,
   subDays,
@@ -34,6 +35,10 @@ import {
   FeatureValue,
   MarketingCta,
   Post,
+  ReputationEvent,
+  ReputationReason,
+  reputationReasonAmount,
+  ReputationType,
   Source,
   User,
   UserMarketingCta,
@@ -77,6 +82,7 @@ import {
   deleteKeysByPattern,
   deleteRedisKey,
   getRedisObject,
+  ioRedisPool,
   setRedisObjectWithExpiry,
 } from '../src/redis';
 import { generateStorageKey, StorageKey, StorageTopic } from '../src/config';
@@ -676,6 +682,10 @@ describe('query userStreaks', () => {
       }
     `;
 
+    beforeEach(async () => {
+      await ioRedisPool.execute((client) => client.flushall());
+    });
+
     it('should not authorize when not logged in', async () =>
       await testMutationErrorCode(
         client,
@@ -785,6 +795,19 @@ describe('query userStreaks', () => {
 
       const redisCache = await getRestoreStreakCache({ userId: loggedUser });
       expect(redisCache).toBeNull();
+
+      const reputationEvent = await con.getRepository(ReputationEvent).findOne({
+        select: ['amount', 'targetId'],
+        where: {
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakFirstRecovery,
+        },
+      });
+      expect(reputationEvent).toBeTruthy();
+      expect(reputationEvent!.amount).toEqual(0);
+      expect(reputationEvent!.targetId).toEqual(
+        format(new Date(), 'dd-MM-yyyy'),
+      );
     });
 
     it('should not update maxStreak if the recovered streak is less than the current maxStreak', async () => {
@@ -855,6 +878,202 @@ describe('query userStreaks', () => {
       expect(recoverStreak).toBeTruthy();
       expect(recoverStreak.current).toEqual(21);
       expect(recoverStreak.max).toEqual(21);
+    });
+
+    it('should recover streak with 0 points on the first time', async () => {
+      loggedUser = '1';
+      const missing = await con.getRepository(ReputationEvent).findOneBy({
+        targetType: ReputationType.Streak,
+        reason: ReputationReason.StreakFirstRecovery,
+      });
+      expect(missing).toBeNull();
+      await con.getRepository(UserStreak).update(
+        { userId: loggedUser },
+        {
+          currentStreak: 1,
+          maxStreak: 20,
+          lastViewAt: subDays(new Date(), 2),
+        },
+      );
+      await con
+        .getRepository(User)
+        .update({ id: loggedUser }, { reputation: 25 });
+
+      // insert redis key with old streak length
+      const oldLength = 20;
+      const redisKey = generateStorageKey(
+        StorageTopic.Streak,
+        StorageKey.Reset,
+        loggedUser,
+      );
+      await setRedisObjectWithExpiry(
+        redisKey,
+        oldLength,
+        addDays(new Date(), 1).getTime(),
+      );
+
+      const { data, errors } = await client.mutate(MUTATION);
+      const { recoverStreak } = data;
+      expect(errors).toBeFalsy();
+      expect(recoverStreak).toBeTruthy();
+      expect(recoverStreak.current).toEqual(21);
+      expect(recoverStreak.max).toEqual(21);
+      const reputationEvent = await con
+        .getRepository(ReputationEvent)
+        .findOneBy({
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakFirstRecovery,
+        });
+      expect(reputationEvent).toBeTruthy();
+      expect(reputationEvent!.amount).toEqual(0);
+    });
+
+    it('should recover streak with 25 points on the second time', async () => {
+      loggedUser = '1';
+      const yesterday = subDays(new Date(), 1);
+      await con.getRepository(ReputationEvent).save({
+        targetType: ReputationType.Streak,
+        reason: ReputationReason.StreakFirstRecovery,
+        timestamp: yesterday,
+        grantToId: '1',
+        targetId: format(yesterday, 'dd-MM-yyyy'),
+        amount: reputationReasonAmount.streak_recover_for_free,
+      });
+      await con.getRepository(UserStreakAction).save([
+        {
+          userId: loggedUser,
+          type: UserStreakActionType.Recover,
+          createdAt: yesterday,
+        },
+      ]);
+      await con.getRepository(UserStreak).update(
+        { userId: loggedUser },
+        {
+          currentStreak: 1,
+          maxStreak: 20,
+          lastViewAt: subDays(new Date(), 2),
+        },
+      );
+      await con
+        .getRepository(User)
+        .update({ id: loggedUser }, { reputation: 25 });
+
+      // insert redis key with old streak length
+      const oldLength = 20;
+      const redisKey = generateStorageKey(
+        StorageTopic.Streak,
+        StorageKey.Reset,
+        loggedUser,
+      );
+      await setRedisObjectWithExpiry(
+        redisKey,
+        oldLength,
+        addDays(new Date(), 1).getTime(),
+      );
+
+      const { data, errors } = await client.mutate(MUTATION);
+      const { recoverStreak } = data;
+      expect(errors).toBeFalsy();
+      expect(recoverStreak).toBeTruthy();
+      expect(recoverStreak.current).toEqual(21);
+      expect(recoverStreak.max).toEqual(21);
+      const redisCache = await getRestoreStreakCache({ userId: loggedUser });
+      expect(redisCache).toBeNull();
+
+      const reputationEvent = await con.getRepository(ReputationEvent).findOne({
+        select: ['amount', 'targetId'],
+        where: {
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakRecover,
+        },
+      });
+      expect(reputationEvent).toBeTruthy();
+      expect(reputationEvent!.amount).toEqual(-25);
+      expect(reputationEvent!.targetId).toEqual(
+        format(new Date(), 'dd-MM-yyyy'),
+      );
+    });
+
+    it('should recover streak with 25 points on the third time', async () => {
+      loggedUser = '1';
+      const yesterday = subDays(new Date(), 1);
+      const twoDaysAgo = subDays(yesterday, 1);
+      await con.getRepository(ReputationEvent).save([
+        {
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakFirstRecovery,
+          timestamp: yesterday,
+          grantToId: '1',
+          targetId: format(twoDaysAgo, 'dd-MM-yyyy'),
+          amount: reputationReasonAmount.streak_recover_for_free,
+        },
+        {
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakRecover,
+          timestamp: yesterday,
+          grantToId: '1',
+          targetId: format(yesterday, 'dd-MM-yyyy'),
+          amount: reputationReasonAmount.streak_recover,
+        },
+      ]);
+      await con.getRepository(UserStreakAction).save([
+        {
+          userId: loggedUser,
+          type: UserStreakActionType.Recover,
+          createdAt: twoDaysAgo,
+        },
+        {
+          userId: loggedUser,
+          type: UserStreakActionType.Recover,
+          createdAt: yesterday,
+        },
+      ]);
+      await con.getRepository(UserStreak).update(
+        { userId: loggedUser },
+        {
+          currentStreak: 1,
+          maxStreak: 20,
+          lastViewAt: subDays(new Date(), 2),
+        },
+      );
+      await con
+        .getRepository(User)
+        .update({ id: loggedUser }, { reputation: 25 });
+
+      // insert redis key with old streak length
+      const oldLength = 20;
+      const redisKey = generateStorageKey(
+        StorageTopic.Streak,
+        StorageKey.Reset,
+        loggedUser,
+      );
+      await setRedisObjectWithExpiry(
+        redisKey,
+        oldLength,
+        addDays(new Date(), 1).getTime(),
+      );
+
+      const { data, errors } = await client.mutate(MUTATION);
+      const { recoverStreak } = data;
+      expect(errors).toBeFalsy();
+      expect(recoverStreak).toBeTruthy();
+      expect(recoverStreak.current).toEqual(21);
+      expect(recoverStreak.max).toEqual(21);
+      const redisCache = await getRestoreStreakCache({ userId: loggedUser });
+      expect(redisCache).toBeNull();
+
+      const reputationEvents = await con.getRepository(ReputationEvent).find({
+        select: ['amount'],
+        where: {
+          targetType: ReputationType.Streak,
+          reason: ReputationReason.StreakRecover,
+        },
+      });
+      expect(reputationEvents.length).toEqual(2);
+      const sameAmounts = reputationEvents.every(
+        ({ amount }) => amount === -25,
+      );
+      expect(sameAmounts).toBeTruthy();
     });
   });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -606,69 +606,6 @@ describe('query userStreaks', () => {
 
       await expectStreak(5, 5, lastViewAt);
     });
-
-    describe('streak recover query', () => {
-      const QUERY = `query StreakRecover {
-        streakRecover {
-          canRecover
-          cost
-          oldStreakLength
-        }
-      }`;
-
-      it('should return recover data when user fetch query', async () => {
-        nock('http://localhost:5000').post('/e').reply(204);
-        loggedUser = '1';
-
-        const { data, errors } = await client.query(QUERY);
-        expect(errors).toBeFalsy();
-        const { streakRecover } = data;
-        expect(streakRecover).toHaveProperty('canRecover');
-        expect(streakRecover).toHaveProperty('cost');
-        expect(streakRecover).toHaveProperty('oldStreakLength');
-      });
-
-      it('should disallow recover when user is not authenticated', async () => {
-        loggedUser = null;
-        return testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED');
-      });
-
-      it('should disallow recover when user has no streak', async () => {
-        loggedUser = '2';
-        const { data, errors } = await client.query(QUERY);
-        expect(errors).toBeFalsy();
-        expect(data.streakRecover.canRecover).toBeFalsy();
-      });
-
-      it('should allow recover when user has streak', async () => {
-        loggedUser = '1';
-        const oldLength = 5;
-        await con.getRepository(UserStreak).save({
-          userId: loggedUser,
-          currentStreak: 0,
-          lastViewAt: subDays(new Date(), 2),
-        });
-
-        // insert redis key with old streak length
-        const redisKey = generateStorageKey(
-          StorageTopic.Streak,
-          StorageKey.Reset,
-          loggedUser,
-        );
-        await setRedisObjectWithExpiry(
-          redisKey,
-          oldLength,
-          addDays(new Date(), 1).getTime(),
-        );
-
-        const { data, errors } = await client.query(QUERY);
-        expect(errors).toBeFalsy();
-        expect(data.streakRecover.canRecover).toBeTruthy();
-        expect(data.streakRecover.oldStreakLength).toBe(oldLength);
-
-        await deleteRedisKey(redisKey);
-      });
-    });
   });
 
   it('should not reset streak on Saturday when last read is Friday', async () => {
@@ -799,6 +736,69 @@ describe('query userStreaks', () => {
 
     jest.useFakeTimers({ advanceTimers: true, now: fakeTodayTz });
     await expectStreak(5, 5, lastViewAtTz);
+  });
+});
+
+describe('streak recover query', () => {
+  const QUERY = `query StreakRecover {
+    streakRecover {
+      canRecover
+      cost
+      oldStreakLength
+    }
+  }`;
+
+  it('should return recover data when user fetch query', async () => {
+    nock('http://localhost:5000').post('/e').reply(204);
+    loggedUser = '1';
+
+    const { data, errors } = await client.query(QUERY);
+    expect(errors).toBeFalsy();
+    const { streakRecover } = data;
+    expect(streakRecover).toHaveProperty('canRecover');
+    expect(streakRecover).toHaveProperty('cost');
+    expect(streakRecover).toHaveProperty('oldStreakLength');
+  });
+
+  it('should disallow recover when user is not authenticated', async () => {
+    loggedUser = null;
+    return testQueryErrorCode(client, { query: QUERY }, 'UNAUTHENTICATED');
+  });
+
+  it('should disallow recover when user has no streak', async () => {
+    loggedUser = '2';
+    const { data, errors } = await client.query(QUERY);
+    expect(errors).toBeFalsy();
+    expect(data.streakRecover.canRecover).toBeFalsy();
+  });
+
+  it('should allow recover when user has streak', async () => {
+    loggedUser = '1';
+    const oldLength = 5;
+    await con.getRepository(UserStreak).save({
+      userId: loggedUser,
+      currentStreak: 0,
+      lastViewAt: subDays(new Date(), 2),
+    });
+
+    // insert redis key with old streak length
+    const redisKey = generateStorageKey(
+      StorageTopic.Streak,
+      StorageKey.Reset,
+      loggedUser,
+    );
+    await setRedisObjectWithExpiry(
+      redisKey,
+      oldLength,
+      addDays(new Date(), 1).getTime(),
+    );
+
+    const { data, errors } = await client.query(QUERY);
+    expect(errors).toBeFalsy();
+    expect(data.streakRecover.canRecover).toBeTruthy();
+    expect(data.streakRecover.oldStreakLength).toBe(oldLength);
+
+    await deleteRedisKey(redisKey);
   });
 });
 

--- a/src/entity/user/UserStreakAction.ts
+++ b/src/entity/user/UserStreakAction.ts
@@ -1,14 +1,9 @@
 import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import type { User } from './User';
-import { ReputationReason, reputationReasonAmount } from '../ReputationEvent';
 
 export enum UserStreakActionType {
   Recover = 'recover',
 }
-
-export const streakRecoverCost = Math.abs(
-  reputationReasonAmount[ReputationReason.StreakRecover],
-);
 
 @Entity()
 export class UserStreakAction {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -99,6 +99,7 @@ import { UserCompany } from '../entity/UserCompany';
 import { generateVerifyCode } from '../ids';
 import { validateUserUpdate } from '../entity/user/utils';
 import { getRestoreStreakCache } from '../workers/cdc/primary';
+import { format } from 'date-fns';
 
 export interface GQLUpdateUserInput {
   name: string;
@@ -2011,7 +2012,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       const reputationEvent = {
         grantToId: userId,
-        targetId: userId,
+        targetId: format(new Date(), 'dd-MM-yyyy'),
         targetType: ReputationType.Streak,
         reason: isFirstRecover
           ? ReputationReason.StreakFirstRecovery

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1313,7 +1313,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       return {
         canRecover: true,
         oldStreakLength,
-        cost,
+        cost: Math.abs(cost),
       };
     },
     userReads: async (): Promise<number> => {


### PR DESCRIPTION
Restoring for the 3rd time might introduce an issue. In this case, we should just use when the restoration happened for the target id to provide uniqueness.