### PR TITLE
fix: use subapp instead on api-bg

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -112,7 +112,7 @@ if (isPersonalizedDigestEnabled) {
     name,
     isAdhocEnv,
     addLabelsToWorkers(personalizedDigestWorkers, {
-      app: name,
+      app: `${name}-personalized-digest`,
       subapp: 'personalized-digest',
     }),
     { dependsOn: [deadLetterTopic] },
@@ -393,7 +393,10 @@ if (isAdhocEnv) {
       },
       metric: {
         type: 'pubsub',
-        labels: { app: name, subapp: 'personalized-digest' },
+        labels: {
+          app: `${name}-personalized-digest`,
+          subapp: 'personalized-digest',
+        },
         targetAverageValue: 100_000,
       },
       ...vols,

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -112,7 +112,7 @@ if (isPersonalizedDigestEnabled) {
     name,
     isAdhocEnv,
     addLabelsToWorkers(personalizedDigestWorkers, {
-      app: `${name}-personalized-digest`,
+      app: name,
       subapp: 'personalized-digest',
     }),
     { dependsOn: [deadLetterTopic] },
@@ -240,7 +240,10 @@ if (isAdhocEnv) {
       requests: bgRequests,
       metric: {
         type: 'pubsub',
-        labels: { app: name },
+        labels: {
+          app: name,
+          subapp: 'background',
+        },
         targetAverageValue: 50,
       },
       ports: [{ containerPort: 9464, name: 'metrics' }],
@@ -264,7 +267,10 @@ if (isAdhocEnv) {
       requests: bgRequests,
       metric: {
         type: 'pubsub',
-        labels: { app: name, subapp: 'personalized-digest' },
+        labels: {
+          app: name,
+          subapp: 'personalized-digest',
+        },
         targetAverageValue: 50,
       },
       ports: [{ containerPort: 9464, name: 'metrics' }],
@@ -331,7 +337,10 @@ if (isAdhocEnv) {
       requests: bgRequests,
       metric: {
         type: 'pubsub',
-        labels: { app: name },
+        labels: {
+          app: name,
+          subapp: 'background',
+        },
         targetAverageValue: 100,
       },
       ports: [{ containerPort: 9464, name: 'metrics' }],

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -403,7 +403,7 @@ if (isAdhocEnv) {
       metric: {
         type: 'pubsub',
         labels: {
-          app: `${name}-personalized-digest`,
+          app: name,
           subapp: 'personalized-digest',
         },
         targetAverageValue: 100_000,


### PR DESCRIPTION
This is to prevent the HPA for api-bg to scale up when digest subscription is filled