### PR TITLE
fix: add lettericon endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,8 +314,8 @@ export default async function app(
 
         proxySearchParams.set('domain', reqSearchParams.get('url') ?? '');
         proxySearchParams.set('sz', reqSearchParams.get('size') ?? '');
-
-        return proxySearchParams.toString();
+        //app.daily.dev/squads/discover/my
+        https: return proxySearchParams.toString();
       },
     },
     preValidation: async (req: FastifyRequest, res) => {
@@ -324,6 +324,18 @@ export default async function app(
         res.status(400).send({ error: 'url and size are required' });
       }
     },
+    preHandler: async (req, res) => {
+      res.helmet({
+        crossOriginResourcePolicy: {
+          policy: 'cross-origin',
+        },
+      });
+    },
+  });
+  app.register(proxy, {
+    upstream:
+      'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder',
+    prefix: 'lettericon',
     preHandler: async (req, res) => {
       res.helmet({
         crossOriginResourcePolicy: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,8 +314,7 @@ export default async function app(
 
         proxySearchParams.set('domain', reqSearchParams.get('url') ?? '');
         proxySearchParams.set('sz', reqSearchParams.get('size') ?? '');
-        //app.daily.dev/squads/discover/my
-        https: return proxySearchParams.toString();
+        return proxySearchParams.toString();
       },
     },
     preValidation: async (req: FastifyRequest, res) => {


### PR DESCRIPTION
Uploaded a placeholder based on our library and color schema to cloudinary.
Which now resolves when `lettericon` endpoint hits.

Tested in both variations of the bar:
![Screenshot 2024-11-08 at 11 02 00](https://github.com/user-attachments/assets/20d3d9ad-51b3-4cb8-b3b2-46324cbadc1d)
![Screenshot 2024-11-08 at 11 01 35](https://github.com/user-attachments/assets/593da86d-c2ab-4d01-92d3-68f304626123)
