### PR TITLE
feat: add date columns for feed_tag

### DIFF
--- a/src/entity/FeedTag.ts
+++ b/src/entity/FeedTag.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import type { Feed } from './Feed';
 
 @Entity()
@@ -12,6 +20,12 @@ export class FeedTag {
 
   @Column({ default: false })
   blocked: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 
   @ManyToOne('Feed', {
     lazy: true,

--- a/src/entity/FeedTag.ts
+++ b/src/entity/FeedTag.ts
@@ -24,6 +24,7 @@ export class FeedTag {
   @CreateDateColumn()
   createdAt: Date;
 
+  @Index()
   @UpdateDateColumn()
   updatedAt: Date;
 

--- a/src/migration/1731315131357-FeedTagDateColumns.ts
+++ b/src/migration/1731315131357-FeedTagDateColumns.ts
@@ -11,6 +11,10 @@ export class FeedTagDateColumns1731315131357 implements MigrationInterface {
       `ALTER TABLE "feed_tag" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`,
     );
 
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c04e86377257df2a6a4181421f" ON "feed_tag" ("updatedAt") `,
+    );
+
     await queryRunner.query(`
       CREATE OR REPLACE FUNCTION feed_tag_updated_at_time()
         RETURNS TRIGGER
@@ -33,6 +37,10 @@ export class FeedTagDateColumns1731315131357 implements MigrationInterface {
       'DROP TRIGGER IF EXISTS feed_tag_updated_at_update_trigger ON "feed_tag"',
     );
     await queryRunner.query('DROP FUNCTION IF EXISTS feed_tag_updated_at_time');
+
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c04e86377257df2a6a4181421f"`,
+    );
 
     await queryRunner.query(`ALTER TABLE "feed_tag" DROP COLUMN "updatedAt"`);
     await queryRunner.query(`ALTER TABLE "feed_tag" DROP COLUMN "createdAt"`);

--- a/src/migration/1731315131357-FeedTagDateColumns.ts
+++ b/src/migration/1731315131357-FeedTagDateColumns.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FeedTagDateColumns1731315131357 implements MigrationInterface {
+  name = 'FeedTagDateColumns1731315131357';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "feed_tag" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "feed_tag" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION feed_tag_updated_at_time()
+        RETURNS TRIGGER
+        LANGUAGE PLPGSQL
+        AS
+      $$
+      BEGIN
+        NEW."updatedAt" = now();
+        RETURN NEW;
+      END;
+      $$
+    `);
+    await queryRunner.query(
+      'CREATE OR REPLACE TRIGGER feed_tag_updated_at_update_trigger BEFORE UPDATE ON "feed_tag" FOR EACH ROW WHEN (OLD.blocked IS DISTINCT FROM NEW.blocked) EXECUTE PROCEDURE feed_tag_updated_at_time()',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'DROP TRIGGER IF EXISTS feed_tag_updated_at_update_trigger ON "feed_tag"',
+    );
+    await queryRunner.query('DROP FUNCTION IF EXISTS feed_tag_updated_at_time');
+
+    await queryRunner.query(`ALTER TABLE "feed_tag" DROP COLUMN "updatedAt"`);
+    await queryRunner.query(`ALTER TABLE "feed_tag" DROP COLUMN "createdAt"`);
+  }
+}


### PR DESCRIPTION
- add createdAt and updatedAt columns
- added updatedAt trigger so updatedAt is correctly set when updating filters (included only blocked column change since that is the only one that can really change)
- added index for filtering over updatedAt in migration script

Since migration is lot more heavy then I thought this will allow us to do a migration in more incremental way where we can set a date when we start it and then incrementally only update rows which changed after the set date.