### PR TITLE
fix: rolls back `@opentelemetry/instrumentation-http` upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@opentelemetry/instrumentation-fastify": "^0.41.0",
         "@opentelemetry/instrumentation-graphql": "^0.44.0",
         "@opentelemetry/instrumentation-grpc": "^0.54.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "0.53.0",
         "@opentelemetry/instrumentation-ioredis": "^0.44.0",
         "@opentelemetry/instrumentation-pg": "^0.47.0",
         "@opentelemetry/instrumentation-pino": "^0.43.0",
@@ -2485,15 +2485,62 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.54.0.tgz",
-      "integrity": "sha512-ovl0UrL+vGpi0O7fdZ1mHRdiQkuv6NGMRBRKZZygVCUFNXdoqTpvJRRbTYih5U5FC+PHIFssEordmlblRCaGUg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
+      "integrity": "sha512-H74ErMeDuZfj7KgYCTOFGWF5W9AfaPnqLQQxeFq85+D29wwV2yqHbz2IKLYpkOh7EI6QwDEl7rZCIxjJLyc/CQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
-        "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -6743,11 +6790,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/forwarded-parse": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
     },
     "node_modules/fs-capacitor": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@opentelemetry/instrumentation-fastify": "^0.41.0",
     "@opentelemetry/instrumentation-graphql": "^0.44.0",
     "@opentelemetry/instrumentation-grpc": "^0.54.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "0.53.0",
     "@opentelemetry/instrumentation-ioredis": "^0.44.0",
     "@opentelemetry/instrumentation-pg": "^0.47.0",
     "@opentelemetry/instrumentation-pino": "^0.43.0",


### PR DESCRIPTION
rolls back `@opentelemetry/instrumentation-http` because of issue with malformed forwarded headers that might occur

A [fix is proposed](https://github.com/open-telemetry/opentelemetry-js/pull/5099), so once that has been approved and released, we can upgrade this dependency