### PR TITLE
chore: reduce logging on lettericon proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import fastify, {
   FastifyInstance,
   FastifyError,
   FastifyReply,
+  type FastifyRegisterOptions,
 } from 'fastify';
 import fastifyRawBody from 'fastify-raw-body';
 import helmet from '@fastify/helmet';
@@ -11,7 +12,7 @@ import cors from '@fastify/cors';
 import mercurius, { MercuriusError } from 'mercurius';
 import MercuriusGQLUpload from 'mercurius-upload';
 import MercuriusCache from 'mercurius-cache';
-import proxy from '@fastify/http-proxy';
+import proxy, { type FastifyHttpProxyOptions } from '@fastify/http-proxy';
 import { NoSchemaIntrospectionCustomRule } from 'graphql';
 // import fastifyWebsocket from '@fastify/websocket';
 
@@ -333,7 +334,7 @@ export default async function app(
     },
   });
 
-  const letterProxy = {
+  const letterProxy: FastifyRegisterOptions<FastifyHttpProxyOptions> = {
     upstream:
       'https://media.daily.dev/image/upload/s--zchx8x3n--/f_auto,q_auto/v1731056371/webapp/shortcut-placeholder',
     preHandler: async (req: FastifyRequest, res: FastifyReply) => {
@@ -343,6 +344,7 @@ export default async function app(
         },
       });
     },
+    logLevel: 'warn',
   };
 
   app.register(proxy, {


### PR DESCRIPTION
Since we added lettericon proxy to API, we've been getting lots of extra logs, making it more difficult to go through production logs because of all the extra spam.

So this sets the log level for the proxy to `warn` instead of `info`