### PR TITLE
fix: squad create as public if `isPrivate` was not passed;

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1741,7 +1741,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         description,
         memberPostingRole = SourceMemberRoles.Member,
         memberInviteRole = SourceMemberRoles.Member,
-        isPrivate,
+        isPrivate = true,
         categoryId,
       }: SquadCreateInputArgs,
       ctx: AuthContext,


### PR DESCRIPTION
This was a retro-compatibility fix. 
Current frontend do not send the `isPrivate` field and make every squad created a public squad.


Tested create/edit/delete squads both private and public, everything seems to be ok 👍 