### PR TITLE
feat: content updated protobuf format

### DIFF
--- a/__tests__/common/pubsub.ts
+++ b/__tests__/common/pubsub.ts
@@ -1,0 +1,39 @@
+import { ContentUpdatedMessage } from '@dailydotdev/schema';
+import { publishEvent, pubsub } from '../../src/common/pubsub';
+import { logger } from '../../src/logger';
+
+describe('publishEvent', () => {
+  beforeEach(() => {
+    process.env.ENABLE_PUBSUB = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.ENABLE_PUBSUB;
+  });
+
+  it('should publish JSON message', async () => {
+    const topic = pubsub.topic('api.v1.test');
+    topic.publishMessage = jest.fn();
+
+    await publishEvent(logger, topic, { test: 'data' });
+
+    expect(topic.publishMessage).toHaveBeenCalledTimes(1);
+    expect(topic.publishMessage).toHaveBeenCalledWith({
+      json: {
+        test: 'data',
+      },
+    });
+  });
+
+  it('should publish protobuf message', async () => {
+    const topic = pubsub.topic('api.v1.test');
+    topic.publishMessage = jest.fn();
+
+    await publishEvent(logger, topic, new ContentUpdatedMessage());
+
+    expect(topic.publishMessage).toHaveBeenCalledTimes(1);
+    expect(topic.publishMessage).toHaveBeenCalledWith({
+      data: expect.any(Buffer),
+    });
+  });
+});

--- a/__tests__/fixture/post.ts
+++ b/__tests__/fixture/post.ts
@@ -358,6 +358,8 @@ export const postAuthorsFixture = [
   },
 ];
 
+const contentUpdatedPostCreatedAtNs = Date.now() * 1000;
+
 export const contentUpdatedPost = {
   yggdrasilId: 'f30cdfd4-80cd-4955-bed1-0442dc5511bf',
   id: 'p4',
@@ -365,8 +367,8 @@ export const contentUpdatedPost = {
   shortId: 'sp4',
   type: PostType.Article,
   title: 'Post for testing',
-  createdAt: Date.now() - 1000,
-  metadataChangedAt: Date.now(),
+  createdAt: contentUpdatedPostCreatedAtNs,
+  metadataChangedAt: contentUpdatedPostCreatedAtNs + 1000,
   sourceId: 'a',
   tagsStr: 'javascript,webdev,react',
   banned: false,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3267,6 +3267,7 @@ describe('post content updated', () => {
       type: PostType.Article,
       url: 'http://p4.com',
       canonicalUrl: 'http://p4c.com',
+      contentMeta: '{}',
     };
     await expectSuccessfulBackground(
       worker,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3257,6 +3257,39 @@ describe('post content updated', () => {
       ],
     );
   });
+
+  it('should transform ns timestamp to seconds', async () => {
+    type ArticlePostJsonB = Omit<ArticlePost, 'contentMeta'> & {
+      contentMeta: string;
+    };
+    const after: ChangeObject<ArticlePostJsonB> = {
+      ...contentUpdatedPost,
+      type: PostType.Article,
+      url: 'http://p4.com',
+      canonicalUrl: 'http://p4c.com',
+    };
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ArticlePostJsonB>({
+        after,
+        before: after,
+        op: 'u',
+        table: 'post',
+      }),
+    );
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toMatchObject(
+      [
+        'api.v1.content-updated',
+        {
+          createdAt: Math.floor(contentUpdatedPost.createdAt / 1_000_000),
+          updatedAt: Math.floor(
+            contentUpdatedPost.metadataChangedAt / 1_000_000,
+          ),
+        },
+      ],
+    );
+  });
 });
 
 describe('user streak change', () => {

--- a/src/common/date.ts
+++ b/src/common/date.ts
@@ -26,3 +26,9 @@ export const isWeekend = (
       return day === DayOfWeek.Saturday || day === DayOfWeek.Sunday;
   }
 };
+
+export const getSecondsTimestamp = (ms: number | Date): number => {
+  const msValue = ms instanceof Date ? ms.getTime() : ms;
+
+  return Math.floor(msValue / 1000);
+};

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -33,6 +33,7 @@ import { DataSource } from 'typeorm';
 import { FastifyLoggerInstance } from 'fastify';
 import pino from 'pino';
 import { PersonalizedDigestFeatureConfig } from '../growthbook';
+import { Message as ProtobufMessage } from '@bufbuild/protobuf';
 
 export const pubsub = new PubSub();
 const postCommentedTopic = pubsub.topic('post-commented');
@@ -100,10 +101,18 @@ export const publishEvent = async (
         process.env.NODE_ENV === 'production' ||
         process.env.ENABLE_PUBSUB === 'true'
       ) {
+        const isProtobufMessage = payload instanceof ProtobufMessage;
+
         try {
-          await topic.publishMessage({
-            json: payload,
-          });
+          await topic.publishMessage(
+            isProtobufMessage
+              ? {
+                  data: Buffer.from(payload.toBinary()),
+                }
+              : {
+                  json: payload,
+                },
+          );
         } catch (err) {
           log.error(
             { err, topic: topic.name, payload },

--- a/src/workers/cdc/common.ts
+++ b/src/workers/cdc/common.ts
@@ -14,8 +14,10 @@ import {
 import { ChangeObject } from '../../types';
 import { PostKeyword, Source } from '../../entity';
 import { triggerTypedEvent } from '../../common';
+import { getSecondsTimestamp } from '../../common/date';
 import { logger } from '../../logger';
 import { JsonValue, Message } from '@bufbuild/protobuf';
+import { debeziumTimeToDate } from '../../common/utils';
 
 export const isChanged = <T>(before: T, after: T, property: keyof T): boolean =>
   before[property] != after[property];
@@ -88,12 +90,12 @@ export const notifyPostContentUpdated = async ({
     postId: post.id,
     type: post.type,
     title: post.title,
-    createdAt: post.createdAt,
-    updatedAt: post.metadataChangedAt,
+    createdAt: getSecondsTimestamp(debeziumTimeToDate(post.createdAt)),
+    updatedAt: getSecondsTimestamp(debeziumTimeToDate(post.metadataChangedAt)),
     source: source
       ? {
           ...source,
-          createdAt: +source.createdAt,
+          createdAt: getSecondsTimestamp(source.createdAt),
         }
       : undefined,
     tags: post.tagsStr?.split(',') || [],
@@ -116,7 +118,7 @@ export const notifyPostContentUpdated = async ({
     }),
     relatedPosts: relatedPosts.map((item) => ({
       ...item,
-      createdAt: +item.createdAt,
+      createdAt: getSecondsTimestamp(item.createdAt),
     })),
     contentCuration: post.contentCuration || [],
     contentQuality: decodeJsonField({


### PR DESCRIPTION
- content updated topic will now get messages in protobuf format (Viktor is the only subscriber currently)
- added support to send Buffer messages to `publishEvent`
- also fixes sending ns/ms instead of seconds as timestamp