### PR TITLE
fix: optimizations for reading tag query

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -293,7 +293,6 @@ export const getUserReadingTags = (
   con: DataSource,
   { userId, dateRange: { start, end }, limit = 8 }: ReadingDaysArgs,
 ): Promise<TagsReadingStatus[]> => {
-  console.log(userId, start, end, limit);
   return con.query(
     `
       WITH filtered_view AS (
@@ -330,18 +329,18 @@ export const getUserReadingTags = (
       )
       SELECT
         tag,
-        readingdays,
-        tr.readingdays * 1.0 / dd.total_days AS percentage,
+        "readingDays",
+        tr."readingDays" * 1.0 / dd.total_days AS percentage,
         dd.total_days AS total
       FROM (
         SELECT
           tr.tag,
-          tr. "readingDays" AS readingdays
+          tr. "readingDays"
         FROM
           tag_readings tr
         ORDER BY
           tr. "readingDays" DESC
-        LIMIT 5) tr
+        LIMIT $4) tr
         CROSS JOIN distinct_days dd
       LIMIT $4
     `,
@@ -392,8 +391,6 @@ export const getUserReadingRank = async (
       dateRange: { start, end },
     });
   };
-
-  console.log(req.getQueryAndParameters());
 
   const [readingStreakResult, tags] = await Promise.all([
     req.getRawOne<ReadingRankQueryResult>(),

--- a/src/entity/View.ts
+++ b/src/entity/View.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import type { Post } from './posts';
+import type { User } from './user';
 
 @Entity()
 @Index(['userId', 'timestamp'])
@@ -16,7 +17,7 @@ export class View {
   })
   post: Promise<Post>;
 
-  @PrimaryColumn({ type: 'text' })
+  @PrimaryColumn({ length: 36, type: 'varchar' })
   @Index()
   userId: string;
 

--- a/src/entity/View.ts
+++ b/src/entity/View.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
 import type { Post } from './posts';
-import type { User } from './user';
 
 @Entity()
 @Index(['userId', 'timestamp'])

--- a/src/migration/1728989030929-ViewRelationUserId.ts
+++ b/src/migration/1728989030929-ViewRelationUserId.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ViewRelationUserId1728989030929 implements MigrationInterface {
+  name = 'ViewRelationUserId1728989030929';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['VIEW', 'active_view', 'public'],
+    );
+    await queryRunner.query(`DROP VIEW "active_view"`);
+    await queryRunner.query(
+      `ALTER TABLE "public"."view" ALTER COLUMN "userId" TYPE character varying(36)`,
+    );
+    await queryRunner.query(
+      `CREATE VIEW "active_view" AS SELECT view.* FROM "public"."view" "view" LEFT JOIN "public"."post" "post" ON "post"."id" = "view"."postId" WHERE "post"."deleted" = false`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'VIEW',
+        'active_view',
+        'SELECT view.* FROM "public"."view" "view" LEFT JOIN "public"."post" "post" ON "post"."id" = "view"."postId" WHERE "post"."deleted" = false',
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['VIEW', 'active_view', 'public'],
+    );
+    await queryRunner.query(`DROP VIEW "active_view"`);
+    await queryRunner.query(
+      `ALTER TABLE "public"."view" ALTER COLUMN "userId" TYPE character varying`,
+    );
+    await queryRunner.query(
+      `CREATE VIEW "active_view" AS SELECT view.* FROM "public"."view" "view" LEFT JOIN "public"."post" "post" ON "post"."id" = "view"."postId" WHERE "post"."deleted" = false`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'VIEW',
+        'active_view',
+        'SELECT view.* FROM "public"."view" "view" LEFT JOIN "public"."post" "post" ON "post"."id" = "view"."postId" WHERE "post"."deleted" = false',
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Decided not to introduce the uniqueKey index, see discussion [here](https://dailydotdev.slack.com/archives/C02E2C3C13R/p1728989949471359).

The query format changes a little bit (mostly order optimization that PG prefers)
And making the types of `userId` match to help reduce another 20/30ms delay.

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-15 at 13 09 11](https://github.com/user-attachments/assets/728c0199-0dc2-4226-9856-617be03b06c6) | ![Screenshot 2024-10-15 at 13 10 04](https://github.com/user-attachments/assets/1db5c2d7-f20f-4902-8fb9-3eee4763d42c) | 

> Note: This doesn't include the varchar changes yet.
> Note: It's averages, ran about 10 queries on each type this was average

WT-2229 #done 