### PR TITLE
fix: content preference state on follow queries

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -146,9 +146,12 @@ const obj = new GraphORM({
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
               .where(`${childAlias}."referenceId" = "${parentAlias}".id`)
-              .andWhere(`${childAlias}."userId" = :userId`, {
-                userId: ctx.userId,
-              })
+              .andWhere(
+                `${childAlias}."userId" = :currentContentPreferenceUserId`,
+                {
+                  currentContentPreferenceUserId: ctx.userId,
+                },
+              )
               .andWhere(`"${childAlias}".type = :type`, {
                 type: ContentPreferenceType.User,
               });


### PR DESCRIPTION
Fixes following (no pun intended 😆 ) [issue](https://dailydotdev.slack.com/archives/C07ATUPBPJ9/p1726756727350719)

Basically following and followers queries already define `:userId` parameter which means that inside graphorm `contentPreference` field resolver it gets overwritten and then it always takes the state from parent entity.

This fixes it by naming the param inside the field resolver to unique name. 