### PR TITLE
fix: external links submission

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3662,24 +3662,44 @@ describe('mutation createSourcePostModeration', () => {
 
   it('should successfully create a squad post moderation entry of type freeform', async () => {
     loggedUser = '4';
+    const commentary = 'commentary';
     const res = await client.mutate(MUTATION, {
-      variables: { ...params, type: PostType.Freeform },
+      variables: { ...params, commentary, type: PostType.Freeform },
     });
     expect(res.errors).toBeFalsy();
     expect(res.data.createSourcePostModeration).toBeTruthy();
     expect(res.data.createSourcePostModeration.type).toEqual(PostType.Freeform);
-    expect(res.data.createSourcePostModeration.contentHtml).toBeDefined();
+    expect(res.data.createSourcePostModeration.title).toEqual('My first post');
+    expect(res.data.createSourcePostModeration.titleHtml).toBeNull();
+    expect(res.data.createSourcePostModeration.content).toEqual('Hello World');
+    expect(res.data.createSourcePostModeration.contentHtml).toEqual(
+      '<p>Hello World</p>',
+    );
+    expect(res.data.createSourcePostModeration.title).not.toEqual(commentary);
+    expect(res.data.createSourcePostModeration.content).not.toEqual(commentary);
   });
 
   it('should successfully create a squad post moderation entry of type share', async () => {
     loggedUser = '4';
     const res = await client.mutate(MUTATION, {
-      variables: { ...params, sharedPostId: 'p1', type: PostType.Share },
+      variables: {
+        ...params,
+        commentary: 'I am sharing a post',
+        sharedPostId: 'p1',
+        type: PostType.Share,
+      },
     });
     expect(res.errors).toBeFalsy();
     expect(res.data.createSourcePostModeration).toBeTruthy();
     expect(res.data.createSourcePostModeration.type).toEqual(PostType.Share);
-    expect(res.data.createSourcePostModeration.contentHtml).toBeDefined();
+    expect(res.data.createSourcePostModeration.title).toEqual(
+      'I am sharing a post',
+    );
+    expect(res.data.createSourcePostModeration.titleHtml).toEqual(
+      '<p>I am sharing a post</p>',
+    );
+    expect(res.data.createSourcePostModeration.content).toBeNull();
+    expect(res.data.createSourcePostModeration.contentHtml).toBeNull();
     expect(res.data.createSourcePostModeration.sharedPostId).toEqual('p1');
   });
 
@@ -3703,7 +3723,14 @@ describe('mutation createSourcePostModeration', () => {
     expect(res.data.createSourcePostModeration.image).toEqual(
       externalParams.imageUrl,
     );
-    expect(res.data.createSourcePostModeration.titleHtml).toEqual(
+    expect(res.data.createSourcePostModeration.title).toEqual(
+      'External Link Title',
+    );
+    expect(res.data.createSourcePostModeration.titleHtml).toBeNull();
+    expect(res.data.createSourcePostModeration.content).toEqual(
+      'This is an awesome link',
+    );
+    expect(res.data.createSourcePostModeration.contentHtml).toEqual(
       '<p>This is an awesome link</p>',
     );
     expect(res.data.createSourcePostModeration.externalLink).toEqual(

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3662,6 +3662,32 @@ describe('mutation createSourcePostModeration', () => {
     );
   });
 
+  it('should throw an error if type is welcome', async () => {
+    loggedUser = '4';
+
+    return await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...params, type: PostType.Welcome },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should throw an error if type is article', async () => {
+    loggedUser = '4';
+
+    return await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...params, type: PostType.Article },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
   it('should successfully create a squad post moderation entry of type freeform', async () => {
     loggedUser = '4';
     const commentary = 'commentary';

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -4837,6 +4837,9 @@ describe('source_post_moderation', () => {
         'api.v1.source-post-moderation-approved',
         { post: after },
       ]);
+
+      const list = await con.getRepository(Post).find();
+      expect(list.length).toEqual(2); // to ensure nothing new was created other than the share post
     });
 
     it('should update the content if post id is present', async () => {

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -487,6 +487,23 @@ export const processApprovedModeratedPost = async (
 
   if (externalLink) {
     const cleanUrl = standardizeURL(externalLink);
+    const existingPost = await getExistingPost(con, cleanUrl);
+
+    if (existingPost) {
+      const post = await createSharePost({
+        con,
+        args: {
+          sourceId,
+          commentary: content,
+          authorId: createdById,
+          postId: existingPost.id,
+          visible: existingPost.visible,
+        },
+      });
+
+      return { ...moderated, postId: post.id };
+    }
+
     const post = await createExternalLink({
       con,
       args: {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1705,6 +1705,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLSourcePostModeration> => {
+      if (![PostType.Share, PostType.Freeform].includes(type)) {
+        throw new ValidationError('Invalid post type!');
+      }
+
       const { con, userId } = ctx;
 
       const sourceMember = await con.getRepository(SourceMember).findOne({


### PR DESCRIPTION
There are two things fixed here, separated by each commit:
- In our CDC pipeline, there can be a case where two of the same links were submitted. Is it not possible to process them at the same time when approved, in this case, the external link would have been created on the first instance, and on the second instance, it would produce an error due to having the same link.
- Second fix was on the submission of post for moderation. The values passed through the mutation would be present depending on the case. We have title, content, and commentary but the post entity only has a title and content.
  - Freeform: must have a title and content. Empty `titleHtml` but `contentHtml` should be defined.
  - Share (from internal id): must have `title` and `titleHtml`. Empty `content` and `contentHtml`.
  - Share (from external link): must have `title` that is going to be used as the title of the then-created Article post, which won't have `titleHtml`. The `content` and `contentHtml` should be present and be used as the `title` of the `Share` post created.
- Also made the tests more explicit.