### PR TITLE
fix: members count trigger when creating a squad

### DIFF
--- a/bin/syncMembersCount.ts
+++ b/bin/syncMembersCount.ts
@@ -15,19 +15,26 @@ const QUEUE_CONCURRENCY = 1;
   const con = await createOrGetConnection();
   await con.transaction(async (manager) => {
     console.log('initializing stream');
+    const subq = manager
+      .createQueryBuilder()
+      .subQuery()
+      .select('COUNT(*)')
+      .from(SourceMember, 'sm2')
+      .where('sm2."sourceId" = sm1."sourceId"')
+      .andWhere(`sm2.role != 'blocked'`)
+      .getQuery();
+
     const builder = manager
       .getRepository(SourceMember)
-      .createQueryBuilder('sm')
-      .select('COUNT(sm.*)', 'count')
-      .addSelect('sm."sourceId"')
-      .innerJoin(Source, 's', 's.id = sm."sourceId"')
-      .where(`sm.role != 'blocked'`)
-      .andWhere(`sm."sourceId" IS NOT NULL`)
-      .andWhere(
-        `COALESCE((s.flags->>'totalMembers')::integer, 0) != COUNT(sm.*)`,
-      )
+      .createQueryBuilder('sm1')
+      .select('COUNT(sm1.*)', 'count')
+      .addSelect('sm1."sourceId"')
+      .innerJoin(Source, 's', 's.id = sm1."sourceId"')
+      .where(`sm1.role != 'blocked'`)
+      .andWhere(`sm1."sourceId" IS NOT NULL`)
+      .andWhere(`COALESCE((s.flags->>'totalMembers')::integer, 0) != ${subq}`)
       .limit(1000)
-      .groupBy('sm."sourceId"');
+      .groupBy('sm1."sourceId"');
 
     const stream = await builder.stream();
 

--- a/bin/syncMembersCount.ts
+++ b/bin/syncMembersCount.ts
@@ -20,7 +20,13 @@ const QUEUE_CONCURRENCY = 1;
       .createQueryBuilder('sm')
       .select('COUNT(sm.*)', 'count')
       .addSelect('sm."sourceId"')
+      .innerJoin(Source, 's', 's.id = sm."sourceId"')
       .where(`sm.role != 'blocked'`)
+      .andWhere(`sm."sourceId" IS NOT NULL`)
+      .andWhere(
+        `COALESCE((s.flags->>'totalMembers')::integer, 0) != COUNT(sm.*)`,
+      )
+      .limit(1000)
       .groupBy('sm."sourceId"');
 
     const stream = await builder.stream();

--- a/src/migration/1726147441577-SourceMembersCountFix.ts
+++ b/src/migration/1726147441577-SourceMembersCountFix.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SourceMembersCountFix1726147441577 implements MigrationInterface {
+  name = 'SourceMembersCountFix1726147441577';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+      CREATE OR REPLACE FUNCTION increment_squad_members_count()
+        RETURNS TRIGGER
+        LANGUAGE PLPGSQL
+        AS
+      $$
+      BEGIN
+        UPDATE  source
+        SET     flags = jsonb_set(
+                          flags,
+                          '{totalMembers}',
+                          to_jsonb(COALESCE(CAST(flags->>'totalMembers' AS INTEGER), 0) + 1)
+                        )
+        WHERE   id = NEW."sourceId"
+        AND     type = 'squad';
+        RETURN NEW;
+      END;
+      $$
+    `);
+    queryRunner.query(
+      `
+      CREATE OR REPLACE TRIGGER increment_squad_members_count
+      AFTER INSERT ON "source_member"
+      FOR EACH ROW
+      WHEN (NEW.role != 'blocked')
+      EXECUTE PROCEDURE increment_squad_members_count()
+    `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(
+      'DROP TRIGGER IF EXISTS increment_squad_members_count ON post',
+    );
+    queryRunner.query('DROP FUNCTION IF EXISTS increment_squad_members_count');
+  }
+}

--- a/src/migration/1726147441577-SourceMembersCountFix.ts
+++ b/src/migration/1726147441577-SourceMembersCountFix.ts
@@ -35,9 +35,33 @@ export class SourceMembersCountFix1726147441577 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+      CREATE OR REPLACE FUNCTION increment_squad_members_count()
+        RETURNS TRIGGER
+        LANGUAGE PLPGSQL
+        AS
+      $$
+      BEGIN
+        UPDATE  source
+        SET     flags = jsonb_set(
+                          flags,
+                          '{totalMembers}',
+                          to_jsonb(COALESCE(CAST(flags->>'totalMembers' AS INTEGER), 0) + 1)
+                        )
+        WHERE   id = NEW."sourceId"
+        AND     type = 'squad';
+        RETURN NEW;
+      END;
+      $$
+    `);
     queryRunner.query(
-      'DROP TRIGGER IF EXISTS increment_squad_members_count ON post',
+      `
+      CREATE OR REPLACE TRIGGER increment_squad_members_count
+      AFTER INSERT ON "source_member"
+      FOR EACH ROW
+      WHEN (NEW.role = 'member')
+      EXECUTE PROCEDURE increment_squad_members_count()
+    `,
     );
-    queryRunner.query('DROP FUNCTION IF EXISTS increment_squad_members_count');
   }
 }


### PR DESCRIPTION
There is an instance where the user does not start being a member, that is when creating a new Squad. To make it more accurate, we check whether the user is not blocked.