### PR TITLE
fix: Changed the default value of moderationRequired in createSquad

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1711,7 +1711,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         description,
         memberPostingRole = SourceMemberRoles.Member,
         memberInviteRole = SourceMemberRoles.Member,
-        moderationRequired = true,
+        moderationRequired,
         isPrivate = true,
         categoryId,
       }: SquadCreateInputArgs,


### PR DESCRIPTION
There was an issue with the fact that "moderationRequired" was set to true as a default value, but it cannot be changed in the frontend yet.

This means, if one were to create a squad set with posting permission to moderator, it would cause a validation error.