### PR TITLE
feat: reuse manager and pool connect calls

### DIFF
--- a/src/common/queryDataSource.ts
+++ b/src/common/queryDataSource.ts
@@ -1,0 +1,14 @@
+import { DataSource, QueryRunner, ReplicationMode } from 'typeorm';
+
+export const queryDataSource = async <T>(
+  con: DataSource,
+  callback: ({ queryRunner }: { queryRunner: QueryRunner }) => Promise<T>,
+  options?: Partial<{
+    mode: ReplicationMode;
+  }>,
+): Promise<T> => {
+  const queryRunner = con.createQueryRunner(options?.mode || 'master');
+  const result = await callback({ queryRunner });
+  await queryRunner.release();
+  return result;
+};

--- a/src/common/queryReadReplica.ts
+++ b/src/common/queryReadReplica.ts
@@ -1,11 +1,11 @@
 import { DataSource, QueryRunner } from 'typeorm';
+import { queryDataSource } from './queryDataSource';
 
 export const queryReadReplica = async <T>(
   con: DataSource,
   callback: ({ queryRunner }: { queryRunner: QueryRunner }) => Promise<T>,
 ): Promise<T> => {
-  const queryRunner = con.createQueryRunner('slave');
-  const result = await callback({ queryRunner });
-  await queryRunner.release();
-  return result;
+  return queryDataSource(con, callback, {
+    mode: 'slave',
+  });
 };

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -10,7 +10,7 @@ import {
   NotificationReferenceType,
 } from '../entity';
 import { ValidationError } from 'apollo-server-errors';
-import { DataSource, EntityManager, IsNull } from 'typeorm';
+import { DataSource, EntityManager, IsNull, QueryRunner } from 'typeorm';
 import {
   NotFoundError,
   TypeOrmError,
@@ -226,10 +226,10 @@ export const streamNotificationUsers = (
 };
 
 export const getUnreadNotificationsCount = async (
-  con: DataSource,
+  con: DataSource | QueryRunner,
   userId: string,
 ) =>
-  await con.getRepository(UserNotification).count({
+  await con.manager.getRepository(UserNotification).count({
     where: {
       userId,
       public: true,

--- a/src/schema/alerts.ts
+++ b/src/schema/alerts.ts
@@ -2,7 +2,7 @@ import { Alerts, ALERTS_DEFAULT, UserActionType } from '../entity';
 import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
 import { AuthContext, BaseContext, Context } from '../Context';
-import { DataSource } from 'typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
 import { insertOrIgnoreAction } from './actions';
 import { GQLEmptyResponse } from './common';
 
@@ -216,11 +216,11 @@ export const updateAlerts = async (
 };
 
 export const getAlerts = async (
-  con: DataSource,
+  con: DataSource | QueryRunner,
   userId?: string,
 ): Promise<Omit<Alerts, 'flags'>> => {
   const alerts = userId
-    ? await con.getRepository(Alerts).findOneBy({
+    ? await con.manager.getRepository(Alerts).findOneBy({
         userId,
       })
     : undefined;

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -10,7 +10,7 @@ import {
 import { isValidHttpUrl, toGQLEnum } from '../common';
 import { ValidationError } from 'apollo-server-errors';
 import { v4 as uuidv4 } from 'uuid';
-import { DataSource } from 'typeorm';
+import { DataSource, QueryRunner } from 'typeorm';
 
 interface GQLSettings {
   userId: string;
@@ -281,11 +281,11 @@ export const typeDefs = /* GraphQL */ `
 type PartialBookmarkSharing = Pick<GQLBookmarksSharing, 'slug'>;
 
 export const getSettings = async (
-  con: DataSource,
+  con: DataSource | QueryRunner,
   userId: string,
 ): Promise<Omit<Settings, 'user'>> => {
   try {
-    const repo = con.getRepository(Settings);
+    const repo = con.manager.getRepository(Settings);
     const settings = await repo.findOneBy({ userId });
     if (!settings) {
       return { ...SETTINGS_DEFAULT, updatedAt: null, userId };

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -81,7 +81,7 @@ import {
 } from '../errors';
 import { deleteUser } from '../directive/user';
 import { randomInt } from 'crypto';
-import { ArrayContains, DataSource, In, IsNull } from 'typeorm';
+import { ArrayContains, DataSource, In, IsNull, QueryRunner } from 'typeorm';
 import { DisallowHandle } from '../entity/DisallowHandle';
 import { ContentLanguage, UserVote, UserVoteEntity } from '../types';
 import { markdown } from '../common/markdown';
@@ -1104,7 +1104,7 @@ const timestampAtTimezone = `"timestamp"::timestamptz ${userTimezone}`;
 const MAX_README_LENGTH = 10_000;
 
 export const getMarketingCta = async (
-  con: DataSource,
+  con: DataSource | QueryRunner,
   log: FastifyBaseLogger,
   userId: string,
 ) => {


### PR DESCRIPTION
I found the reason why we have multiple `pg-pool.connect` in boot traces. Even though pool manages connection reuse each call to `queryReadReplica` still has to query a connection from a pool, which has some cost, usually few ms, but sometimes as seen in production few 10s or 100s of ms.

I optimized boot so all read replica calls are bundled inside single `queryReadReplica` call, which reuses `QueryRunner`, which then does a single `pg-pool.connect` call under the hood.

After optimization the number of calls fell from 8 to 4. 

Looking further I realized that same thing happens with `con.query`, `con.find` or other calls. So I added a `queryDataSource` abstraction which allows us to also reuse single manager for `master` calls. After this it fell to only 2 calls for `loggedInBoot`, one for `master` and one for `slave` (read replica).

We need to deploy to see the difference it will make and if it will eliminate the high `pg-pool.connect` calls in production but looks much better already locally. 

Other changes include types refactor from `con: DataSource` to `con: DataSource | QueryRunner` to support passing a runner instance from parent calls.

Example traces before/after (from local jaeger):

Before:
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/00dd531e-ff95-4b8d-912d-4e7bb7d5b116">

After:
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/dbf98bbb-236d-4315-a30c-53f8799d21ef">

We can also see smaller number of spans due to pool calls being reused:

Before:
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/3f4573c1-e404-467a-b2e2-726dc729d165">

After:
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/69e27384-2b31-4253-82bf-5369f2dbbcce">