### PR TITLE
feat: increase pool size

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -6,7 +6,7 @@ export const AppDataSource = new DataSource({
   schema: 'public',
   synchronize: false,
   extra: {
-    max: 20,
+    max: 30,
     idleTimeoutMillis: 120000,
   },
   logging: false,


### PR DESCRIPTION
https://github.com/dailydotdev/daily-api/pull/2340 fixed amount of pool calls that boot does but I still see some longer calls. 

Now I can confirm that calls that take longer are the new connections that need to be added to pool, while just querying existing connection from pool is "cheap".

To try and mitigate I increased `max` connections allowed inside pool which should lower amount of times the pool needs to create new connections. Our max con on pg instances is 1000.

Trace below from production, below connect call takes 80% of total request time, which makes boot latency spike.

<img width="1074" alt="Screenshot 2024-10-15 at 12 36 46" src="https://github.com/user-attachments/assets/5975c111-a4ce-4da4-a08c-f7f70bef1965">

[WT-2230](https://dailydotdev.atlassian.net/jira/software/projects/WT/boards/11?selectedIssue=WT-2230)

[WT-2230]: https://dailydotdev.atlassian.net/browse/WT-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ