### PR TITLE
chore: reduce logging on icon proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,6 +307,7 @@ export default async function app(
   app.register(proxy, {
     upstream: 'https://www.google.com/s2/favicons',
     prefix: '/icon',
+    logLevel: 'warn',
     replyOptions: {
       queryString: (search, reqUrl, req) => {
         const reqSearchParams = new URLSearchParams(


### PR DESCRIPTION
I only set log level on `lettericons`, and forgot `icon` which is the noisiest 🙈 