### PR TITLE
fix: rejection reason note

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1324,6 +1324,8 @@ describe('storeNotificationBundle', () => {
       sourceId: 'a',
       createdById: '2',
       status: SourcePostModerationStatus.Rejected,
+      rejectionReason: 'Other',
+      moderatorMessage: 'Lacks value.',
     });
     const type = NotificationType.SourcePostRejected;
     const ctx: NotificationPostModerationContext = {
@@ -1343,9 +1345,9 @@ describe('storeNotificationBundle', () => {
     expect(actual.notification.referenceId).toEqual(post.id);
     expect(actual.notification.referenceType).toEqual('post_moderation');
     expect(actual.notification.title).toEqual(
-      'Your post in A was not approved for the following reason: null. Please review the feedback and consider making changes before resubmitting.',
+      'Your post in A was not approved for the following reason: Other. Please review the feedback and consider making changes before resubmitting.',
     );
-    expect(actual.notification.description).toBeFalsy();
+    expect(actual.notification.description).toEqual('Lacks value.');
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/squads/a/moderate',
     );

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -168,6 +168,7 @@ export const generateNotificationMap: Record<
       .icon(NotificationIcon.Bell)
       .referencePostModeration(ctx.post)
       .targetSourceModeration(ctx.source)
+      .description(ctx.post.moderatorMessage ?? '')
       .avatarSource(ctx.source),
   source_post_submitted: (builder, ctx: NotificationPostModerationContext) =>
     builder


### PR DESCRIPTION
Rejection notification should now add the message.

Also, I noticed we don't require rejection reason, which should not be the case when rejecting a post. I will open a separate PR.