### PR TITLE
feat: add block mutations

### DIFF
--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -22,7 +22,14 @@ import {
   ContentPreferenceType,
 } from '../src/entity/contentPreference/types';
 import { NotificationPreferenceUser } from '../src/entity/notifications/NotificationPreferenceUser';
-import { Feed, FeedSource, Keyword, Source, SourceType } from '../src/entity';
+import {
+  Feed,
+  FeedSource,
+  FeedTag,
+  Keyword,
+  Source,
+  SourceType,
+} from '../src/entity';
 import { ContentPreferenceFeedKeyword } from '../src/entity/contentPreference/ContentPreferenceFeedKeyword';
 import { ContentPreferenceSource } from '../src/entity/contentPreference/ContentPreferenceSource';
 import {
@@ -1101,5 +1108,450 @@ describe('query contentPreferenceStatus', () => {
       },
       'UNAUTHENTICATED',
     );
+  });
+});
+
+describe('mutation block', () => {
+  const MUTATION = `mutation Block($id: ID!, $entity: ContentPreferenceType!) {
+    block(id: $id, entity: $entity) {
+      _
+    }
+  }`;
+
+  beforeEach(async () => {
+    await saveFixtures(
+      con,
+      User,
+      usersFixture.map((item) => {
+        return {
+          ...item,
+          id: `${item.id}-blm`,
+          username: `${item.username}-blm`,
+        };
+      }),
+    );
+  });
+
+  it('should block user', async () => {
+    loggedUser = '1-blm';
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '3-blm',
+        entity: ContentPreferenceType.User,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-blm',
+        referenceId: '3-blm',
+      });
+
+    expect(contentPreference).not.toBeNull();
+    expect(contentPreference!.status).toBe(ContentPreferenceStatus.Blocked);
+
+    const notificationPreferences = await con
+      .getRepository(NotificationPreferenceUser)
+      .findBy({
+        userId: '1-blm',
+        referenceUserId: '3-blm',
+      });
+
+    expect(notificationPreferences).toHaveLength(0);
+  });
+
+  it('should not block yourself', async () => {
+    loggedUser = '1-blm';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          id: '1-blm',
+          entity: ContentPreferenceType.User,
+        },
+      },
+      'CONFLICT',
+    );
+  });
+
+  it('should not block ghost user', async () => {
+    loggedUser = '1-blm';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          id: ghostUser.id,
+          entity: ContentPreferenceType.User,
+        },
+      },
+      'CONFLICT',
+    );
+  });
+
+  describe('keyword', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, Keyword, [
+        { value: 'keyword-bl1', occurrences: 300, status: 'allow' },
+        { value: 'keyword-bl2', occurrences: 200, status: 'allow' },
+        { value: 'keyword-bl3', occurrences: 100, status: 'allow' },
+      ]);
+
+      await saveFixtures(con, Feed, [{ id: '1-blm', userId: '1-blm' }]);
+    });
+
+    it('should block', async () => {
+      loggedUser = '1-blm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'keyword-bl1',
+          entity: ContentPreferenceType.Keyword,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceFeedKeyword)
+        .findOneBy({
+          userId: '1-blm',
+          referenceId: 'keyword-bl1',
+        });
+
+      expect(contentPreference).not.toBeNull();
+      expect(contentPreference!.status).toBe(ContentPreferenceStatus.Blocked);
+
+      const feedTag = await con.getRepository(FeedTag).findOneBy({
+        feedId: loggedUser,
+        tag: 'keyword-bl1',
+        blocked: true,
+      });
+
+      expect(feedTag).not.toBeNull();
+      expect(feedTag!.blocked).toBe(true);
+    });
+  });
+
+  describe('source', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, Source, [
+        {
+          id: 'a-blm',
+          name: 'A-blm',
+          image: 'http://image.com/a-fm',
+          handle: 'a-blm',
+          type: SourceType.Machine,
+        },
+      ]);
+
+      await saveFixtures(con, Feed, [{ id: '1-blm', userId: '1-blm' }]);
+    });
+
+    it('should block', async () => {
+      loggedUser = '1-blm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'a-blm',
+          entity: ContentPreferenceType.Source,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-blm',
+          referenceId: 'a-blm',
+        });
+
+      expect(contentPreference).not.toBeNull();
+      expect(contentPreference!.status).toBe(ContentPreferenceStatus.Blocked);
+
+      const feedSource = await con.getRepository(FeedSource).findOneBy({
+        feedId: '1-blm',
+        sourceId: 'a-blm',
+      });
+      expect(feedSource).not.toBeNull();
+      expect(feedSource!.blocked).toBe(true);
+    });
+  });
+});
+
+describe('mutation unblock', () => {
+  const MUTATION = `mutation Unblock($id: ID!, $entity: ContentPreferenceType!) {
+    unblock(id: $id, entity: $entity) {
+      _
+    }
+  }`;
+
+  beforeEach(async () => {
+    await saveFixtures(
+      con,
+      User,
+      usersFixture.map((item) => {
+        return {
+          ...item,
+          id: `${item.id}-ublm`,
+          username: `${item.username}-ublm`,
+        };
+      }),
+    );
+
+    await con.getRepository(ContentPreferenceUser).save([
+      {
+        userId: '1-ublm',
+        referenceId: '2-ublm',
+        referenceUserId: '2-ublm',
+        status: ContentPreferenceStatus.Blocked,
+      },
+      {
+        userId: '2-ublm',
+        referenceId: '1-ublm',
+        referenceUserId: '1-ublm',
+        status: ContentPreferenceStatus.Blocked,
+      },
+    ]);
+  });
+
+  it('should unblock user', async () => {
+    loggedUser = '1-ublm';
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '2-ublm',
+        entity: ContentPreferenceType.User,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-ublm',
+        referenceId: '2-ublm',
+      });
+
+    expect(contentPreference).toBeNull();
+
+    const notificationPreferences = await con
+      .getRepository(NotificationPreferenceUser)
+      .findBy({
+        userId: '1-ublm',
+        referenceUserId: '2-ublm',
+      });
+
+    expect(notificationPreferences).toHaveLength(0);
+  });
+
+  it('should do nothing if user is not blocked', async () => {
+    loggedUser = '1-ublm';
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '3-ublm',
+        entity: ContentPreferenceType.User,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-ublm',
+        referenceId: '3-ublm',
+      });
+
+    expect(contentPreference).toBeNull();
+
+    const notificationPreferences = await con
+      .getRepository(NotificationPreferenceUser)
+      .findBy({
+        userId: '1-ublm',
+        referenceUserId: '3-ublm',
+      });
+
+    expect(notificationPreferences).toHaveLength(0);
+  });
+
+  it('should remove notification preferences', async () => {
+    loggedUser = '1-ublm';
+
+    await con.getRepository(NotificationPreferenceUser).save([
+      {
+        userId: '1-ublm',
+        referenceUserId: '2-ublm',
+        referenceId: '2-ublm',
+        status: NotificationPreferenceStatus.Subscribed,
+        notificationType: NotificationType.UserPostAdded,
+      },
+    ]);
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '2-ublm',
+        entity: ContentPreferenceType.User,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-ublm',
+        referenceId: '2-ublm',
+      });
+
+    expect(contentPreference).toBeNull();
+
+    const notificationPreferences = await con
+      .getRepository(NotificationPreferenceUser)
+      .findBy({
+        userId: '1-ublm',
+        referenceUserId: '2-ublm',
+      });
+
+    expect(notificationPreferences).toHaveLength(0);
+  });
+
+  describe('keyword', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, Keyword, [
+        { value: 'keyword-ublm1', occurrences: 300, status: 'allow' },
+        { value: 'keyword-ublm2', occurrences: 200, status: 'allow' },
+        { value: 'keyword-ublm3', occurrences: 100, status: 'allow' },
+      ]);
+
+      await saveFixtures(con, Feed, [{ id: '1-ublm', userId: '1-ublm' }]);
+
+      await con.getRepository(ContentPreferenceFeedKeyword).save([
+        {
+          userId: '1-ublm',
+          referenceId: 'keyword-ublm1',
+          feedId: '1-ublm',
+          status: ContentPreferenceStatus.Blocked,
+        },
+        {
+          userId: '2-ublm',
+          referenceId: 'keyword-ublm2',
+          feedId: '1-ublm',
+          status: ContentPreferenceStatus.Blocked,
+        },
+      ]);
+
+      await con.getRepository(FeedTag).save([
+        {
+          feedId: '1-ublm',
+          tag: 'keyword-ublm1',
+          blocked: true,
+        },
+        {
+          feedId: '1-ublm',
+          tag: 'keyword-ublm2',
+          blocked: true,
+        },
+      ]);
+    });
+
+    it('should unblock', async () => {
+      loggedUser = '1-ublm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: '2-ublm',
+          entity: ContentPreferenceType.Keyword,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceFeedKeyword)
+        .findOneBy({
+          userId: '2-ublm',
+          referenceId: 'keyword-ublm1',
+        });
+
+      expect(contentPreference).toBeNull();
+
+      const feedSource = await con.getRepository(FeedTag).findOneBy({
+        feedId: '2-fm',
+        tag: 'keyword-ublm1',
+      });
+      expect(feedSource).toBeNull();
+    });
+  });
+
+  describe('source', () => {
+    beforeEach(async () => {
+      await saveFixtures(con, Source, [
+        {
+          id: 'a-ublm',
+          name: 'A-ublm',
+          image: 'http://image.com/a-ublm',
+          handle: 'a-ublm',
+          type: SourceType.Machine,
+        },
+      ]);
+
+      await saveFixtures(con, Feed, [{ id: '1-ublm', userId: '1-ublm' }]);
+
+      await con.getRepository(ContentPreferenceSource).save([
+        {
+          userId: '1-ublm',
+          referenceId: 'a-ublm',
+          feedId: '1-ublm',
+          status: ContentPreferenceStatus.Blocked,
+        },
+      ]);
+
+      await con.getRepository(FeedSource).save([
+        {
+          feedId: '1-ublm',
+          sourceId: 'a-ublm',
+          blocked: true,
+        },
+      ]);
+    });
+
+    it('should unblock', async () => {
+      loggedUser = '1-ublm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'a-ublm',
+          entity: ContentPreferenceType.Source,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceFeedKeyword)
+        .findOneBy({
+          userId: '1-ublm',
+          referenceId: 'a-ublm',
+        });
+
+      expect(contentPreference).toBeNull();
+
+      const feedSource = await con.getRepository(FeedSource).findOneBy({
+        feedId: '1-ublm',
+        sourceId: 'a-ublm',
+      });
+      expect(feedSource).toBeNull();
+    });
   });
 });

--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -948,6 +948,47 @@ describe('mutation unfollow', () => {
     expect(notificationPreferences).toHaveLength(0);
   });
 
+  it('should not remove muted notification preferences', async () => {
+    loggedUser = '1-um';
+
+    await con.getRepository(NotificationPreferenceUser).save([
+      {
+        userId: '1-um',
+        referenceUserId: '2-um',
+        referenceId: '2-um',
+        status: NotificationPreferenceStatus.Muted,
+        notificationType: NotificationType.UserPostAdded,
+      },
+    ]);
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '2-um',
+        entity: ContentPreferenceType.User,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-um',
+        referenceId: '2-um',
+      });
+
+    expect(contentPreference).toBeNull();
+
+    const notificationPreferences = await con
+      .getRepository(NotificationPreferenceUser)
+      .findBy({
+        userId: '1-um',
+        referenceUserId: '2-um',
+      });
+
+    expect(notificationPreferences).toHaveLength(1);
+  });
+
   describe('keyword', () => {
     beforeEach(async () => {
       await saveFixtures(con, Keyword, [

--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -660,6 +660,7 @@ describe('mutation follow', () => {
 
       expect(contentPreference).not.toBeNull();
       expect(contentPreference!.status).toBe(ContentPreferenceStatus.Follow);
+      expect(contentPreference!.flags.referralToken).not.toBeNull();
 
       const feedSource = await con.getRepository(FeedSource).findOneBy({
         feedId: '1-fm',
@@ -700,6 +701,50 @@ describe('mutation follow', () => {
       });
       expect(feedSource).not.toBeNull();
       expect(feedSource!.blocked).toBe(false);
+    });
+
+    it('should not overwrite referralToken if preference already exists', async () => {
+      loggedUser = '1-fm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'a-fm',
+          entity: ContentPreferenceType.Source,
+          status: ContentPreferenceStatus.Follow,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreferenceBefore = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-fm',
+          referenceId: 'a-fm',
+        });
+
+      expect(contentPreferenceBefore).not.toBeNull();
+
+      const res2 = await client.query(MUTATION, {
+        variables: {
+          id: 'a-fm',
+          entity: ContentPreferenceType.Source,
+          status: ContentPreferenceStatus.Subscribed,
+        },
+      });
+
+      expect(res2.errors).toBeFalsy();
+
+      const contentPreferenceAfter = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-fm',
+          referenceId: 'a-fm',
+        });
+
+      expect(contentPreferenceBefore!.flags.referralToken).toBe(
+        contentPreferenceAfter!.flags.referralToken,
+      );
     });
   });
 
@@ -1283,6 +1328,48 @@ describe('mutation block', () => {
       });
       expect(feedSource).not.toBeNull();
       expect(feedSource!.blocked).toBe(true);
+    });
+
+    it('should not overwrite referralToken if preference already exists', async () => {
+      loggedUser = '1-blm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'a-blm',
+          entity: ContentPreferenceType.Source,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreferenceBefore = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-blm',
+          referenceId: 'a-blm',
+        });
+
+      expect(contentPreferenceBefore).not.toBeNull();
+
+      const res2 = await client.query(MUTATION, {
+        variables: {
+          id: 'a-blm',
+          entity: ContentPreferenceType.Source,
+        },
+      });
+
+      expect(res2.errors).toBeFalsy();
+
+      const contentPreferenceAfter = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-blm',
+          referenceId: 'a-blm',
+        });
+
+      expect(contentPreferenceBefore!.flags.referralToken).toBe(
+        contentPreferenceAfter!.flags.referralToken,
+      );
     });
   });
 });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -217,9 +217,11 @@ const saveFeedFixtures = async (): Promise<void> => {
   await saveFixtures(con, ContentPreferenceSource, [
     {
       feedId: '1',
-      flags: {},
+      flags: {
+        role: SourceMemberRoles.Member,
+        referralToken: randomUUID(),
+      },
       referenceId: 'a',
-      role: SourceMemberRoles.Member,
       sourceId: 'a',
       status: ContentPreferenceStatus.Blocked,
       type: ContentPreferenceType.Source,
@@ -227,9 +229,11 @@ const saveFeedFixtures = async (): Promise<void> => {
     },
     {
       feedId: '1',
-      flags: {},
+      flags: {
+        role: SourceMemberRoles.Member,
+        referralToken: randomUUID(),
+      },
       referenceId: 'b',
-      role: SourceMemberRoles.Member,
       sourceId: 'b',
       status: ContentPreferenceStatus.Blocked,
       type: ContentPreferenceType.Source,
@@ -2177,9 +2181,11 @@ describe('mutation addFiltersToFeed', () => {
       {
         createdAt: expect.any(Date),
         feedId: '1',
-        flags: {},
+        flags: {
+          role: SourceMemberRoles.Member,
+          referralToken: expect.any(String),
+        },
         referenceId: 'a',
-        role: SourceMemberRoles.Member,
         sourceId: 'a',
         status: ContentPreferenceStatus.Blocked,
         type: ContentPreferenceType.Source,
@@ -2188,9 +2194,11 @@ describe('mutation addFiltersToFeed', () => {
       {
         createdAt: expect.any(Date),
         feedId: '1',
-        flags: {},
+        flags: {
+          role: SourceMemberRoles.Member,
+          referralToken: expect.any(String),
+        },
         referenceId: 'b',
-        role: SourceMemberRoles.Member,
         sourceId: 'b',
         status: ContentPreferenceStatus.Blocked,
         type: ContentPreferenceType.Source,
@@ -2427,9 +2435,11 @@ describe('mutation removeFiltersFromFeed', () => {
       {
         createdAt: expect.any(Date),
         feedId: '1',
-        flags: {},
+        flags: {
+          role: SourceMemberRoles.Member,
+          referralToken: expect.any(String),
+        },
         referenceId: 'a',
-        role: SourceMemberRoles.Member,
         sourceId: 'a',
         status: ContentPreferenceStatus.Blocked,
         type: ContentPreferenceType.Source,
@@ -2438,9 +2448,11 @@ describe('mutation removeFiltersFromFeed', () => {
       {
         createdAt: expect.any(Date),
         feedId: '1',
-        flags: {},
+        flags: {
+          role: SourceMemberRoles.Member,
+          referralToken: expect.any(String),
+        },
         referenceId: 'b',
-        role: SourceMemberRoles.Member,
         sourceId: 'b',
         status: ContentPreferenceStatus.Blocked,
         type: ContentPreferenceType.Source,

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -4,8 +4,11 @@ import {
   ContentPreferenceType,
 } from '../entity/contentPreference/types';
 import { ContentPreferenceUser } from '../entity/contentPreference/ContentPreferenceUser';
-import { NotificationType } from '../notifications/common';
-import { EntityManager, EntityTarget, In } from 'typeorm';
+import {
+  NotificationPreferenceStatus,
+  NotificationType,
+} from '../notifications/common';
+import { EntityManager, EntityTarget, In, Not } from 'typeorm';
 import { ConflictError } from '../errors';
 import { ContentPreferenceFeedKeyword } from '../entity/contentPreference/ContentPreferenceFeedKeyword';
 import { ContentPreferenceSource } from '../entity/contentPreference/ContentPreferenceSource';
@@ -91,6 +94,7 @@ export const cleanContentNotificationPreference = async ({
     userId,
     referenceId: id,
     notificationType: In(notificationTypes),
+    status: Not(NotificationPreferenceStatus.Muted),
   });
 };
 

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -55,6 +55,7 @@ export const entityToNotificationTypeMap: Record<
   [ContentPreferenceType.Source]: [
     NotificationType.SourcePostAdded,
     NotificationType.SquadPostAdded,
+    NotificationType.SquadMemberJoined,
   ],
 };
 

--- a/src/entity/SourceMember.ts
+++ b/src/entity/SourceMember.ts
@@ -1,11 +1,7 @@
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
-import { randomBytes } from 'crypto';
 import type { Source } from './Source';
 import type { User } from './user';
-import { promisify } from 'util';
 import { SourceMemberRoles } from '../roles';
-
-const randomBytesAsync = promisify(randomBytes);
 
 export type SourceMemberFlags = Partial<{
   hideFeedPosts: boolean;
@@ -54,7 +50,3 @@ export class SourceMember {
   @Column({ type: 'jsonb', default: {} })
   flags: SourceMemberFlags;
 }
-
-const TOKEN_BYTES = 32;
-export const generateMemberToken = async (): Promise<string> =>
-  (await randomBytesAsync(TOKEN_BYTES)).toString('base64url');

--- a/src/entity/contentPreference/ContentPreferenceSource.ts
+++ b/src/entity/contentPreference/ContentPreferenceSource.ts
@@ -1,10 +1,16 @@
-import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
+import { ChildEntity, Column, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { ContentPreference } from './ContentPreference';
 import { ContentPreferenceType } from './types';
 import type { Feed } from '../Feed';
 import type { Source } from 'graphql';
 import { SourceMemberRoles } from '../../roles';
 import type { SourceMemberFlags } from '../SourceMember';
+
+export type ContentPreferenceSourceFlags = Partial<{
+  role: SourceMemberRoles;
+  referralToken: string;
+}> &
+  SourceMemberFlags;
 
 @ChildEntity(ContentPreferenceType.Source)
 export class ContentPreferenceSource extends ContentPreference {
@@ -14,11 +20,9 @@ export class ContentPreferenceSource extends ContentPreference {
   @Column({ type: 'text', default: null })
   feedId: string;
 
-  @Column({ type: 'text', default: SourceMemberRoles.Member })
-  role: SourceMemberRoles;
-
   @Column({ type: 'jsonb', default: {} })
-  flags: SourceMemberFlags;
+  @Index('IDX_content_preference_flags_referralToken', { synchronize: false })
+  flags: ContentPreferenceSourceFlags;
 
   @ManyToOne('Source', { lazy: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'sourceId' })

--- a/src/migration/1730390077794-ContentPreferenceSquad.ts
+++ b/src/migration/1730390077794-ContentPreferenceSquad.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ContentPreferenceSquad1730390077794 implements MigrationInterface {
+  name = 'ContentPreferenceSquad1730390077794';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_content_preference_flags_referralToken" ON "content_preference" ((flags->>'referralToken'))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "IDX_content_preference_flags_referralToken"`,
+    );
+  }
+}

--- a/src/schema/contentPreference.ts
+++ b/src/schema/contentPreference.ts
@@ -7,7 +7,12 @@ import {
   ContentPreferenceStatus,
   ContentPreferenceType,
 } from '../entity/contentPreference/types';
-import { followEntity, unfollowEntity } from '../common/contentPreference';
+import {
+  blockEntity,
+  followEntity,
+  unblockEntity,
+  unfollowEntity,
+} from '../common/contentPreference';
 import { GQLEmptyResponse, offsetPageGenerator } from './common';
 import graphorm from '../graphorm';
 import { Connection, ConnectionArguments } from 'graphql-relay';
@@ -145,6 +150,34 @@ export const typeDefs = /* GraphQL */ `
       id: ID!
       """
       Entity unfollow (user, source..)
+      """
+      entity: ContentPreferenceType!
+    ): EmptyResponse @auth
+
+    """
+    Block entity
+    """
+    block(
+      """
+      Id of the entity
+      """
+      id: ID!
+      """
+      Entity to block (user, source..)
+      """
+      entity: ContentPreferenceType!
+    ): EmptyResponse @auth
+
+    """
+    Unblock entity
+    """
+    unblock(
+      """
+      Id of the entity
+      """
+      id: ID!
+      """
+      Entity to unblock (user, source..)
       """
       entity: ContentPreferenceType!
     ): EmptyResponse @auth
@@ -303,6 +336,28 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await unfollowEntity({ ctx, id, entity });
+
+      return {
+        _: true,
+      };
+    },
+    block: async (
+      _,
+      { id, entity }: { id: string; entity: ContentPreferenceType },
+      ctx: AuthContext,
+    ): Promise<GQLEmptyResponse> => {
+      await blockEntity({ ctx, id, entity });
+
+      return {
+        _: true,
+      };
+    },
+    unblock: async (
+      _,
+      { id, entity }: { id: string; entity: ContentPreferenceType },
+      ctx: AuthContext,
+    ): Promise<GQLEmptyResponse> => {
+      await unblockEntity({ ctx, id, entity });
 
       return {
         _: true,

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -76,6 +76,8 @@ import { popularFeedClient } from '../integrations/feed/generators';
 import { ContentPreferenceFeedKeyword } from '../entity/contentPreference/ContentPreferenceFeedKeyword';
 import { ContentPreferenceStatus } from '../entity/contentPreference/types';
 import { ContentPreferenceSource } from '../entity/contentPreference/ContentPreferenceSource';
+import { randomUUID } from 'crypto';
+import { SourceMemberRoles } from '../roles';
 
 interface GQLTagsCategory {
   id: string;
@@ -1876,6 +1878,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                   sourceId: source.id,
                   feedId: feedId,
                   status: ContentPreferenceStatus.Follow,
+                  flags: {
+                    role: SourceMemberRoles.Member,
+                    referralToken: randomUUID(),
+                  },
                 })) as ContentPreferenceSource[],
               )
               .orUpdate(['status'], ['referenceId', 'userId'])
@@ -1908,6 +1914,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                   sourceId: source.id,
                   feedId: feedId,
                   status: ContentPreferenceStatus.Blocked,
+                  flags: {
+                    role: SourceMemberRoles.Member,
+                    referralToken: randomUUID(),
+                  },
                 })) as ContentPreferenceSource[],
               )
               .orUpdate(['status'], ['referenceId', 'userId'])

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -4,7 +4,7 @@ import { ConnectionArguments } from 'graphql-relay';
 import { AuthContext, BaseContext, Context } from '../Context';
 import {
   createSharePost,
-  generateMemberToken,
+  NotificationPreferenceSource,
   Source,
   SourceFeed,
   SourceFlagsPublic,
@@ -66,6 +66,12 @@ import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { traceResolvers } from './trace';
 import { SourceCategory } from '../entity/sources/SourceCategory';
 import { validate } from 'uuid';
+import { ContentPreferenceStatus } from '../entity/contentPreference/types';
+import { ContentPreferenceSource } from '../entity/contentPreference/ContentPreferenceSource';
+import {
+  cleanContentNotificationPreference,
+  entityToNotificationTypeMap,
+} from '../common/contentPreference';
 
 export interface GQLSourceCategory {
   id: string;
@@ -1095,10 +1101,27 @@ const addNewSourceMember = async (
   con: DataSource | EntityManager,
   member: Omit<DeepPartial<SourceMember>, 'referralToken'>,
 ): Promise<void> => {
+  const referralToken = randomUUID();
+
   await con.getRepository(SourceMember).insert({
     ...member,
-    referralToken: await generateMemberToken(),
+    referralToken,
   });
+
+  await con.getRepository(ContentPreferenceSource).insert(
+    con.getRepository(ContentPreferenceSource).create({
+      userId: member.userId,
+      referenceId: member.sourceId,
+      sourceId: member.sourceId,
+      feedId: member.userId,
+      status: ContentPreferenceStatus.Subscribed,
+      flags: {
+        ...member.flags,
+        role: member.role,
+        referralToken,
+      },
+    }),
+  );
 };
 
 export const getPermissionsForMember = (
@@ -1154,14 +1177,25 @@ const updateHideFeedPostsFlag = async (
 ): Promise<GQLEmptyResponse> => {
   await ensureSourcePermissions(ctx, sourceId, SourcePermissions.View);
 
-  await ctx.con.getRepository(SourceMember).update(
-    { sourceId, userId: ctx.userId },
-    {
-      flags: updateFlagsStatement<SourceMember>({
-        hideFeedPosts: value,
-      }),
-    },
-  );
+  await ctx.con.transaction(async (entityManager) => {
+    await entityManager.getRepository(SourceMember).update(
+      { sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          hideFeedPosts: value,
+        }),
+      },
+    );
+
+    await entityManager.getRepository(ContentPreferenceSource).update(
+      { referenceId: sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<ContentPreferenceSource>({
+          hideFeedPosts: value,
+        }),
+      },
+    );
+  });
 
   return { _: true };
 };
@@ -1173,14 +1207,25 @@ const togglePinnedPosts = async (
 ): Promise<GQLEmptyResponse> => {
   await ensureSourcePermissions(ctx, sourceId, SourcePermissions.View);
 
-  await ctx.con.getRepository(SourceMember).update(
-    { sourceId, userId: ctx.userId },
-    {
-      flags: updateFlagsStatement<SourceMember>({
-        collapsePinnedPosts: value,
-      }),
-    },
-  );
+  await ctx.con.transaction(async (entityManager) => {
+    await entityManager.getRepository(SourceMember).update(
+      { sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          collapsePinnedPosts: value,
+        }),
+      },
+    );
+
+    await entityManager.getRepository(ContentPreferenceSource).update(
+      { referenceId: sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          collapsePinnedPosts: value,
+        }),
+      },
+    );
+  });
 
   return { _: true };
 };
@@ -1887,10 +1932,27 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Leave);
-      await ctx.con.getRepository(SourceMember).delete({
-        sourceId,
-        userId: ctx.userId,
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager.getRepository(SourceMember).delete({
+          sourceId,
+          userId: ctx.userId,
+        });
+
+        await entityManager.getRepository(ContentPreferenceSource).delete({
+          userId: ctx.userId,
+          referenceId: sourceId,
+        });
+
+        await cleanContentNotificationPreference({
+          ctx,
+          entityManager,
+          id: sourceId,
+          notificationTypes: entityToNotificationTypeMap.source,
+          notficationEntity: NotificationPreferenceSource,
+          userId: ctx.userId,
+        });
       });
+
       return { _: true };
     },
     updateMemberRole: async (
@@ -1917,9 +1979,34 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         }
       }
 
-      await ctx.con
-        .getRepository(SourceMember)
-        .update({ sourceId, userId: memberId }, { role });
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager
+          .getRepository(SourceMember)
+          .update({ sourceId, userId: memberId }, { role });
+
+        const isBlock = role === SourceMemberRoles.Blocked;
+
+        await entityManager.getRepository(ContentPreferenceSource).update(
+          { userId: memberId, referenceId: sourceId },
+          {
+            status: isBlock ? ContentPreferenceStatus.Blocked : undefined,
+            flags: updateFlagsStatement<ContentPreferenceSource>({
+              role,
+            }),
+          },
+        );
+
+        if (isBlock) {
+          await cleanContentNotificationPreference({
+            ctx,
+            entityManager,
+            id: sourceId,
+            notificationTypes: entityToNotificationTypeMap.source,
+            notficationEntity: NotificationPreferenceSource,
+            userId: memberId,
+          });
+        }
+      });
 
       return { _: true };
     },
@@ -1934,9 +2021,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         SourcePermissions.MemberUnblock,
       );
 
-      await ctx.con
-        .getRepository(SourceMember)
-        .delete({ sourceId, userId: memberId });
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager
+          .getRepository(SourceMember)
+          .delete({ sourceId, userId: memberId });
+
+        await entityManager.getRepository(ContentPreferenceSource).delete({
+          userId: memberId,
+          referenceId: sourceId,
+        });
+      });
 
       return { _: true };
     },


### PR DESCRIPTION
AS-651

- add block mutations for all supported entities so far (with backward compatibility)
- squad entities (from other #2378)