### PR TITLE
chore: fix deprecation warnings and re-enable tracing with 0 sampling

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -106,9 +106,9 @@ config:
       secure: AAABAI/bDI+xz5PMlMZseI2kW5oanHk3z1KcAOZJb+/G8arhgSP1EMdqdOTk0kku1t6KTWtl9+oSSDKWYNH1CG5D+Ac1ZPFAWc/ldmEb/iU=
     onesignalAppId:
       secure: AAABALTizkxZkCfsq6/fx2v7nXxsVP7psWBfSUct0zeyrX0ABxPpD30zIsyx5r5wqt1UJIIXDIVOnhM7W3vzrzaatrE=
-    otelEnabled: false
+    otelEnabled: true
     otelTracesSampler: parentbased_traceidratio
-    otelTracesSamplerArg: 0.05
+    otelTracesSamplerArg: 0
     personalizedDigestFeed:
       secure: AAABABnHXr0d1pbDX7KRjoBXvFnr7ImTUJ7Y88GlhlaC7EiSG/nxVLHtnQL0hgczHqt1bPn25TN/R8Au6CEAQpq6dGXLwCfA+gWPypTVHg==
     personalizedDigestSecret:

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@opentelemetry/resource-detector-container": "^0.4.1",
         "@opentelemetry/resource-detector-gcp": "^0.29.11",
         "@opentelemetry/sdk-node": "^0.53.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@sendgrid/eventwebhook": "^8.0.0",
         "@slack/web-api": "^7.4.0",
         "@slack/webhook": "^7.0.3",
@@ -1357,6 +1358,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/pubsub/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@google-cloud/storage": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.12.1.tgz",
@@ -2262,14 +2272,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.53.0.tgz",
@@ -2414,14 +2416,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
@@ -2457,14 +2451,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.43.0.tgz",
@@ -2494,14 +2480,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
@@ -2517,14 +2495,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
@@ -2543,14 +2513,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-pg": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.44.0.tgz",
@@ -2567,14 +2529,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
@@ -2711,14 +2665,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/resource-detector-container/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/resource-detector-gcp": {
       "version": "0.29.11",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.11.tgz",
@@ -2736,14 +2682,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/resource-detector-gcp/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/resources": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
@@ -2757,14 +2695,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
@@ -2827,14 +2757,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
@@ -2849,14 +2771,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
@@ -2879,9 +2793,10 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@opentelemetry/resource-detector-container": "^0.4.1",
     "@opentelemetry/resource-detector-gcp": "^0.29.11",
     "@opentelemetry/sdk-node": "^0.53.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0",
     "@sendgrid/eventwebhook": "^8.0.0",
     "@slack/web-api": "^7.4.0",
     "@slack/webhook": "^7.0.3",

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -3,11 +3,11 @@ import isNetworkError from './networkError';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { runInSpan } from '../telemetry';
 import {
-  SEMATTRS_EXCEPTION_MESSAGE,
-  SEMATTRS_EXCEPTION_TYPE,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_HTTP_URL,
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_TYPE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions';
 
 export class AbortError extends Error {
@@ -98,9 +98,9 @@ export function retryFetch(
     asyncRetry(async () => {
       const res = await fetch(url, fetchOpts);
       span.setAttributes({
-        [SEMATTRS_HTTP_URL]: url.toString(),
-        [SEMATTRS_HTTP_STATUS_CODE]: res.status,
-        [SEMATTRS_HTTP_METHOD]: fetchOpts.method,
+        [ATTR_URL_FULL]: url.toString(),
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: res.status,
+        [ATTR_HTTP_REQUEST_METHOD]: fetchOpts.method,
       });
       if (res.ok) {
         return res;
@@ -108,8 +108,8 @@ export function retryFetch(
       const err = new HttpError(url.toString(), res.status, await res.text());
       if (res.status < 500) {
         span.setAttributes({
-          [SEMATTRS_EXCEPTION_TYPE]: err.name,
-          [SEMATTRS_EXCEPTION_MESSAGE]: err.message,
+          [ATTR_EXCEPTION_TYPE]: err.name,
+          [ATTR_EXCEPTION_MESSAGE]: err.message,
         });
         throw new AbortError(err);
       }

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -1,14 +1,14 @@
 import retry, { OperationOptions } from 'retry';
 import isNetworkError from './networkError';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
+import { runInSpan } from '../telemetry';
 import {
-  runInSpan,
   SEMATTRS_EXCEPTION_MESSAGE,
   SEMATTRS_EXCEPTION_TYPE,
   SEMATTRS_HTTP_METHOD,
   SEMATTRS_HTTP_STATUS_CODE,
   SEMATTRS_HTTP_URL,
-} from '../telemetry';
+} from '@opentelemetry/semantic-conventions';
 
 export class AbortError extends Error {
   public originalError: Error;

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -1,7 +1,14 @@
 import retry, { OperationOptions } from 'retry';
 import isNetworkError from './networkError';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
-import { runInSpan, TelemetrySemanticAttributes } from '../telemetry';
+import {
+  runInSpan,
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_TYPE,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_HTTP_URL,
+} from '../telemetry';
 
 export class AbortError extends Error {
   public originalError: Error;
@@ -91,9 +98,9 @@ export function retryFetch(
     asyncRetry(async () => {
       const res = await fetch(url, fetchOpts);
       span.setAttributes({
-        [TelemetrySemanticAttributes.HTTP_URL]: url.toString(),
-        [TelemetrySemanticAttributes.HTTP_STATUS_CODE]: res.status,
-        [TelemetrySemanticAttributes.HTTP_METHOD]: fetchOpts.method,
+        [SEMATTRS_HTTP_URL]: url.toString(),
+        [SEMATTRS_HTTP_STATUS_CODE]: res.status,
+        [SEMATTRS_HTTP_METHOD]: fetchOpts.method,
       });
       if (res.ok) {
         return res;
@@ -101,8 +108,8 @@ export function retryFetch(
       const err = new HttpError(url.toString(), res.status, await res.text());
       if (res.status < 500) {
         span.setAttributes({
-          [TelemetrySemanticAttributes.EXCEPTION_TYPE]: err.name,
-          [TelemetrySemanticAttributes.EXCEPTION_MESSAGE]: err.message,
+          [SEMATTRS_EXCEPTION_TYPE]: err.name,
+          [SEMATTRS_EXCEPTION_MESSAGE]: err.message,
         });
         throw new AbortError(err);
       }

--- a/src/telemetry/common.ts
+++ b/src/telemetry/common.ts
@@ -3,7 +3,8 @@ import dc from 'node:diagnostics_channel';
 import { SemanticAttributes as SemAttr } from '@opentelemetry/semantic-conventions';
 import type { MetricOptions } from '@opentelemetry/api';
 
-export const channel = dc.channel('fastify.initialization');
+export { dc };
+export const channelName = 'fastify.initialization';
 
 // Try to get the app version from the header, then query param, then default to unknown
 export const getAppVersion = (req: FastifyRequest): string => {

--- a/src/telemetry/common.ts
+++ b/src/telemetry/common.ts
@@ -1,6 +1,4 @@
 import { FastifyRequest } from 'fastify';
-export { default as dc } from 'node:diagnostics_channel';
-export * from '@opentelemetry/semantic-conventions';
 import type { MetricOptions } from '@opentelemetry/api';
 
 export const channelName = 'fastify.initialization';

--- a/src/telemetry/common.ts
+++ b/src/telemetry/common.ts
@@ -1,9 +1,8 @@
 import { FastifyRequest } from 'fastify';
-import dc from 'node:diagnostics_channel';
-import { SemanticAttributes as SemAttr } from '@opentelemetry/semantic-conventions';
+export { default as dc } from 'node:diagnostics_channel';
+export * from '@opentelemetry/semantic-conventions';
 import type { MetricOptions } from '@opentelemetry/api';
 
-export { dc };
 export const channelName = 'fastify.initialization';
 
 // Try to get the app version from the header, then query param, then default to unknown
@@ -11,10 +10,7 @@ export const getAppVersion = (req: FastifyRequest): string => {
   return req.headers['x-app-version'] || req.query['v'] || 'unknown';
 };
 
-export const TelemetrySemanticAttributes = {
-  ...SemAttr,
-  DAILY_APPS_VERSION: 'dailydev.apps.version',
-  DAILY_APPS_USER_ID: 'dailydev.apps.userId',
-};
+export const SEMATTRS_DAILY_APPS_VERSION = 'dailydev.apps.version';
+export const SEMATTRS_DAILY_APPS_USER_ID = 'dailydev.apps.userId';
 
 export type CounterOptions = { name: string } & MetricOptions;

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -1,7 +1,11 @@
+import dc from 'node:diagnostics_channel';
 import type { FastifyInstance } from 'fastify';
 import { api, resources, metrics } from '@opentelemetry/sdk-node';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_ROUTE,
+  SEMRESATTRS_SERVICE_NAME,
+} from '@opentelemetry/semantic-conventions';
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
@@ -11,9 +15,7 @@ import { logger } from '../logger';
 import {
   channelName,
   CounterOptions,
-  dc,
   getAppVersion,
-  SEMATTRS_HTTP_ROUTE,
   SEMATTRS_DAILY_APPS_VERSION,
 } from './common';
 
@@ -131,7 +133,7 @@ export const startMetrics = (serviceName: string): void => {
   ];
 
   const resource = new resources.Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SEMRESATTRS_SERVICE_NAME]: serviceName,
   }).merge(
     resources.detectResourcesSync({
       detectors: [containerDetector, gcpDetector, new GcpDetectorSync()],

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -13,7 +13,8 @@ import {
   CounterOptions,
   dc,
   getAppVersion,
-  TelemetrySemanticAttributes,
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_DAILY_APPS_VERSION,
 } from './common';
 
 const counterMap = {
@@ -148,8 +149,8 @@ export const startMetrics = (serviceName: string): void => {
       }
 
       counters?.api?.requests?.add(1, {
-        [TelemetrySemanticAttributes.HTTP_ROUTE]: req.routeOptions.url,
-        [TelemetrySemanticAttributes.DAILY_APPS_VERSION]: getAppVersion(req),
+        [SEMATTRS_HTTP_ROUTE]: req.routeOptions.url,
+        [SEMATTRS_DAILY_APPS_VERSION]: getAppVersion(req),
       });
     });
   });

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -3,8 +3,8 @@ import type { FastifyInstance } from 'fastify';
 import { api, resources, metrics } from '@opentelemetry/sdk-node';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import {
-  SEMATTRS_HTTP_ROUTE,
-  SEMRESATTRS_SERVICE_NAME,
+  ATTR_HTTP_ROUTE,
+  ATTR_SERVICE_NAME,
 } from '@opentelemetry/semantic-conventions';
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
@@ -133,7 +133,7 @@ export const startMetrics = (serviceName: string): void => {
   ];
 
   const resource = new resources.Resource({
-    [SEMRESATTRS_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_NAME]: serviceName,
   }).merge(
     resources.detectResourcesSync({
       detectors: [containerDetector, gcpDetector, new GcpDetectorSync()],
@@ -151,7 +151,7 @@ export const startMetrics = (serviceName: string): void => {
       }
 
       counters?.api?.requests?.add(1, {
-        [SEMATTRS_HTTP_ROUTE]: req.routeOptions.url,
+        [ATTR_HTTP_ROUTE]: req.routeOptions.url,
         [SEMATTRS_DAILY_APPS_VERSION]: getAppVersion(req),
       });
     });

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -9,8 +9,9 @@ import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
 
 import { logger } from '../logger';
 import {
-  channel,
+  channelName,
   CounterOptions,
+  dc,
   getAppVersion,
   TelemetrySemanticAttributes,
 } from './common';
@@ -139,7 +140,7 @@ export const startMetrics = (serviceName: string): void => {
   const meterProvider = new metrics.MeterProvider({ resource, readers });
   api.metrics.setGlobalMeterProvider(meterProvider);
 
-  channel.subscribe(({ fastify }: { fastify: FastifyInstance }) => {
+  dc.subscribe(channelName, ({ fastify }: { fastify: FastifyInstance }) => {
     // Decorate the main span with some metadata
     fastify.addHook('onResponse', async (req) => {
       if (req.routeOptions.url === '/graphql') {

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -24,7 +24,12 @@ import {
   channelName,
   dc,
   getAppVersion,
-  TelemetrySemanticAttributes,
+  SEMATTRS_DAILY_APPS_USER_ID,
+  SEMATTRS_DAILY_APPS_VERSION,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
+  SEMATTRS_MESSAGING_SYSTEM,
 } from './common';
 
 const resourceDetectors = [
@@ -45,9 +50,8 @@ export const addApiSpanLabels = (
   res?: FastifyReply,
 ): void => {
   span.setAttributes({
-    [TelemetrySemanticAttributes.DAILY_APPS_VERSION]: getAppVersion(req),
-    [TelemetrySemanticAttributes.DAILY_APPS_USER_ID]:
-      req.userId || req.trackingId || 'unknown',
+    [SEMATTRS_DAILY_APPS_VERSION]: getAppVersion(req),
+    [SEMATTRS_DAILY_APPS_USER_ID]: req.userId || req.trackingId || 'unknown',
   });
 };
 
@@ -57,11 +61,10 @@ export const addPubsubSpanLabels = (
   message: Message | { id: string; data?: Buffer },
 ): void => {
   span.setAttributes({
-    [TelemetrySemanticAttributes.MESSAGING_SYSTEM]: 'pubsub',
-    [TelemetrySemanticAttributes.MESSAGING_DESTINATION]: subscription,
-    [TelemetrySemanticAttributes.MESSAGING_MESSAGE_ID]: message.id,
-    [TelemetrySemanticAttributes.MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES]:
-      message.data.length,
+    [SEMATTRS_MESSAGING_SYSTEM]: 'pubsub',
+    [SEMATTRS_MESSAGING_DESTINATION]: subscription,
+    [SEMATTRS_MESSAGING_MESSAGE_ID]: message.id,
+    [SEMATTRS_MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES]: message.data.length,
   });
 };
 

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -10,6 +10,8 @@ import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
 import { TypeormInstrumentation } from 'opentelemetry-instrumentation-typeorm';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 
+import dc from 'node:diagnostics_channel';
+
 import { NodeSDK, logs, node, api, resources } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
@@ -22,15 +24,16 @@ import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
 import { isProd } from '../common/utils';
 import {
   channelName,
-  dc,
   getAppVersion,
   SEMATTRS_DAILY_APPS_USER_ID,
   SEMATTRS_DAILY_APPS_VERSION,
+} from './common';
+import {
   SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_MESSAGE_ID,
   SEMATTRS_MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
   SEMATTRS_MESSAGING_SYSTEM,
-} from './common';
+} from '@opentelemetry/semantic-conventions';
 
 const resourceDetectors = [
   resources.envDetectorSync,

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -29,11 +29,11 @@ import {
   SEMATTRS_DAILY_APPS_VERSION,
 } from './common';
 import {
-  SEMATTRS_MESSAGING_DESTINATION,
-  SEMATTRS_MESSAGING_MESSAGE_ID,
-  SEMATTRS_MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES,
-  SEMATTRS_MESSAGING_SYSTEM,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_MESSAGE_BODY_SIZE,
+  ATTR_MESSAGING_MESSAGE_ID,
+  ATTR_MESSAGING_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 
 const resourceDetectors = [
   resources.envDetectorSync,
@@ -64,10 +64,10 @@ export const addPubsubSpanLabels = (
   message: Message | { id: string; data?: Buffer },
 ): void => {
   span.setAttributes({
-    [SEMATTRS_MESSAGING_SYSTEM]: 'pubsub',
-    [SEMATTRS_MESSAGING_DESTINATION]: subscription,
-    [SEMATTRS_MESSAGING_MESSAGE_ID]: message.id,
-    [SEMATTRS_MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES]: message.data.length,
+    [ATTR_MESSAGING_SYSTEM]: 'pubsub',
+    [ATTR_MESSAGING_DESTINATION_NAME]: subscription,
+    [ATTR_MESSAGING_MESSAGE_ID]: message.id,
+    [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: message.data.length,
   });
 };
 

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -20,7 +20,12 @@ import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
 
 import { isProd } from '../common/utils';
-import { channel, getAppVersion, TelemetrySemanticAttributes } from './common';
+import {
+  channelName,
+  dc,
+  getAppVersion,
+  TelemetrySemanticAttributes,
+} from './common';
 
 const resourceDetectors = [
   resources.envDetectorSync,
@@ -120,7 +125,7 @@ export const tracer = (serviceName: string) => {
     // textMapPropagator: new CloudPropagator(),
   });
 
-  channel.subscribe(({ fastify }: { fastify: FastifyInstance }) => {
+  dc.subscribe(channelName, ({ fastify }: { fastify: FastifyInstance }) => {
     fastify.decorate('tracer', api.trace.getTracer(serviceName));
     fastify.decorateRequest('span', null);
 


### PR DESCRIPTION
I have verified on local environment if I set the traceparent header to force sampling, it will let us trigger tracing when sampling ratio is 0.