### PR TITLE
fix: null notifications

### DIFF
--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -68,6 +68,7 @@ export class NotificationBuilder {
   static new(type: NotificationType, userIds: string[]): NotificationBuilder {
     return new NotificationBuilder(type, userIds);
   }
+
   buildV2(): NotificationBundleV2 {
     return {
       notification: this.notification,
@@ -307,7 +308,12 @@ export class NotificationBuilder {
       newBuilder = newBuilder.avatarSource(source);
     }
     if (post.type === PostType.Share && sharedPost) {
-      const title = post.title?.length ? simplifyComment(post.title) : '';
+      const sharedTitle = sharedPost.title?.length
+        ? simplifyComment(sharedPost.title)
+        : '';
+      const title = post.title?.length
+        ? simplifyComment(post.title)
+        : sharedTitle;
       newBuilder = newBuilder.description(title).attachmentPost(sharedPost);
     } else {
       newBuilder = newBuilder.attachmentPost(post);

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -39,7 +39,7 @@ const getPostOrSharedPostTitle = (
     return ctx.post.title;
   }
 
-  if (ctx.sharedPost?.title && ctx.sharedPost?.title?.length > 0) {
+  if (ctx.sharedPost?.title?.length > 0) {
     return ctx.sharedPost.title;
   }
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -96,7 +96,7 @@ export const notificationTitleMap: Record<
     `The collection "<b>${ctx.post.title}</b>" just got updated with new details`,
   dev_card_unlocked: () => 'DevCard unlocked!',
   post_bookmark_reminder: (ctx: NotificationPostContext) =>
-    `Reading reminder! <b>${ctx.post.title}</b>`,
+    `Reading reminder! <b>${ctx.post.title ? ctx.post.title : ctx.sharedPost?.title ? ctx.sharedPost?.title : undefined}</b>`,
   source_post_added: (
     ctx: NotificationPostContext & NotificationDoneByContext,
   ) => `New post from <b>${ctx.source.name}</b>, check it out now!`,

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -32,6 +32,20 @@ import { format } from 'date-fns';
 
 const systemTitle = () => undefined;
 
+const getPostOrSharedPostTitle = (
+  ctx: NotificationPostContext,
+): string | null | undefined => {
+  if (ctx.post.title?.length > 0) {
+    return ctx.post.title;
+  }
+
+  if (ctx.sharedPost?.title?.length > 0) {
+    return ctx.sharedPost?.title;
+  }
+
+  return undefined;
+};
+
 export const notificationTitleMap: Record<
   NotificationType,
   (ctx: never) => string | undefined
@@ -96,7 +110,7 @@ export const notificationTitleMap: Record<
     `The collection "<b>${ctx.post.title}</b>" just got updated with new details`,
   dev_card_unlocked: () => 'DevCard unlocked!',
   post_bookmark_reminder: (ctx: NotificationPostContext) =>
-    `Reading reminder! <b>${ctx.post.title ? ctx.post.title : ctx.sharedPost?.title ? ctx.sharedPost?.title : undefined}</b>`,
+    `Reading reminder! <b>${getPostOrSharedPostTitle(ctx)}</b>`,
   source_post_added: (
     ctx: NotificationPostContext & NotificationDoneByContext,
   ) => `New post from <b>${ctx.source.name}</b>, check it out now!`,

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -39,7 +39,7 @@ const getPostOrSharedPostTitle = (
     return ctx.post.title;
   }
 
-  if (ctx.sharedPost?.title?.length > 0) {
+  if (ctx.sharedPost?.title?.length) {
     return ctx.sharedPost.title;
   }
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -35,7 +35,7 @@ const systemTitle = () => undefined;
 const getPostOrSharedPostTitle = (
   ctx: NotificationPostContext,
 ): string | null | undefined => {
-  if (ctx.post.title && ctx.post.title?.length > 0) {
+  if (ctx.post?.title?.length > 0) {
     return ctx.post.title;
   }
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -35,12 +35,12 @@ const systemTitle = () => undefined;
 const getPostOrSharedPostTitle = (
   ctx: NotificationPostContext,
 ): string | null | undefined => {
-  if (ctx.post.title?.length > 0) {
+  if (ctx.post.title && ctx.post.title?.length > 0) {
     return ctx.post.title;
   }
 
-  if (ctx.sharedPost?.title?.length > 0) {
-    return ctx.sharedPost?.title;
+  if (ctx.sharedPost?.title && ctx.sharedPost?.title?.length > 0) {
+    return ctx.sharedPost.title;
   }
 
   return undefined;

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -35,7 +35,7 @@ const systemTitle = () => undefined;
 const getPostOrSharedPostTitle = (
   ctx: NotificationPostContext,
 ): string | null | undefined => {
-  if (ctx.post?.title?.length > 0) {
+  if (ctx.post?.title?.length) {
     return ctx.post.title;
   }
 


### PR DESCRIPTION
There's an [issue](https://github.com/dailydotdev/daily/issues/1488) where if you bookmark shared post without title it will show `null`.
This was actually a deeper lying issue in notification generation.

So decided to fallback in several places to sharedPost.title if it exists.

![Screenshot 2024-10-11 at 14 42 33](https://github.com/user-attachments/assets/b5adf86c-ac70-4fff-9b96-c9b3aede9b29)
