### PR TITLE
fix: upsert when entry exists

### DIFF
--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -519,6 +519,40 @@ describe('mutation follow', () => {
     expect(contentPreference?.status).toBe(ContentPreferenceStatus.Subscribed);
   });
 
+  it('should subscribe when already following', async () => {
+    loggedUser = '1-fm';
+
+    const resFollow = await client.query(MUTATION, {
+      variables: {
+        id: '2-fm',
+        entity: ContentPreferenceType.User,
+        status: ContentPreferenceStatus.Follow,
+      },
+    });
+
+    expect(resFollow.errors).toBeFalsy();
+
+    const res = await client.query(MUTATION, {
+      variables: {
+        id: '2-fm',
+        entity: ContentPreferenceType.User,
+        status: ContentPreferenceStatus.Subscribed,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const contentPreference = await con
+      .getRepository(ContentPreferenceUser)
+      .findOneBy({
+        userId: '1-fm',
+        referenceId: '2-fm',
+      });
+
+    expect(contentPreference).not.toBeNull();
+    expect(contentPreference?.status).toBe(ContentPreferenceStatus.Subscribed);
+  });
+
   it('should not follow yourself', async () => {
     loggedUser = '1-fm';
 
@@ -621,6 +655,42 @@ describe('mutation follow', () => {
       expect(contentPreference).not.toBeNull();
       expect(contentPreference!.status).toBe(ContentPreferenceStatus.Follow);
     });
+
+    it('should subscribe when already following', async () => {
+      loggedUser = '1-fm';
+
+      const resFollow = await client.query(MUTATION, {
+        variables: {
+          id: 'keyword-f1',
+          entity: ContentPreferenceType.Keyword,
+          status: ContentPreferenceStatus.Follow,
+        },
+      });
+
+      expect(resFollow.errors).toBeFalsy();
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'keyword-f1',
+          entity: ContentPreferenceType.Keyword,
+          status: ContentPreferenceStatus.Subscribed,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceKeyword)
+        .findOneBy({
+          userId: '1-fm',
+          referenceId: 'keyword-f1',
+        });
+
+      expect(contentPreference).not.toBeNull();
+      expect(contentPreference?.status).toBe(
+        ContentPreferenceStatus.Subscribed,
+      );
+    });
   });
 
   describe('source', () => {
@@ -701,6 +771,42 @@ describe('mutation follow', () => {
       });
       expect(feedSource).not.toBeNull();
       expect(feedSource!.blocked).toBe(false);
+    });
+
+    it('should subscribe when already following', async () => {
+      loggedUser = '1-fm';
+
+      const resFollow = await client.query(MUTATION, {
+        variables: {
+          id: 'a-fm',
+          entity: ContentPreferenceType.Source,
+          status: ContentPreferenceStatus.Follow,
+        },
+      });
+
+      expect(resFollow.errors).toBeFalsy();
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'a-fm',
+          entity: ContentPreferenceType.Source,
+          status: ContentPreferenceStatus.Subscribed,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreference = await con
+        .getRepository(ContentPreferenceSource)
+        .findOneBy({
+          userId: '1-fm',
+          referenceId: 'a-fm',
+        });
+
+      expect(contentPreference).not.toBeNull();
+      expect(contentPreference?.status).toBe(
+        ContentPreferenceStatus.Subscribed,
+      );
     });
 
     it('should not overwrite referralToken if preference already exists', async () => {

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -117,6 +117,7 @@ const followUser: FollowEntity = async ({ ctx, id, status }) => {
       referenceId: id,
       referenceUserId: id,
       status,
+      type: ContentPreferenceType.User,
     });
 
     await repository.save(contentPreference);
@@ -165,6 +166,7 @@ const followKeyword: FollowEntity = async ({ ctx, id, status }) => {
       keywordId: id,
       feedId: ctx.userId,
       status,
+      type: ContentPreferenceType.Keyword,
     });
 
     await repository.save(contentPreference);
@@ -282,6 +284,7 @@ const blockUser: BlockEntity = async ({ ctx, id }) => {
       referenceId: id,
       referenceUserId: id,
       status: ContentPreferenceStatus.Blocked,
+      type: ContentPreferenceType.User,
     });
 
     await repository.save(contentPreference);
@@ -307,6 +310,7 @@ const blockKeyword: BlockEntity = async ({ ctx, id }) => {
       keywordId: id,
       feedId: ctx.userId,
       status: ContentPreferenceStatus.Blocked,
+      type: ContentPreferenceType.Keyword,
     });
 
     await repository.save(contentPreference);


### PR DESCRIPTION
Just noticed in error logs some warns of PK violations due to existing records. Typeorm does not set correct type for sub entity. 