### PR TITLE
feat: unique dedup post added notifications

### DIFF
--- a/src/entity/notifications/NotificationV2.ts
+++ b/src/entity/notifications/NotificationV2.ts
@@ -14,10 +14,14 @@ export type NotificationReferenceType =
 @Entity()
 @Index('ID_notification_v2_reference', ['referenceId', 'referenceType'])
 @Index(
-  'ID_notification_v2_uniq',
-  ['type', 'referenceId', 'referenceType', 'uniqueKey'],
-  { unique: true },
+  'IDX_notification_v2_post_added_unique',
+  ['referenceId', 'referenceType'],
+  {
+    unique: true,
+    where: `type IN ('user_post_added', 'source_post_added', 'squad_post_added')`,
+  },
 )
+@Index('ID_notification_v2_reference', ['referenceId', 'referenceType'])
 export class NotificationV2 {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/migration/1727870383565-NotificationV2PostAddedUnique.ts
+++ b/src/migration/1727870383565-NotificationV2PostAddedUnique.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationV2PostAddedUnique1727870383565
+  implements MigrationInterface
+{
+  name = 'NotificationV2PostAddedUnique1727870383565';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_notification_v2_post_added_unique" ON "notification_v2" ("referenceId", "referenceType") WHERE type IN ('user_post_added', 'source_post_added', 'squad_post_added')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_notification_v2_post_added_unique"`,
+    );
+  }
+}


### PR DESCRIPTION
AS-602 When user is subscribed to source and user we want them to receive only one notification.

Tried a bunch of stuff, querying on different places, dedup logic and this morning had an idea with triggers but everything involved some kind of additional query(s) to the DB which I wanted to avoid because notifications can be sent to a lot of users at the same time. 

At the end realized that because all post added notifications have same post id (referenceId) and referenceType (post) with which we can dedup them with unique index over post added types.

Minor edge case is that depending on which order notifications get published user will sometimes get `user_post_added` notification and sometimes `source_post_added` because its basically race condition. We should not be worried about that though (confirmed with Ido over gathering).

TODO:
- [x] deduplicate in the DB because we won't be able to add unique index until we do

Prepared the query, currently around 78 notifications need to be deduped, so it will be fast, will run it before deployment.