### PR TITLE
chore: add query read replica implementation

### DIFF
--- a/src/schema/actions.ts
+++ b/src/schema/actions.ts
@@ -82,12 +82,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   Query: {
     actions: (_, __, ctx: AuthContext, info): Promise<GQLUserAction[]> =>
       graphorm.query<GQLUserAction>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder.where(
-          {
-            userId: ctx.userId,
-          },
-          true,
-        );
+        builder.queryBuilder = builder.queryBuilder.where({
+          userId: ctx.userId,
+        });
 
         return builder;
       }),

--- a/src/schema/actions.ts
+++ b/src/schema/actions.ts
@@ -82,9 +82,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   Query: {
     actions: (_, __, ctx: AuthContext, info): Promise<GQLUserAction[]> =>
       graphorm.query<GQLUserAction>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder.where({
-          userId: ctx.userId,
-        });
+        builder.queryBuilder = builder.queryBuilder.where(
+          {
+            userId: ctx.userId,
+          },
+          true,
+        );
 
         return builder;
       }),

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -764,16 +764,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const comment = await graphorm.queryOneOrFail<GQLComment>(
         ctx,
         info,
-        (builder) => (
-          {
-            ...builder,
-            queryBuilder: builder.queryBuilder.where(
-              `"${builder.alias}"."id" = :id`,
-              { id },
-            ),
-          },
-          true
-        ),
+        (builder) => ({
+          ...builder,
+          queryBuilder: builder.queryBuilder.where(
+            `"${builder.alias}"."id" = :id`,
+            { id },
+          ),
+        }),
       );
 
       const post = await ctx.con

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -549,17 +549,12 @@ const getCommentById = async (
   ctx: Context,
   info: GraphQLResolveInfo,
 ): Promise<GQLComment> => {
-  const res = await graphorm.query<GQLComment>(
-    ctx,
-    info,
-    (builder) => {
-      builder.queryBuilder = builder.queryBuilder
-        .andWhere(`${builder.alias}.id = :id`, { id })
-        .limit(1);
-      return builder;
-    },
-    true,
-  );
+  const res = await graphorm.query<GQLComment>(ctx, info, (builder) => {
+    builder.queryBuilder = builder.queryBuilder
+      .andWhere(`${builder.alias}.id = :id`, { id })
+      .limit(1);
+    return builder;
+  });
   return res[0];
 };
 

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -549,12 +549,17 @@ const getCommentById = async (
   ctx: Context,
   info: GraphQLResolveInfo,
 ): Promise<GQLComment> => {
-  const res = await graphorm.query<GQLComment>(ctx, info, (builder) => {
-    builder.queryBuilder = builder.queryBuilder
-      .andWhere(`${builder.alias}.id = :id`, { id })
-      .limit(1);
-    return builder;
-  });
+  const res = await graphorm.query<GQLComment>(
+    ctx,
+    info,
+    (builder) => {
+      builder.queryBuilder = builder.queryBuilder
+        .andWhere(`${builder.alias}.id = :id`, { id })
+        .limit(1);
+      return builder;
+    },
+    true,
+  );
   return res[0];
 };
 
@@ -717,14 +722,19 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         return [];
       }
 
-      return graphorm.query(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .where(`"${builder.alias}".id IN (:...ids)`, { ids })
-          .orderBy(`"${builder.alias}".name`)
-          .limit(limit);
+      return graphorm.query(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .where(`"${builder.alias}".id IN (:...ids)`, { ids })
+            .orderBy(`"${builder.alias}".name`)
+            .limit(limit);
 
-        return builder;
-      });
+          return builder;
+        },
+        true,
+      );
     },
     commentPreview: async (
       _,
@@ -759,13 +769,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const comment = await graphorm.queryOneOrFail<GQLComment>(
         ctx,
         info,
-        (builder) => ({
-          ...builder,
-          queryBuilder: builder.queryBuilder.where(
-            `"${builder.alias}"."id" = :id`,
-            { id },
-          ),
-        }),
+        (builder) => (
+          {
+            ...builder,
+            queryBuilder: builder.queryBuilder.where(
+              `"${builder.alias}"."id" = :id`,
+              { id },
+            ),
+          },
+          true
+        ),
       );
 
       const post = await ctx.con

--- a/src/schema/compatibility.ts
+++ b/src/schema/compatibility.ts
@@ -147,17 +147,22 @@ function compatFeedResolver<
     info,
   ): Promise<GQLPost[]> =>
     compatGenerateFeed(source, args, ctx, (_, limit, offset, opts) =>
-      graphorm.query(ctx, info, (builder) => {
-        builder.queryBuilder = applyFeedWhere(
-          ctx,
-          query(ctx, args, opts, builder.queryBuilder, builder.alias),
-          builder.alias,
-          ['article'],
-        )
-          .limit(limit)
-          .offset(offset);
-        return builder;
-      }),
+      graphorm.query(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = applyFeedWhere(
+            ctx,
+            query(ctx, args, opts, builder.queryBuilder, builder.alias),
+            builder.alias,
+            ['article'],
+          )
+            .limit(limit)
+            .offset(offset);
+          return builder;
+        },
+        true,
+      ),
     );
 }
 

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -149,14 +149,19 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLKeyword | null> => {
-      const res = await graphorm.query<GQLKeyword>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.occurrences >= ${PENDING_THRESHOLD}`)
-          .andWhere(`${builder.alias}.status = 'pending'`)
-          .orderBy(`${builder.alias}.occurrences`, 'DESC')
-          .limit(30);
-        return builder;
-      });
+      const res = await graphorm.query<GQLKeyword>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .andWhere(`${builder.alias}.occurrences >= ${PENDING_THRESHOLD}`)
+            .andWhere(`${builder.alias}.status = 'pending'`)
+            .orderBy(`${builder.alias}.occurrences`, 'DESC')
+            .limit(30);
+          return builder;
+        },
+        true,
+      );
       if (res.length) {
         return res[Math.floor(Math.random() * res.length)];
       }
@@ -206,12 +211,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: Context,
       info,
     ): Promise<GQLKeyword | null> => {
-      const res = await graphorm.query<GQLKeyword>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.value = :value`, { value })
-          .limit(1);
-        return builder;
-      });
+      const res = await graphorm.query<GQLKeyword>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .andWhere(`${builder.alias}.value = :value`, { value })
+            .limit(1);
+          return builder;
+        },
+        true,
+      );
       return res?.[0] ?? null;
     },
   },

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1068,20 +1068,13 @@ const getPostById = async (
   info: GraphQLResolveInfo,
   id: string,
 ): Promise<GQLPost> => {
-  const res = await graphorm.query<GQLPost>(
-    ctx,
-    info,
-    (builder) => (
-      {
-        ...builder,
-        queryBuilder: builder.queryBuilder.where(
-          `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false`,
-          { id },
-        ),
-      },
+  const res = await graphorm.query<GQLPost>(ctx, info, (builder) => ({
+    ...builder,
+    queryBuilder: builder.queryBuilder.where(
+      `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false`,
+      { id },
     ),
-    true
-  );
+  }));
   if (res.length) {
     return res[0];
   }
@@ -1156,18 +1149,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const res = await graphorm.query(
         ctx,
         info,
-        (builder) => (
-          {
-            ...builder,
-            queryBuilder: builder.queryBuilder
-              .where(
-                `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url) AND "${builder.alias}"."deleted" = false`,
-                { url: standardizedUrl },
-              )
-              .limit(1),
-          },
-        ),
-        true
+        (builder) => ({
+          ...builder,
+          queryBuilder: builder.queryBuilder
+            .where(
+              `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url) AND "${builder.alias}"."deleted" = false`,
+              { url: standardizedUrl },
+            )
+            .limit(1),
+        }),
+        true,
       );
       if (res.length) {
         const post = res[0] as GQLPost;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1068,13 +1068,20 @@ const getPostById = async (
   info: GraphQLResolveInfo,
   id: string,
 ): Promise<GQLPost> => {
-  const res = await graphorm.query<GQLPost>(ctx, info, (builder) => ({
-    ...builder,
-    queryBuilder: builder.queryBuilder.where(
-      `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false`,
-      { id },
+  const res = await graphorm.query<GQLPost>(
+    ctx,
+    info,
+    (builder) => (
+      {
+        ...builder,
+        queryBuilder: builder.queryBuilder.where(
+          `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false`,
+          { id },
+        ),
+      },
     ),
-  }));
+    true
+  );
   if (res.length) {
     return res[0];
   }
@@ -1146,15 +1153,22 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLPost> => {
       const standardizedUrl = standardizeURL(url);
-      const res = await graphorm.query(ctx, info, (builder) => ({
-        ...builder,
-        queryBuilder: builder.queryBuilder
-          .where(
-            `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url) AND "${builder.alias}"."deleted" = false`,
-            { url: standardizedUrl },
-          )
-          .limit(1),
-      }));
+      const res = await graphorm.query(
+        ctx,
+        info,
+        (builder) => (
+          {
+            ...builder,
+            queryBuilder: builder.queryBuilder
+              .where(
+                `("${builder.alias}"."canonicalUrl" = :url OR "${builder.alias}"."url" = :url) AND "${builder.alias}"."deleted" = false`,
+                { url: standardizedUrl },
+              )
+              .limit(1),
+          },
+        ),
+        true
+      );
       if (res.length) {
         const post = res[0] as GQLPost;
         if (post.private) {
@@ -1244,6 +1258,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             .orderBy('random()', 'DESC')
             .limit(3),
         }),
+        true,
       );
       await setRedisObjectWithExpiry(
         key,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1093,12 +1093,17 @@ const getSourceById = async (
   info: GraphQLResolveInfo,
   id: string,
 ): Promise<GQLSource> => {
-  const res = await graphorm.query<GQLSource>(ctx, info, (builder) => {
-    builder.queryBuilder = builder.queryBuilder
-      .andWhere('(id = :id or handle = :id)', { id })
-      .limit(1);
-    return builder;
-  });
+  const res = await graphorm.query<GQLSource>(
+    ctx,
+    info,
+    (builder) => {
+      builder.queryBuilder = builder.queryBuilder
+        .andWhere('(id = :id or handle = :id)', { id })
+        .limit(1);
+      return builder;
+    },
+    true,
+  );
   if (!res.length) {
     throw new EntityNotFoundError(Source, 'not found');
   }
@@ -1207,17 +1212,22 @@ const getFormattedSources = async <Entity>(
 ): Promise<GQLSource[]> => {
   const { limit = 10 } = args;
 
-  return await graphorm.query(ctx, info, (builder) => {
-    builder.queryBuilder
-      .innerJoin(
-        ctx.con.getMetadata(entity).tableName,
-        'ts',
-        `ts."sourceId" = ${builder.alias}.id`,
-      )
-      .orderBy('r', 'DESC')
-      .limit(limit);
-    return builder;
-  });
+  return await graphorm.query(
+    ctx,
+    info,
+    (builder) => {
+      builder.queryBuilder
+        .innerJoin(
+          ctx.con.getMetadata(entity).tableName,
+          'ts',
+          `ts."sourceId" = ${builder.alias}.id`,
+        )
+        .orderBy('r', 'DESC')
+        .limit(limit);
+      return builder;
+    },
+    true,
+  );
 };
 
 const paginateSourceMembers = (
@@ -1485,13 +1495,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLSource[]> => {
       const { limit = 10 } = args;
-      return await graphorm.query(ctx, info, (builder) => {
-        builder.queryBuilder
-          .where({ active: true, type: SourceType.Machine })
-          .orderBy('"createdAt"', 'DESC')
-          .limit(limit);
-        return builder;
-      });
+      return await graphorm.query(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder
+            .where({ active: true, type: SourceType.Machine })
+            .orderBy('"createdAt"', 'DESC')
+            .limit(limit);
+          return builder;
+        },
+        true,
+      );
     },
     trendingSources: async (
       _,
@@ -1705,6 +1720,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             .limit(1);
           return builder;
         },
+        true,
       );
       if (!res.length) {
         throw new EntityNotFoundError(SourceMember, 'not found');

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1093,17 +1093,12 @@ const getSourceById = async (
   info: GraphQLResolveInfo,
   id: string,
 ): Promise<GQLSource> => {
-  const res = await graphorm.query<GQLSource>(
-    ctx,
-    info,
-    (builder) => {
-      builder.queryBuilder = builder.queryBuilder
-        .andWhere('(id = :id or handle = :id)', { id })
-        .limit(1);
-      return builder;
-    },
-    true,
-  );
+  const res = await graphorm.query<GQLSource>(ctx, info, (builder) => {
+    builder.queryBuilder = builder.queryBuilder
+      .andWhere('(id = :id or handle = :id)', { id })
+      .limit(1);
+    return builder;
+  });
   if (!res.length) {
     throw new EntityNotFoundError(Source, 'not found');
   }

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -132,16 +132,21 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 >({
   Query: {
     tags: (_, __, ctx: Context, info): Promise<GQLKeyword[]> =>
-      graphorm.query<GQLKeyword>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .where({
-            status: 'allow',
-          })
-          .orderBy('value', 'ASC')
-          .limit(1000);
+      graphorm.query<GQLKeyword>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .where({
+              status: 'allow',
+            })
+            .orderBy('value', 'ASC')
+            .limit(1000);
 
-        return builder;
-      }),
+          return builder;
+        },
+        true,
+      ),
     trendingTags: async (
       _,
       args: TagQueryArgs,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1147,15 +1147,20 @@ const getUserStreakQuery = async (
 };
 
 const getUserCompanies = async (_, ctx: Context, info: GraphQLResolveInfo) => {
-  return await graphorm.query<GQLUserCompany>(ctx, info, (builder) => {
-    builder.queryBuilder = builder.queryBuilder
-      .andWhere(`${builder.alias}."userId" = :userId`, {
-        userId: ctx.userId,
-      })
-      .andWhere(`${builder.alias}."verified" = true`);
+  return await graphorm.query<GQLUserCompany>(
+    ctx,
+    info,
+    (builder) => {
+      builder.queryBuilder = builder.queryBuilder
+        .andWhere(`${builder.alias}."userId" = :userId`, {
+          userId: ctx.userId,
+        })
+        .andWhere(`${builder.alias}."verified" = true`);
 
-    return builder;
-  });
+      return builder;
+    },
+    true,
+  );
 };
 
 export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
@@ -1164,12 +1169,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 >({
   Query: {
     whoami: async (_, __, ctx: AuthContext, info: GraphQLResolveInfo) => {
-      const res = await graphorm.query<GQLUser>(ctx, info, (builder) => {
-        builder.queryBuilder = builder.queryBuilder
-          .andWhere(`${builder.alias}.id = :id`, { id: ctx.userId })
-          .limit(1);
-        return builder;
-      });
+      const res = await graphorm.query<GQLUser>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .andWhere(`${builder.alias}.id = :id`, { id: ctx.userId })
+            .limit(1);
+          return builder;
+        },
+        true,
+      );
       if (!res[0]) {
         throw new NotFoundError('user not found');
       }
@@ -1546,6 +1556,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
             return builder;
           },
+          true,
         );
 
       if (personalizedDigest.length === 0) {


### PR DESCRIPTION
Add implementations for read replica on all `graphorm.query` calls that can use it.