### PR TITLE
feat: remote config key as env

### DIFF
--- a/.env
+++ b/.env
@@ -47,6 +47,7 @@ MEILI_TOKEN=dev
 EXPERIMENTATION_KEY=6FA4C8D3DD2400B9D614BB7A229FD69B
 #GROWTHBOOK_CLIENT_KEY=override_me_in_env.development
 #GROWTHBOOK_API_CONFIG_CLIENT_KEY=override_me_in_env.development
+API_CONFIG_FEATURE_KEY=api-config
 
 JWT_PUBLIC_KEY_PATH=../apps/.cert/public.pem
 JWT_PRIVATE_KEY_PATH=../apps/.cert/key.pem

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -32,6 +32,7 @@ config:
       secure: AAABAGn2bvhAkQJ6kvEVRaS8pTG3B51Wspk8XUlHtyUSpfM3km2D9hEgN/rB3oED7W1/IjmCuSnfFMBDG4hl2g==
     analyticsUrl:
       secure: AAABAE0N2Ev1AukY16BKL3cJdx985Y2xZqSl2B9GJM0fSvxfBHxVbV9+OuRWdPOHLgMH+A==
+    apiConfigFeatureKey: api-config
     authorTwitterAccessTokenKey:
       secure: AAABADnvoAQhCnUKTmRoO0HRTKYMHDy5NbVP0QyGhMwAWVn7QlxCyBqW3FxugkakzUxaOhL/kQu2IkGRVQgEXceLYgcEcKhzrCLowUh3quyQdg==
     authorTwitterAccessTokenSecret:

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -11,7 +11,6 @@ type RemoteConfigValue = {
 
 class RemoteConfig {
   private gb?: GrowthBook;
-  private readonly configKey = 'api-config';
 
   async init(): Promise<void> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
@@ -43,7 +42,10 @@ class RemoteConfig {
       throw new Error('remote config not initialized');
     }
 
-    const result = this.gb.getFeatureValue(this.configKey, null);
+    const result = this.gb.getFeatureValue(
+      process.env.API_CONFIG_FEATURE_KEY,
+      null,
+    );
 
     if (!result) {
       logger.error('failed to get remote config');


### PR DESCRIPTION
Just to make it easier when working locally to replace config key with something else without doing any code changes that can be committed accidentally. 