### PR TITLE
fix: reduce members limit for source

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -408,8 +408,8 @@ const obj = new GraphORM({
               }),
         },
         pagination: {
-          limit: 50,
-          hasNextPage: (size): boolean => size === 50,
+          limit: 5,
+          hasNextPage: (size): boolean => size === 5,
           hasPreviousPage: (): boolean => false,
           nodeToCursor: (node: GQLComment): string =>
             base64(`time:${new Date(node.createdAt).getTime()}`),


### PR DESCRIPTION
By default we used to return 50 members and we show only 5.
 That's a lot of unused data. and I mean A LOT! 🤯