### PR TITLE
fix: allow content preference on search

### DIFF
--- a/src/common/search.ts
+++ b/src/common/search.ts
@@ -4,6 +4,7 @@ export type SearchSuggestionArgs = {
   query: string;
   version: number;
   limit?: number;
+  includeContentPreference?: boolean;
 };
 
 export const defaultSearchLimit = 3;

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -432,7 +432,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     searchUserSuggestions: async (
       source,
       { query, limit, includeContentPreference }: SearchSuggestionArgs,
-      ctx: AuthContext,
+      ctx: Context,
     ): Promise<GQLSearchSuggestionsResults> => {
       if (!query || query.length < 3 || query.length > 100) {
         return {
@@ -465,7 +465,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               });
           }),
         );
-      if (includeContentPreference) {
+      if (includeContentPreference && ctx.userId) {
         searchQuery.addSelect((contentPreferenceQueryBuilder) => {
           return contentPreferenceQueryBuilder
             .select('to_json(res)')

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -484,9 +484,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         .orderBy('u.reputation', 'DESC')
         .andWhere(whereVordrFilter('u'))
         .limit(getSearchLimit({ limit: Math.max(limit, 10) }));
-      console.log(searchQuery.getQueryAndParameters());
       const hits = await searchQuery.getRawMany();
-      console.log(hits);
       return {
         query,
         hits: hits.slice(0, limit),


### PR DESCRIPTION
@capJavert Please let me know what you think before I proceed.
The idea is that for the page query we can enable this and for the suggestion query we omit it.

Since the contentpreference is needed for more then 1 entity this seemed ok, but let me know if you are against it.