### PR TITLE
fix: flaky comment feed test

### DIFF
--- a/__tests__/triggers/user.ts
+++ b/__tests__/triggers/user.ts
@@ -2,7 +2,13 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { saveFixtures } from '../helpers';
 import { badUsersFixture, usersFixture } from '../fixture/user';
-import { Post, Source, User, UserStreak, Comment } from '../../src/entity';
+import {
+  Source,
+  User,
+  UserStreak,
+  Comment,
+  ArticlePost,
+} from '../../src/entity';
 import { sourcesFixture } from '../fixture';
 import { postsFixture } from '../fixture/post';
 
@@ -41,38 +47,46 @@ describe('user', () => {
       await saveFixtures(con, User, usersFixture);
       await saveFixtures(con, User, badUsersFixture);
       await saveFixtures(con, Source, sourcesFixture);
-      await saveFixtures(con, Post, postsFixture);
+      await saveFixtures(con, ArticlePost, [
+        {
+          ...postsFixture[0],
+          id: 'pvr1',
+          shortId: 'pvr1',
+          url: 'http://pvr1.com',
+          canonicalUrl: 'http://pvr1c.com',
+        },
+      ]);
       await saveFixtures(con, Comment, [
         {
-          id: 'c1',
-          postId: 'p1',
+          id: 'cvr1',
+          postId: 'pvr1',
           userId: '1',
           content: 'comment',
           contentHtml: '<p>comment</p>',
           flags: { vordr: false },
         },
         {
-          id: 'c2',
-          parentId: 'c1',
-          postId: 'p1',
+          id: 'cvr2',
+          parentId: 'cvr1',
+          postId: 'pvr1',
           userId: '1',
           content: 'comment',
           contentHtml: '<p>comment</p>',
           flags: { vordr: false },
         },
         {
-          id: 'c3',
-          parentId: 'c1',
-          postId: 'p1',
+          id: 'cvr3',
+          parentId: 'cvr1',
+          postId: 'pvr1',
           userId: 'vordr',
           content: 'comment',
           contentHtml: '<p>comment</p>',
           flags: { vordr: true },
         },
         {
-          id: 'c4',
-          parentId: 'c1',
-          postId: 'p1',
+          id: 'cvr4',
+          parentId: 'cvr1',
+          postId: 'pvr1',
           userId: 'vordr',
           content: 'comment',
           contentHtml: '<p>comment</p>',


### PR DESCRIPTION
Hopefully fixes flaky test with comments feed. https://app.circleci.com/pipelines/github/dailydotdev/daily-api/9579/workflows/ed62130f-b122-451c-bd8a-4350e8035d4a/jobs/38531/tests

I found that `vordr flag` suite saves fixture for 4 comments to have `vordr: true` which is exact difference of test case failing:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/0b5a32ad-b9f2-4b11-b813-280369c5bd2c">

This happens because we run our tests in parallel (over multiple workers) so even though its in describe they will execute in the same time against the db, hence the flakiness. 