### PR TITLE
feat(strict-ts): apply to graphorm

### DIFF
--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -92,7 +92,7 @@ export class GraphORM {
   mappings: GraphORMMapping | null;
 
   constructor(mappings?: GraphORMMapping) {
-    this.mappings = mappings;
+    this.mappings = mappings || null;
   }
 
   /**
@@ -114,7 +114,7 @@ export class GraphORM {
     parentMetadata: EntityMetadata,
     childMetadata: EntityMetadata,
     field: string,
-  ): GraphORMRelation {
+  ): GraphORMRelation | null {
     const relation = childMetadata.relations.find(
       (rel) => rel.inverseEntityMetadata.name === parentMetadata.name,
     );
@@ -441,7 +441,9 @@ export class GraphORM {
   getMetadataOrNull(ctx: Context, type: string): EntityMetadata | undefined {
     try {
       return this.getMetadata(ctx, type);
-    } catch (err) {
+    } catch (originalError) {
+      const err = originalError as Error;
+
       if (err?.name === 'EntityMetadataNotFoundError') {
         return;
       }
@@ -491,9 +493,9 @@ export class GraphORM {
       (field) => field.name === hierarchy[0],
     );
     if (hierarchy.length === 1) {
-      return child;
+      return child!;
     }
-    return this.getFieldByHierarchy(child, hierarchy.slice(1));
+    return this.getFieldByHierarchy(child!, hierarchy.slice(1));
   }
 
   /**
@@ -591,7 +593,7 @@ export class GraphORM {
 
     if (!res.length) {
       throw new EntityNotFoundError(
-        entityName ?? resolveInfo.path.typename,
+        entityName ?? resolveInfo.path.typename!,
         'not found',
       );
     }

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -53,14 +53,18 @@ const existsByUserAndPost =
 const nullIfNotLoggedIn = <T>(value: T, ctx: Context): T | null =>
   ctx.userId ? value : null;
 
-const transformDate = (value: string | Date): Date =>
+const transformDate = (value: string | Date): Date | undefined =>
   value ? new Date(value) : undefined;
 
 const nullIfNotSameUser = <T>(
   value: T,
   ctx: Context,
-  parent: Pick<User, 'id'>,
-): T | null => (ctx.userId === parent.id ? value : null);
+  parent: unknown,
+): T | null => {
+  const user = parent as Pick<User, 'id'>;
+
+  return ctx.userId === user.id ? value : null;
+};
 
 const createI18nField = ({
   field,
@@ -208,14 +212,16 @@ const obj = new GraphORM({
         transform: nullIfNotLoggedIn,
       },
       views: {
-        transform: (value: number, ctx, parent: Post): number | null => {
-          const isAuthor = parent?.authorId && ctx.userId === parent.authorId;
+        transform: (value: number, ctx, parent): number | null => {
+          const post = parent as Post;
+
+          const isAuthor = post?.authorId && ctx.userId === post.authorId;
 
           if (isAuthor) {
             return value;
           }
 
-          const isScout = parent?.scoutId && ctx.userId === parent.scoutId;
+          const isScout = post?.scoutId && ctx.userId === post.scoutId;
           if (isScout) {
             return value;
           }
@@ -431,11 +437,9 @@ const obj = new GraphORM({
             .where(`postingSquad.id = ${alias}."sourceId"`);
           return `${query.getQuery()}`;
         },
-        transform: (
-          value: [number, number],
-          ctx: Context,
-          member: SourceMember,
-        ) => {
+        transform: (value: [number, number], ctx: Context, parent) => {
+          const member = parent as SourceMember;
+
           if (!ctx.userId || member.userId !== ctx.userId) {
             return null;
           }
@@ -455,14 +459,16 @@ const obj = new GraphORM({
               ${sourceRoleRankKeys
                 .map(
                   (role) =>
-                    `WHEN "role" = '${role}' THEN ${sourceRoleRank[role]}`,
+                    `WHEN "role" = '${role}' THEN ${sourceRoleRank[role as keyof typeof sourceRoleRank]}`,
                 )
                 .join(' ')}
             ELSE 0 END)
           `,
       },
       referralToken: {
-        transform: (value: string, ctx: Context, member: SourceMember) => {
+        transform: (value: string, ctx: Context, parent) => {
+          const member = parent as SourceMember;
+
           return nullIfNotSameUser(value, ctx, { id: member.userId });
         },
       },


### PR DESCRIPTION
This is the one of the PRs in a series to bring our TypeScript types to comply with [strict](https://www.typescriptlang.org/tsconfig/#strict) config option. This will allow us better type checking during builds and development and allow us to ship with more confidence.

We are doing this as a series of PRs to have easier review and also to incrementally deploy to production.

This one focuses on: 
- graphorm