### PR TITLE
AS-615 reduce freeform post minimum content length

### DIFF
--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -2,7 +2,7 @@ import { ChildEntity, Column } from 'typeorm';
 import { Post, PostType } from './Post';
 
 // Minimun content length required for new posts to trigger content-requested
-export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 50;
+export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 5;
 
 // Minimun content length required for updated posts to trigger content-requested
 export const FREEFORM_POST_MINIMUM_CHANGE_LENGTH = 200;


### PR DESCRIPTION
Reduced `FREEFORM_POST_MINIMUM_CONTENT_LENGTH` to process most of the posts. Probably could set to 0 as well?
Did not change `FREEFORM_POST_MINIMUM_CHANGE_LENGTH`.