### PR TITLE
feat: allow scheduling clickhouse sync onto spot nodes

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -677,6 +677,7 @@ if (!isAdhocEnv) {
           memory: '4096Mi',
         },
       },
+      toleratesSpot: true,
     },
     { provider: vpcNativeProvider?.provider },
   );

--- a/.infra/package-lock.json
+++ b/.infra/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "api",
       "dependencies": {
-        "@dailydotdev/pulumi-common": "^1.40.0",
+        "@dailydotdev/pulumi-common": "^1.41.0",
         "@pulumi/gcp": "^8.6.0",
         "@pulumi/kubernetes": "^4.18.2",
         "@pulumi/pulumi": "^3.137.0"
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@dailydotdev/pulumi-common": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.40.0.tgz",
-      "integrity": "sha512-8/0arWJ8hUhJI9QpwM1GKLfbsT5AH6Tg/MiNK8u82B2Cny2fQbdnpWe3Ha92UIP/jLFneuHMGXfp2sRpDdbJqw==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.0.tgz",
+      "integrity": "sha512-me9pPDyxPGvkkYAiGjayfcTCvPj099EMeVz5tpIuoZzjOZ/vy1yTpH6LQSnnWzk1UNQLh32tFE1Wxm+6Y1iTrQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@google-cloud/pubsub": "^4.8.0",
@@ -27,7 +27,7 @@
         "@pulumi/pulumi": "^3.137.0",
         "knex": "^3.1.0",
         "mysql": "^2.18.1",
-        "pg": "^8.13.0",
+        "pg": "^8.13.1",
         "yaml": "^2.6.0"
       }
     },
@@ -4736,9 +4736,9 @@
   },
   "dependencies": {
     "@dailydotdev/pulumi-common": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.40.0.tgz",
-      "integrity": "sha512-8/0arWJ8hUhJI9QpwM1GKLfbsT5AH6Tg/MiNK8u82B2Cny2fQbdnpWe3Ha92UIP/jLFneuHMGXfp2sRpDdbJqw==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.0.tgz",
+      "integrity": "sha512-me9pPDyxPGvkkYAiGjayfcTCvPj099EMeVz5tpIuoZzjOZ/vy1yTpH6LQSnnWzk1UNQLh32tFE1Wxm+6Y1iTrQ==",
       "requires": {
         "@google-cloud/pubsub": "^4.8.0",
         "@pulumi/gcp": "^8.6.0",
@@ -4746,7 +4746,7 @@
         "@pulumi/pulumi": "^3.137.0",
         "knex": "^3.1.0",
         "mysql": "^2.18.1",
-        "pg": "^8.13.0",
+        "pg": "^8.13.1",
         "yaml": "^2.6.0"
       }
     },

--- a/.infra/package.json
+++ b/.infra/package.json
@@ -4,7 +4,7 @@
     "@types/node": "20.12.x"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "^1.40.0",
+    "@dailydotdev/pulumi-common": "^1.41.0",
     "@pulumi/gcp": "^8.6.0",
     "@pulumi/kubernetes": "^4.18.2",
     "@pulumi/pulumi": "^3.137.0"


### PR DESCRIPTION
We already kill it every hour or so, so I think it can safely live on a spot node