### PR TITLE
feat: feed type content preference

### DIFF
--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -30,13 +30,13 @@ import {
   Source,
   SourceType,
 } from '../src/entity';
-import { ContentPreferenceFeedKeyword } from '../src/entity/contentPreference/ContentPreferenceFeedKeyword';
 import { ContentPreferenceSource } from '../src/entity/contentPreference/ContentPreferenceSource';
 import {
   NotificationPreferenceStatus,
   NotificationType,
 } from '../src/notifications/common';
 import { ghostUser } from '../src/common';
+import { ContentPreferenceKeyword } from '../src/entity/contentPreference/ContentPreferenceKeyword';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -612,7 +612,7 @@ describe('mutation follow', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceKeyword)
         .findOneBy({
           userId: '1-fm',
           referenceId: 'keyword-f1',
@@ -999,7 +999,7 @@ describe('mutation unfollow', () => {
 
       await saveFixtures(con, Feed, [{ id: '1-um', userId: '1-um' }]);
 
-      await con.getRepository(ContentPreferenceFeedKeyword).save([
+      await con.getRepository(ContentPreferenceKeyword).save([
         {
           userId: '1-um',
           referenceId: 'keyword-uf1',
@@ -1028,7 +1028,7 @@ describe('mutation unfollow', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceKeyword)
         .findOneBy({
           userId: '1-um',
           referenceId: 'keyword-f1',
@@ -1064,6 +1064,7 @@ describe('mutation unfollow', () => {
           referenceId: 'a-ufm',
           feedId: '1-um',
           status: ContentPreferenceStatus.Follow,
+          sourceId: 'a-ufm',
         },
       ]);
 
@@ -1089,7 +1090,7 @@ describe('mutation unfollow', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceSource)
         .findOneBy({
           userId: '1-um',
           referenceId: 'a-ufm',
@@ -1306,7 +1307,7 @@ describe('mutation block', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceKeyword)
         .findOneBy({
           userId: '1-blm',
           referenceId: 'keyword-bl1',
@@ -1564,7 +1565,7 @@ describe('mutation unblock', () => {
 
       await saveFixtures(con, Feed, [{ id: '1-ublm', userId: '1-ublm' }]);
 
-      await con.getRepository(ContentPreferenceFeedKeyword).save([
+      await con.getRepository(ContentPreferenceKeyword).save([
         {
           userId: '1-ublm',
           referenceId: 'keyword-ublm1',
@@ -1606,7 +1607,7 @@ describe('mutation unblock', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceKeyword)
         .findOneBy({
           userId: '2-ublm',
           referenceId: 'keyword-ublm1',
@@ -1642,6 +1643,7 @@ describe('mutation unblock', () => {
           referenceId: 'a-ublm',
           feedId: '1-ublm',
           status: ContentPreferenceStatus.Blocked,
+          sourceId: 'a-ublm',
         },
       ]);
 
@@ -1667,7 +1669,7 @@ describe('mutation unblock', () => {
       expect(res.errors).toBeFalsy();
 
       const contentPreference = await con
-        .getRepository(ContentPreferenceFeedKeyword)
+        .getRepository(ContentPreferenceSource)
         .findOneBy({
           userId: '1-ublm',
           referenceId: 'a-ublm',

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -64,12 +64,12 @@ import { base64 } from 'graphql-relay/utils/base64';
 import { maxFeedsPerUser, UserVote } from '../src/types';
 import { SubmissionFailErrorMessage } from '../src/errors';
 import { baseFeedConfig } from '../src/integrations/feed';
-import { ContentPreferenceFeedKeyword } from '../src/entity/contentPreference/ContentPreferenceFeedKeyword';
 import {
   ContentPreferenceStatus,
   ContentPreferenceType,
 } from '../src/entity/contentPreference/types';
 import { ContentPreferenceSource } from '../src/entity/contentPreference/ContentPreferenceSource';
+import { ContentPreferenceKeyword } from '../src/entity/contentPreference/ContentPreferenceKeyword';
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -188,7 +188,7 @@ const saveFeedFixtures = async (): Promise<void> => {
     { feedId: '1', sourceId: 'b' },
     { feedId: '1', sourceId: 'c' },
   ]);
-  await saveFixtures(con, ContentPreferenceFeedKeyword, [
+  await saveFixtures(con, ContentPreferenceKeyword, [
     {
       feedId: '1',
       keywordId: 'golang',
@@ -2124,7 +2124,7 @@ describe('mutation addFiltersToFeed', () => {
     });
 
     const contentPreferenceTags = await con
-      .getRepository(ContentPreferenceFeedKeyword)
+      .getRepository(ContentPreferenceKeyword)
       .find({
         where: {
           userId: '1',
@@ -2378,7 +2378,7 @@ describe('mutation removeFiltersFromFeed', () => {
     await saveFeedFixtures();
 
     const contentPreferenceTags = await con
-      .getRepository(ContentPreferenceFeedKeyword)
+      .getRepository(ContentPreferenceKeyword)
       .find({
         where: {
           userId: '1',
@@ -2471,7 +2471,7 @@ describe('mutation removeFiltersFromFeed', () => {
     });
 
     const contentPreferenceTagsAfter = await con
-      .getRepository(ContentPreferenceFeedKeyword)
+      .getRepository(ContentPreferenceKeyword)
       .find({
         where: {
           userId: '1',

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -216,7 +216,7 @@ const followSource: FollowEntity = async ({ ctx, id, status }) => {
       .insert()
       .into(ContentPreferenceSource)
       .values(contentPreference)
-      .orUpdate(['status'], ['referenceId', 'userId'])
+      .orUpdate(['status'], ['userId', 'referenceId', 'type'])
       .execute();
 
     if (status !== ContentPreferenceStatus.Subscribed) {
@@ -341,7 +341,7 @@ const blockSource: BlockEntity = async ({ ctx, id }) => {
       .insert()
       .into(ContentPreferenceSource)
       .values(contentPreference)
-      .orUpdate(['status'], ['referenceId', 'userId'])
+      .orUpdate(['status'], ['userId', 'referenceId', 'type'])
       .execute();
 
     cleanContentNotificationPreference({

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -10,7 +10,6 @@ import {
 } from '../notifications/common';
 import { EntityManager, EntityTarget, In, Not } from 'typeorm';
 import { ConflictError } from '../errors';
-import { ContentPreferenceFeedKeyword } from '../entity/contentPreference/ContentPreferenceFeedKeyword';
 import { ContentPreferenceSource } from '../entity/contentPreference/ContentPreferenceSource';
 import {
   FeedSource,
@@ -22,6 +21,7 @@ import {
 import { ghostUser } from './utils';
 import { randomUUID } from 'crypto';
 import { SourceMemberRoles } from '../roles';
+import { ContentPreferenceKeyword } from '../entity/contentPreference/ContentPreferenceKeyword';
 
 type FollowEntity = ({
   ctx,
@@ -55,6 +55,7 @@ export const entityToNotificationTypeMap: Record<
 > = {
   [ContentPreferenceType.User]: [NotificationType.UserPostAdded],
   [ContentPreferenceType.Keyword]: [],
+  [ContentPreferenceType.FeedKeyword]: [],
   [ContentPreferenceType.Source]: [
     NotificationType.SourcePostAdded,
     NotificationType.SquadPostAdded,
@@ -155,9 +156,7 @@ const unfollowUser: UnFollowEntity = async ({ ctx, id }) => {
 
 const followKeyword: FollowEntity = async ({ ctx, id, status }) => {
   await ctx.con.transaction(async (entityManager) => {
-    const repository = entityManager.getRepository(
-      ContentPreferenceFeedKeyword,
-    );
+    const repository = entityManager.getRepository(ContentPreferenceKeyword);
 
     const contentPreference = repository.create({
       userId: ctx.userId,
@@ -179,9 +178,7 @@ const followKeyword: FollowEntity = async ({ ctx, id, status }) => {
 
 const unfollowKeyword: UnFollowEntity = async ({ ctx, id }) => {
   await ctx.con.transaction(async (entityManager) => {
-    const repository = entityManager.getRepository(
-      ContentPreferenceFeedKeyword,
-    );
+    const repository = entityManager.getRepository(ContentPreferenceKeyword);
 
     await repository.delete({
       userId: ctx.userId,
@@ -301,9 +298,7 @@ const blockUser: BlockEntity = async ({ ctx, id }) => {
 
 const blockKeyword: BlockEntity = async ({ ctx, id }) => {
   await ctx.con.transaction(async (entityManager) => {
-    const repository = entityManager.getRepository(
-      ContentPreferenceFeedKeyword,
-    );
+    const repository = entityManager.getRepository(ContentPreferenceKeyword);
 
     const contentPreference = repository.create({
       userId: ctx.userId,

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -61,6 +61,7 @@ export const entityToNotificationTypeMap: Record<
     NotificationType.SquadPostAdded,
     NotificationType.SquadMemberJoined,
   ],
+  [ContentPreferenceType.FeedSource]: [],
 };
 
 // TODO fix api.new-notification-mail condition to handle all types when follow phase 3 is implemented

--- a/src/entity/contentPreference/ContentPreference.ts
+++ b/src/entity/contentPreference/ContentPreference.ts
@@ -19,7 +19,7 @@ export class ContentPreference {
   @PrimaryColumn({ type: 'text' })
   userId: string;
 
-  @Column({ type: 'text' })
+  @PrimaryColumn({ type: 'text' })
   type: ContentPreferenceType;
 
   @Column({ default: () => 'now()' })

--- a/src/entity/contentPreference/ContentPreferenceFeedKeyword.ts
+++ b/src/entity/contentPreference/ContentPreferenceFeedKeyword.ts
@@ -1,22 +1,6 @@
-import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
-import { ContentPreference } from './ContentPreference';
+import { ChildEntity } from 'typeorm';
 import { ContentPreferenceType } from './types';
-import type { Keyword } from '../Keyword';
-import type { Feed } from '../Feed';
+import { ContentPreferenceKeyword } from './ContentPreferenceKeyword';
 
-@ChildEntity(ContentPreferenceType.Keyword)
-export class ContentPreferenceFeedKeyword extends ContentPreference {
-  @Column({ type: 'text', default: null })
-  keywordId: string;
-
-  @Column({ type: 'text', default: null })
-  feedId: string;
-
-  @ManyToOne('Keyword', { lazy: true, onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'keywordId' })
-  keyword: Promise<Keyword>;
-
-  @ManyToOne('Feed', { lazy: true, onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'feedId' })
-  feed: Promise<Feed>;
-}
+@ChildEntity(ContentPreferenceType.FeedKeyword)
+export class ContentPreferenceFeedKeyword extends ContentPreferenceKeyword {}

--- a/src/entity/contentPreference/ContentPreferenceFeedSource.ts
+++ b/src/entity/contentPreference/ContentPreferenceFeedSource.ts
@@ -1,0 +1,6 @@
+import { ChildEntity } from 'typeorm';
+import { ContentPreferenceType } from './types';
+import { ContentPreferenceSource } from './ContentPreferenceSource';
+
+@ChildEntity(ContentPreferenceType.FeedSource)
+export class ContentPreferenceFeedSource extends ContentPreferenceSource {}

--- a/src/entity/contentPreference/ContentPreferenceKeyword.ts
+++ b/src/entity/contentPreference/ContentPreferenceKeyword.ts
@@ -1,0 +1,22 @@
+import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
+import { ContentPreference } from './ContentPreference';
+import { ContentPreferenceType } from './types';
+import type { Keyword } from '../Keyword';
+import type { Feed } from '../Feed';
+
+@ChildEntity(ContentPreferenceType.Keyword)
+export class ContentPreferenceKeyword extends ContentPreference {
+  @Column({ type: 'text', default: null })
+  keywordId: string;
+
+  @Column({ type: 'text', default: null })
+  feedId: string;
+
+  @ManyToOne('Keyword', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'keywordId' })
+  keyword: Promise<Keyword>;
+
+  @ManyToOne('Feed', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'feedId' })
+  feed: Promise<Feed>;
+}

--- a/src/entity/contentPreference/types.ts
+++ b/src/entity/contentPreference/types.ts
@@ -3,6 +3,7 @@ export enum ContentPreferenceType {
   Keyword = 'keyword',
   FeedKeyword = 'feedKeyword',
   Source = 'source',
+  FeedSource = 'feedSource',
 }
 
 export enum ContentPreferenceStatus {

--- a/src/entity/contentPreference/types.ts
+++ b/src/entity/contentPreference/types.ts
@@ -1,6 +1,7 @@
 export enum ContentPreferenceType {
   User = 'user',
   Keyword = 'keyword',
+  FeedKeyword = 'feedKeyword',
   Source = 'source',
 }
 

--- a/src/migration/1731044639557-ContentPreferencePKType.ts
+++ b/src/migration/1731044639557-ContentPreferencePKType.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ContentPreferencePKType1731044639557
+  implements MigrationInterface
+{
+  name = 'ContentPreferencePKType1731044639557';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" DROP CONSTRAINT "PK_3f50987656b7555fa8195d6f05b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" ADD CONSTRAINT "PK_846a533ad3da996c916074b773a" PRIMARY KEY ("referenceId", "userId", "type")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" DROP CONSTRAINT "PK_846a533ad3da996c916074b773a"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "content_preference" ADD CONSTRAINT "PK_3f50987656b7555fa8195d6f05b" PRIMARY KEY ("referenceId", "userId")`,
+    );
+  }
+}

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -79,6 +79,7 @@ import { ContentPreferenceSource } from '../entity/contentPreference/ContentPref
 import { randomUUID } from 'crypto';
 import { SourceMemberRoles } from '../roles';
 import { ContentPreferenceKeyword } from '../entity/contentPreference/ContentPreferenceKeyword';
+import { ContentPreferenceFeedSource } from '../entity/contentPreference/ContentPreferenceFeedSource';
 
 interface GQLTagsCategory {
   id: string;
@@ -1873,7 +1874,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             manager
               .createQueryBuilder()
               .insert()
-              .into(ContentPreferenceSource)
+              .into(
+                isMyFeed
+                  ? ContentPreferenceSource
+                  : ContentPreferenceFeedSource,
+              )
               .values(
                 includedSources.map((source) => ({
                   userId: ctx.userId,
@@ -1909,7 +1914,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             manager
               .createQueryBuilder()
               .insert()
-              .into(ContentPreferenceSource)
+              .into(
+                isMyFeed
+                  ? ContentPreferenceSource
+                  : ContentPreferenceFeedSource,
+              )
               .values(
                 excludedSources.map((source) => ({
                   userId: ctx.userId,
@@ -2026,11 +2035,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               })
               .andWhere('blocked = false')
               .execute(),
-            manager.getRepository(ContentPreferenceSource).delete({
-              userId: ctx.userId,
-              referenceId: In(filters.includeSources),
-              feedId,
-            }),
+            manager
+              .getRepository(
+                isMyFeed
+                  ? ContentPreferenceSource
+                  : ContentPreferenceFeedSource,
+              )
+              .delete({
+                userId: ctx.userId,
+                referenceId: In(filters.includeSources),
+                feedId,
+              }),
           ]);
         }
         if (filters?.excludeSources?.length) {
@@ -2045,11 +2060,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               })
               .andWhere('blocked = true')
               .execute(),
-            manager.getRepository(ContentPreferenceSource).delete({
-              userId: ctx.userId,
-              referenceId: In(filters.excludeSources),
-              feedId,
-            }),
+            manager
+              .getRepository(
+                isMyFeed
+                  ? ContentPreferenceSource
+                  : ContentPreferenceFeedSource,
+              )
+              .delete({
+                userId: ctx.userId,
+                referenceId: In(filters.excludeSources),
+                feedId,
+              }),
           ]);
         }
         if (filters?.includeTags?.length) {

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1892,7 +1892,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                   },
                 })) as ContentPreferenceSource[],
               )
-              .orUpdate(['status'], ['referenceId', 'userId'])
+              .orUpdate(['status'], ['userId', 'referenceId', 'type'])
               .execute(),
           ]);
         }
@@ -1932,7 +1932,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                   },
                 })) as ContentPreferenceSource[],
               )
-              .orUpdate(['status'], ['referenceId', 'userId'])
+              .orUpdate(['status'], ['userId', 'referenceId', 'type'])
               .execute(),
           ]);
         }
@@ -1968,7 +1968,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                 status: ContentPreferenceStatus.Follow,
               })) as ContentPreferenceKeyword[],
             )
-            .orUpdate(['status'], ['referenceId', 'userId'])
+            .orUpdate(['status'], ['userId', 'referenceId', 'type'])
             .execute();
         }
         if (filters?.blockedTags?.length) {
@@ -2004,7 +2004,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                 status: ContentPreferenceStatus.Blocked,
               })) as ContentPreferenceKeyword[],
             )
-            .orUpdate(['status'], ['referenceId', 'userId'])
+            .orUpdate(['status'], ['userId', 'referenceId', 'type'])
             .execute();
         }
       });

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -1156,7 +1156,7 @@ const addNewSourceMember = async (
       },
     }),
     {
-      conflictPaths: ['userId', 'referenceId'],
+      conflictPaths: ['userId', 'referenceId', 'type'],
     },
   );
 };


### PR DESCRIPTION
- PK for content_preference is now userId + referenceId + type
- solves deduplication of content_preference over [feed](https://dailydotdev.slack.com/archives/C07ATUPBPJ9/p1730894715539879)
- ContentPreferenceKeyword is used for my feed rows of feed_tag (feedId === userId)
- ContentPreferenceFeedKeyword is used for other rows like custom feeds
  - same is done for ContentPreferenceSource with new ContentPreferenceFeedSource