### PR TITLE
feat: disable top reader worker locally due to crash after seed

### DIFF
--- a/src/workers/notifications/userTopReaderAdded.ts
+++ b/src/workers/notifications/userTopReaderAdded.ts
@@ -11,6 +11,10 @@ export const userTopReaderAdded =
   generateTypedNotificationWorker<'api.v1.user-top-reader'>({
     subscription: 'api.user-top-reader-added',
     handler: async ({ userTopReader }, con) => {
+      if (process.env.NODE_ENV === 'development') {
+        return;
+      }
+
       const { id, userId, keywordValue } = userTopReader;
       const topReader = await con.getRepository(UserTopReader).findOneBy({
         id,


### PR DESCRIPTION
Noticed after seed it goes into infinite loop due to scraper missing locally when generating badges, this is just a quick fix so it does not break dev locally.

cc: @omBratteng