### PR TITLE
feat: add search source endpoints

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -75,6 +75,7 @@ import {
 } from '../common/contentPreference';
 import { MIN_SEARCH_QUERY_LENGTH } from './tags';
 import { categorizedSquads } from '../../bin/categorizedSquads';
+import { getSearchLimit } from '../common/search';
 
 export interface GQLSourceCategory {
   id: string;
@@ -1546,7 +1547,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               query: `%${query}%`,
             })
             .andWhere({ active: true, private: false })
-            .limit(limit);
+            .limit(getSearchLimit({ limit }));
           return builder;
         },
         true,
@@ -1584,7 +1585,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               ids: rawSourcesIds,
             })
             .orderBy(`array_position(array[${idsStr}], ${builder.alias}.id)`)
-            .limit(limit);
+            .limit(getSearchLimit({ limit }));
           return builder;
         },
         true,

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -73,6 +73,8 @@ import {
   cleanContentNotificationPreference,
   entityToNotificationTypeMap,
 } from '../common/contentPreference';
+import { MIN_SEARCH_QUERY_LENGTH } from './tags';
+import { categorizedSquads } from '../../bin/categorizedSquads';
 
 export interface GQLSourceCategory {
   id: string;
@@ -384,6 +386,36 @@ export const typeDefs = /* GraphQL */ `
       """
       sortByMembersCount: Boolean
     ): SourceConnection!
+
+    """
+    Get available sources for given query
+    """
+    searchSources(
+      """
+      Search query
+      """
+      query: String!
+
+      """
+      Limit the number of sources returned
+      """
+      limit: Int
+    ): [Source] @cacheControl(maxAge: 600)
+
+    """
+    Get source recommendation based on given tags
+    """
+    sourceRecommendationByTags(
+      """
+      Tags to recommend sources for
+      """
+      tags: [String]!
+
+      """
+      Limit the number of sources returned
+      """
+      limit: Int
+    ): [Source] @cacheControl(maxAge: 600)
 
     """
     Get the most recent sources
@@ -1492,6 +1524,69 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           return builder;
         },
         undefined,
+        true,
+      );
+    },
+    searchSources: async (
+      source,
+      { query, limit = 5 }: { query: string; limit: number },
+      ctx: Context,
+      info,
+    ): Promise<GQLSource[]> => {
+      if (query.length < MIN_SEARCH_QUERY_LENGTH) {
+        return [];
+      }
+
+      return await graphorm.query<GQLSource>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder
+            .where(`name ILIKE :query OR handle ILIKE :query`, {
+              query: `%${query}%`,
+            })
+            .andWhere({ active: true, private: false })
+            .limit(limit);
+          return builder;
+        },
+        true,
+      );
+    },
+    sourceRecommendationByTags: async (
+      source,
+      { tags, limit = 10 }: { tags: string[]; limit: number },
+      ctx: Context,
+      info,
+    ): Promise<GQLSource[]> => {
+      const excludedSources = ['unknown', 'community', 'collections'];
+      const rawSources = await ctx.con.getRepository(SourceTagView).find({
+        where: { tag: In(tags), sourceId: Not(In(excludedSources)) },
+        select: ['sourceId'],
+        order: { count: 'DESC' },
+      });
+
+      const filter: FindOptionsWhere<Source> = {
+        active: true,
+        private: false,
+      };
+
+      const rawSourcesIds = rawSources.map(({ sourceId }) => sourceId);
+      const idsStr = rawSources.length
+        ? rawSources.map(({ sourceId }) => `'${sourceId}'`).join(',')
+        : `'nosuchid'`;
+      return graphorm.query(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder
+            .andWhere(filter)
+            .andWhere('id IN (:...ids)', {
+              ids: rawSourcesIds,
+            })
+            .orderBy(`array_position(array[${idsStr}], ${builder.alias}.id)`)
+            .limit(limit);
+          return builder;
+        },
         true,
       );
     },

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -75,7 +75,6 @@ import {
   entityToNotificationTypeMap,
 } from '../common/contentPreference';
 import { MIN_SEARCH_QUERY_LENGTH } from './tags';
-import { categorizedSquads } from '../../bin/categorizedSquads';
 import { getSearchLimit } from '../common/search';
 import {
   SourcePostModeration,


### PR DESCRIPTION
Introduces 2 new endpoints needed for source selection in onboarding.

- searchSources => Used for when you use the search box, needed slight different result from the suggestions one we have, so decided to do custom one.
- sourceRecommendationByTags => Initial page load, we pass the tags you selected on previous screen and find highest matching sources. (Needed to do 2 queries to avoid messy graphORM logic we couldn't deduplicate, and since it's once off this is fine)

AS-678