### PR TITLE
fix: ensure span is still recording when adding gql attributes

### DIFF
--- a/src/schema/trace.ts
+++ b/src/schema/trace.ts
@@ -22,7 +22,7 @@ export function traceResolver<
     context: TContext,
     info: GraphQLResolveInfo,
   ): Promise<TReturn> => {
-    if (context?.span) {
+    if (context?.span && context?.span?.isRecording()) {
       context.span.setAttributes({
         ['graphql.operation.name']: info.operation?.name?.value,
         ['graphql.operation.type']: info.operation.operation,


### PR DESCRIPTION
Noticed that there's still some error messages on the graphql requests