### PR TITLE
refactor: use a single query for feed filters

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -7,9 +7,7 @@ Object {
   ],
   "blockedTags": Array [],
   "excludeSourceTypes": Array [],
-  "excludeSources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "excludeSources": Array [],
   "excludeTypes": Array [],
   "includeTags": Array [],
   "sourceIds": Array [],
@@ -23,9 +21,7 @@ Object {
   "excludeSourceTypes": Array [
     "squad",
   ],
-  "excludeSources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "excludeSources": Array [],
   "excludeTypes": Array [],
   "includeTags": Array [],
   "sourceIds": Array [],
@@ -37,9 +33,7 @@ Object {
   "blockedContentCuration": Array [],
   "blockedTags": Array [],
   "excludeSourceTypes": Array [],
-  "excludeSources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "excludeSources": Array [],
   "excludeTypes": Array [],
   "includeTags": Array [],
   "sourceIds": Array [

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -4,7 +4,6 @@ import {
   maxFeedNameLength,
   Ranking,
   updateFlagsStatement,
-  WATERCOOLER_ID,
 } from '../src/common';
 import {
   AdvancedSettings,
@@ -370,7 +369,6 @@ describe('query anonymousFeed', () => {
         fresh_page_size: '4',
         offset: 0,
         user_id: '1',
-        blocked_sources: [WATERCOOLER_ID],
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],
@@ -415,7 +413,7 @@ describe('query anonymousFeed', () => {
         fresh_page_size: '4',
         offset: 0,
         blocked_tags: ['python', 'java'],
-        blocked_sources: ['a', 'b', WATERCOOLER_ID],
+        blocked_sources: ['a', 'b'],
         user_id: '1',
       })
       .reply(200, {
@@ -723,7 +721,6 @@ describe('query feed', () => {
         offset: 0,
         fresh_page_size: '4',
         user_id: '1',
-        blocked_sources: [WATERCOOLER_ID],
         ...baseFeedConfig,
         config: {
           providers: {},
@@ -2319,7 +2316,6 @@ describe('function feedToFilters', () => {
     expect(filters.excludeSources).toEqual([
       'excludedSource',
       'settingsCombinationSource',
-      WATERCOOLER_ID,
     ]);
   });
 
@@ -2343,14 +2339,8 @@ describe('function feedToFilters', () => {
     expect(filters.includeTags?.length).toBe(2);
     expect(filters.blockedTags).toEqual(expect.arrayContaining(['golang']));
     expect(filters.blockedTags?.length).toBe(1);
-    expect(filters.excludeSources).toEqual(
-      expect.arrayContaining([
-        'b',
-        'c',
-        'fd062672-63b7-4a10-87bd-96dcd10e9613',
-      ]),
-    );
-    expect(filters.excludeSources?.length).toBe(3);
+    expect(filters.excludeSources).toEqual(expect.arrayContaining(['b', 'c']));
+    expect(filters.excludeSources?.length).toBe(2);
   });
 
   it('should return filters with source memberships', async () => {
@@ -2508,7 +2498,6 @@ describe('query feedPreview', () => {
         fresh_page_size: '7',
         user_id: '1',
         allowed_tags: ['html'],
-        blocked_sources: [WATERCOOLER_ID],
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],
@@ -3439,7 +3428,6 @@ describe('query customFeed', () => {
         total_pages: 1,
         fresh_page_size: '4',
         allowed_tags: ['webdev', 'html', 'data'],
-        blocked_sources: [WATERCOOLER_ID],
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -39,7 +39,6 @@ import {
   FeedUserStateConfigGenerator,
 } from '../../src/integrations/feed/configs';
 import { ILofnClient } from '../../src/integrations/lofn';
-import { WATERCOOLER_ID } from '../../src/common';
 
 let con: DataSource;
 let ctx: Context;
@@ -525,7 +524,7 @@ describe('FeedLofnConfigGenerator', () => {
         fresh_page_size: '4',
         allowed_tags: expect.arrayContaining(['javascript', 'golang']),
         blocked_tags: expect.arrayContaining(['python', 'java']),
-        blocked_sources: expect.arrayContaining(['a', 'b', WATERCOOLER_ID]),
+        blocked_sources: expect.arrayContaining(['a', 'b']),
         squad_ids: expect.arrayContaining(['a', 'b']),
         allowed_post_types: expect.arrayContaining([
           'article',

--- a/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
+++ b/__tests__/workers/__snapshots__/personalizedDigestEmail.ts.snap
@@ -187,9 +187,7 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user in timezone ahead UTC 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "blocked_sources": Array [],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -300,9 +298,7 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user in timezone behind UTC 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "blocked_sources": Array [],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -413,9 +409,7 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user with provided config 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "blocked_sources": Array [],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,
@@ -526,9 +520,7 @@ Object {
 exports[`personalizedDigestEmail worker should generate personalized digest for user with subscription 2`] = `
 Object {
   "allowed_tags": Array [],
-  "blocked_sources": Array [
-    "fd062672-63b7-4a10-87bd-96dcd10e9613",
-  ],
+  "blocked_sources": Array [],
   "blocked_tags": Array [],
   "date_from": Any<String>,
   "date_to": Any<String>,

--- a/bin/traces.ts
+++ b/bin/traces.ts
@@ -1,0 +1,177 @@
+import { GoogleAuth, OAuth2Client } from 'google-auth-library';
+import path from 'path';
+import fs from 'fs/promises';
+
+interface Span {
+  spanId: string;
+  name: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface Trace {
+  projectId: string;
+  traceId: string;
+  spans: Span[];
+}
+
+interface TracesResponse {
+  traces?: Trace[];
+  nextPageToken?: string;
+}
+
+interface SpanTiming {
+  startTime: string;
+  durationMs: number;
+}
+
+class CloudTraceAnalyzer {
+  private projectId?: string;
+  private baseUrl: string;
+  private getAccessToken: (() => Promise<string>) | null = null;
+
+  constructor(projectId?: string) {
+    this.projectId = projectId;
+    this.baseUrl = 'https://cloudtrace.googleapis.com/v1';
+  }
+
+  async initialize(): Promise<void> {
+    const auth = new GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    const client = (await auth.getClient()) as OAuth2Client;
+
+    if (!this.projectId) {
+      this.projectId = await auth.getProjectId();
+    }
+
+    this.getAccessToken = async () => {
+      const token = await client.getAccessToken();
+      return token.token || '';
+    };
+  }
+
+  async *getTraces(
+    startTime: Date,
+    endTime: Date,
+    filter: string = '',
+    pageSize: number = 100,
+  ): AsyncGenerator<Trace[]> {
+    if (!this.getAccessToken) {
+      throw new Error('Analyzer not initialized. Call initialize() first.');
+    }
+
+    let nextPageToken = '';
+
+    do {
+      console.log('fetching page...');
+      const token = await this.getAccessToken();
+      const params = new URLSearchParams({
+        pageSize: pageSize.toString(),
+        pageToken: nextPageToken,
+        filter,
+        orderBy: 'start desc',
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        view: 'COMPLETE',
+      });
+
+      const response = await fetch(
+        `${this.baseUrl}/projects/${this.projectId}/traces?${params}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+
+      if (!response.ok) {
+        if (response.status === 429) {
+          console.log('rate limit exceeded, breaking');
+          break;
+        }
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data: TracesResponse = await response.json();
+      if (data.traces) {
+        yield data.traces;
+      }
+      nextPageToken = data.nextPageToken || '';
+    } while (nextPageToken);
+  }
+
+  async exportSpanTimings(
+    traces: AsyncGenerator<Trace[]>,
+    spanName: string,
+    outputPath: string,
+  ): Promise<void> {
+    const timings: SpanTiming[] = [];
+
+    for await (const page of traces) {
+      if (page) {
+        for (const trace of page) {
+          for (const span of trace.spans) {
+            if (span.name === spanName) {
+              const spanTiming = this.processSpan(span);
+              timings.push(spanTiming);
+            }
+          }
+        }
+      }
+    }
+
+    const csv = this.convertToCSV(timings);
+    await fs.writeFile(path.resolve(outputPath), csv);
+  }
+
+  private processSpan(span: Span): SpanTiming {
+    return {
+      startTime: span.startTime,
+      durationMs: this.calculateDurationMs(span.startTime, span.endTime),
+    };
+  }
+
+  private calculateDurationMs(startTime: string, endTime: string): number {
+    const start = new Date(startTime).getTime();
+    const end = new Date(endTime).getTime();
+    return end - start;
+  }
+
+  private convertToCSV(timings: SpanTiming[]): string {
+    const header = 'startTime,durationMs\n';
+    const rows = timings.map(
+      (timing) => `${timing.startTime},${timing.durationMs}`,
+    );
+    return header + rows.join('\n');
+  }
+}
+
+async function analyzeTraces(): Promise<void> {
+  const analyzer = new CloudTraceAnalyzer();
+  await analyzer.initialize();
+
+  const endTime = new Date();
+  const startTime = new Date(endTime.getTime() - 24 * 60 * 60 * 1000);
+
+  try {
+    const spanName = 'FeedPreferencesConfigGenerator';
+    const traces = analyzer.getTraces(
+      startTime,
+      endTime,
+      `+span:${spanName}`,
+      1000,
+    );
+    await analyzer.exportSpanTimings(traces, spanName, 'span_timings.csv');
+  } catch (error) {
+    console.error(
+      'Error analyzing traces:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+analyzeTraces()
+  .then(() => process.exit())
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -5,7 +5,13 @@ import {
   SourceType,
   UserPost,
 } from '../entity';
-import { Brackets, DataSource, SelectQueryBuilder } from 'typeorm';
+import {
+  Brackets,
+  DataSource,
+  ObjectLiteral,
+  QueryBuilder,
+  SelectQueryBuilder,
+} from 'typeorm';
 import { Connection, ConnectionArguments } from 'graphql-relay';
 import { IFieldResolver } from '@graphql-tools/utils';
 import {
@@ -30,7 +36,6 @@ import { mapArrayToOjbect } from './object';
 import { runInSpan } from '../telemetry';
 import { whereVordrFilter } from './vordr';
 import { baseFeedConfig } from '../integrations/feed';
-import { queryReadReplica } from './queryReadReplica';
 
 export const WATERCOOLER_ID = 'fd062672-63b7-4a10-87bd-96dcd10e9613';
 
@@ -73,24 +78,78 @@ export const whereKeyword = (
   return `EXISTS${query}`;
 };
 
-export const getExcludedAdvancedSettings = async (
+const rawFilterSelect = <T extends ObjectLiteral>(
   con: DataSource,
-  feedId?: string,
-): Promise<Partial<AdvancedSettings>[]> => {
-  if (!feedId) {
-    return [];
-  }
+  name: string,
+  func: (qb: QueryBuilder<T>) => QueryBuilder<T>,
+): QueryBuilder<T> =>
+  con.createQueryBuilder().select('jsonb_agg(res)', name).from(func, 'res');
 
-  const [settings, feedAdvancedSettings] = await Promise.all([
-    con.getRepository(AdvancedSettings).find(),
-    con.getRepository(FeedAdvancedSettings).findBy({ feedId }),
-  ]);
+type RawFiltersData = {
+  settings:
+    | Pick<
+        AdvancedSettings,
+        'id' | 'defaultEnabledState' | 'group' | 'options'
+      >[]
+    | null;
+  feedAdvancedSettings:
+    | Pick<FeedAdvancedSettings, 'advancedSettingsId' | 'enabled'>[]
+    | null;
+  tags: Pick<FeedTag, 'tag' | 'blocked'>[] | null;
+  excludeSources: Pick<FeedSource, 'sourceId'>[] | null;
+  memberships: { sourceId: SourceMember['sourceId']; hide: boolean }[] | null;
+};
+
+const getRawFiltersData = async (
+  con: DataSource,
+  feedId: string,
+  userId: string,
+): Promise<RawFiltersData | undefined> => {
+  const selects = [
+    rawFilterSelect(con, 'settings', (qb) =>
+      qb
+        .select(['id', '"defaultEnabledState"', '"group"', 'options'])
+        .from(AdvancedSettings, 't'),
+    ),
+    rawFilterSelect(con, 'feedAdvancedSettings', (qb) =>
+      qb
+        .select(['"advancedSettingsId"', 'enabled'])
+        .from(FeedAdvancedSettings, 't'),
+    ),
+    rawFilterSelect(con, 'tags', (qb) =>
+      qb.select(['tag', 'blocked']).from(FeedTag, 't').where('"feedId" = $1'),
+    ),
+    rawFilterSelect(con, 'excludeSources', (qb) =>
+      qb
+        .select('"sourceId"')
+        .from(FeedSource, 't')
+        .where('"feedId" = $1')
+        .andWhere('blocked = TRUE'),
+    ),
+    rawFilterSelect(con, 'memberships', (qb) =>
+      qb
+        .select('"sourceId"')
+        .addSelect("COALESCE((flags->'hideFeedPosts')::boolean, FALSE)", 'hide')
+        .from(SourceMember, 't')
+        .where('"userId" = $2'),
+    ),
+  ];
+  const query =
+    'select ' + selects.map((select) => `(${select.getQuery()})`).join(', ');
+  const res = await con.query(query, [feedId, userId]);
+  return res[0];
+};
+
+export const getExcludedAdvancedSettings = ({
+  settings,
+  feedAdvancedSettings,
+}: RawFiltersData): Partial<AdvancedSettings>[] => {
   const userSettings = mapArrayToOjbect(
-    feedAdvancedSettings,
+    feedAdvancedSettings || [],
     'advancedSettingsId',
     'enabled',
   );
-  const excludedSettings = settings.filter((adv) => {
+  const excludedSettings = (settings || []).filter((adv) => {
     if (userSettings[adv.id] !== undefined) {
       return userSettings[adv.id] === false;
     }
@@ -104,60 +163,40 @@ export const getExcludedAdvancedSettings = async (
   }));
 };
 
-export const feedToFilters = async (
-  con: DataSource,
-  feedId?: string,
-  userId?: string,
-): Promise<AnonymousFeedFilters> => {
-  const settings = await getExcludedAdvancedSettings(con, feedId);
-  const [tags, excludeSources, memberships]: [
-    FeedTag[],
-    Source[],
-    { sourceId: SourceMember['sourceId']; hide: boolean }[],
-  ] = await Promise.all([
-    feedId
-      ? queryReadReplica(con, ({ queryRunner }) => {
-          return queryRunner.manager.getRepository(FeedTag).find({
-            where: { feedId },
-            select: ['tag', 'blocked'],
-          });
-        })
-      : [],
-    feedId
-      ? con
-          .getRepository(Source)
-          .createQueryBuilder('s')
-          .select('s.id AS "id"')
-          .where((qb) => {
-            const subQuery = qb
-              .subQuery()
-              .select('fs."sourceId"')
-              .from(FeedSource, 'fs')
-              .where('fs."feedId" = :feedId', { feedId })
-              .andWhere('fs.blocked = TRUE')
-              .getQuery();
+const advancedSettingsToFilters = (
+  rawData: RawFiltersData,
+): {
+  excludeTypes: string[];
+  blockedContentCuration: string[];
+  excludeSourceTypes: string[];
+} => {
+  const settings = getExcludedAdvancedSettings(rawData);
+  return settings.reduce<ReturnType<typeof advancedSettingsToFilters>>(
+    (acc, curr) => {
+      if (curr.options?.type) {
+        if (curr.group === 'content_types') {
+          acc.excludeTypes.push(curr.options.type);
+        }
+        if (curr.group === 'source_types') {
+          acc.excludeSourceTypes.push(curr.options.type);
+        }
+        if (curr.group === 'content_curation') {
+          acc.blockedContentCuration.push(curr.options.type);
+        }
+      }
+      return acc;
+    },
+    { excludeTypes: [], blockedContentCuration: [], excludeSourceTypes: [] },
+  );
+};
 
-            return `s.id IN (${subQuery})`;
-          })
-          .execute()
-      : [],
-    feedId && userId
-      ? con
-          .getRepository(SourceMember)
-          .createQueryBuilder('sm')
-          .select('sm."sourceId"')
-          .addSelect(
-            "COALESCE((flags->'hideFeedPosts')::boolean, FALSE)",
-            'hide',
-          )
-          .where('sm."userId" = :userId', { userId })
-          .execute()
-      : [],
-  ]);
-  const tagFilters = tags.reduce<{
-    includeTags: string[];
-    blockedTags: string[];
-  }>(
+const tagsToFilters = ({
+  tags,
+}: RawFiltersData): {
+  includeTags: string[];
+  blockedTags: string[];
+} => {
+  return (tags || []).reduce<ReturnType<typeof tagsToFilters>>(
     (acc, value) => {
       if (value.blocked) {
         acc.blockedTags.push(value.tag);
@@ -168,32 +207,17 @@ export const feedToFilters = async (
     },
     { includeTags: [], blockedTags: [] },
   );
+};
 
-  const { excludeTypes, blockedContentCuration, excludeSourceTypes } =
-    settings.reduce<{
-      excludeTypes: string[];
-      blockedContentCuration: string[];
-      excludeSourceTypes: string[];
-    }>(
-      (acc, curr) => {
-        if (curr.options?.type) {
-          if (curr.group === 'content_types') {
-            acc.excludeTypes.push(curr.options.type);
-          }
-          if (curr.group === 'source_types') {
-            acc.excludeSourceTypes.push(curr.options.type);
-          }
-          if (curr.group === 'content_curation') {
-            acc.blockedContentCuration.push(curr.options.type);
-          }
-        }
-        return acc;
-      },
-      { excludeTypes: [], blockedContentCuration: [], excludeSourceTypes: [] },
-    );
-
+const sourcesToFilters = ({
+  excludeSources,
+  memberships,
+}: RawFiltersData): {
+  excludeSources: string[];
+  sourceIds: string[];
+} => {
   // Split memberships by hide flag
-  const membershipsByHide = memberships.reduce<{
+  const membershipsByHide = (memberships || []).reduce<{
     hide: string[];
     show: string[];
   }>(
@@ -204,20 +228,32 @@ export const feedToFilters = async (
     { hide: [], show: [] },
   );
 
-  // If the user is not a member of the watercooler, hide it
-  if (!membershipsByHide.show.includes(WATERCOOLER_ID)) {
-    membershipsByHide.hide.push(WATERCOOLER_ID);
+  return {
+    excludeSources: (excludeSources || [])
+      .map((s) => s.sourceId)
+      .concat(membershipsByHide.hide),
+    sourceIds: membershipsByHide.show,
+  };
+};
+
+export const feedToFilters = async (
+  con: DataSource,
+  feedId?: string,
+  userId?: string,
+): Promise<AnonymousFeedFilters> => {
+  if (!feedId || !userId) {
+    return {};
+  }
+
+  const rawData = await getRawFiltersData(con, feedId, userId);
+  if (!rawData) {
+    return {};
   }
 
   return {
-    ...tagFilters,
-    excludeTypes,
-    excludeSources: excludeSources
-      .map((sources: Source) => sources.id)
-      .concat(membershipsByHide.hide),
-    sourceIds: membershipsByHide.show,
-    blockedContentCuration,
-    excludeSourceTypes,
+    ...advancedSettingsToFilters(rawData),
+    ...tagsToFilters(rawData),
+    ...sourcesToFilters(rawData),
   };
 };
 


### PR DESCRIPTION
In an effort to reduce the load on the database, I merged together the different queries used to generate the feed filters object.

It also includes some minor optimizations.

If this will not reduce the load we can consider redis. Now with a single query it can be easier to cache it. I may also consider moving the javascript logic to the query itself but let's see.