### PR TITLE
feat: adjust idle timeout

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -7,7 +7,7 @@ export const AppDataSource = new DataSource({
   synchronize: false,
   extra: {
     max: 30,
-    idleTimeoutMillis: 120000,
+    idleTimeoutMillis: 240000,
   },
   logging: false,
   entities: ['src/entity/**/*.{js,ts}'],


### PR DESCRIPTION
Looks like #2351 lowered latency spikes significantly, there are some lower spikes still in 2-3 minutes period.

I can see that when those spikes happen its because pool needs to create new connections. Increasing idle timeout for connections in pool to see if retaining connections for a bit longer would lower amount of those smaller spikes since pool would be at maximum capacity for a bit longer. 