### PR TITLE
hotfix: revert reading streak to master

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -7,7 +7,7 @@ import {
   UserStreakActionType,
 } from '../entity';
 import { differenceInDays, isSameDay, max, startOfDay } from 'date-fns';
-import { DataSource, EntityManager, In, Not, QueryRunner } from 'typeorm';
+import { DataSource, EntityManager, In, Not } from 'typeorm';
 import { CommentMention, Comment, View, Source, SourceMember } from '../entity';
 import { getTimezonedStartOfISOWeek, getTimezonedEndOfISOWeek } from './utils';
 import { GraphQLResolveInfo } from 'graphql';
@@ -499,10 +499,10 @@ export const checkUserStreak = (
 };
 
 export const getLastStreakRecoverDate = async (
-  con: DataSource | QueryRunner,
+  con: DataSource | EntityManager,
   userId: string,
 ) => {
-  const lastRecoverAction = await con.manager
+  const lastRecoverAction = await con
     .getRepository(UserStreakAction)
     .createQueryBuilder()
     .select(
@@ -519,7 +519,7 @@ export const getLastStreakRecoverDate = async (
 };
 
 export const checkAndClearUserStreak = async (
-  con: DataSource | QueryRunner,
+  con: DataSource | EntityManager,
   info: GraphQLResolveInfo,
   streak: GQLUserStreakTz,
 ): Promise<boolean> => {
@@ -530,7 +530,7 @@ export const checkAndClearUserStreak = async (
     return false;
   }
 
-  const result = await clearUserStreak(con.manager, [streak.userId]);
+  const result = await clearUserStreak(con, [streak.userId]);
   const clearedSuccess = result > 0;
 
   if (clearedSuccess) {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -105,7 +105,6 @@ import { reportFunctionMap } from '../common/reporting';
 import { format } from 'date-fns';
 import { ContentPreferenceUser } from '../entity/contentPreference/ContentPreferenceUser';
 import { ContentPreferenceStatus } from '../entity/contentPreference/types';
-import { queryReadReplica } from '../common/queryReadReplica';
 
 export interface GQLUpdateUserInput {
   name: string;
@@ -1354,13 +1353,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         };
       }
 
-      const hasClearedStreak = await queryReadReplica(
+      const hasClearedStreak = await checkAndClearUserStreak(
         ctx.con,
-        ({ queryRunner }) => {
-          return checkAndClearUserStreak(queryRunner, info, streak);
-        },
+        info,
+        streak,
       );
-
       if (hasClearedStreak) {
         return { ...streak, current: 0 };
       }


### PR DESCRIPTION
Reading streak queries also write while reading so we can't use read replica in this query. Found it from [logs](https://console.cloud.google.com/logs/query;query=labels.%22k8s-pod%2Fapp%22%3D%22api%22%0AjsonPayload.err.message%3D%22cannot%20execute%20UPDATE%20in%20a%20read-only%20transaction%22;summaryFields=:false:32:beginning;cursorTimestamp=2024-10-15T12:23:00.385Z;duration=P2D?project=devkit-prod&authuser=2)

Left the index from original PR. Reverts https://github.com/dailydotdev/daily-api/pull/2339