### PR TITLE
fix: add missing fields in type

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -288,6 +288,18 @@ export const typeDefs = /* GraphQL */ `
     """
     sharedPostId: String
     """
+    Shared post
+    """
+    sharedPost: Post
+    """
+    Post
+    """
+    post: Post
+    """
+    Post id
+    """
+    postId: String
+    """
     external link url
     """
     externalLink: String


### PR DESCRIPTION
Added sharedPost and post field in type, needed in moderation page list in order to show post preview