### PR TITLE
feat(strict-ts): apply to workers

### DIFF
--- a/src/common/twitter.ts
+++ b/src/common/twitter.ts
@@ -6,7 +6,9 @@ export const truncateToTweet = (text?: string): string => {
   return text.length <= 130 ? text : `${text.substring(0, 127)}...`;
 };
 
-export const truncatePostToTweet = (post: Pick<Post, 'title'>): string => {
+export const truncatePostToTweet = (
+  post: Pick<Post, 'title'> | undefined,
+): string => {
   if (!post || !post.title?.length) return '';
 
   return truncateToTweet(post.title);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -103,7 +103,9 @@ export const isProd = process.env.NODE_ENV === 'production';
 
 export const isTest = process.env.NODE_ENV === 'test';
 
-export const parseDate = (date: string | Date): Date | undefined => {
+export const parseDate = (
+  date: string | Date | undefined,
+): Date | undefined => {
   if (!date) {
     return undefined;
   }

--- a/src/entity/ContentImage.ts
+++ b/src/entity/ContentImage.ts
@@ -19,8 +19,8 @@ export class ContentImage {
   createdAt: Date;
 
   @Column({ type: 'text', nullable: true })
-  usedByType: ContentImageUsedByType;
+  usedByType: ContentImageUsedByType | null;
 
   @Column({ type: 'text', nullable: true })
-  usedById: string;
+  usedById: string | null;
 }

--- a/src/entity/posts/ArticlePost.ts
+++ b/src/entity/posts/ArticlePost.ts
@@ -30,7 +30,7 @@ export class ArticlePost extends Post {
   siteTwitter?: string;
 
   @Column({ type: 'text', nullable: true })
-  creatorTwitter?: string;
+  creatorTwitter?: string | null;
 
   @Column({ nullable: true })
   readTime?: number;

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -138,7 +138,7 @@ export class Post {
 
   @Column({ type: 'text', nullable: true })
   @Index('IDX_tags')
-  tagsStr: string;
+  tagsStr: string | null;
 
   @Column({ type: 'integer', default: 0 })
   @Index('IDX_post_upvotes')
@@ -205,7 +205,7 @@ export class Post {
   visible: boolean;
 
   @Column({ default: null })
-  visibleAt: Date;
+  visibleAt: Date | null;
 
   @Column({ default: null })
   @Index()

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -204,7 +204,7 @@ export class Post {
   @Column({ default: true })
   visible: boolean;
 
-  @Column({ default: null })
+  @Column({ type: 'timestamp', default: null })
   visibleAt: Date | null;
 
   @Column({ default: null })

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -38,7 +38,7 @@ export type NotificationPostContext<T extends Post = Post> =
   NotificationBaseContext &
     NotificationSourceContext & {
       post: Reference<T>;
-      sharedPost?: Reference<Post>;
+      sharedPost?: Reference<Post> | null;
     };
 
 export type NotificationCommentContext = NotificationPostContext & {

--- a/src/workers/cdc/common.ts
+++ b/src/workers/cdc/common.ts
@@ -89,7 +89,7 @@ export const notifyPostContentUpdated = async ({
     yggdrasilId: post.yggdrasilId,
     postId: post.id,
     type: post.type,
-    title: post.title,
+    title: post.title || undefined,
     createdAt: getSecondsTimestamp(debeziumTimeToDate(post.createdAt)),
     updatedAt: getSecondsTimestamp(debeziumTimeToDate(post.metadataChangedAt)),
     source: source
@@ -104,7 +104,7 @@ export const notifyPostContentUpdated = async ({
     private: post.private,
     visible: post.visible,
     origin: post.origin,
-    url: articlePost.url,
+    url: articlePost.url || undefined,
     canonicalUrl: articlePost.canonicalUrl,
     image: articlePost.image,
     description: articlePost.description,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -869,10 +869,10 @@ const onUserStreakChange = async (
 ) => {
   if (data.payload.op === 'u') {
     if (
-      data.payload.after.currentStreak === 0 &&
-      data.payload.before.currentStreak >= VALID_STREAK_RESET
+      data.payload.after!.currentStreak === 0 &&
+      data.payload.before!.currentStreak >= VALID_STREAK_RESET
     ) {
-      await setRestoreStreakCache(con, data.payload.before);
+      await setRestoreStreakCache(con, data.payload.before!);
     }
 
     await triggerTypedEvent(logger, 'api.v1.user-streak-updated', {

--- a/src/workers/generators/generateEditImagesHandler.ts
+++ b/src/workers/generators/generateEditImagesHandler.ts
@@ -4,10 +4,13 @@ import {
   ContentImageUsedByType,
   updateUsedImagesInContent,
 } from '../../entity';
-import { messageToJson } from '../worker';
+import { Message, messageToJson } from '../worker';
+import { DataSource } from 'typeorm';
 
 interface Content {
   id: string;
+  contentHtml?: string;
+  readmeHtml?: string;
 }
 
 interface Data<T extends Content> {
@@ -23,9 +26,9 @@ export const generateEditImagesHandler =
     key: keyof T,
     type: ContentImageUsedByType,
     { shouldClearOnly }: OptionalParams = {},
-    contentKey: keyof Data<Content> = 'contentHtml',
+    contentKey: keyof ChangeObject<Content> = 'contentHtml',
   ) =>
-  async (message, con): Promise<void> => {
+  async (message: Pick<Message, 'data'>, con: DataSource): Promise<void> => {
     const data: T = messageToJson(message);
     const obj = data[key];
 

--- a/src/workers/notifications/userStreakResetNotification.ts
+++ b/src/workers/notifications/userStreakResetNotification.ts
@@ -26,7 +26,7 @@ const worker = generateTypedNotificationWorker<'api.v1.user-streak-updated'>({
       streak: {
         ...streak,
         currentStreak: parseInt(lastStreak, 10),
-        lastViewAt: streak.lastViewAt ? new Date(streak.lastViewAt) : null,
+        lastViewAt: new Date(streak.lastViewAt!).getTime(),
       },
     };
 

--- a/src/workers/notifications/userStreakResetNotification.ts
+++ b/src/workers/notifications/userStreakResetNotification.ts
@@ -26,7 +26,7 @@ const worker = generateTypedNotificationWorker<'api.v1.user-streak-updated'>({
       streak: {
         ...streak,
         currentStreak: parseInt(lastStreak, 10),
-        lastViewAt: new Date(streak.lastViewAt).getTime(),
+        lastViewAt: streak.lastViewAt ? new Date(streak.lastViewAt) : null,
       },
     };
 

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -64,7 +64,7 @@ export const buildPostContext = async (
   const post = await con
     .getRepository(Post)
     .findOne({ where: { id: postId }, relations: ['source'] });
-  let sharedPost: Post;
+  let sharedPost: Post | null = null;
   if (post) {
     if (post.type === PostType.Share) {
       sharedPost = await con

--- a/src/workers/personalizedDigestEmail.ts
+++ b/src/workers/personalizedDigestEmail.ts
@@ -87,6 +87,8 @@ const digestTypeToFunctionMap: Record<
         personalizedDigest.flags.sendType as UserPersonalizedDigestSendType
       ] || features.personalizedDigest;
     let featureValue: PersonalizedDigestFeatureConfig;
+    const defaultValue =
+      featureInstance.defaultValue as PersonalizedDigestFeatureConfig;
 
     if (config) {
       featureValue = config;
@@ -99,12 +101,12 @@ const digestTypeToFunctionMap: Record<
 
       featureValue = growthbookClient.getFeatureValue(
         featureInstance.id,
-        featureInstance.defaultValue,
+        defaultValue,
       );
     }
 
     // gb does not handle default values for nested objects
-    const digestFeature = deepmerge(featureInstance.defaultValue, featureValue);
+    const digestFeature = deepmerge(defaultValue, featureValue);
 
     const currentDate = new Date();
 
@@ -176,7 +178,8 @@ const digestTypeToFunctionMap: Record<
     }
 
     if (
-      isSameDay(currentDate, userStreak.lastViewAt) ||
+      (userStreak.lastViewAt &&
+        isSameDay(currentDate, userStreak.lastViewAt)) ||
       userStreak.currentStreak === 0
     ) {
       return;

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -61,7 +61,7 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
         );
 
         if (source.private && source.type === SourceType.Squad) {
-          const admin: Pick<SourceMember, 'referralToken'> = await con
+          const admin: Pick<SourceMember, 'referralToken'> | null = await con
             .getRepository(SourceMember)
             .findOne({
               select: ['referralToken'],
@@ -126,7 +126,9 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
                 if (
                   ![
                     SlackApiErrorCode.MethodNotSupportedForChannelType,
-                  ].includes(conversationsJoinError.data?.error)
+                  ].includes(
+                    conversationsJoinError.data?.error as SlackApiErrorCode,
+                  )
                 ) {
                   throw originalJoinError;
                 }

--- a/src/workers/userCreatedPersonalizedDigestSendType.ts
+++ b/src/workers/userCreatedPersonalizedDigestSendType.ts
@@ -1,7 +1,11 @@
 import deepmerge from 'deepmerge';
 import { updateFlagsStatement, User } from '../common';
 import { UserPersonalizedDigest } from '../entity';
-import { features, getUserGrowthBookInstace } from '../growthbook';
+import {
+  features,
+  getUserGrowthBookInstace,
+  PersonalizedDigestFeatureConfig,
+} from '../growthbook';
 import { messageToJson, workerToExperimentWorker } from './worker';
 
 interface Data {
@@ -27,10 +31,10 @@ const worker = workerToExperimentWorker({
     const featureValue = growthbookClient.getFeatureValue(
       features.dailyDigest.id,
       features.dailyDigest.defaultValue,
-    ) as typeof features.dailyDigest.defaultValue;
+    ) as PersonalizedDigestFeatureConfig;
 
     const digestFeature = deepmerge(
-      features.dailyDigest.defaultValue,
+      features.dailyDigest.defaultValue as PersonalizedDigestFeatureConfig,
       featureValue,
     );
 


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- workers
- handling email/notification worker
- stuff that accumulated in the meantime