### PR TITLE
chore: minor opentelemetry tweaks

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -67,7 +67,7 @@ config:
     nodeEnv: development
     ogUrl: http://localhost:3000
     otelEnabled: false
-    otelExporterOtlpEndpoint: http://jaeger-collector.local.svc.cluster.local:4317
+    otelExporterOtlpEndpoint: http://jaeger-collector.local.svc.cluster.local:4318/v1/traces
     otelTracesSampler: parentbased_traceidratio
     otelTracesSamplerArg: 1
     personalizedDigestSecret: topsecret

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@fastify/rate-limit": "^9.1.0",
         "@fastify/websocket": "^10.0.1",
         "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.3.0",
-        "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.19.0",
         "@google-cloud/opentelemetry-resource-util": "^2.3.0",
         "@google-cloud/pubsub": "^4.7.0",
         "@google-cloud/storage": "^7.12.1",
@@ -1266,21 +1265,6 @@
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0"
-      }
-    },
-    "node_modules/@google-cloud/opentelemetry-cloud-trace-propagator": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-trace-propagator/-/opentelemetry-cloud-trace-propagator-0.19.0.tgz",
-      "integrity": "sha512-TIWpfaWFmMrPgNbJn+jB7FBRQ4O10k+jUABSWvyUt/P4ObxAxsAoqCNXwVUBR6pj21XLcCkshCdISgpy8TdY+w==",
-      "dependencies": {
-        "hex2dec": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "^1.0.0"
       }
     },
     "node_modules/@google-cloud/opentelemetry-resource-util": {
@@ -7355,11 +7339,6 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "dev": true
-    },
-    "node_modules/hex2dec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/hex2dec/-/hex2dec-1.1.2.tgz",
-      "integrity": "sha512-Yu+q/XWr2fFQ11tHxPq4p4EiNkb2y+lAacJNhAdRXVfRIcDH6gi7htWFnnlIzvqHMHoWeIsfXlNAjZInpAOJDA=="
     },
     "node_modules/hexoid": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@fastify/rate-limit": "^9.1.0",
     "@fastify/websocket": "^10.0.1",
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.3.0",
-    "@google-cloud/opentelemetry-cloud-trace-propagator": "^0.19.0",
     "@google-cloud/opentelemetry-resource-util": "^2.3.0",
     "@google-cloud/pubsub": "^4.7.0",
     "@google-cloud/storage": "^7.12.1",

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -122,9 +122,9 @@ export const tracer = (serviceName: string) => {
 
   const sdk = new NodeSDK({
     serviceName,
-    logRecordProcessor: new logs.SimpleLogRecordProcessor(
-      new logs.ConsoleLogRecordExporter(),
-    ),
+    logRecordProcessors: [
+      new logs.SimpleLogRecordProcessor(new logs.ConsoleLogRecordExporter()),
+    ],
     spanProcessors: [spanProcessor],
     instrumentations,
     resourceDetectors,

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -13,7 +13,7 @@ import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import dc from 'node:diagnostics_channel';
 
 import { NodeSDK, logs, node, api, resources } from '@opentelemetry/sdk-node';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
 // import { CloudPropagator } from '@google-cloud/opentelemetry-cloud-trace-propagator';

--- a/src/telemetry/opentelemetry.ts
+++ b/src/telemetry/opentelemetry.ts
@@ -16,7 +16,6 @@ import { NodeSDK, logs, node, api, resources } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import { GcpDetectorSync } from '@google-cloud/opentelemetry-resource-util';
-// import { CloudPropagator } from '@google-cloud/opentelemetry-cloud-trace-propagator';
 
 import { containerDetector } from '@opentelemetry/resource-detector-container';
 import { gcpDetector } from '@opentelemetry/resource-detector-gcp';
@@ -128,7 +127,6 @@ export const tracer = (serviceName: string) => {
     spanProcessors: [spanProcessor],
     instrumentations,
     resourceDetectors,
-    // textMapPropagator: new CloudPropagator(),
   });
 
   dc.subscribe(channelName, ({ fastify }: { fastify: FastifyInstance }) => {


### PR DESCRIPTION
- Fix deprecated config
  ```
  logRecordProcessor: LogRecordProcessor;
  ```
  got deprecated in favour of
  ```
  logRecordProcessors?: LogRecordProcessor[];
  ```
- Change exporter used in adhoc to a more stable one
  The GRPC exporter was sometimes complaining about jaeger being too slow to respond, so replaced it with HTTP exporter. **This is only relevant for adhoc**
- Remove gcloud cloud-trace-propagator
  It was not being used, and wont be used