### PR TITLE
fix: cache expiry value with timezone in consideration

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -122,6 +122,7 @@ import {
   ioRedisPool,
   setRedisObject,
 } from '../../../src/redis';
+import * as redisFile from '../../../src/redis';
 import {
   StorageKey,
   StorageTopic,
@@ -3754,6 +3755,7 @@ describe('user streak change', () => {
     });
 
     it('should set cache of previous streak for recovery considering the timezone', async () => {
+      const spy = jest.spyOn(redisFile, 'setRedisObjectWithExpiry');
       jest
         .useFakeTimers({ doNotFake })
         .setSystemTime(new Date('2024-09-05T18:32:53')); // Thursday UTC - Friday Asia/Manila
@@ -3790,6 +3792,7 @@ describe('user streak change', () => {
       expect(lastStreak).toEqual(3);
       const alert = await con.getRepository(Alerts).findOneBy({ userId: '1' });
       expect(alert.showRecoverStreak).toEqual(true);
+      expect(spy).toHaveBeenCalledWith('streak:reset:1', 3, 77227);
     });
 
     it('should set cache of previous streak for recovery considering the timezone earlier than UTC', async () => {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -543,9 +543,9 @@ const getAbsoluteDifferenceInDays: typeof differenceInDays = (date1, date2) => {
 export const shouldAllowRestore = async (
   con: DataSource,
   streak: ChangeObject<UserStreak>,
+  user: DbUser,
 ) => {
   const { userId, lastViewAt: lastViewAtDb } = streak;
-  const user = await con.getRepository(DbUser).findOneBy({ id: userId });
   const timezone = user.timezone || DEFAULT_TIMEZONE;
   const today = utcToZonedTime(new Date(), timezone);
   const lastView = utcToZonedTime(new Date(lastViewAtDb), timezone);


### PR DESCRIPTION
The cache expiry could be inaccurate on certain cases. One example is:
- User with timezone of UTC+3.
- Logs in at 1am
- Everything cleared, user should be able to restore.
- Now we are setting the cache.
- UTC is still 10pm.
- Calculates the next day is about 2 hours based on UTC.
- Did not restore immediately, later that day, tried to restore but cache expired.
- Value should've been about 23 hours.

Can be seen from the failing test that the value expected is wrong. Test passed on the next commit.