### PR TITLE
feat: cors origins support for remote config

### DIFF
--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -9,6 +9,7 @@ type RemoteConfigValue = {
   vordrIps: string[];
   ignoredWorkEmailDomains: string[];
   pricingIds: Record<string, SubscriptionCycles>;
+  origins: string[];
 };
 
 class RemoteConfig {


### PR DESCRIPTION
- added origins support for remote config so I can test deployment easily without moving to *.daily.dev
- fallbacks to our original regex