### PR TITLE
feat: following feed API

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -10,6 +10,8 @@ Object {
   "excludeSourceTypes": Array [],
   "excludeSources": Array [],
   "excludeTypes": Array [],
+  "followingSources": Array [],
+  "followingUsers": Array [],
   "includeTags": Array [],
   "sourceIds": Array [],
 }
@@ -25,6 +27,8 @@ Object {
   ],
   "excludeSources": Array [],
   "excludeTypes": Array [],
+  "followingSources": Array [],
+  "followingUsers": Array [],
   "includeTags": Array [],
   "sourceIds": Array [],
 }
@@ -38,6 +42,8 @@ Object {
   "excludeSourceTypes": Array [],
   "excludeSources": Array [],
   "excludeTypes": Array [],
+  "followingSources": Array [],
+  "followingUsers": Array [],
   "includeTags": Array [],
   "sourceIds": Array [
     "a",

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -42,6 +42,7 @@ import { ContentPreferenceSource } from '../../src/entity/contentPreference/Cont
 import { ContentPreferenceKeyword } from '../../src/entity/contentPreference/ContentPreferenceKeyword';
 import { ContentPreferenceStatus } from '../../src/entity/contentPreference/types';
 import { ContentPreferenceWord } from '../../src/entity/contentPreference/ContentPreferenceWord';
+import { ContentPreferenceUser } from '../../src/entity/contentPreference/ContentPreferenceUser';
 
 let con: DataSource;
 let ctx: Context;
@@ -207,6 +208,42 @@ describe('FeedPreferencesConfigGenerator', () => {
     await con.getRepository(ContentPreferenceSource).save([
       {
         feedId: '1',
+        sourceId: 'c',
+        userId: '1',
+        status: ContentPreferenceStatus.Follow,
+        referenceId: 'c',
+      },
+      {
+        feedId: '1',
+        sourceId: 'p',
+        userId: '1',
+        status: ContentPreferenceStatus.Subscribed,
+        referenceId: 'd',
+      },
+    ]);
+    await con.getRepository(ContentPreferenceUser).save([
+      {
+        feedId: '1',
+        userId: '1',
+        status: ContentPreferenceStatus.Follow,
+        referenceId: '2',
+      },
+      {
+        feedId: '1',
+        userId: '1',
+        status: ContentPreferenceStatus.Subscribed,
+        referenceId: '3',
+      },
+      {
+        feedId: '1',
+        userId: '1',
+        status: ContentPreferenceStatus.Blocked,
+        referenceId: '4',
+      },
+    ]);
+    await con.getRepository(ContentPreferenceSource).save([
+      {
+        feedId: '1',
         sourceId: 'a',
         userId: '1',
         status: ContentPreferenceStatus.Blocked,
@@ -273,6 +310,8 @@ describe('FeedPreferencesConfigGenerator', () => {
         includeAllowedTags: true,
         includePostTypes: true,
         includeBlockedWords: true,
+        includeFollowedUsers: true,
+        includeFollowedSources: true,
       },
     );
 
@@ -287,6 +326,8 @@ describe('FeedPreferencesConfigGenerator', () => {
         blocked_sources: expect.arrayContaining(['a', 'b']),
         blocked_tags: expect.arrayContaining(['python', 'java']),
         blocked_title_words: expect.arrayContaining(['word-abc', 'word-def']),
+        followed_sources: expect.arrayContaining(['c', 'p']),
+        followed_user_ids: expect.arrayContaining(['2', '3']),
         allowed_post_types: postTypes.filter(
           (x) => x !== PostType.VideoYouTube,
         ),

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -12,7 +12,7 @@ import { runInSpan } from '../../telemetry';
 import { ILofnClient } from '../lofn';
 import { Context } from '../../Context';
 
-type Options = {
+export type Options = {
   includeAllowedTags?: boolean;
   includeBlockedTags?: boolean;
   includeBlockedSources?: boolean;
@@ -20,6 +20,8 @@ type Options = {
   includePostTypes?: boolean;
   includeContentCuration?: boolean;
   includeBlockedWords?: boolean;
+  includeFollowedSources?: boolean;
+  includeFollowedUsers?: boolean;
   feedId?: string;
 };
 
@@ -109,6 +111,12 @@ const addFiltersToConfig = ({
   }
   if (filters.blockedWords?.length && opts.includeBlockedWords) {
     baseConfig.blocked_title_words = filters.blockedWords;
+  }
+  if (filters.followingSources?.length && opts.includeFollowedSources) {
+    baseConfig.followed_sources = filters.followingSources;
+  }
+  if (filters.followingUsers?.length && opts.includeFollowedUsers) {
+    baseConfig.followed_user_ids = filters.followingUsers;
   }
 
   return baseConfig;

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -12,6 +12,7 @@ import { FeedClient } from './clients';
 import {
   FeedLofnConfigGenerator,
   FeedPreferencesConfigGenerator,
+  Options,
   SimpleFeedConfigGenerator,
 } from './configs';
 import { SnotraClient } from '../snotra';
@@ -77,7 +78,7 @@ export const popularFeedClient = new FeedClient(process.env.POPULAR_FEED, {
   garmr: garmFeedService,
 });
 
-const opts = {
+const opts: Options = {
   includeBlockedTags: true,
   includeAllowedTags: true,
   includeBlockedSources: true,
@@ -123,11 +124,14 @@ export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
     ),
   });
 
-export const versionToFeedGenerator = (version: number): FeedGenerator => {
+export const versionToFeedGenerator = (
+  version: number | FeedVersion,
+  inputOpts?: Options,
+): FeedGenerator => {
   return new FeedGenerator(
     feedClient,
     new FeedLofnConfigGenerator(baseFeedConfig, lofnClient, {
-      ...opts,
+      ...(inputOpts ?? opts),
       feed_version: version.toString() as FeedVersion,
     }),
   );

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -50,6 +50,8 @@ export type FeedConfig = {
   allowed_post_types?: string[];
   allowed_content_curations?: string[];
   blocked_title_words?: string[];
+  followed_user_ids?: string[];
+  followed_sources?: string[];
   squad_ids?: string[];
   providers?: Record<string, FeedProvider>;
   source_types?: ('machine' | 'squad')[];
@@ -99,7 +101,8 @@ export type FeedVersion =
   | 'popular'
   | 'onboarding'
   | 'post_similarity'
-  | '30';
+  | '30'
+  | 'f1';
 
 export const baseFeedConfig: Partial<FeedConfig> = {
   source_types: ['machine', 'squad'],

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -196,6 +196,16 @@ export const typeDefs = /* GraphQL */ `
     Post must not include these words in their title
     """
     blockedWords: [String!]
+
+    """
+    Include posts from these sources
+    """
+    followingSources: [ID!]
+
+    """
+    Include posts from these users
+    """
+    followingUsers: [ID!]
   }
 
   type FeedFlagsPublic {
@@ -375,6 +385,21 @@ export const typeDefs = /* GraphQL */ `
       Array of supported post types
       """
       supportedTypes: [String!]
+    ): PostConnection! @auth
+
+    """
+    Get user following feed
+    """
+    followingFeed(
+      """
+      Paginate after opaque cursor
+      """
+      after: String
+
+      """
+      Paginate first
+      """
+      first: Int
     ): PostConnection! @auth
 
     """
@@ -1308,6 +1333,27 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         );
       }
       return feedResolverV1(source, args, ctx, info);
+    },
+    followingFeed: async (source, args: FeedArgs, ctx: Context, info) => {
+      return feedResolverCursor(
+        source,
+        {
+          ...(args as FeedArgs),
+          generator: versionToFeedGenerator('f1', {
+            includeBlockedTags: true,
+            includeAllowedTags: false,
+            includeBlockedSources: true,
+            includeSourceMemberships: false,
+            includePostTypes: true,
+            includeContentCuration: true,
+            includeBlockedWords: true,
+            includeFollowedSources: true,
+            includeFollowedUsers: true,
+          }),
+        },
+        ctx,
+        info,
+      );
     },
     customFeed: async (
       source,


### PR DESCRIPTION
Following feed API.

Went for the easy implementation, we should monitor the rawFeedFilter query and maybe rethink.
(can be later I feel like)

Also re-used versionToFeed which isn't 100% optional, but was the faster implementation to re-use lofn feed.