### PR TITLE
fix: add missing indexes for content preference

### DIFF
--- a/src/entity/contentPreference/ContentPreferenceSource.ts
+++ b/src/entity/contentPreference/ContentPreferenceSource.ts
@@ -14,6 +14,7 @@ export type ContentPreferenceSourceFlags = Partial<{
 @ChildEntity(ContentPreferenceType.Source)
 export class ContentPreferenceSource extends ContentPreference {
   @Column({ type: 'text', default: null })
+  @Index('IDX_content_preference_source_id')
   sourceId: string;
 
   @Column({ type: 'jsonb', default: {} })

--- a/src/entity/contentPreference/ContentPreferenceUser.ts
+++ b/src/entity/contentPreference/ContentPreferenceUser.ts
@@ -1,4 +1,4 @@
-import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
+import { ChildEntity, Column, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { ContentPreference } from './ContentPreference';
 import { ContentPreferenceType } from './types';
 import type { User } from '../user/User';
@@ -6,6 +6,7 @@ import type { User } from '../user/User';
 @ChildEntity(ContentPreferenceType.User)
 export class ContentPreferenceUser extends ContentPreference {
   @Column({ type: 'text', default: null })
+  @Index('IDX_content_preference_reference_user_id')
   referenceUserId: string;
 
   @Column({ type: 'text', default: null })

--- a/src/migration/1732464610853-ContentPreferenceIndexes.ts
+++ b/src/migration/1732464610853-ContentPreferenceIndexes.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ContentPreferenceIndexes1732464610853 implements MigrationInterface {
+  name = 'ContentPreferenceIndexes1732464610853'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_content_preference_source_id" ON "content_preference" ("sourceId") `);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_content_preference_reference_user_id" ON "content_preference" ("referenceUserId") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_content_preference_reference_user_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_content_preference_source_id"`);
+  }
+}


### PR DESCRIPTION
These should be run first before merge, so that it doesn't hang on migration.

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_content_preference_source_id" ON "content_preference" ("sourceId");
CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_content_preference_reference_user_id" ON "content_preference" ("referenceUserId");
```

This should fix the high query time when deleting user/ squad

<details>
<summary>Explain analyze results on user</summary>

```
"Delete on ""user""  (cost=0.43..8.45 rows=0 width=0) (actual time=0.062..0.063 rows=0 loops=1)"
  ->  Index Scan using ""PK_03b91d2b8321aa7ba32257dc321"" on ""user""  (cost=0.43..8.45 rows=1 width=6) (actual time=0.034..0.035 rows=1 loops=1)"
        Index Cond: ((id)::text = 'LqpkFJyK0mXCplwKwBMen'::text)"
        Filter: (((id)::text = '404'::text) IS NOT TRUE)"
Planning Time: 0.160 ms
Trigger for constraint FK_502d51183cb036c2b2f39270648 on user: time=0.148 calls=1
Trigger for constraint FK_61c64496bf096b321869175021a on user: time=0.085 calls=1
Trigger for constraint FK_6bffe5dffe26a589d67af08343c on user: time=0.158 calls=1
Trigger for constraint FK_70a77f197a0f92324256c983fc6 on user: time=0.052 calls=1
Trigger for constraint FK_78b22c2fb692b073d4e6d165867 on user: time=0.055 calls=1
Trigger for constraint FK_7bd626272858ef6464aa2579094 on user: time=0.061 calls=1
Trigger for constraint FK_91bfeec7a9574f458e5b592472d on user: time=0.042 calls=1
Trigger for constraint FK_9b77a6c894823e05648bbb964e0 on user: time=0.066 calls=1
Trigger for constraint FK_a49f9325cc4a61812fa7da5449e on user: time=7.708 calls=1
Trigger for constraint FK_a51326b93176f2b2ebf3eda9fef on user: time=0.365 calls=1
Trigger for constraint FK_ab57b9b261d32985dab19184382 on user: time=0.140 calls=1
Trigger for constraint FK_bd51d362dd91064109b22f29061 on user: time=4.998 calls=1
Trigger for constraint FK_cc568f9fc855fc9ada0cfba6cd6 on user: time=5.537 calls=1
Trigger for constraint FK_d1d5a13218f895570f4d7ad5897 on user: time=0.177 calls=1
Trigger for constraint FK_dce2a8927967051c447ae10bc8b on user: time=0.088 calls=1
Trigger for constraint FK_e41f5df92c3048b9d242b8e1a51 on user: time=0.119 calls=1
Trigger for constraint FK_f1305337f54e8211d5a84da0cc5 on user: time=0.071 calls=1
Trigger for constraint FK_f1bb0e9a2279673a76520d2adc5 on user: time=0.268 calls=1
Trigger for constraint FK_f5d76a882255aab76133a175b55 on user: time=0.057 calls=1
Trigger for constraint FK_f8006ee80f0cdd5dfeb73930a23 on user: time=20.605 calls=1
Trigger for constraint FK_user_personalized_digest_user on user: time=0.343 calls=1
Trigger for constraint FK_3d8ec0aea914605bd0455034673 on user: time=0.113 calls=1
Trigger for constraint FK_52b027499322daf67dacb8fe368 on user: time=57.819 calls=1
Trigger for constraint FK_ebd475b57b16b0039934dc31a14 on user: time=0.160 calls=1
Trigger for constraint FK_c8721bd56ae600308745ad49744 on user: time=16.570 calls=1
Trigger for constraint FK_c025478b45e60017ed10c77f99c on user: time=0.168 calls=1
Trigger for constraint FK_f2678f7b11e5128abbbc4511906 on user: time=0.098 calls=1
Trigger for constraint FK_e389fc192c59bdce0847ef9ef8b on user: time=0.091 calls=1
Trigger for constraint FK_9175e059b0a720536f7726a88c7 on user: time=0.052 calls=1
Trigger for constraint FK_b35c67d61943214aff1e7c94abd on user: time=0.036 calls=1
Trigger for constraint FK_70952a3f1b3717e7021a439edda on user: time=0.075 calls=1
Trigger for constraint FK_cb822e7eeeb23bf497848d081fb on user: time=0.116 calls=1
Trigger for constraint FK_f65f2e8ad23133abd53e72d9ca0 on user: time=0.044 calls=1
Trigger for constraint FK_8f82dc90297a05bb4377ef811c9 on user: time=0.044 calls=1
Trigger for constraint FK_2f89aead53ebdaaf3dca910ed56 on user: time=0.044 calls=1
Trigger for constraint FK_85728503871528f18bba6f3c579 on user: time=0.045 calls=1
Trigger for constraint FK_8db78849191c339d5776307ff45 on user: time=0.057 calls=1
Trigger for constraint FK_db149e671aa7c677101676d2331 on user: time=0.079 calls=1
Trigger for constraint FK_87628fa2c15a77f4f29726ed8ae on user: time=0.243 calls=1
Trigger for constraint FK_231b13306df1d5046ffa7c4568b on user: time=48142.310 calls=1
Trigger for constraint FK_c9c1cda086ffe214d856ab17522 on user: time=0.339 calls=1
Trigger for constraint FK_01d5bc49fc5802c4e067d7ba4c9 on feed: time=0.151 calls=1
Trigger for constraint FK_8c6d05462bc68459e00f165d51c on feed: time=0.148 calls=1
Trigger for constraint FK_b08384d9c394e68429a9eea4df7 on feed: time=0.127 calls=1
Trigger for constraint FK_1623a286347b83ea1f43d4940e0 on feed: time=0.103 calls=1
Execution Time: 48260.307 ms
```

</details>

<details>
<summary>Explain analyze results on source</summary>

```
Delete on source  (cost=0.41..8.43 rows=0 width=0) (actual time=0.117..0.117 rows=0 loops=1)
   ->  Index Scan using ""PK_2f5238e5a67e9c18a3468b4134d"" on source  (cost=0.41..8.43 rows=1 width=6) (actual time=0.025..0.025 rows=1 loops=1)"
         Index Cond: (id = 'e3e54d64-fbf0-485d-a4b8-eab44944b901'::text)"
Planning Time: 0.173 ms
Trigger for constraint FK_43f03127c54baaae6d0fc649725 on source: time=16.630 calls=1
Trigger for constraint FK_4f708e773c1df9c288180fbb555 on source: time=9.584 calls=1
Trigger for constraint FK_83c8ae07417cd6de65b8b994587 on source: time=14.770 calls=1
Trigger for constraint FK_a4ead2fdceb9998b4dc4d01935b on source: time=0.252 calls=1
Trigger for constraint FK_ad5e759962cd86ff322cb480d09 on source: time=8.660 calls=1
Trigger for constraint FK_b557c5ebed1e6df65d7271807df on source: time=1.407 calls=1
Trigger for constraint FK_588b9bbf0415aba1e4fed23b8f7 on source: time=2.242 calls=1
Trigger for constraint FK_4d2e0ef44957797dc421ad7fa83 on source: time=4.027 calls=1
Trigger for constraint FK_532c94738c6b1334e4bc27c41cf on source: time=0.226 calls=1
Trigger for constraint FK_367689a89c5a4e4adeb22d4f0da on source: time=15230.811 calls=1
Trigger for constraint FK_047c6c6dfe33e269ca2754e29a9 on post: time=13.338 calls=61
Trigger for constraint FK_0950b72419f03dba7e68ef326a2 on post: time=168.269 calls=61
Trigger for constraint FK_0e7cbc85b452229a89e3c551720 on post: time=35.925 calls=61
Trigger for constraint FK_2a31e87a2a08355c43fc87de547 on post: time=10.355 calls=61
Trigger for constraint FK_3eb8e2db42e1474c4e900b96688 on post: time=68.960 calls=61
Trigger for constraint FK_4953d54459dedcf97afe3c8c03d on post: time=971.122 calls=61
Trigger for constraint FK_82db04e5b5686aec67abf4577e9 on post: time=120.266 calls=61
Trigger for constraint FK_88d97436b07e1462d5a7877dcb3 on post: time=139.584 calls=61
Trigger for constraint FK_b0df46b7939819e8bc14cf9f45c on post: time=96.918 calls=61
Trigger for constraint FK_c740e7b1564ee3e52aef9f21fe0 on post: time=91.426 calls=61
Trigger for constraint FK_d82dbf00f15d651edf917c8167f on post: time=10.183 calls=61
Trigger for constraint FK_f3c0b831daae119196482c99379 on post: time=117.437 calls=61
Trigger for constraint FK_41925c29ce7a2820e87ff8d22fd on post: time=87.512 calls=61
Trigger for constraint FK_3d96addd8ef4ca68fab5d3bdd37 on post: time=17.216 calls=61
Trigger for constraint FK_4f7beb468ea0b38eb944b2234ab on post: time=13.207 calls=61
Trigger removed_squad_members_count on source_member: time=3.918 calls=2
Trigger user_post_vote_delete_trigger on user_post: time=1.209 calls=4
Trigger for constraint FK_0752f6682fb89a7dbad0d98434e on comment: time=190.590 calls=12
Trigger for constraint FK_a719456a191b6f8a42e4ae96d91 on comment: time=29.849 calls=12
Trigger for constraint FK_cb2ce95b74f2ee583447362d508 on comment: time=12.160 calls=12
Trigger for constraint FK_f8dbf9ed06bbdc84d8a5e99f7e4 on comment: time=14.224 calls=12
Trigger for constraint FK_b7d2dcc1d8826d4ef2fc5716bf4 on comment: time=14.824 calls=12
Trigger decrement_comment_count_delete_trigger on comment: time=1.475 calls=1
Trigger decrement_post_comment_count_delete_trigger on comment: time=2.964 calls=12
Trigger delete_comment_notifications on comment: time=41.293 calls=12
Trigger user_comment_vote_delete_trigger on user_comment: time=7.039 calls=5
Execution Time: 17571.093 ms
```

</details>