### PR TITLE
As 652 squad content preference

### DIFF
--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -17,6 +17,7 @@ import {
   NotificationPreferenceUser,
 } from '../entity';
 import { ghostUser } from './utils';
+import { randomUUID } from 'crypto';
 
 type FollowEntity = ({
   ctx,
@@ -195,9 +196,16 @@ const followSource: FollowEntity = async ({ ctx, id, status }) => {
       sourceId: id,
       feedId: ctx.userId,
       status,
+      referralToken: randomUUID(),
     });
 
-    await repository.save(contentPreference);
+    await repository
+      .createQueryBuilder()
+      .insert()
+      .into(ContentPreferenceSource)
+      .values(contentPreference)
+      .orUpdate(['status'], ['referenceId', 'userId'])
+      .execute();
 
     if (status !== ContentPreferenceStatus.Subscribed) {
       cleanContentNotificationPreference({
@@ -309,9 +317,16 @@ const blockSource: BlockEntity = async ({ ctx, id }) => {
       sourceId: id,
       feedId: ctx.userId,
       status: ContentPreferenceStatus.Blocked,
+      referralToken: randomUUID(),
     });
 
-    await repository.save(contentPreference);
+    await repository
+      .createQueryBuilder()
+      .insert()
+      .into(ContentPreferenceSource)
+      .values(contentPreference)
+      .orUpdate(['status'], ['referenceId', 'userId'])
+      .execute();
 
     cleanContentNotificationPreference({
       ctx,

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -45,7 +45,7 @@ type BlockEntity = ({
   id: string;
 }) => Promise<void>;
 
-const entityToNotificationTypeMap: Record<
+export const entityToNotificationTypeMap: Record<
   ContentPreferenceType,
   NotificationType[]
 > = {
@@ -61,18 +61,20 @@ export const contentPreferenceNotificationTypes = Object.values(
   entityToNotificationTypeMap,
 ).flat();
 
-const cleanContentNotificationPreference = async ({
+export const cleanContentNotificationPreference = async ({
   ctx,
   entityManager,
   id,
   notificationTypes,
   notficationEntity,
+  userId,
 }: {
   ctx: AuthContext;
   entityManager?: EntityManager;
   id: string;
   notificationTypes: NotificationType[];
   notficationEntity: EntityTarget<NotificationPreference>;
+  userId: string;
 }) => {
   const notificationRepository = (entityManager ?? ctx.con).getRepository(
     notficationEntity,
@@ -83,7 +85,7 @@ const cleanContentNotificationPreference = async ({
   }
 
   await notificationRepository.delete({
-    userId: ctx.userId,
+    userId,
     referenceId: id,
     notificationType: In(notificationTypes),
   });
@@ -117,6 +119,7 @@ const followUser: FollowEntity = async ({ ctx, id, status }) => {
         id,
         notificationTypes: entityToNotificationTypeMap.user,
         notficationEntity: NotificationPreferenceUser,
+        userId: ctx.userId,
       });
     }
   });
@@ -138,6 +141,7 @@ const unfollowUser: UnFollowEntity = async ({ ctx, id }) => {
       id,
       notificationTypes: entityToNotificationTypeMap.user,
       notficationEntity: NotificationPreferenceUser,
+      userId: ctx.userId,
     });
   });
 };
@@ -214,6 +218,7 @@ const followSource: FollowEntity = async ({ ctx, id, status }) => {
         id,
         notificationTypes: entityToNotificationTypeMap.source,
         notficationEntity: NotificationPreferenceSource,
+        userId: ctx.userId,
       });
     }
 
@@ -242,6 +247,7 @@ const unfollowSource: UnFollowEntity = async ({ ctx, id }) => {
       id,
       notificationTypes: entityToNotificationTypeMap.source,
       notficationEntity: NotificationPreferenceSource,
+      userId: ctx.userId,
     });
 
     await entityManager.getRepository(FeedSource).delete({
@@ -278,6 +284,7 @@ const blockUser: BlockEntity = async ({ ctx, id }) => {
       id,
       notificationTypes: entityToNotificationTypeMap.user,
       notficationEntity: NotificationPreferenceUser,
+      userId: ctx.userId,
     });
   });
 };
@@ -334,6 +341,7 @@ const blockSource: BlockEntity = async ({ ctx, id }) => {
       id,
       notificationTypes: entityToNotificationTypeMap.source,
       notficationEntity: NotificationPreferenceSource,
+      userId: ctx.userId,
     });
 
     // TODO follow phase 3 remove when backward compatibility is done

--- a/src/entity/SourceMember.ts
+++ b/src/entity/SourceMember.ts
@@ -1,11 +1,7 @@
 import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
-import { randomBytes } from 'crypto';
 import type { Source } from './Source';
 import type { User } from './user';
-import { promisify } from 'util';
 import { SourceMemberRoles } from '../roles';
-
-const randomBytesAsync = promisify(randomBytes);
 
 export type SourceMemberFlags = Partial<{
   hideFeedPosts: boolean;
@@ -54,7 +50,3 @@ export class SourceMember {
   @Column({ type: 'jsonb', default: {} })
   flags: SourceMemberFlags;
 }
-
-const TOKEN_BYTES = 32;
-export const generateMemberToken = async (): Promise<string> =>
-  (await randomBytesAsync(TOKEN_BYTES)).toString('base64url');

--- a/src/entity/contentPreference/ContentPreferenceSource.ts
+++ b/src/entity/contentPreference/ContentPreferenceSource.ts
@@ -1,4 +1,4 @@
-import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
+import { ChildEntity, Column, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { ContentPreference } from './ContentPreference';
 import { ContentPreferenceType } from './types';
 import type { Feed } from '../Feed';
@@ -19,6 +19,10 @@ export class ContentPreferenceSource extends ContentPreference {
 
   @Column({ type: 'jsonb', default: {} })
   flags: SourceMemberFlags;
+
+  @Column({ type: 'text' })
+  @Index({ unique: true })
+  referralToken: string;
 
   @ManyToOne('Source', { lazy: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'sourceId' })

--- a/src/migration/1730390077794-ContentPreferenceSquad.ts
+++ b/src/migration/1730390077794-ContentPreferenceSquad.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ContentPreferenceSquad1730390077794 implements MigrationInterface {
+  name = 'ContentPreferenceSquad1730390077794';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" ADD "referralToken" text`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_ae47f6c65e5835c5a104974aa3" ON "content_preference" ("referralToken") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ae47f6c65e5835c5a104974aa3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" DROP COLUMN "referralToken"`,
+    );
+  }
+}

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -4,7 +4,7 @@ import { ConnectionArguments } from 'graphql-relay';
 import { AuthContext, BaseContext, Context } from '../Context';
 import {
   createSharePost,
-  generateMemberToken,
+  NotificationPreferenceSource,
   Source,
   SourceFeed,
   SourceFlagsPublic,
@@ -66,6 +66,12 @@ import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { traceResolvers } from './trace';
 import { SourceCategory } from '../entity/sources/SourceCategory';
 import { validate } from 'uuid';
+import { ContentPreferenceStatus } from '../entity/contentPreference/types';
+import { ContentPreferenceSource } from '../entity/contentPreference/ContentPreferenceSource';
+import {
+  cleanContentNotificationPreference,
+  entityToNotificationTypeMap,
+} from '../common/contentPreference';
 
 export interface GQLSourceCategory {
   id: string;
@@ -1095,10 +1101,25 @@ const addNewSourceMember = async (
   con: DataSource | EntityManager,
   member: Omit<DeepPartial<SourceMember>, 'referralToken'>,
 ): Promise<void> => {
+  const referralToken = randomUUID();
+
   await con.getRepository(SourceMember).insert({
     ...member,
-    referralToken: await generateMemberToken(),
+    referralToken,
   });
+
+  await con.getRepository(ContentPreferenceSource).insert(
+    con.getRepository(ContentPreferenceSource).create({
+      userId: member.userId,
+      referenceId: member.sourceId,
+      sourceId: member.sourceId,
+      feedId: member.userId,
+      status: ContentPreferenceStatus.Subscribed,
+      role: member.role,
+      flags: member.flags,
+      referralToken,
+    }),
+  );
 };
 
 export const getPermissionsForMember = (
@@ -1154,14 +1175,25 @@ const updateHideFeedPostsFlag = async (
 ): Promise<GQLEmptyResponse> => {
   await ensureSourcePermissions(ctx, sourceId, SourcePermissions.View);
 
-  await ctx.con.getRepository(SourceMember).update(
-    { sourceId, userId: ctx.userId },
-    {
-      flags: updateFlagsStatement<SourceMember>({
-        hideFeedPosts: value,
-      }),
-    },
-  );
+  await ctx.con.transaction(async (entityManager) => {
+    await entityManager.getRepository(SourceMember).update(
+      { sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          hideFeedPosts: value,
+        }),
+      },
+    );
+
+    await entityManager.getRepository(ContentPreferenceSource).update(
+      { referenceId: sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<ContentPreferenceSource>({
+          hideFeedPosts: value,
+        }),
+      },
+    );
+  });
 
   return { _: true };
 };
@@ -1173,14 +1205,25 @@ const togglePinnedPosts = async (
 ): Promise<GQLEmptyResponse> => {
   await ensureSourcePermissions(ctx, sourceId, SourcePermissions.View);
 
-  await ctx.con.getRepository(SourceMember).update(
-    { sourceId, userId: ctx.userId },
-    {
-      flags: updateFlagsStatement<SourceMember>({
-        collapsePinnedPosts: value,
-      }),
-    },
-  );
+  await ctx.con.transaction(async (entityManager) => {
+    await entityManager.getRepository(SourceMember).update(
+      { sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          collapsePinnedPosts: value,
+        }),
+      },
+    );
+
+    await entityManager.getRepository(ContentPreferenceSource).update(
+      { referenceId: sourceId, userId: ctx.userId },
+      {
+        flags: updateFlagsStatement<SourceMember>({
+          collapsePinnedPosts: value,
+        }),
+      },
+    );
+  });
 
   return { _: true };
 };
@@ -1887,10 +1930,27 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Leave);
-      await ctx.con.getRepository(SourceMember).delete({
-        sourceId,
-        userId: ctx.userId,
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager.getRepository(SourceMember).delete({
+          sourceId,
+          userId: ctx.userId,
+        });
+
+        await entityManager.getRepository(ContentPreferenceSource).delete({
+          userId: ctx.userId,
+          referenceId: sourceId,
+        });
+
+        await cleanContentNotificationPreference({
+          ctx,
+          entityManager,
+          id: sourceId,
+          notificationTypes: entityToNotificationTypeMap.source,
+          notficationEntity: NotificationPreferenceSource,
+          userId: ctx.userId,
+        });
       });
+
       return { _: true };
     },
     updateMemberRole: async (
@@ -1917,9 +1977,32 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         }
       }
 
-      await ctx.con
-        .getRepository(SourceMember)
-        .update({ sourceId, userId: memberId }, { role });
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager
+          .getRepository(SourceMember)
+          .update({ sourceId, userId: memberId }, { role });
+
+        const isBlock = role === SourceMemberRoles.Blocked;
+
+        await entityManager.getRepository(ContentPreferenceSource).update(
+          { userId: memberId, referenceId: sourceId },
+          {
+            role,
+            status: isBlock ? ContentPreferenceStatus.Blocked : undefined,
+          },
+        );
+
+        if (isBlock) {
+          await cleanContentNotificationPreference({
+            ctx,
+            entityManager,
+            id: sourceId,
+            notificationTypes: entityToNotificationTypeMap.source,
+            notficationEntity: NotificationPreferenceSource,
+            userId: memberId,
+          });
+        }
+      });
 
       return { _: true };
     },
@@ -1934,9 +2017,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         SourcePermissions.MemberUnblock,
       );
 
-      await ctx.con
-        .getRepository(SourceMember)
-        .delete({ sourceId, userId: memberId });
+      await ctx.con.transaction(async (entityManager) => {
+        await entityManager
+          .getRepository(SourceMember)
+          .delete({ sourceId, userId: memberId });
+
+        await entityManager.getRepository(ContentPreferenceSource).delete({
+          userId: memberId,
+          referenceId: sourceId,
+        });
+      });
 
       return { _: true };
     },


### PR DESCRIPTION
AS-652

- add support for referralToken (managed to add it to base ContentPreferenceSource to not complicate with another ContentPreferenceType of `squad`)
- backward compatibility for mutations in sources schema
- few more relevant comments in code