### PR TITLE
fix: only add span labels if span is still open

### DIFF
--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -141,7 +141,9 @@ export const tracer = (serviceName: string) => {
 
     // Decorate the main span with some metadata
     fastify.addHook('onResponse', async (req, res) => {
-      addApiSpanLabels(req.span, req, res);
+      if (req.span.isRecording()) {
+        addApiSpanLabels(req.span, req, res);
+      }
     });
   });
 


### PR DESCRIPTION
Ensure that we only set span labels while the span is still open.
In cases where the request is cancelled while it is still running (i.e. user navigated away)