### PR TITLE
fix: user post duplicate notification

### DIFF
--- a/src/workers/notifications/postAddedUserNotification.ts
+++ b/src/workers/notifications/postAddedUserNotification.ts
@@ -58,7 +58,14 @@ export const postAddedUserNotification =
       const contentPreferenceQuery = con
         .getRepository(ContentPreference)
         .createQueryBuilder('cp')
-        .leftJoin(NotificationPreferenceUser, 'np', 'np.userId = cp."userId"')
+        .leftJoin(
+          NotificationPreferenceUser,
+          'np',
+          'np.userId = cp."userId" AND np."notificationType" = :notificationType',
+          {
+            notificationType: NotificationType.UserPostAdded,
+          },
+        )
         .select('cp."referenceId"')
         .addSelect('cp."userId"')
         .where('cp."referenceId" IN(:...referencedUserIds)', {


### PR DESCRIPTION
So the issue was that on join with `notification_preference` table I did not include `notificationType`, which would mean for users that subscribed to some other notificationType their rows would be returned inside the worker.
<img width="629" alt="image" src="https://github.com/user-attachments/assets/6542353e-ce70-4cd3-b98e-8177e82b98a2">

With added condition on join now we only get single row per user (NULL if no preference or subscribed if user resubscribed to type)
<img width="638" alt="image" src="https://github.com/user-attachments/assets/1b78470e-23bf-4fbd-b32b-7ada6908efc3">
