### PR TITLE
fix: filter non-featured flags

### DIFF
--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -323,6 +323,25 @@ describe('query sources', () => {
     expect(isFeatured).toBeTruthy();
   });
 
+  it('should return only non-featured sources - this means when flag is false or undefined', async () => {
+    await prepareFeaturedTests();
+    await con.getRepository(Source).save(sourcesFixture[2]);
+    await con
+      .getRepository(Source)
+      .update({ id: 'c' }, { type: SourceType.Squad, private: false });
+    const res = await client.query(
+      QUERY({ first: 10, filterOpenSquads: true, featured: false }),
+    );
+    const isNonFeatured = res.data.sources.edges.every(
+      ({ node }) => node.flags.featured !== true,
+    );
+    expect(isNonFeatured).toBeTruthy();
+    const emptyFlags = res.data.sources.edges.find(
+      ({ node }) => node.id === 'c',
+    );
+    expect(emptyFlags).toBeTruthy();
+  });
+
   it('should return only not featured sources', async () => {
     await prepareFeaturedTests();
     const res = await client.query(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1245,10 +1245,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
           if (!isNullOrUndefined(args.featured)) {
             builder.queryBuilder.andWhere(
-              `(${builder.alias}.flags->'featured')::boolean = :featured`,
-              {
-                featured: args.featured,
-              },
+              `COALESCE((${builder.alias}.flags->'featured')::boolean, FALSE) = :featured`,
+              { featured: args.featured },
             );
           }
 


### PR DESCRIPTION
Filtering `featured` squads is easy, as we just need to know if the value is true. However, when we want to filter non-featured Squads, we must also check whether the flags exist already. As seen on the first commit, the query failed.