### PR TITLE
fix: should not return empty title posts

### DIFF
--- a/__tests__/search.ts
+++ b/__tests__/search.ts
@@ -357,6 +357,17 @@ describe('query searchPostSuggestions', () => {
     });
   });
 
+  it('should not return search suggestions if post has no title', async () => {
+    await con.getRepository(ArticlePost).update({ id: 'p1' }, { title: null });
+    const res = await client.query(QUERY('p1'));
+    expect(res.data).toEqual({
+      searchPostSuggestions: {
+        query: 'p1',
+        hits: [{ title: 'P2' }],
+      },
+    });
+  });
+
   it('should not return search suggestion if private source', async () => {
     await con.getRepository(Source).update({ id: 'a' }, { private: true });
     const res = await client.query(QUERY('p1'));

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -331,6 +331,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         .where('post.id IN (:...ids)', {
           ids: hits.length ? hits.map((x) => x.post_id) : ['nosuchid'],
         })
+        .andWhere('post.title IS NOT NULL')
         .orderBy(`array_position(array[${idsStr}], post.id)`);
       if (ctx.userId) {
         newBuilder = newBuilder


### PR DESCRIPTION
not a 100% sure what Meili has indexed for shared posts, but maybe it's the related post?
This should fix it on API side to not return those.