### PR TITLE
fix: add missing index to `user_stats` table

### DIFF
--- a/src/entity/user/UserStats.ts
+++ b/src/entity/user/UserStats.ts
@@ -1,4 +1,4 @@
-import { DataSource, ViewColumn, ViewEntity } from 'typeorm';
+import { DataSource, Index, ViewColumn, ViewEntity } from 'typeorm';
 import { ghostUser } from '../../common';
 
 @ViewEntity({
@@ -52,6 +52,7 @@ import { ghostUser } from '../../common';
 })
 export class UserStats {
   @ViewColumn()
+  @Index('IDX_user_stats_id')
   id: string;
 
   @ViewColumn()

--- a/src/migration/1730860362949-UserStatsIndex.ts
+++ b/src/migration/1730860362949-UserStatsIndex.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserStatsIndex1730860362949 implements MigrationInterface {
+  name = 'UserStatsIndex1730860362949'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_user_stats_id" ON "public"."user_stats" ("id")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_user_stats_id"`);
+  }
+}


### PR DESCRIPTION
Query time goes from ~900ms to ~125ms.

Plan before index
```
Limit  (cost=0.15..88978.65 rows=3 width=96) (actual time=137.771..705.455 rows=5 loops=1)
  ->  Index Scan using ""IDX_user_top_reader_userId_issuedAt"" on user_top_reader user_top_reader_2ex  (cost=0.15..88978.65 rows=3 width=96) (actual time=137.769..705.452 rows=5 loops=1)"
        Index Cond: ((""userId"")::text = 'XDCZD-PHG'::text)"
        SubPlan 1
          ->  Seq Scan on user_stats us  (cost=0.00..29645.69 rows=1 width=8) (actual time=140.782..140.988 rows=1 loops=5)
                Filter: ((id)::text = (user_top_reader_2ex.""userId"")::text)"
                Rows Removed by Filter: 1244454
        SubPlan 2
          ->  Subquery Scan on res  (cost=0.43..8.46 rows=1 width=32) (actual time=0.066..0.067 rows=1 loops=5)
                ->  Limit  (cost=0.43..8.45 rows=1 width=22) (actual time=0.049..0.049 rows=1 loops=5)
                      ->  Index Scan using ""IDX_keyword_value"" on keyword keyword_vpq  (cost=0.43..8.45 rows=1 width=22) (actual time=0.044..0.044 rows=1 loops=5)"
                            Index Cond: (value = user_top_reader_2ex.""keywordValue"")"
Planning Time: 0.195 ms
Execution Time: 705.506 ms
```

Plan after index
```
Limit  (cost=11.31..62.06 rows=3 width=96) (actual time=0.127..0.279 rows=5 loops=1)
  ->  Result  (cost=11.31..62.06 rows=3 width=96) (actual time=0.126..0.277 rows=5 loops=1)
        ->  Sort  (cost=11.31..11.31 rows=3 width=120) (actual time=0.044..0.045 rows=5 loops=1)
              Sort Key: user_top_reader_2ex.""issuedAt"" DESC"
              Sort Method: quicksort  Memory: 25kB
              ->  Bitmap Heap Scan on user_top_reader user_top_reader_2ex  (cost=4.17..11.28 rows=3 width=120) (actual time=0.029..0.032 rows=8 loops=1)
                    Recheck Cond: ((""userId"")::text = 'XDCZD-PHG'::text)"
                    Heap Blocks: exact=1
                    ->  Bitmap Index Scan on ""IDX_user_top_reader_userId_issuedAt""  (cost=0.00..4.17 rows=3 width=0) (actual time=0.019..0.019 rows=15 loops=1)"
                          Index Cond: ((""userId"")::text = 'XDCZD-PHG'::text)"
        SubPlan 1
          ->  Index Scan using ""IDX_user_stats_id"" on user_stats us  (cost=0.43..8.45 rows=1 width=8) (actual time=0.015..0.015 rows=1 loops=5)"
                Index Cond: ((id)::text = (user_top_reader_2ex.""userId"")::text)"
        SubPlan 2
          ->  Subquery Scan on res  (cost=0.43..8.46 rows=1 width=32) (actual time=0.027..0.028 rows=1 loops=5)
                ->  Limit  (cost=0.43..8.45 rows=1 width=22) (actual time=0.022..0.022 rows=1 loops=5)
                      ->  Index Scan using ""IDX_keyword_value"" on keyword keyword_vpq  (cost=0.43..8.45 rows=1 width=22) (actual time=0.022..0.022 rows=1 loops=5)"
                            Index Cond: (value = user_top_reader_2ex.""keywordValue"")"
Planning Time: 0.304 ms
Execution Time: 0.341 ms
```