### PR TITLE
feat: do not use rr in boot

### DIFF
--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -59,7 +59,6 @@ import {
 } from '../telemetry';
 import { getUnreadNotificationsCount } from '../notifications/common';
 import { maxFeedsPerUser } from '../types';
-import { queryReadReplica } from '../common/queryReadReplica';
 import { queryDataSource } from '../common/queryDataSource';
 
 export type BootSquadSource = Omit<GQLSource, 'currentMember'> & {
@@ -421,8 +420,17 @@ const loggedInBoot = async ({
       visit,
       roles,
       extra,
-      [alerts, settings, marketingCta],
-      [user, squads, lastBanner, exp, feeds, unreadNotificationsCount],
+      [
+        alerts,
+        settings,
+        marketingCta,
+        user,
+        squads,
+        lastBanner,
+        exp,
+        feeds,
+        unreadNotificationsCount,
+      ],
     ] = await Promise.all([
       visitSection(req, res),
       getRoles(userId),
@@ -432,10 +440,6 @@ const loggedInBoot = async ({
           getAlerts(queryRunner, userId),
           getSettings(queryRunner, userId),
           getMarketingCta(queryRunner, log, userId),
-        ]);
-      }),
-      queryReadReplica(con, async ({ queryRunner }) => {
-        return Promise.all([
           getUser(queryRunner, userId),
           getSquads(queryRunner, userId),
           getAndUpdateLastBannerRedis(queryRunner),


### PR DESCRIPTION
It could be that connection pool is the same for replica and master (30 clients) and since we query more from master the clients fill up the the pool and then replica has to evict and create new client for its connection. Trying to see if it will change anything. 

[Thread](https://dailydotdev.slack.com/archives/C02E2C3C13R/p1729084883568339)