### PR TITLE
feat: run migration jobs on spot nodes

### DIFF
--- a/.infra/package-lock.json
+++ b/.infra/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "api",
       "dependencies": {
-        "@dailydotdev/pulumi-common": "^1.41.0",
+        "@dailydotdev/pulumi-common": "^1.41.1",
         "@pulumi/gcp": "^8.6.0",
         "@pulumi/kubernetes": "^4.18.2",
         "@pulumi/pulumi": "^3.137.0"
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@dailydotdev/pulumi-common": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.0.tgz",
-      "integrity": "sha512-me9pPDyxPGvkkYAiGjayfcTCvPj099EMeVz5tpIuoZzjOZ/vy1yTpH6LQSnnWzk1UNQLh32tFE1Wxm+6Y1iTrQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.1.tgz",
+      "integrity": "sha512-k4eGy/uycC8xc16xWagFr28LDU+zbt14bDR8Uy3+jy9KJbyPbDXNsYb+SAwhUr2tHGMzpNRpPUgD/d19RJOefA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@google-cloud/pubsub": "^4.8.0",
@@ -4736,9 +4736,9 @@
   },
   "dependencies": {
     "@dailydotdev/pulumi-common": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.0.tgz",
-      "integrity": "sha512-me9pPDyxPGvkkYAiGjayfcTCvPj099EMeVz5tpIuoZzjOZ/vy1yTpH6LQSnnWzk1UNQLh32tFE1Wxm+6Y1iTrQ==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-1.41.1.tgz",
+      "integrity": "sha512-k4eGy/uycC8xc16xWagFr28LDU+zbt14bDR8Uy3+jy9KJbyPbDXNsYb+SAwhUr2tHGMzpNRpPUgD/d19RJOefA==",
       "requires": {
         "@google-cloud/pubsub": "^4.8.0",
         "@pulumi/gcp": "^8.6.0",

--- a/.infra/package.json
+++ b/.infra/package.json
@@ -4,7 +4,7 @@
     "@types/node": "20.12.x"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "^1.41.0",
+    "@dailydotdev/pulumi-common": "^1.41.1",
     "@pulumi/gcp": "^8.6.0",
     "@pulumi/kubernetes": "^4.18.2",
     "@pulumi/pulumi": "^3.137.0"


### PR DESCRIPTION
Enabled by default, so just updating pulumi-common