### PR TITLE
feat: temp disable pool connection timeout

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -7,7 +7,7 @@ export const AppDataSource = new DataSource({
   synchronize: false,
   extra: {
     max: 30,
-    idleTimeoutMillis: 240000,
+    idleTimeoutMillis: 0,
   },
   logging: false,
   entities: ['src/entity/**/*.{js,ts}'],


### PR DESCRIPTION
We want to test if spikes of the p99 latency of boot are due to pools catching up with traffic all the time after connections expiring due to being temporary unused. 