### PR TITLE
chore: increase sub comment limit

### DIFF
--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -546,8 +546,8 @@ const obj = new GraphORM({
           },
         },
         pagination: {
-          limit: 50,
-          hasNextPage: (size): boolean => size === 50,
+          limit: 100,
+          hasNextPage: (size): boolean => size === 100,
           hasPreviousPage: (): boolean => false,
           nodeToCursor: (node: GQLComment): string =>
             base64(`time:${new Date(node.createdAt).getTime()}`),


### PR DESCRIPTION
Intermediate fix to enable more children comment loading.
Current limit was 50, we have comments with over 50 sub comments.

See issue:
https://github.com/dailydotdev/daily/issues/1483

Note:
This is a quick fix, we should work on better comment handling in general.