### PR TITLE
fix: post moderation submission email props

### DIFF
--- a/__tests__/workers/newNotificationV2Mail.ts
+++ b/__tests__/workers/newNotificationV2Mail.ts
@@ -1770,6 +1770,7 @@ describe('source_post_submitted notification', () => {
     await con
       .getRepository(Source)
       .update({ id: 'a' }, { type: SourceType.Squad });
+    await con.getRepository(User).update({ id: '1' }, { reputation: 100 });
     const post = await con.getRepository(SourcePostModeration).save({
       sourceId: 'a',
       createdById: '1',
@@ -1803,9 +1804,10 @@ describe('source_post_submitted notification', () => {
       .calls[0][0] as SendEmailRequestWithTemplate;
     expect(args.message_data).toEqual({
       full_name: 'Tsahi',
-      profile_image: 'https://daily.dev/tsahi.jpg',
+      profile_image: 'https://daily.dev/ido.jpg',
       squad_name: 'A',
-      commenter_reputation: '10',
+      creator_name: 'Ido',
+      creator_reputation: '100',
       squad_image: 'http://image.com/a',
       post_link: `http://localhost:5002/squads/a/moderate`,
       post_image: 'https://daily.dev/image.jpg',
@@ -1820,6 +1822,7 @@ describe('source_post_submitted notification', () => {
     await con
       .getRepository(Source)
       .update({ id: 'a' }, { type: SourceType.Squad });
+    await con.getRepository(User).update({ id: '1' }, { reputation: 100 });
     const post = await con.getRepository(SourcePostModeration).save({
       sourceId: 'a',
       createdById: '1',
@@ -1852,9 +1855,10 @@ describe('source_post_submitted notification', () => {
       .calls[0][0] as SendEmailRequestWithTemplate;
     expect(args.message_data).toEqual({
       full_name: 'Tsahi',
-      profile_image: 'https://daily.dev/tsahi.jpg',
+      profile_image: 'https://daily.dev/ido.jpg',
       squad_name: 'A',
-      commenter_reputation: '10',
+      creator_name: 'Ido',
+      creator_reputation: '100',
       squad_image: 'http://image.com/a',
       post_link: `http://localhost:5002/squads/a/moderate`,
       post_image: null,

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -176,7 +176,12 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     }
 
     const { sharedPostId } = moderation;
-    const [squad, createdBy, sharedPost, moderator] = await Promise.all([
+    const [squad, createdBy, sharedPost, moderator]: [
+      Pick<SquadSource, 'type' | 'name' | 'handle' | 'image'> | null,
+      Pick<User, 'name' | 'reputation' | 'image'> | null,
+      Pick<ArticlePost, 'title' | 'image'> | null,
+      Pick<User, 'name' | 'reputation' | 'image'> | null,
+    ] = await Promise.all([
       con.getRepository(SquadSource).findOne({
         where: { id: moderation.sourceId },
         select: ['type', 'name', 'handle', 'image'],

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -151,7 +151,15 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
   source_post_submitted: async (con, user, notification) => {
     const moderation = await con.getRepository(SourcePostModeration).findOne({
       where: { id: notification.referenceId },
-      select: ['sourceId', 'image', 'title', 'content', 'type', 'sharedPostId'],
+      select: [
+        'createdById',
+        'sourceId',
+        'image',
+        'title',
+        'content',
+        'type',
+        'sharedPostId',
+      ],
     });
 
     if (!moderation) {
@@ -159,13 +167,13 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     }
 
     const { sharedPostId } = moderation;
-    const [squad, createdBy, sharedPost] = await Promise.all([
+    const [squad, createdBy, sharedPost, moderator] = await Promise.all([
       con.getRepository(SquadSource).findOne({
         where: { id: moderation.sourceId },
         select: ['type', 'name', 'handle', 'image'],
       }),
       con.getRepository(User).findOne({
-        where: { id: user.id },
+        where: { id: moderation.createdById },
         select: ['name', 'image', 'reputation'],
       }),
       moderation.type === PostType.Share && sharedPostId
@@ -174,18 +182,23 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
             select: ['title', 'image'],
           })
         : Promise.resolve(null),
+      con.getRepository(User).findOne({
+        where: { id: user.id },
+        select: ['name', 'image', 'reputation'],
+      }),
     ]);
 
-    if (!squad || !createdBy) {
+    if (!squad || !createdBy || !moderator) {
       return null;
     }
 
     return {
-      full_name: createdBy.name,
+      full_name: moderator.name,
       profile_image: createdBy.image,
       squad_name: squad.name,
       squad_image: squad.image,
-      commenter_reputation: createdBy.reputation.toString(),
+      creator_name: createdBy.name,
+      creator_reputation: createdBy.reputation.toString(),
       post_link: `${getSourceLink(squad)}/moderate`,
       post_image: (sharedPost as ArticlePost)?.image || moderation.image,
       post_title: sharedPost?.title || moderation.title,

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -149,7 +149,16 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     };
   },
   source_post_submitted: async (con, user, notification) => {
-    const moderation = await con.getRepository(SourcePostModeration).findOne({
+    const moderation: Pick<
+      SourcePostModeration,
+      | 'createdById'
+      | 'sourceId'
+      | 'image'
+      | 'title'
+      | 'content'
+      | 'type'
+      | 'sharedPostId'
+    > | null = await con.getRepository(SourcePostModeration).findOne({
       where: { id: notification.referenceId },
       select: [
         'createdById',


### PR DESCRIPTION
Currently, there is only 1 prop for us to send a name. We need to make it two so the names of the moderator and creator of the post be distinct from one another.