### PR TITLE
fix: minor adjustments to top reader

### DIFF
--- a/queries/calculateTopReaders.sql
+++ b/queries/calculateTopReaders.sql
@@ -9,6 +9,7 @@ views AS (
     INNER JOIN "public"."post_keyword" "pk" ON "v"."postId" = "pk"."postId"
   WHERE
     "pk"."status" = 'allow'
+    AND "pk"."keyword" NOT IN ('dailydev')
     AND "v"."timestamp" >= (date_trunc('month', CURRENT_DATE) - INTERVAL '1 month')
     -- Example 2024-10-01 00:00:00+00
     AND "v"."timestamp" <  (date_trunc('month', CURRENT_DATE))

--- a/src/cron/calculateTopReaders.ts
+++ b/src/cron/calculateTopReaders.ts
@@ -123,12 +123,12 @@ export const calculateTopReaders: Cron = {
             'calculateTopReaders: Inserted rows',
           );
         }
-
-        logger.info('calculateTopReaders: Refreshing materialized view');
-        await manager.query(
-          `REFRESH MATERIALIZED VIEW ${con.getRepository(UserStats).metadata.tableName}`,
-        );
       });
+
+      logger.info('calculateTopReaders: Refreshing materialized view');
+      await con.query(
+        `REFRESH MATERIALIZED VIEW ${con.getRepository(UserStats).metadata.tableName}`,
+      );
 
       logger.info(
         'calculateTopReaders: All done. So long and thanks for all the fish!',

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -284,7 +284,7 @@ export class NotificationBuilder {
   ): NotificationBuilder {
     this.avatars.push({
       type: 'top_reader_badge',
-      name: ctx.keyword.flags.title,
+      name: ctx.keyword.flags?.title || ctx.keyword.value,
       targetUrl: '',
       referenceId: ctx.userTopReader.id,
       image: defaultImage.placeholder,

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -129,7 +129,7 @@ export const notificationTitleMap: Record<
     return `New post from <b>${userName}</b>, check it out now!`;
   },
   user_given_top_reader: (ctx: NotificationUserTopReaderContext) => {
-    const keyword = ctx.keyword.flags.title;
+    const keyword = ctx.keyword.flags?.title || ctx.keyword.value;
     return `Great news! You've earned the top reader badge in ${keyword}.`;
   },
 };

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -725,7 +725,7 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     return {
       image: userTopReader.image,
       issuedAt: formatMailDate(userTopReader.issuedAt),
-      keyword: keyword.flags.title || keyword.value,
+      keyword: keyword?.flags?.title || keyword.value,
     };
   },
 };


### PR DESCRIPTION
Minor adjustments to top reader:
- Moves the materialized view refresh out of transcation
- Excludes `dailydev` keyword from future runs
- Fallback to keyword value if `title` flag does not exist