### PR TITLE
feat: clear image based on preset

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1002,8 +1002,8 @@ describe('streak recover query', () => {
 
 describe('clearImage mutation', () => {
   const MUTATION = `
-    mutation ClearUserImage($preset: UploadPreset!) {
-      clearImage(preset: $preset) {
+    mutation ClearUserImage($presets: [UploadPreset]!) {
+      clearImage(presets: $presets) {
         _
       }
     }
@@ -1012,18 +1012,12 @@ describe('clearImage mutation', () => {
   it('should not allow unauthenticated users', async () =>
     await testMutationErrorCode(
       client,
-      { mutation: MUTATION, variables: { preset: UploadPreset.ProfileCover } },
+      {
+        mutation: MUTATION,
+        variables: { presets: [UploadPreset.ProfileCover] },
+      },
       'UNAUTHENTICATED',
     ));
-
-  it('should throw an error when type is not found', async () => {
-    loggedUser = '1';
-    await testMutationErrorCode(
-      client,
-      { mutation: MUTATION, variables: { preset: UploadPreset.FreeformGif } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
 
   it("should clear user's avatar", async () => {
     loggedUser = '1';
@@ -1033,7 +1027,7 @@ describe('clearImage mutation', () => {
       .update({ id: loggedUser }, { image: 'test', cover: 'cover' });
 
     const res = await client.mutate(MUTATION, {
-      variables: { preset: UploadPreset.Avatar },
+      variables: { presets: [UploadPreset.Avatar] },
     });
 
     expect(res.errors).toBeFalsy();
@@ -1051,14 +1045,14 @@ describe('clearImage mutation', () => {
       .update({ id: loggedUser }, { image: 'test', cover: 'cover' });
 
     const res = await client.mutate(MUTATION, {
-      variables: { preset: UploadPreset.Avatar },
+      variables: { presets: [UploadPreset.ProfileCover] },
     });
 
     expect(res.errors).toBeFalsy();
 
     const user = await con.getRepository(User).findOneBy({ id: loggedUser });
-    expect(user.image).toBeNull();
-    expect(user.cover).not.toBeNull();
+    expect(user.image).not.toBeNull();
+    expect(user.cover).toBeNull();
   });
 });
 

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -105,6 +105,10 @@ type PostPreset =
   | UploadPreset.FreeformGif;
 
 export const clearFile = (referenceId: string, preset: UploadPreset) => {
+  if (!process.env.CLOUDINARY_URL) {
+    return Promise.resolve();
+  }
+
   const id = `${preset}_${referenceId}`;
 
   return cloudinary.v2.uploader.destroy(id);

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -106,7 +106,7 @@ type PostPreset =
 
 export const clearFile = (referenceId: string, preset: UploadPreset) => {
   if (!process.env.CLOUDINARY_URL) {
-    return Promise.resolve();
+    return
   }
 
   const id = `${preset}_${referenceId}`;

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -1,6 +1,5 @@
 import cloudinary from 'cloudinary';
 import { Readable } from 'stream';
-import { type ConnectionManager, User } from '../entity';
 
 export const uploadLogo = (name: string, stream: Readable): Promise<string> =>
   new Promise((resolve, reject) => {
@@ -118,29 +117,6 @@ export const clearFile = ({ referenceId, preset }: ClearFileProps) => {
   const id = `${preset}_${referenceId}`;
 
   return cloudinary.v2.uploader.destroy(id);
-};
-
-interface ClearImagePreset {
-  con: ConnectionManager;
-  preset: UploadPreset;
-  userId: string;
-}
-
-export const clearImagePreset = async ({
-  con,
-  preset,
-  userId,
-}: ClearImagePreset) => {
-  switch (preset) {
-    case UploadPreset.ProfileCover:
-      await con.getRepository(User).update({ id: userId }, { cover: null });
-      await clearFile({ referenceId: userId, preset });
-      break;
-    case UploadPreset.Avatar:
-      await con.getRepository(User).update({ id: userId }, { image: null });
-      await clearFile({ referenceId: userId, preset });
-      break;
-  }
 };
 
 export const uploadPostFile = (

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -106,7 +106,7 @@ type PostPreset =
 
 export const clearFile = (referenceId: string, preset: UploadPreset) => {
   if (!process.env.CLOUDINARY_URL) {
-    return
+    return;
   }
 
   const id = `${preset}_${referenceId}`;

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -1,6 +1,6 @@
 import cloudinary from 'cloudinary';
 import { Readable } from 'stream';
-import { ConnectionManager, User } from '../entity';
+import { type ConnectionManager, User } from '../entity';
 
 export const uploadLogo = (name: string, stream: Readable): Promise<string> =>
   new Promise((resolve, reject) => {

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -104,6 +104,12 @@ type PostPreset =
   | UploadPreset.FreeformImage
   | UploadPreset.FreeformGif;
 
+export const clearFile = (referenceId: string, preset: UploadPreset) => {
+  const id = `${preset}_${referenceId}`;
+
+  return cloudinary.v2.uploader.destroy(id);
+};
+
 export const uploadPostFile = (
   name: string,
   stream: Readable,
@@ -112,8 +118,8 @@ export const uploadPostFile = (
 
 export function mapCloudinaryUrl(url: string): string;
 export function mapCloudinaryUrl(url: undefined): undefined;
-export function mapCloudinaryUrl(url?: string): string | undefined;
-export function mapCloudinaryUrl(url?: string): string | undefined {
+export function mapCloudinaryUrl(url?: string | null): string | undefined;
+export function mapCloudinaryUrl(url?: string | null): string | undefined {
   return url?.replace(
     /(?:res\.cloudinary\.com\/daily-now|daily-now-res\.cloudinary\.com)/g,
     'media.daily.dev',

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -25,7 +25,7 @@ export interface User {
   id: string;
   email: string;
   name: string;
-  image: string;
+  image?: string | null;
   infoConfirmed: boolean;
   premium?: boolean;
   reputation: number;

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -49,10 +49,10 @@ export class User {
   email: string;
 
   @Column({ type: 'text', nullable: true })
-  image: string;
+  image?: string | null;
 
   @Column({ type: 'text', nullable: true })
-  cover?: string;
+  cover?: string | null;
 
   @Column({ type: 'text', nullable: true })
   company?: string;

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -34,6 +34,7 @@ import { NotificationIcon } from './icons';
 import { SourceMemberRoles } from '../roles';
 import { NotificationType } from './common';
 import { SourcePostModeration } from '../entity/SourcePostModeration';
+import { fallbackImages } from '../config';
 
 const MAX_COMMENT_LENGTH = 320;
 
@@ -273,7 +274,7 @@ export class NotificationBuilder {
     this.avatars.push({
       type: 'user',
       referenceId: user.id,
-      image: user.image,
+      image: user.image ?? fallbackImages.avatar,
       name: user.name || user.username,
       targetUrl: getUserPermalink(user),
     });
@@ -286,7 +287,7 @@ export class NotificationBuilder {
       (user): DeepPartial<NotificationAvatarV2> => ({
         type: 'user',
         referenceId: user.id,
-        image: user.image,
+        image: user.image ?? fallbackImages.avatar,
         name: user.name,
         targetUrl: getUserPermalink(user),
       }),

--- a/src/routes/devcards.ts
+++ b/src/routes/devcards.ts
@@ -6,7 +6,7 @@ import { retryFetch } from '../integrations/retry';
 import { getDevCardDataV1 } from '../common/devcard';
 import { generateDevCard } from '../templates/devcard';
 import { TypeORMQueryFailedError } from '../errors';
-import { WEBAPP_MAGIC_IMAGE_PREFIX } from '../config';
+import { fallbackImages, WEBAPP_MAGIC_IMAGE_PREFIX } from '../config';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get<{ Params: { id: string } }>(
@@ -26,7 +26,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
           await getDevCardDataV1(devCard.userId, con);
         const svgString = generateDevCard({
           username: user.username!,
-          profileImage: user.image,
+          profileImage: user.image ?? fallbackImages.avatar,
           articlesRead,
           tags,
           sourcesLogos,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -29,6 +29,7 @@ import {
   getAuthorPostStats,
   Alerts,
   reputationReasonAmount,
+  ConnectionManager,
 } from '../entity';
 import {
   AuthenticationError,
@@ -70,7 +71,7 @@ import {
   type GQLUserTopReader,
   mapCloudinaryUrl,
   UploadPreset,
-  clearImagePreset,
+  clearFile,
 } from '../common';
 import { getSearchQuery, GQLEmptyResponse, processSearchQuery } from './common';
 import { ActiveView } from '../entity/ActiveView';
@@ -1246,6 +1247,29 @@ const getUserCompanies = async (
     },
     true,
   );
+};
+
+interface ClearImagePreset {
+  con: ConnectionManager;
+  preset: UploadPreset;
+  userId: string;
+}
+
+export const clearImagePreset = async ({
+  con,
+  preset,
+  userId,
+}: ClearImagePreset) => {
+  switch (preset) {
+    case UploadPreset.ProfileCover:
+      await con.getRepository(User).update({ id: userId }, { cover: null });
+      await clearFile({ referenceId: userId, preset });
+      break;
+    case UploadPreset.Avatar:
+      await con.getRepository(User).update({ id: userId }, { image: null });
+      await clearFile({ referenceId: userId, preset });
+      break;
+  }
 };
 
 export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1786,15 +1786,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     ): Promise<GQLEmptyResponse> => {
       switch (preset) {
         case UploadPreset.ProfileCover:
-          await con.getRepository(User).update(userId, {
-            cover: null,
-          });
+          await con.getRepository(User).update({ id: userId }, { cover: null });
           await clearFile(userId, preset);
           break;
         case UploadPreset.Avatar:
-          await con.getRepository(User).update(userId, {
-            image: null,
-          });
+          await con.getRepository(User).update(
+            { id: userId },
+            {
+              image: null,
+            },
+          );
           await clearFile(userId, preset);
           break;
         default:


### PR DESCRIPTION
Rather than having a nullable prop that would signify that we should clear the image on certain mutations, we introduced a mutation to specifically do it. This makes maintaining how the clearance works much easier than remembering the meaning of the passed null values.