### PR TITLE
fix: update subscription tracking

### DIFF
--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -97,7 +97,7 @@ const getUserId = async ({
   subscriptionId,
   userId,
 }: {
-  subscriptionId?: false | string | null | unknown;
+  subscriptionId?: false | string | null;
   userId?: string | undefined;
 }): Promise<string> => {
   if (userId) {
@@ -122,7 +122,7 @@ const planChanged = async (data: SubscriptionUpdatedEvent) => {
   const customData = data.data?.customData as { user_id: string };
   const userId = await getUserId({
     userId: customData?.user_id,
-    subscriptionId: 'subscriptionId' in data.data && data.data.subscriptionId,
+    subscriptionId: data.data && data.data.id,
   });
   const con = await createOrGetConnection();
   const flags = await con.getRepository(User).findOne({
@@ -154,7 +154,9 @@ const logPaddleAnalyticsEvent = async (
   const currency = data.data?.items?.[0]?.price?.unitPrice?.currencyCode;
   const userId = await getUserId({
     userId: customData?.user_id,
-    subscriptionId: 'subscriptionId' in data.data && data.data.subscriptionId,
+    subscriptionId:
+      ('subscriptionId' in data.data && data.data.subscriptionId) ||
+      data.data.id,
   });
   if (!userId) {
     return;

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -97,7 +97,7 @@ const getUserId = async ({
   subscriptionId,
   userId,
 }: {
-  subscriptionId?: false | string | null;
+  subscriptionId?: false | string | null | unknown;
   userId?: string | undefined;
 }): Promise<string> => {
   if (userId) {

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -122,7 +122,7 @@ const planChanged = async (data: SubscriptionUpdatedEvent) => {
   const customData = data.data?.customData as { user_id: string };
   const userId = await getUserId({
     userId: customData?.user_id,
-    subscriptionId: data.data && data.data.id,
+    subscriptionId: data.data?.id,
   });
   const con = await createOrGetConnection();
   const flags = await con.getRepository(User).findOne({

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -131,7 +131,7 @@ const planChanged = async (data: SubscriptionUpdatedEvent) => {
   });
 
   return (
-    (flags?.subscriptionFlags?.cycle as string) ===
+    (flags?.subscriptionFlags?.cycle as string) !==
     extractSubscriptionType(data.data?.items)
   );
 };
@@ -225,7 +225,8 @@ export const paddle = async (fastify: FastifyInstance): Promise<void> => {
                 );
                 break;
               case EventName.SubscriptionUpdated:
-                if (!(await planChanged(eventData))) {
+                const didPlanChange = await planChanged(eventData);
+                if (didPlanChange) {
                   await updateUserSubscription({
                     data: eventData,
                     state: true,


### PR DESCRIPTION
We should only fire the event if subscription cycle actually changed, not any of the other changes.
I also decided to update our flags in this case so we have the right setting stored at all times.

AS-744 #done 