### PR TITLE
fix: properly sync all topics to cio

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -102,6 +102,7 @@ import { CommentReport } from '../src/entity/CommentReport';
 import { getRestoreStreakCache } from '../src/workers/cdc/primary';
 import { ContentPreferenceUser } from '../src/entity/contentPreference/ContentPreferenceUser';
 import { ContentPreferenceStatus } from '../src/entity/contentPreference/types';
+import { identifyUserPersonalizedDigest } from '../src/cio';
 
 let con: DataSource;
 let app: FastifyInstance;
@@ -116,6 +117,11 @@ jest.mock('../src/common/mailing.ts', () => ({
     unknown
   >),
   sendEmail: jest.fn(),
+}));
+
+jest.mock('../src/cio', () => ({
+  ...(jest.requireActual('../src/cio') as Record<string, unknown>),
+  identifyUserPersonalizedDigest: jest.fn(),
 }));
 
 beforeAll(async () => {
@@ -4306,6 +4312,14 @@ describe('mutation subscribePersonalizedDigest', () => {
       preferredDay: DayOfWeek.Monday,
       preferredHour: 9,
     });
+
+    expect(
+      jest.mocked(identifyUserPersonalizedDigest).mock.calls[0][0],
+    ).toEqual({
+      cio: expect.any(Object),
+      userId: '1',
+      subscribed: true,
+    });
   });
 
   it('should subscribe to personal digest for user with settings', async () => {
@@ -4408,6 +4422,14 @@ describe('mutation unsubscribePersonalizedDigest', () => {
         userId: loggedUser,
       });
     expect(personalizedDigest).toBeNull();
+
+    expect(
+      jest.mocked(identifyUserPersonalizedDigest).mock.calls[0][0],
+    ).toEqual({
+      cio: expect.any(Object),
+      userId: '1',
+      subscribed: false,
+    });
   });
 
   it('should not throw error if not subscribed', async () => {

--- a/__tests__/workers/userCreatedCio.ts
+++ b/__tests__/workers/userCreatedCio.ts
@@ -39,7 +39,9 @@ describe('userCreatedCio', () => {
     updatedAt: 1714577744717000,
     bio: 'bio',
     readme: 'readme',
+    notificationEmail: true,
     acceptedMarketing: true,
+    followingEmail: true,
   };
 
   it('should be registered', () => {
@@ -65,6 +67,9 @@ describe('userCreatedCio', () => {
       referral_link: referral,
       accepted_marketing: true,
       'cio_subscription_preferences.topics.topic_4': true,
+      'cio_subscription_preferences.topics.topic_7': true,
+      'cio_subscription_preferences.topics.topic_8': false,
+      'cio_subscription_preferences.topics.topic_9': true,
     });
   });
 
@@ -73,11 +78,12 @@ describe('userCreatedCio', () => {
     await expectSuccessfulTypedBackground(worker, {
       user: { ...base, acceptedMarketing: false },
     } as unknown as PubSubSchema['api.v1.user-created']);
-    expect(
-      mocked(cio.identify).mock.calls[0][1][
-        'cio_subscription_preferences.topics.topic_4'
-      ],
-    ).toEqual(false);
+    expect(mocked(cio.identify).mock.calls[0][1]).toMatchObject({
+      'cio_subscription_preferences.topics.topic_4': false,
+      'cio_subscription_preferences.topics.topic_7': true,
+      'cio_subscription_preferences.topics.topic_8': false,
+      'cio_subscription_preferences.topics.topic_9': true,
+    });
   });
 
   it('should not update customer.io if user is ghost user', async () => {

--- a/src/workers/userCompanyApprovedCio.ts
+++ b/src/workers/userCompanyApprovedCio.ts
@@ -28,7 +28,7 @@ const worker: TypedWorker<'api.v1.user-company-approved'> = {
       return;
     }
 
-    await identifyUserCompany(log, cioV2, userCompany, company);
+    await identifyUserCompany({ cio: cioV2, userCompany, company });
   },
 };
 

--- a/src/workers/userCreatedCio.ts
+++ b/src/workers/userCreatedCio.ts
@@ -17,7 +17,12 @@ const worker: TypedWorker<'api.v1.user-created'> = {
       return;
     }
 
-    await identifyUser(log, cio, user);
+    await identifyUser({
+      con,
+      log,
+      cio,
+      user,
+    });
     log.info({ userId: user.id }, 'created user profile in customerio');
   },
 };

--- a/src/workers/userCreatedCio.ts
+++ b/src/workers/userCreatedCio.ts
@@ -19,7 +19,6 @@ const worker: TypedWorker<'api.v1.user-created'> = {
 
     await identifyUser({
       con,
-      log,
       cio,
       user,
     });

--- a/src/workers/userStreakUpdatedCio.ts
+++ b/src/workers/userStreakUpdatedCio.ts
@@ -8,7 +8,7 @@ const days = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 const worker: TypedWorker<'api.v1.user-streak-updated'> = {
   subscription: 'api.user-streak-updated-cio',
-  handler: async (message, con, log) => {
+  handler: async (message, con) => {
     if (!process.env.CIO_SITE_ID) {
       return;
     }
@@ -44,7 +44,10 @@ const worker: TypedWorker<'api.v1.user-streak-updated'> = {
       lastSevenDays,
     };
 
-    await identifyUserStreak(log, cio, userStreakData);
+    await identifyUserStreak({
+      cio,
+      data: userStreakData,
+    });
   },
 };
 

--- a/src/workers/userUpdatedCio.ts
+++ b/src/workers/userUpdatedCio.ts
@@ -26,7 +26,6 @@ const worker: TypedWorker<'user-updated'> = {
 
     await identifyUser({
       con,
-      log,
       cio,
       user,
     });

--- a/src/workers/userUpdatedCio.ts
+++ b/src/workers/userUpdatedCio.ts
@@ -24,7 +24,12 @@ const worker: TypedWorker<'user-updated'> = {
       await resubscribeUser(cio, user.id);
     }
 
-    await identifyUser(log, cio, user);
+    await identifyUser({
+      con,
+      log,
+      cio,
+      user,
+    });
     log.info({ userId: user.id }, 'updated user profile in customerio');
   },
 };


### PR DESCRIPTION
> When sending `cio_subscription_preferences` from `cio.identify` (for user) we have to include all existing topics in the object. If not CIO will take what it has and make everything else a default value (that is set in cio topics area) and for stuff like digest and follow it will become "subscribed" again.

Above was hotfixed in https://github.com/dailydotdev/daily-api/pull/2314

In addition to above, this PR also sync other subs in the same way. 

In addition it also syncs digest after subscribe/unsubscribe mutations through `identifyUserPersonalizedDigest` util.

More discussion in [thread](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1728038592931229) 