### PR TITLE
refactor: user streak to include last view with timezone

### DIFF
--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -42,6 +42,7 @@ export interface GQLUserStreak {
   total?: number;
   current: number;
   lastViewAt?: Date;
+  lastViewAtTz?: Date;
   userId: string;
   weekStart: DayOfWeek;
 }

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -669,6 +669,7 @@ export const typeDefs = /* GraphQL */ `
     total: Int
     current: Int
     lastViewAt: DateTime
+    lastViewAtTz: DateTime
     weekStart: Int
   }
 
@@ -1204,7 +1205,8 @@ const getUserStreakQuery = async (
     ...builder,
     queryBuilder: builder.queryBuilder
       .addSelect(
-        `(date_trunc('day', "${builder.alias}"."lastViewAt" at time zone COALESCE(u.timezone, 'utc'))::date) AS "lastViewAtTz"`,
+        `(date_trunc('day', "${builder.alias}"."lastViewAt" at time zone COALESCE(u.timezone, 'utc'))::date)`,
+        'lastViewAtTz',
       )
       .addSelect('u.id', 'userId')
       .addSelect('u.timezone', 'timezone')


### PR DESCRIPTION
Expose the column that contains the timezone-adjusted column for last view at.