### PR TITLE
fix: make sure release is called in case of error

### DIFF
--- a/src/common/queryDataSource.ts
+++ b/src/common/queryDataSource.ts
@@ -8,7 +8,16 @@ export const queryDataSource = async <T>(
   }>,
 ): Promise<T> => {
   const queryRunner = con.createQueryRunner(options?.mode || 'master');
-  const result = await callback({ queryRunner });
-  await queryRunner.release();
+
+  let result: T;
+
+  try {
+    result = await callback({ queryRunner });
+  } catch (error) {
+    throw error;
+  } finally {
+    await queryRunner.release();
+  }
+
   return result;
 };

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -568,10 +568,18 @@ export class GraphORM {
       builder.queryBuilder.setQueryRunner(slaveRunner);
     }
 
-    const res = await builder.queryBuilder.getRawMany();
-    if (slaveRunner) {
-      await slaveRunner.release();
+    let res: any[];
+
+    try {
+      res = await builder.queryBuilder.getRawMany();
+    } catch (error) {
+      throw error;
+    } finally {
+      if (slaveRunner) {
+        await slaveRunner.release();
+      }
     }
+
     return res.map((value) =>
       this.transformType(ctx, value, rootType, fieldsByTypeName),
     );


### PR DESCRIPTION
I noticed that in case of query failed `release` would not be throw. Don't think it had impact because we don't have failed queries on these but good to be safe in those cases.