### PR TITLE
feat: order by priority column

### DIFF
--- a/bin/categorizedSquads.ts
+++ b/bin/categorizedSquads.ts
@@ -1,0 +1,570 @@
+export const categorizedSquads = [
+  {
+    handle: 'code_build',
+    category: 'Web',
+  },
+  {
+    handle: 'codingcatdev',
+    category: 'DevRel',
+  },
+  {
+    handle: 'syntax',
+    category: 'Web',
+  },
+  {
+    handle: 'traversymedia',
+    category: 'Web',
+  },
+  {
+    handle: 'vuejsdevs',
+    category: 'Web',
+  },
+  {
+    handle: 'nuxtandvue',
+    category: 'Web',
+  },
+  {
+    handle: 'angulardev',
+    category: 'Languages',
+  },
+  {
+    handle: 'dotnetangularfullstack',
+    category: 'Web',
+  },
+  {
+    handle: 'buildwithastro',
+    category: 'Web',
+  },
+  {
+    handle: 'laraveldev',
+    category: 'Languages',
+  },
+  {
+    handle: 'wordpress_dev',
+    category: 'Web',
+  },
+  {
+    handle: 'bricksbuilder',
+    category: 'DevTools',
+  },
+  {
+    handle: 'nextjs',
+    category: 'Web',
+  },
+  {
+    handle: 'startbase',
+    category: 'DevTools',
+  },
+  {
+    handle: 'webstylepress',
+    category: 'Web',
+  },
+  {
+    handle: 'builderio',
+    category: 'DevTools',
+  },
+  {
+    handle: 'nestjsdevs',
+    category: 'Web',
+  },
+  {
+    handle: 'thedevcraft',
+    category: 'Career',
+  },
+  {
+    handle: 'opensauced',
+    category: 'DevRel',
+  },
+  {
+    handle: 'ossph',
+    category: 'Open Source',
+  },
+  {
+    handle: 'opensourcequeens',
+    category: 'Open Source',
+  },
+  {
+    handle: 'opensourcefrontend',
+    category: 'Open Source',
+  },
+  {
+    handle: 'opensource',
+    category: 'Open Source',
+  },
+  {
+    handle: 'opensourcesquad',
+    category: 'Open Source',
+  },
+  {
+    handle: '4c',
+    category: 'DevRel',
+  },
+  {
+    handle: 'githubtrending',
+    category: 'Fun',
+  },
+  {
+    handle: 'trunkio',
+    category: 'DevTools',
+  },
+  {
+    handle: 'appwrite',
+    category: 'DevTools',
+  },
+  {
+    handle: 'java_devs',
+    category: 'Languages',
+  },
+  {
+    handle: 'justjava',
+    category: 'Languages',
+  },
+  {
+    handle: 'justkotlin',
+    category: 'Languages',
+  },
+  {
+    handle: 'rustdevs',
+    category: 'Languages',
+  },
+  {
+    handle: 'golangdevs',
+    category: 'Languages',
+  },
+  {
+    handle: 'lpython',
+    category: 'Languages',
+  },
+  {
+    handle: 'onlydjango',
+    category: 'Web',
+  },
+  {
+    handle: 'elixirdevs',
+    category: 'Languages',
+  },
+  {
+    handle: 'buildwithgo',
+    category: 'Languages',
+  },
+  {
+    handle: 'svelte_developers',
+    category: 'Web',
+  },
+  {
+    handle: 'nodejsdevelopers',
+    category: 'Languages',
+  },
+  {
+    handle: 'dartdevs',
+    category: 'Mobile',
+  },
+  {
+    handle: 'deploy',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'leleontech',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'lambdatest',
+    category: 'DevTools',
+  },
+  {
+    handle: 'scaleupsaas',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'DevOps & Clouddigest',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'joinDevOps & Cloud',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'kubesquad',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'cloudsoftwaredevelopment',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'cloud',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'DevOps & Clouddaily',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'cloudgeeks',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'amigoscode',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'hackingthecloud',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'DevOps & Cloudstep1',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'ai',
+    category: 'AI',
+  },
+  {
+    handle: 'wxpythonllmhacks',
+    category: 'AI',
+  },
+  {
+    handle: 'datascience',
+    category: 'AI',
+  },
+  {
+    handle: 'buildwithgenai',
+    category: 'AI',
+  },
+  {
+    handle: 'aidevenviorment',
+    category: 'AI',
+  },
+  {
+    handle: 'refactai',
+    category: 'AI',
+  },
+  {
+    handle: 'javascriptai',
+    category: 'AI',
+  },
+  {
+    handle: 'techadventurers',
+    category: 'Web',
+  },
+  {
+    handle: 'dataengineering',
+    category: 'AI',
+  },
+  {
+    handle: 'postgresdaily',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'databasedaily',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'expressots',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'developerfilipsquad',
+    category: 'Web',
+  },
+  {
+    handle: 'packagemain',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'golangnuts',
+    category: 'Languages',
+  },
+  {
+    handle: 'phpdev',
+    category: 'Languages',
+  },
+  {
+    handle: 'cloudnativecorner',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'depotdev',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'idrinth_api_bench',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'timescale',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'couchbaseplatform',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'adonisjsdevelopers',
+    category: 'DevOps & Cloud',
+  },
+  {
+    handle: 'exceptionalfrontend',
+    category: 'Web',
+  },
+  {
+    handle: 'michal_wrzosek',
+    category: 'Web',
+  },
+  {
+    handle: 'webdev',
+    category: 'Web',
+  },
+  {
+    handle: 'frontendA11y',
+    category: 'Web',
+  },
+  {
+    handle: 'progractivity',
+    category: 'Web',
+  },
+  {
+    handle: 'blazorexperts',
+    category: 'Web',
+  },
+  {
+    handle: 'thedevdojo',
+    category: 'Web',
+  },
+  {
+    handle: 'headless',
+    category: 'Web',
+  },
+  {
+    handle: 'cms_squad',
+    category: 'Web',
+  },
+  {
+    handle: 'shopifydevs',
+    category: 'Web',
+  },
+  {
+    handle: 'drupalcms',
+    category: 'Web',
+  },
+  {
+    handle: 'wpwoo',
+    category: 'Web',
+  },
+  {
+    handle: 'learn-with-tapas',
+    category: 'Career',
+  },
+  {
+    handle: 'careerswitchers',
+    category: 'Career',
+  },
+  {
+    handle: 'thedeveloperbootcamp',
+    category: 'Career',
+  },
+  {
+    handle: 'managingdev',
+    category: 'Career',
+  },
+  {
+    handle: 'grocto',
+    category: 'Career',
+  },
+  {
+    handle: 'engineeringleadership',
+    category: 'Career',
+  },
+  {
+    handle: 'cso',
+    category: 'Career',
+  },
+  {
+    handle: 'roadmap',
+    category: 'Career',
+  },
+  {
+    handle: 'advanceddotnet',
+    category: 'Career',
+  },
+  {
+    handle: 'justanothercto',
+    category: 'Career',
+  },
+  {
+    handle: 'mtmattei',
+    category: 'Career',
+  },
+  {
+    handle: 'devleader',
+    category: 'Career',
+  },
+  {
+    handle: 'devassure',
+    category: 'Web',
+  },
+  {
+    handle: 'game_developers',
+    category: 'Games',
+  },
+  {
+    handle: 'unity_developers',
+    category: 'Games',
+  },
+  {
+    handle: 'mobile',
+    category: 'Mobile',
+  },
+  {
+    handle: 'fluttersquad',
+    category: 'Mobile',
+  },
+  {
+    handle: 'deepflutter',
+    category: 'Mobile',
+  },
+  {
+    handle: 'dartdevs',
+    category: 'Mobile',
+  },
+  {
+    handle: 'devfm',
+    category: 'Mobile',
+  },
+  {
+    handle: 'nvim',
+    category: 'DevTools',
+  },
+  {
+    handle: 'dotfiles',
+    category: 'DevTools',
+  },
+  {
+    handle: 'piecesfordevelopers',
+    category: 'DevTools',
+  },
+  {
+    handle: 'devtools',
+    category: 'DevTools',
+  },
+  {
+    handle: 'fusionauth',
+    category: 'DevTools',
+  },
+  {
+    handle: 'projectboard',
+    category: 'Fun',
+  },
+  {
+    handle: 'nativesensors',
+    category: 'DevTools',
+  },
+  {
+    handle: 'permitio',
+    category: 'DevTools',
+  },
+  {
+    handle: 'freshcodeit',
+    category: 'DevTools',
+  },
+  {
+    handle: 'm365workplacehub',
+    category: 'DevTools',
+  },
+  {
+    handle: 'thedevrel',
+    category: 'DevRel',
+  },
+  {
+    handle: 'devrel',
+    category: 'DevRel',
+  },
+  {
+    handle: 'devsquad',
+    category: 'DevRel',
+  },
+  {
+    handle: 'opensource',
+    category: 'DevRel',
+  },
+  {
+    handle: 'cloudnativecorner',
+    category: 'DevRel',
+  },
+  {
+    handle: 'daily_updates',
+    category: 'DevRel',
+  },
+  {
+    handle: 'dailydevworld',
+    category: 'DevRel',
+  },
+  {
+    handle: 'thecoverlikers',
+    category: 'Fun',
+  },
+  {
+    handle: 'softwarephilosophy',
+    category: 'Fun',
+  },
+  {
+    handle: 'shiftmag',
+    category: 'DevRel',
+  },
+  {
+    handle: 'controversy',
+    category: 'Fun',
+  },
+  {
+    handle: 'codegreen',
+    category: 'Fun',
+  },
+  {
+    handle: 'passiveint',
+    category: 'Fun',
+  },
+  {
+    handle: 'watercooler',
+    category: 'Fun',
+  },
+  {
+    handle: 'ramiel',
+    category: 'Web',
+  },
+  {
+    handle: 'horde',
+    category: 'Web',
+  },
+  {
+    handle: 'devstogetherstrong',
+    category: 'Career',
+  },
+  {
+    handle: 'adnanssquad',
+    category: 'Fun',
+  },
+  {
+    handle: 'codu',
+    category: 'DevRel',
+  },
+  {
+    handle: 'developertimeline',
+    category: 'Career',
+  },
+  {
+    handle: 'francescociull4',
+    category: 'DevRel',
+  },
+  {
+    handle: 'languagedesign',
+    category: 'Languages',
+  },
+  {
+    handle: 'solanadeveloper',
+    category: 'Languages',
+  },
+  {
+    handle: 'andresalvarezpython',
+    category: 'Languages',
+  },
+];

--- a/bin/categorizedSquads.ts
+++ b/bin/categorizedSquads.ts
@@ -5,7 +5,7 @@ export const categorizedSquads = [
   },
   {
     handle: 'codingcatdev',
-    category: 'DevRel',
+    category: 'Web',
   },
   {
     handle: 'syntax',

--- a/bin/common.ts
+++ b/bin/common.ts
@@ -1,0 +1,26 @@
+import fastq from 'fastq';
+import { ReadStream } from 'fs';
+
+const QUEUE_CONCURRENCY = 1;
+
+export const runInQueueStream = async <T>(
+  stream: ReadStream,
+  callback: (props: T) => Promise<void>,
+  queue = QUEUE_CONCURRENCY,
+) => {
+  let insertCount = 0;
+  const insertQueue = fastq.promise(async (props: T) => {
+    await callback(props);
+
+    insertCount += 1;
+  }, queue);
+
+  stream.on('data', insertQueue.push);
+
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  await insertQueue.drained();
+  console.log('update finished with a total of: ', insertCount);
+};

--- a/bin/insertCategories.sql
+++ b/bin/insertCategories.sql
@@ -1,0 +1,28 @@
+INSERT INTO "source_category"
+(title, enabled)
+VALUES
+('Languages', true),
+('Web', true),
+('Mobile', true),
+('Games', true),
+('Career', true),
+('Fun', true),
+('DevTools', true),
+('AI', true),
+('DevRel', true),
+('Open Source', true),
+('DevOps & Cloud', true)
+ON CONFLICT DO NOTHING;
+
+DO $$
+DECLARE
+    categories TEXT[] := ARRAY['Languages','Web','Mobile','DevOps & Cloud','AI','Games','DevTools','Career','Open Source','DevRel','Fun'];
+    i INT;
+BEGIN
+    -- Iterate over the array and update the table
+    FOR i IN 1..array_length(categories, 1) LOOP
+        UPDATE source_category
+        SET priority = i
+        WHERE slug = trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(categories[i],100),''))), '[^a-z0-9-]+', '-', 'gi'));
+    END LOOP;
+END $$;

--- a/bin/updateSquadsCategory.ts
+++ b/bin/updateSquadsCategory.ts
@@ -1,0 +1,71 @@
+import fastq from 'fastq';
+import '../src/config';
+import createOrGetConnection from '../src/db';
+import { Source, SourceMember, SquadSource } from '../src/entity';
+import { updateFlagsStatement } from '../src/common';
+import { SourceCategory } from '../src/entity/sources/SourceCategory';
+import { categorizedSquads } from './categorizedSquads';
+import { In } from 'typeorm';
+
+interface Result {
+  title: string;
+  id: string;
+}
+
+const QUEUE_CONCURRENCY = 1;
+
+(async () => {
+  const con = await createOrGetConnection();
+  await con.transaction(async (manager) => {
+    console.log('initializing stream');
+    const categories = await manager.getRepository(SourceCategory).find();
+
+    const unfound = [];
+    categorizedSquads.forEach(({ category }) => {
+      const isFound = categories.find(({ title }) => title === category);
+      if (!isFound) {
+        unfound.push(category);
+      }
+      return isFound;
+    });
+
+    if (unfound.length > 0) {
+      console.log('Unfound categories: ', unfound);
+      return;
+    }
+
+    const builder = manager
+      .getRepository(SourceCategory)
+      .createQueryBuilder('sc')
+      .select('sc.title', 'title')
+      .addSelect('sc.id', 'id');
+
+    const stream = await builder.stream();
+
+    let insertCount = 0;
+    const insertQueue = fastq.promise(async ({ title, id }: Result) => {
+      const categorized = categorizedSquads
+        .filter(({ category }) => category === title)
+        .map(({ handle }) => handle);
+
+      await manager
+        .getRepository(SquadSource)
+        .update({ handle: In(categorized) }, { categoryId: id });
+
+      insertCount += 1;
+    }, QUEUE_CONCURRENCY);
+
+    stream.on('data', (result: Result) => {
+      insertQueue.push(result);
+    });
+
+    await new Promise((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('end', resolve);
+    });
+    await insertQueue.drained();
+    console.log('update finished with a total of: ', insertCount);
+  });
+
+  process.exit();
+})();

--- a/bin/updateSquadsCategory.ts
+++ b/bin/updateSquadsCategory.ts
@@ -1,8 +1,7 @@
 import fastq from 'fastq';
 import '../src/config';
 import createOrGetConnection from '../src/db';
-import { Source, SourceMember, SquadSource } from '../src/entity';
-import { updateFlagsStatement } from '../src/common';
+import { SquadSource } from '../src/entity';
 import { SourceCategory } from '../src/entity/sources/SourceCategory';
 import { categorizedSquads } from './categorizedSquads';
 import { In } from 'typeorm';

--- a/bin/updateSquadsCategory.ts
+++ b/bin/updateSquadsCategory.ts
@@ -35,7 +35,10 @@ interface Result {
       .getRepository(SourceCategory)
       .createQueryBuilder('sc')
       .select('sc.title', 'title')
-      .addSelect('sc.id', 'id');
+      .addSelect('sc.id', 'id')
+      .where('sc.title IN (:...categories)', {
+        categories: categorizedSquads.map(({ category }) => category),
+      });
 
     const stream = await builder.stream();
 

--- a/src/entity/sources/SourceCategory.ts
+++ b/src/entity/sources/SourceCategory.ts
@@ -19,6 +19,7 @@ export class SourceCategory {
   enabled: boolean;
 
   @Column({ default: null, nullable: true })
+  @Index('IDX_source_category_priority')
   priority?: number;
 
   @CreateDateColumn()

--- a/src/entity/sources/SourceCategory.ts
+++ b/src/entity/sources/SourceCategory.ts
@@ -18,6 +18,9 @@ export class SourceCategory {
   @Column()
   enabled: boolean;
 
+  @Column({ default: null, nullable: true })
+  priority?: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/migration/1726584940063-SourceCategoryPriority.ts
+++ b/src/migration/1726584940063-SourceCategoryPriority.ts
@@ -5,7 +5,37 @@ export class SourceCategoryPriority1726584940063 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
+      `DELETE FROM "source_category" WHERE "title" IN('Data', 'Cloud', 'DevOps', 'General')`,
+    );
+    await queryRunner.query(`
+      INSERT INTO "source_category"
+      (title, enabled)
+      VALUES
+      ('Basics', true),
+      ('AI', true),
+      ('DevRel', true),
+      ('Open Source', true),
+      ('DevOps & Cloud', true)
+      ON CONFLICT DO NOTHING;
+    `);
+    await queryRunner.query(
       `ALTER TABLE "source_category" ADD "priority" integer`,
+    );
+    await queryRunner.query(
+      `
+        DO $$
+        DECLARE
+            categories TEXT[] := ARRAY['Basics','Web','Mobile','DevOps & Cloud','AI','Games','DevTools','Career','Open Source','DevRel','Fun'];
+            i INT;
+        BEGIN
+            -- Iterate over the array and update the table
+            FOR i IN 1..array_length(categories, 1) LOOP
+                UPDATE source_category
+                SET priority = i
+                WHERE slug = trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(categories[i],100),''))), '[^a-z0-9-]+', '-', 'gi'));
+            END LOOP;
+        END $$;
+      `,
     );
   }
 
@@ -13,5 +43,24 @@ export class SourceCategoryPriority1726584940063 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "source_category" DROP COLUMN "priority"`,
     );
+    await queryRunner.query(
+      `DELETE FROM "source_category" WHERE "title" IN(
+        'Basics',
+        'AI',
+        'DevRel',
+        'Open Source'
+        'DevOps & Cloud'
+      )`,
+    );
+    await queryRunner.query(`
+      INSERT INTO "source_category"
+      (title, enabled)
+      VALUES
+      ('General', true),
+      ('Data', true),
+      ('Cloud', true),
+      ('DevOps', true),
+      ON CONFLICT DO NOTHING;
+    `);
   }
 }

--- a/src/migration/1726584940063-SourceCategoryPriority.ts
+++ b/src/migration/1726584940063-SourceCategoryPriority.ts
@@ -4,62 +4,36 @@ export class SourceCategoryPriority1726584940063 implements MigrationInterface {
   name = 'SourceCategoryPriority1726584940063';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `DELETE FROM "source_category" WHERE "title" IN('Data', 'Cloud', 'DevOps', 'General')`,
-    );
-    await queryRunner.query(`
-      INSERT INTO "source_category"
-      (title, enabled)
-      VALUES
-      ('Basics', true),
-      ('AI', true),
-      ('DevRel', true),
-      ('Open Source', true),
-      ('DevOps & Cloud', true)
-      ON CONFLICT DO NOTHING;
-    `);
+    await queryRunner.query(`DELETE FROM "source_category"`);
     await queryRunner.query(
       `ALTER TABLE "source_category" ADD "priority" integer`,
     );
     await queryRunner.query(
-      `
-        DO $$
-        DECLARE
-            categories TEXT[] := ARRAY['Basics','Web','Mobile','DevOps & Cloud','AI','Games','DevTools','Career','Open Source','DevRel','Fun'];
-            i INT;
-        BEGIN
-            -- Iterate over the array and update the table
-            FOR i IN 1..array_length(categories, 1) LOOP
-                UPDATE source_category
-                SET priority = i
-                WHERE slug = trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(categories[i],100),''))), '[^a-z0-9-]+', '-', 'gi'));
-            END LOOP;
-        END $$;
-      `,
+      `CREATE INDEX "IDX_source_category_priority" ON "source_category" ("priority") `,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "source_category" DROP COLUMN "priority"`,
+      `DROP INDEX "public"."IDX_source_category_priority"`,
     );
     await queryRunner.query(
-      `DELETE FROM "source_category" WHERE "title" IN(
-        'Basics',
-        'AI',
-        'DevRel',
-        'Open Source'
-        'DevOps & Cloud'
-      )`,
+      `ALTER TABLE "source_category" DROP COLUMN "priority"`,
     );
     await queryRunner.query(`
       INSERT INTO "source_category"
       (title, enabled)
       VALUES
       ('General', true),
-      ('Data', true),
-      ('Cloud', true),
+      ('Web', true),
+      ('Mobile', true),
+      ('Games', true),
       ('DevOps', true),
+      ('Cloud', true),
+      ('Career', true),
+      ('Data', true),
+      ('Fun', true),
+      ('DevTools', true)
       ON CONFLICT DO NOTHING;
     `);
   }

--- a/src/migration/1726584940063-SourceCategoryPriority.ts
+++ b/src/migration/1726584940063-SourceCategoryPriority.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SourceCategoryPriority1726584940063 implements MigrationInterface {
+  name = 'SourceCategoryPriority1726584940063';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "source_category" ADD "priority" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "source_category" DROP COLUMN "priority"`,
+    );
+  }
+}

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1042,10 +1042,7 @@ const membershipsPageGenerator = offsetPageGenerator<GQLSourceMember>(100, 500);
 
 const sourcePageGenerator = offsetPageGenerator<GQLSource>(100, 500);
 
-const categoriesPageGenerator = offsetPageGenerator<GQLSourceCategory>(
-  100,
-  500,
-);
+const categoriesPageGenerator = offsetPageGenerator<GQLSourceCategory>(15, 50);
 
 type CreateSquadArgs = {
   name: string;

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -34,7 +34,6 @@ import {
 } from 'typeorm';
 import { GQLUser } from './users';
 import { Connection } from 'graphql-relay/index';
-import { queryPaginatedByDate } from '../common/datePageGenerator';
 import { FileUpload } from 'graphql-upload/GraphQLUpload';
 import { randomUUID } from 'crypto';
 import {
@@ -1043,6 +1042,11 @@ const membershipsPageGenerator = offsetPageGenerator<GQLSourceMember>(100, 500);
 
 const sourcePageGenerator = offsetPageGenerator<GQLSource>(100, 500);
 
+const categoriesPageGenerator = offsetPageGenerator<GQLSourceCategory>(
+  100,
+  500,
+);
+
 type CreateSquadArgs = {
   name: string;
   handle: string;
@@ -1241,14 +1245,26 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       args,
       ctx: Context,
       info,
-    ): Promise<Connection<GQLSourceCategory>> =>
-      queryPaginatedByDate(
+    ): Promise<Connection<GQLSourceCategory>> => {
+      const page = categoriesPageGenerator.connArgsToPage(args);
+
+      return graphorm.queryPaginated(
         ctx,
         info,
-        args,
-        { key: 'createdAt' },
-        { orderByKey: 'DESC' },
-      ),
+        (nodeSize) => categoriesPageGenerator.hasPreviousPage(page, nodeSize),
+        (nodeSize) => categoriesPageGenerator.hasNextPage(page, nodeSize),
+        (node, index) =>
+          categoriesPageGenerator.nodeToCursor(page, args, node, index),
+        (builder) => {
+          builder.queryBuilder
+            .orderBy(`${builder.alias}.priority`, 'ASC')
+            .limit(page.limit)
+            .offset(page.offset);
+
+          return builder;
+        },
+      );
+    },
     sources: async (
       _,
       args: SourcesArgs,


### PR DESCRIPTION
- Introduce a new column to handle ordering based on our demand.
- Apparently, there are some changes with the categories. Rather than reusing an existing entity and just updating the title, it might become inaccurate. Hence, deleting the rows instead. Good thing that we also have no Squads with any category yet. Although they should be safe as cascading would take effect and null would be set in any case.
  - Another option is to turn the `enabled` to `false` values.
  - ~~Removed `['General', 'DevOps', 'Cloud', 'Data']`.~~
  - ~~Added `['Basics', 'DevOps & Cloud', 'AI', 'Open Source', 'DevRel']`~~
  - Removed every category (good thing no one is using any of the items yet). This is to make it easier to manage in the future and better devex. We will run a once off script to insert the data along with the Squad updates. This would make seeding our local env consistent.
- Created the migration for the column and did the necessary insert/delete/update commands at the same time.