### PR TITLE
feat: functional block words

### DIFF
--- a/__tests__/contentPreference.ts
+++ b/__tests__/contentPreference.ts
@@ -38,6 +38,7 @@ import {
 import { ghostUser } from '../src/common';
 import { ContentPreferenceKeyword } from '../src/entity/contentPreference/ContentPreferenceKeyword';
 import { ContentPreferenceWord } from '../src/entity/contentPreference/ContentPreferenceWord';
+import { isFibonacci } from '../src/common/fibonacci';
 
 let con: DataSource;
 let state: GraphQLTestingState;
@@ -1542,6 +1543,34 @@ describe('mutation block', () => {
       expect(contentPreference).not.toBeNull();
       expect(contentPreference!.type).toEqual(ContentPreferenceType.Word);
       expect(contentPreference!.status).toBe(ContentPreferenceStatus.Blocked);
+    });
+
+    it('should block multiple words', async () => {
+      loggedUser = '1-blm';
+
+      const res = await client.query(MUTATION, {
+        variables: {
+          id: 'word-bl1,   word-bl2,  word-bl3   ,',
+          entity: ContentPreferenceType.Word,
+        },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      const contentPreferences = await con
+        .getRepository(ContentPreferenceWord)
+        .findBy({
+          type: ContentPreferenceType.Word,
+        });
+
+      expect(contentPreferences).not.toBeNull();
+      expect(contentPreferences.length).toBe(3);
+
+      contentPreferences.forEach((cp) => {
+        expect(cp.status).toBe(ContentPreferenceStatus.Blocked);
+        expect(cp.type).toEqual(ContentPreferenceType.Word);
+        expect(['word-bl1', 'word-bl2', 'word-bl3']).toContain(cp.referenceId);
+      });
     });
   });
 

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -41,6 +41,7 @@ import { ILofnClient } from '../../src/integrations/lofn';
 import { ContentPreferenceSource } from '../../src/entity/contentPreference/ContentPreferenceSource';
 import { ContentPreferenceKeyword } from '../../src/entity/contentPreference/ContentPreferenceKeyword';
 import { ContentPreferenceStatus } from '../../src/entity/contentPreference/types';
+import { ContentPreferenceWord } from '../../src/entity/contentPreference/ContentPreferenceWord';
 
 let con: DataSource;
 let ctx: Context;
@@ -189,6 +190,20 @@ describe('FeedPreferencesConfigGenerator', () => {
         status: ContentPreferenceStatus.Blocked,
       },
     ]);
+    await con.getRepository(ContentPreferenceWord).save([
+      {
+        feedId: '1',
+        userId: '1',
+        referenceId: 'word-abc',
+        status: ContentPreferenceStatus.Blocked,
+      },
+      {
+        feedId: '1',
+        userId: '1',
+        referenceId: 'word-def',
+        status: ContentPreferenceStatus.Blocked,
+      },
+    ]);
     await con.getRepository(ContentPreferenceSource).save([
       {
         feedId: '1',
@@ -257,6 +272,7 @@ describe('FeedPreferencesConfigGenerator', () => {
         includeBlockedTags: true,
         includeAllowedTags: true,
         includePostTypes: true,
+        includeBlockedWords: true,
       },
     );
 
@@ -270,6 +286,7 @@ describe('FeedPreferencesConfigGenerator', () => {
         allowed_tags: expect.arrayContaining(['javascript', 'golang']),
         blocked_sources: expect.arrayContaining(['a', 'b']),
         blocked_tags: expect.arrayContaining(['python', 'java']),
+        blocked_title_words: expect.arrayContaining(['word-abc', 'word-def']),
         allowed_post_types: postTypes.filter(
           (x) => x !== PostType.VideoYouTube,
         ),
@@ -556,6 +573,20 @@ describe('FeedLofnConfigGenerator', () => {
         status: ContentPreferenceStatus.Blocked,
       },
     ]);
+    await con.getRepository(ContentPreferenceWord).save([
+      {
+        feedId: '1',
+        userId: '1',
+        referenceId: 'word-abc',
+        status: ContentPreferenceStatus.Blocked,
+      },
+      {
+        feedId: '1',
+        userId: '1',
+        referenceId: 'word-def',
+        status: ContentPreferenceStatus.Blocked,
+      },
+    ]);
     await con.getRepository(ContentPreferenceSource).save([
       {
         feedId: '1',
@@ -633,6 +664,7 @@ describe('FeedLofnConfigGenerator', () => {
         includeBlockedSources: true,
         includeSourceMemberships: true,
         includePostTypes: true,
+        includeBlockedWords: true,
         feed_version: '30',
       },
     );
@@ -658,6 +690,7 @@ describe('FeedLofnConfigGenerator', () => {
         fresh_page_size: '4',
         allowed_tags: expect.arrayContaining(['javascript', 'golang']),
         blocked_tags: expect.arrayContaining(['python', 'java']),
+        blocked_title_words: expect.arrayContaining(['word-abc', 'word-def']),
         blocked_sources: expect.arrayContaining(['a', 'b']),
         squad_ids: expect.arrayContaining(['a', 'b']),
         allowed_post_types: expect.arrayContaining([

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -46,6 +46,7 @@ export class FeedClient implements IFeedClient, IGarmrClient {
     extraMetadata?: GenericMetadata,
   ): Promise<FeedResponse> {
     const res = await this.garmr.execute(() => {
+      console.log('config', config);
       return fetchParse<RawFeedServiceResponse>(this.url, {
         ...this.fetchOptions,
         method: 'POST',

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -19,6 +19,7 @@ type Options = {
   includeSourceMemberships?: boolean;
   includePostTypes?: boolean;
   includeContentCuration?: boolean;
+  includeBlockedWords?: boolean;
   feedId?: string;
 };
 
@@ -105,6 +106,9 @@ const addFiltersToConfig = ({
     baseConfig.allowed_content_curations = AllowedContentCurationTypes.filter(
       (type) => !filters.blockedContentCuration!.includes(type),
     );
+  }
+  if (filters.blockedWords?.length && opts.includeBlockedWords) {
+    baseConfig.blocked_title_words = filters.blockedWords;
   }
 
   return baseConfig;

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -84,6 +84,7 @@ const opts = {
   includeSourceMemberships: true,
   includePostTypes: true,
   includeContentCuration: true,
+  includeBlockedWords: true,
 };
 
 export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
@@ -97,6 +98,7 @@ export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
           includeBlockedSources: true,
           includeBlockedTags: true,
           includeContentCuration: true,
+          includeBlockedWords: true,
         },
       ),
       'popular',

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -49,6 +49,7 @@ export type FeedConfig = {
   blocked_sources?: string[];
   allowed_post_types?: string[];
   allowed_content_curations?: string[];
+  blocked_title_words?: string[];
   squad_ids?: string[];
   providers?: Record<string, FeedProvider>;
   source_types?: ('machine' | 'squad')[];

--- a/src/integrations/lofn/clients.ts
+++ b/src/integrations/lofn/clients.ts
@@ -32,6 +32,8 @@ export class LofnClient implements ILofnClient, IGarmrClient {
 
   fetchConfig(payload: LofnFeedConfigPayload): Promise<LofnFeedConfigResponse> {
     return this.garmr.execute(() => {
+      console.log('config', payload);
+
       return fetchParse(`${this.url}/config`, {
         ...this.fetchOptions,
         method: 'POST',

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -1,7 +1,7 @@
 import { GrowthBook } from '@growthbook/growthbook';
 import { logger } from './logger';
 import { isProd } from './common/utils';
-import type { SubscriptionCycles } from './paddle';
+import { SubscriptionCycles } from './paddle';
 
 type RemoteConfigValue = {
   inc: number;
@@ -38,7 +38,13 @@ class RemoteConfig {
 
   get vars(): Partial<RemoteConfigValue> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
-      return {};
+      return {
+        pricingIds: {
+          pri_01jcdp5ef4yhv00p43hr2knrdg: SubscriptionCycles.Monthly,
+          pri_01jcdn6enr5ap3ekkddc6fv6tq: SubscriptionCycles.Yearly,
+          // pri_01gsz8x8sawmvhz1pv30nge1ke: SubscriptionCycles.Yearly,
+        },
+      };
     }
 
     if (!this.gb) {

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1181,7 +1181,9 @@ const feedResolverV1: IFieldResolver<unknown, Context, ConfiguredFeedArgs> =
     {
       fetchQueryParams: async (ctx, args) => {
         const feedId = args.feedId || ctx.userId;
-
+        const filters = await feedToFilters(ctx.con, feedId, ctx.userId);
+        console.log('filters', filters);
+        return filters;
         return feedToFilters(ctx.con, feedId, ctx.userId);
       },
       allowPrivatePosts: false,
@@ -1337,6 +1339,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               includeBlockedSources: true,
               includeBlockedTags: true,
               includeContentCuration: true,
+              includeBlockedWords: true,
               feedId: feedId,
             },
           ),
@@ -1385,6 +1388,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
                 includeBlockedSources: true,
                 includeBlockedTags: true,
                 includeContentCuration: true,
+                includeBlockedWords: true,
                 feedFilters: filters,
               },
             ),


### PR DESCRIPTION
Option to block words and resolve them in feed config.

Note:
So far only `blockWords` accepts a comma seperated string, this is due to the ability to block more then one.
We make it unique and onConflict ignore.