### PR TITLE
fix: user post duplicate user notification

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1198,29 +1198,23 @@ describe('storeNotificationBundle', () => {
       doneBy: usersFixture[1] as Reference<User>,
     };
 
-    const notificationIds: Awaited<
-      ReturnType<typeof storeNotificationBundleV2>
-    > = [];
+    const notificationIds = await con.transaction(async (manager) => {
+      const results = await Promise.all([
+        storeNotificationBundleV2(
+          manager,
+          generateNotificationV2(NotificationType.SourcePostAdded, ctx),
+        ),
+        storeNotificationBundleV2(
+          manager,
+          generateNotificationV2(NotificationType.SquadPostAdded, ctx),
+        ),
+        storeNotificationBundleV2(
+          manager,
+          generateNotificationV2(NotificationType.UserPostAdded, ctx),
+        ),
+      ]);
 
-    await storeNotificationBundleV2(
-      con.createEntityManager(),
-      generateNotificationV2(NotificationType.SourcePostAdded, ctx),
-    ).then((ids) => {
-      notificationIds.push(...ids);
-    });
-
-    await storeNotificationBundleV2(
-      con.createEntityManager(),
-      generateNotificationV2(NotificationType.SquadPostAdded, ctx),
-    ).then((ids) => {
-      notificationIds.push(...ids);
-    });
-
-    await storeNotificationBundleV2(
-      con.createEntityManager(),
-      generateNotificationV2(NotificationType.UserPostAdded, ctx),
-    ).then((ids) => {
-      notificationIds.push(...ids);
+      return results.flat();
     });
 
     expect(notificationIds.length).toEqual(3);

--- a/__tests__/notifications/notificationWorkerToWorker.ts
+++ b/__tests__/notifications/notificationWorkerToWorker.ts
@@ -119,6 +119,7 @@ describe('notificationWorkerToWorker', () => {
         public: true,
         readAt: null,
         userId: '3',
+        uniqueKey: null,
       },
       {
         createdAt: notifications[0].createdAt,
@@ -126,6 +127,7 @@ describe('notificationWorkerToWorker', () => {
         public: true,
         readAt: null,
         userId: '4',
+        uniqueKey: null,
       },
     ]);
   });

--- a/src/entity/notifications/UserNotification.ts
+++ b/src/entity/notifications/UserNotification.ts
@@ -9,6 +9,14 @@ import { NotificationV2 } from './NotificationV2';
   'createdAt',
 ])
 @Index('IDX_user_notification_user_id_read_at', ['userId', 'readAt'])
+@Index(
+  'IDX_user_notification_userId_uniqueKey_unique',
+  ['userId', 'uniqueKey'],
+  {
+    unique: true,
+    where: `"uniqueKey" IS NOT NULL`,
+  },
+)
 export class UserNotification {
   @PrimaryColumn({ type: 'uuid' })
   notificationId: string;
@@ -36,4 +44,7 @@ export class UserNotification {
     onDelete: 'CASCADE',
   })
   user: Promise<User>;
+
+  @Column({ type: 'text', nullable: true })
+  uniqueKey: string | null;
 }

--- a/src/migration/1728030331673-UserNotificationUniqueKey.ts
+++ b/src/migration/1728030331673-UserNotificationUniqueKey.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserNotificationUniqueKey1728030331673
+  implements MigrationInterface
+{
+  name = 'UserNotificationUniqueKey1728030331673';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_notification" ADD "uniqueKey" text`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_user_notification_userId_uniqueKey_unique" ON "user_notification" ("userId", "uniqueKey") WHERE "uniqueKey" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_user_notification_userId_uniqueKey_unique"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_notification" DROP COLUMN "uniqueKey"`,
+    );
+  }
+}

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -258,7 +258,7 @@ export const generateUserNotificationUniqueKey = ({
   referenceId?: string;
   referenceType?: NotificationReferenceType;
 }): string | null => {
-  const uniqueKey = notificationTypeToUniqueKey[type] || null;
+  const uniqueKey = notificationTypeToUniqueKey[type];
 
   if (!uniqueKey) {
     return null;

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -7,6 +7,7 @@ import {
   NotificationAttachmentV2,
   NotificationAvatarV2,
   NotificationV2,
+  NotificationReferenceType,
 } from '../entity';
 import { ValidationError } from 'apollo-server-errors';
 import { DataSource, EntityManager, IsNull } from 'typeorm';
@@ -235,3 +236,33 @@ export const getUnreadNotificationsCount = async (
       readAt: IsNull(),
     },
   });
+
+enum UserNotificationUniqueKey {
+  PostAdded = 'post_added',
+}
+
+const notificationTypeToUniqueKey: Partial<
+  Record<NotificationType, UserNotificationUniqueKey>
+> = {
+  [NotificationType.SquadPostAdded]: UserNotificationUniqueKey.PostAdded,
+  [NotificationType.SourcePostAdded]: UserNotificationUniqueKey.PostAdded,
+  [NotificationType.UserPostAdded]: UserNotificationUniqueKey.PostAdded,
+};
+
+export const generateUserNotificationUniqueKey = ({
+  type,
+  referenceId,
+  referenceType,
+}: {
+  type: NotificationType;
+  referenceId?: string;
+  referenceType?: NotificationReferenceType;
+}): string | null => {
+  const uniqueKey = notificationTypeToUniqueKey[type] || null;
+
+  if (!uniqueKey) {
+    return null;
+  }
+
+  return [uniqueKey, referenceId, referenceType].filter(Boolean).join(':');
+};

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -8,7 +8,7 @@ import { DeepPartial, EntityManager, ObjectLiteral } from 'typeorm';
 import { NotificationBuilder } from './builder';
 import { NotificationBaseContext, NotificationBundleV2 } from './types';
 import { generateNotificationMap, notificationTitleMap } from './generate';
-import { NotificationType } from './common';
+import { generateUserNotificationUniqueKey, NotificationType } from './common';
 import { NotificationHandlerReturn } from '../workers/notifications/worker';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
 
@@ -135,7 +135,9 @@ export async function storeNotificationBundleV2(
     return [];
   }
 
-  const notification = generatedMaps[0];
+  const notification = generatedMaps[0] as NotificationV2;
+  const uniqueKey = generateUserNotificationUniqueKey(notification);
+
   await entityManager
     .createQueryBuilder()
     .insert()
@@ -146,8 +148,10 @@ export async function storeNotificationBundleV2(
         notificationId: notification.id,
         createdAt: notification.createdAt,
         public: notification.public,
+        uniqueKey,
       })),
     )
+    .orIgnore()
     .execute();
 
   return identifiers as { id: string }[];

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -151,7 +151,11 @@ export async function storeNotificationBundleV2(
         uniqueKey,
       })),
     )
-    .orIgnore()
+    // onConflict deprecated (but still usable) because no way to use orIgnore with where clause
+    // https://github.com/typeorm/typeorm/issues/8124#issuecomment-1523780405
+    .onConflict(
+      '("userId", "uniqueKey") WHERE "uniqueKey" IS NOT NULL DO NOTHING',
+    )
     .execute();
 
   return identifiers as { id: string }[];


### PR DESCRIPTION
AS-602

Iteration on https://github.com/dailydotdev/daily-api/pull/2306, still using constraint approach but we now introduce `uniqueKey` for `user_notification` so we can dedup over notification type and other params. 

Unique key is built from notification type, referenceId and referenceType.

We unique constraint over `userId + uniqueKey` because we still want to have notifications across different users. 

By default `uniqueKey` is `NULL` and ignore by constraint. 