### PR TITLE
fix: also needed wildcard domain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,10 +331,23 @@ export default async function app(
       });
     },
   });
+  const letterIconImage =
+    'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder';
+
   app.register(proxy, {
-    upstream:
-      'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder',
     prefix: 'lettericon',
+    upstream: letterIconImage,
+    preHandler: async (req, res) => {
+      res.helmet({
+        crossOriginResourcePolicy: {
+          policy: 'cross-origin',
+        },
+      });
+    },
+  });
+  app.register(proxy, {
+    prefix: '/lettericon/:word',
+    upstream: letterIconImage,
     preHandler: async (req, res) => {
       res.helmet({
         crossOriginResourcePolicy: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,30 +331,26 @@ export default async function app(
       });
     },
   });
-  const letterIconImage =
-    'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder';
+
+  const letterProxy = {
+    upstream:
+      'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder',
+    preHandler: async (req, res) => {
+      res.helmet({
+        crossOriginResourcePolicy: {
+          policy: 'cross-origin',
+        },
+      });
+    },
+  };
 
   app.register(proxy, {
     prefix: 'lettericon',
-    upstream: letterIconImage,
-    preHandler: async (req, res) => {
-      res.helmet({
-        crossOriginResourcePolicy: {
-          policy: 'cross-origin',
-        },
-      });
-    },
+    ...letterProxy,
   });
   app.register(proxy, {
     prefix: '/lettericon/:word',
-    upstream: letterIconImage,
-    preHandler: async (req, res) => {
-      res.helmet({
-        crossOriginResourcePolicy: {
-          policy: 'cross-origin',
-        },
-      });
-    },
+    ...letterProxy,
   });
   app.register(routes, { prefix: '/' });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import fastify, {
   FastifyRequest,
   FastifyInstance,
   FastifyError,
+  FastifyReply,
 } from 'fastify';
 import fastifyRawBody from 'fastify-raw-body';
 import helmet from '@fastify/helmet';
@@ -335,7 +336,7 @@ export default async function app(
   const letterProxy = {
     upstream:
       'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder',
-    preHandler: async (req, res) => {
+    preHandler: async (req: FastifyRequest, res: FastifyReply) => {
       res.helmet({
         crossOriginResourcePolicy: {
           policy: 'cross-origin',


### PR DESCRIPTION
We need to support both the normal endpoint and the wildcard domain for `lettericon`