### PR TITLE
feat: add new notification columns to `User`

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -110,6 +110,8 @@ const LOGGED_IN_BODY = {
     company: null,
     cover: null,
     experienceLevel: null,
+    followNotifications: true,
+    followingEmail: true,
     isTeamMember: false,
     roadmap: null,
     threads: null,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -214,6 +214,8 @@ const defaultUser: ChangeObject<Omit<User, 'createdAt'>> = {
     vordr: false,
   },
   language: null,
+  followingEmail: true,
+  followNotifications: true,
 };
 
 describe('source request', () => {

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -163,6 +163,12 @@ export class User {
   @Column({ type: 'text', nullable: true })
   language: ContentLanguage | null;
 
+  @Column({ type: 'boolean', default: true })
+  followingEmail: boolean;
+
+  @Column({ type: 'boolean', default: true })
+  followNotifications: boolean;
+
   @ManyToOne(() => User, {
     lazy: true,
     onDelete: 'SET NULL',

--- a/src/migration/1726691862710-User.ts
+++ b/src/migration/1726691862710-User.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class User1726691862710 implements MigrationInterface {
+  name = 'User1726691862710'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "followingEmail" boolean NOT NULL DEFAULT true`);
+    await queryRunner.query(`ALTER TABLE "user" ADD "followNotifications" boolean NOT NULL DEFAULT true`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "followNotifications"`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "followingEmail"`);
+  }
+}

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -384,6 +384,8 @@ const getUser = (con: DataSource, userId: string): Promise<User | null> =>
       'cover',
       'experienceLevel',
       'language',
+      'followingEmail',
+      'followNotifications',
     ],
   });
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -132,6 +132,8 @@ export interface GQLUpdateUserInput {
   infoConfirmed?: boolean;
   experienceLevel?: string;
   language?: ContentLanguage;
+  followingEmail?: boolean;
+  followNotifications?: boolean;
 }
 
 interface GQLUserParameters {
@@ -517,6 +519,14 @@ export const typeDefs = /* GraphQL */ `
     Preferred language of the user
     """
     language: String
+    """
+    Whether the user wants to receive follwing email notifications
+    """
+    followingEmail: Boolean
+    """
+    Whether the user wants to receives following push notifications
+    """
+    followNotifications: Boolean
   }
 
   type TagsReadingStatus {


### PR DESCRIPTION
Extends user table to add two new columns, `followingEmail` and `followNotifications`

AS-584