### PR TITLE
fix: allowing boot and graphql endpoints to bots

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -52,7 +52,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get('/robots.txt', (req, res) => {
     return res.type('text/plain').send(`User-agent: *
 Allow: /devcards/
-Allow: /graphql/
+Allow: /graphql
 Allow: /boot
 Disallow: /`);
   });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -52,6 +52,8 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get('/robots.txt', (req, res) => {
     return res.type('text/plain').send(`User-agent: *
 Allow: /devcards/
+Allow: /graphql/
+Allow: /boot
 Disallow: /`);
   });
 


### PR DESCRIPTION
Removing `/boot` and `/graphql` from disallowed paths. 

But maybe we want do the the reverse at some point disabling only the crucial ones and allowing the rest [like gitlab do](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/39520).