### PR TITLE
refactor: cache expiry to be next weekday

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3565,7 +3565,7 @@ describe('user streak change', () => {
       expect(lastStreak).toEqual(3);
       const alert = await con.getRepository(Alerts).findOneBy({ userId: '1' });
       expect(alert!.showRecoverStreak).toEqual(true);
-      expect(spy).toHaveBeenCalledWith('streak:reset:1', 3, 216000); // 60 hours - 2 days = 48 hours + 12 hours
+      expect(spy).toHaveBeenCalledWith('streak:reset:1', 3, 216000); // 60 hours --- 2 days = 48 hours + 12 hours
     });
 
     it('should set cache of previous streak even when weekend had passed if it has only been 2 valid days', async () => {

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -3501,6 +3501,7 @@ describe('user streak change', () => {
     });
 
     it('should set cache of previous streak for recovery', async () => {
+      const spy = jest.spyOn(redisFile, 'setRedisObjectWithExpiry');
       const after: ChangeObject<ObjectType> = {
         ...base,
         ...dates,
@@ -3524,7 +3525,47 @@ describe('user streak change', () => {
       ]);
       expect(lastStreak).toEqual(3);
       const alert = await con.getRepository(Alerts).findOneBy({ userId: '1' });
-      expect(alert.showRecoverStreak).toEqual(true);
+      expect(alert!.showRecoverStreak).toEqual(true);
+      expect(spy).toHaveBeenCalledWith('streak:reset:1', 3, 43200); // 12 hours
+    });
+
+    it('should set cache until next weekday as expiry', async () => {
+      const spy = jest.spyOn(redisFile, 'setRedisObjectWithExpiry');
+      jest
+        .useFakeTimers({ doNotFake })
+        .setSystemTime(new Date('2024-08-31T12:00:00.123Z')); // Saturday
+      const lastViewAt = new Date('2024-08-29T12:00:00'); // previous Thursday
+      const after: ChangeObject<ObjectType> = {
+        ...base,
+        lastViewAt: lastViewAt.toISOString() as never,
+        currentStreak: 0,
+      };
+      await con
+        .getRepository(UserStreak)
+        .update({ userId: '1' }, { lastViewAt });
+      await expectSuccessfulBackground(
+        worker,
+        mockChangeMessage<ObjectType>({
+          after,
+          before: {
+            ...base,
+            currentStreak: 3,
+            lastViewAt: lastViewAt.toISOString() as never,
+          },
+          op: 'u',
+          table: 'user_streak',
+        }),
+      );
+      const lastStreak = await getRestoreStreakCache({ userId: after.userId });
+      expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+      expect(jest.mocked(triggerTypedEvent).mock.calls[0].slice(1)).toEqual([
+        'api.v1.user-streak-updated',
+        { streak: after },
+      ]);
+      expect(lastStreak).toEqual(3);
+      const alert = await con.getRepository(Alerts).findOneBy({ userId: '1' });
+      expect(alert!.showRecoverStreak).toEqual(true);
+      expect(spy).toHaveBeenCalledWith('streak:reset:1', 3, 216000); // 60 hours - 2 days = 48 hours + 12 hours
     });
 
     it('should set cache of previous streak even when weekend had passed if it has only been 2 valid days', async () => {

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -124,7 +124,7 @@ export class User {
   timezone?: string;
 
   @Column({ type: 'int', nullable: true, default: DEFAULT_WEEK_START })
-  weekStart?: DayOfWeek;
+  weekStart: DayOfWeek;
 
   @Column({ type: 'boolean', default: false })
   profileConfirmed: boolean | null;

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -82,6 +82,7 @@ import {
   notifySquadFeaturedUpdated,
   DEFAULT_TIMEZONE,
   notifySourceReport,
+  DayOfWeek,
 } from '../../common';
 import { ChangeMessage, ChangeObject, UserVote } from '../../types';
 import { DataSource, IsNull } from 'typeorm';
@@ -108,7 +109,7 @@ import {
   cancelReminderWorkflow,
   runReminderWorkflow,
 } from '../../temporal/notifications/utils';
-import { addDays } from 'date-fns';
+import { addDays, nextMonday } from 'date-fns';
 import {
   postReportReasonsMap,
   reportCommentReasonsMap,
@@ -116,6 +117,7 @@ import {
 } from '../../entity/common';
 import { utcToZonedTime } from 'date-fns-tz';
 import { SourceReport } from '../../entity/sources/SourceReport';
+import { now } from 'lodash';
 
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,
@@ -857,6 +859,37 @@ const onSquadPublicRequestChange = async (
   });
 };
 
+const WEEKEND_MAP: Partial<Record<DayOfWeek, DayOfWeek[]>> = {
+  [DayOfWeek.Sunday]: [5, 6],
+  [DayOfWeek.Monday]: [6, 0],
+};
+
+const getNextWeekday = (todayTz: Date, weekStart: DayOfWeek): Date => {
+  const weekends = WEEKEND_MAP[weekStart];
+
+  if (!weekends) {
+    throw new Error('Invalid week start: ' + weekStart);
+  }
+
+  if (!weekends.includes(todayTz.getDay())) {
+    return addDays(todayTz, 1);
+  }
+
+  const monday = nextMonday(todayTz);
+  const weekday = weekStart === DayOfWeek.Sunday ? monday : addDays(monday, 1);
+
+  return weekday;
+};
+
+const getNextWeekdayInSeconds = (user: User): number => {
+  const { weekStart } = user;
+  const today = utcToZonedTime(new Date(), user.timezone || DEFAULT_TIMEZONE);
+  const weekday = getNextWeekday(today, weekStart!);
+  const startOfDay = weekday.setHours(0, 0, 0, 0);
+
+  return Math.round((startOfDay - today.getTime()) / 1000);
+};
+
 const setRestoreStreakCache = async (
   con: DataSource,
   streak: ChangeObject<UserStreak>,
@@ -875,10 +908,7 @@ const setRestoreStreakCache = async (
   }
 
   const key = generateStorageKey(StorageTopic.Streak, StorageKey.Reset, userId);
-  const today = utcToZonedTime(new Date(), user.timezone || DEFAULT_TIMEZONE);
-  const now = today.getTime();
-  const nextDay = addDays(now, 1).setHours(0, 0, 0, 0);
-  const differenceInSeconds = Math.round((nextDay - now) / 1000);
+  const differenceInSeconds = getNextWeekdayInSeconds(user);
 
   await Promise.all([
     setRedisObjectWithExpiry(key, previousStreak, differenceInSeconds),

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -883,7 +883,7 @@ const getNextWeekday = (todayTz: Date, weekStart: DayOfWeek): Date => {
 const getNextWeekdayInSeconds = (user: User): number => {
   const { weekStart } = user;
   const today = utcToZonedTime(new Date(), user.timezone || DEFAULT_TIMEZONE);
-  const weekday = getNextWeekday(today, weekStart!);
+  const weekday = getNextWeekday(today, weekStart);
   const startOfDay = weekday.setHours(0, 0, 0, 0);
 
   return Math.round((startOfDay - today.getTime()) / 1000);

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -109,7 +109,7 @@ import {
   cancelReminderWorkflow,
   runReminderWorkflow,
 } from '../../temporal/notifications/utils';
-import { addDays, nextMonday } from 'date-fns';
+import { addDays, nextMonday, nextTuesday } from 'date-fns';
 import {
   postReportReasonsMap,
   reportCommentReasonsMap,
@@ -874,10 +874,10 @@ const getNextWeekday = (todayTz: Date, weekStart: DayOfWeek): Date => {
     return addDays(todayTz, 1);
   }
 
-  const monday = nextMonday(todayTz);
-  const weekday = weekStart === DayOfWeek.Sunday ? monday : addDays(monday, 1);
+  const weekStartEndOfDay =
+    weekStart === DayOfWeek.Sunday ? nextMonday(todayTz) : nextTuesday(todayTz);
 
-  return weekday;
+  return weekStartEndOfDay;
 };
 
 const getNextWeekdayInSeconds = (user: User): number => {

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -117,7 +117,6 @@ import {
 } from '../../entity/common';
 import { utcToZonedTime } from 'date-fns-tz';
 import { SourceReport } from '../../entity/sources/SourceReport';
-import { now } from 'lodash';
 
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,


### PR DESCRIPTION
We set the expiry of the cache until the next day, regardless if the next day is a weekend.

There is one issue though, we have a cron job that resets the cache in an interval, and when it runs on the weekend, let's say Saturday, the cache expires on Sunday which the user might have not logged in and defeats the purpose of the restore on weekends.

We are now setting the cache until the next valid day, so the previous case still applies on weekdays, but now, on weekends, we set the expiry until EOD of the next weekday. In the case above, EOD Monday.