### PR TITLE
fix: approved post notification image

### DIFF
--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -341,7 +341,7 @@ export class NotificationBuilder {
   objectPost(
     post: Reference<Post>,
     source: Reference<Source>,
-    sharedPost?: Reference<Post>,
+    sharedPost?: Reference<Post> | null,
     addSquadAvatar = true,
   ) {
     let newBuilder = this.referencePost(post).targetPost(post);

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -159,10 +159,7 @@ export const generateNotificationMap: Record<
   source_post_approved: (builder, ctx: NotificationPostContext) =>
     builder
       .icon(NotificationIcon.Bell)
-      .referencePost(ctx.post)
-      .attachmentPost(ctx.post)
-      .targetPost(ctx.post)
-      .avatarSource(ctx.source),
+      .objectPost(ctx.post, ctx.source, ctx.sharedPost),
   source_post_rejected: (builder, ctx: NotificationPostModerationContext) =>
     builder
       .icon(NotificationIcon.Bell)


### PR DESCRIPTION
I just noticed, when a request is approved, the image used is not what we would want to display.

Member's POV (issue):

<img width="830" alt="Screenshot 2024-11-23 at 2 24 37 PM" src="https://github.com/user-attachments/assets/3d3e74b6-7177-4069-b145-b58223c02900">

When approved, we should use the right image.