### PR TITLE
fix: use shared and content title and image for post types

### DIFF
--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -942,7 +942,7 @@ describe('personalizedDigestEmail worker', () => {
           createdAt: new Date(),
           tagsStr: 'javascript,webdev',
           type: PostType.Freeform,
-          content: `Freeform content\\n![alt](https://daily.dev/image.jpg)`,
+          content: `Freeform content\\n![alt](https://daily.dev/image.jpg)![alt](https://daily.dev/image2.jpg)`,
           contentHtml:
             '<p>Freeform content</p><img src="https://daily.dev/image.jpg" alt="alt">',
         },

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -159,3 +159,40 @@ export const checkHasMention = (content: string, username: string) => {
     return words.some((word) => word === `@${username}`);
   });
 };
+
+export const findMarkdownTag = ({
+  tokens,
+  tag,
+  depth = 0,
+  maxDepth = 2,
+}: {
+  tokens: Token[];
+  tag: string;
+  depth?: number;
+  maxDepth?: number;
+}): Token | undefined => {
+  if (depth > maxDepth) {
+    return undefined;
+  }
+
+  for (let i = tokens.length - 1; i >= 0; i -= 1) {
+    const token = tokens[i];
+
+    if (token.tag === tag) {
+      return token;
+    }
+
+    if (token.children?.length) {
+      const nestedToken = findMarkdownTag({
+        tokens: token.children,
+        tag,
+        depth: depth + 1,
+        maxDepth,
+      });
+
+      if (nestedToken) {
+        return nestedToken;
+      }
+    }
+  }
+};

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -175,7 +175,7 @@ export const findMarkdownTag = ({
     return undefined;
   }
 
-  for (let i = tokens.length - 1; i >= 0; i -= 1) {
+  for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
 
     if (token.tag === tag) {

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -17,7 +17,7 @@ import {
 } from '../entity';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { isValidHttpUrl, standardizeURL } from './links';
-import { markdown } from './markdown';
+import { findMarkdownTag, markdown } from './markdown';
 import { generateShortId } from '../ids';
 import { GQLPost } from '../schema/posts';
 // @ts-expect-error - no types
@@ -599,4 +599,25 @@ export const validateSourcePostModeration = async (
   }
 
   return pendingPost;
+};
+
+export const findPostImageFromContent = ({
+  post,
+}: {
+  post: Pick<FreeformPost, 'content'>;
+}): string | undefined => {
+  if (!post.content) {
+    return undefined;
+  }
+
+  const contentMarkdown = markdown.parse(post.content, {});
+
+  const imgTag = findMarkdownTag({
+    tokens: contentMarkdown,
+    tag: 'img',
+    depth: 0,
+    maxDepth: 1,
+  });
+
+  return imgTag?.attrGet('src') || undefined;
 };


### PR DESCRIPTION
- no posts in email was due to outdated templates being scheduled on our email platform, it was a temporary issue and it should not happen now that everything scheduled before code change was deploy
- no title is because of shared posts, we can show shared post title
- no image, freeform post without image (we should technically load first image from content)
  - also case for shared post, we would load image of a shared post

Closes https://github.com/dailydotdev/daily/issues/1600