### PR TITLE
feat: create query to fetch Smart Title / original title of post

### DIFF
--- a/__tests__/common/post.ts
+++ b/__tests__/common/post.ts
@@ -1,0 +1,152 @@
+import { getPostSmartTitle, getPostTranslatedTitle } from '../../src/common';
+import { ContentLanguage } from '../../src/types';
+
+describe('getPostTranslatedTitle', () => {
+  it('should return the translated title if it exists', () => {
+    const post = {
+      title: 'Original Title',
+      contentMeta: {
+        translate_title: {
+          translations: {
+            [ContentLanguage.German]: 'Übersetzter Titel',
+          },
+        },
+      },
+    };
+
+    const result = getPostTranslatedTitle(post, ContentLanguage.German);
+    expect(result).toBe('Übersetzter Titel');
+  });
+
+  it('should return the original title if the translation does not exist', () => {
+    const post = {
+      title: 'Original Title',
+      contentMeta: {
+        translate_title: {
+          translations: {
+            [ContentLanguage.Spanish]: 'Título Traducido',
+          },
+        },
+      },
+    };
+
+    const result = getPostTranslatedTitle(post, ContentLanguage.German);
+    expect(result).toBe('Original Title');
+  });
+
+  it('should return the original title if contentMeta is undefined', () => {
+    const post = {
+      title: 'Original Title',
+      contentMeta: undefined,
+    };
+
+    const result = getPostTranslatedTitle(post, ContentLanguage.German);
+    expect(result).toBe('Original Title');
+  });
+
+  it('should return the original title if translate_title is undefined', () => {
+    const post = {
+      title: 'Original Title',
+      contentMeta: {
+        translate_title: undefined,
+      },
+    };
+
+    const result = getPostTranslatedTitle(post, ContentLanguage.German);
+    expect(result).toBe('Original Title');
+  });
+
+  it('should return the original title if translations is undefined', () => {
+    const post = {
+      title: 'Original Title',
+      contentMeta: {
+        translate_title: {
+          translations: undefined,
+        },
+      },
+    };
+
+    const result = getPostTranslatedTitle(post, ContentLanguage.German);
+    expect(result).toBe('Original Title');
+  });
+});
+
+describe('getPostSmartTitle', () => {
+  it('should return the alt title if it exists', () => {
+    const post = {
+      contentMeta: {
+        alt_title: {
+          translations: {
+            [ContentLanguage.Spanish]: 'Título Inteligente',
+          },
+        },
+      },
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
+    expect(result).toBe('Título Inteligente');
+  });
+
+  it('should return undefined if the alt title translation does not exist', () => {
+    const post = {
+      contentMeta: {
+        alt_title: {
+          translations: {
+            [ContentLanguage.Spanish]: 'Título Inteligente',
+          },
+        },
+      },
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.German);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if alt_title is undefined', () => {
+    const post = {
+      contentMeta: {
+        alt_title: undefined,
+      },
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if alt title translations is undefined', () => {
+    const post = {
+      contentMeta: {
+        alt_title: {
+          translations: undefined,
+        },
+      },
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if contentMeta is undefined', () => {
+    const post = {
+      contentMeta: undefined,
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the English alt title translation if contentLanguage is undefined', () => {
+    const post = {
+      contentMeta: {
+        alt_title: {
+          translations: {
+            [ContentLanguage.English]: 'Smart Title',
+          },
+        },
+      },
+    };
+
+    const result = getPostSmartTitle(post, undefined);
+    expect(result).toBe('Smart Title');
+  });
+});

--- a/__tests__/common/post.ts
+++ b/__tests__/common/post.ts
@@ -121,4 +121,20 @@ describe('getPostSmartTitle', () => {
     const result = getPostSmartTitle(post, ContentLanguage.German);
     expect(result).toBe('Default Title');
   });
+
+  it('should return the translated title if no alt title translations are available', () => {
+    const post = {
+      title: 'Default Title',
+      contentMeta: {
+        translate_title: {
+          translations: {
+            [ContentLanguage.German]: 'Übersetzter Titel',
+          },
+        },
+      },
+    };
+
+    const result = getPostSmartTitle(post, ContentLanguage.German);
+    expect(result).toBe('Übersetzter Titel');
+  });
 });

--- a/__tests__/common/post.ts
+++ b/__tests__/common/post.ts
@@ -109,24 +109,8 @@ describe('getPostSmartTitle', () => {
       title: 'Default Title',
     };
 
-    const result = getPostSmartTitle(post);
+    const result = getPostSmartTitle(post, ContentLanguage.German);
     expect(result).toBe('Default Title');
-  });
-
-  it('should return the English alt translated title if no content language is specified', () => {
-    const post = {
-      contentMeta: {
-        alt_title: {
-          translations: {
-            [ContentLanguage.English]: 'Title in English',
-          },
-        },
-      },
-      title: 'Default Title',
-    };
-
-    const result = getPostSmartTitle(post);
-    expect(result).toBe('Title in English');
   });
 
   it('should return the default title if contentMeta is not defined', () => {
@@ -134,7 +118,7 @@ describe('getPostSmartTitle', () => {
       title: 'Default Title',
     };
 
-    const result = getPostSmartTitle(post);
+    const result = getPostSmartTitle(post, ContentLanguage.German);
     expect(result).toBe('Default Title');
   });
 });

--- a/__tests__/common/post.ts
+++ b/__tests__/common/post.ts
@@ -72,81 +72,69 @@ describe('getPostTranslatedTitle', () => {
 });
 
 describe('getPostSmartTitle', () => {
-  it('should return the alt title if it exists', () => {
+  it('should return the alt title for the specified content language', () => {
     const post = {
       contentMeta: {
         alt_title: {
           translations: {
-            [ContentLanguage.Spanish]: 'Título Inteligente',
+            [ContentLanguage.Spanish]: 'Título en Español',
           },
         },
       },
+      title: 'Default Title',
     };
 
     const result = getPostSmartTitle(post, ContentLanguage.Spanish);
-    expect(result).toBe('Título Inteligente');
+    expect(result).toBe('Título en Español');
   });
 
-  it('should return undefined if the alt title translation does not exist', () => {
+  it('should return the English alt title if specified content language is not available', () => {
     const post = {
       contentMeta: {
         alt_title: {
           translations: {
-            [ContentLanguage.Spanish]: 'Título Inteligente',
+            [ContentLanguage.English]: 'Title in English',
           },
         },
       },
-    };
-
-    const result = getPostSmartTitle(post, ContentLanguage.German);
-    expect(result).toBeUndefined();
-  });
-
-  it('should return undefined if alt_title is undefined', () => {
-    const post = {
-      contentMeta: {
-        alt_title: undefined,
-      },
+      title: 'Default Title',
     };
 
     const result = getPostSmartTitle(post, ContentLanguage.Spanish);
-    expect(result).toBeUndefined();
+    expect(result).toBe('Title in English');
   });
 
-  it('should return undefined if alt title translations is undefined', () => {
+  it('should return the default title if no alt title translations are available', () => {
     const post = {
-      contentMeta: {
-        alt_title: {
-          translations: undefined,
-        },
-      },
+      title: 'Default Title',
     };
 
-    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
-    expect(result).toBeUndefined();
+    const result = getPostSmartTitle(post);
+    expect(result).toBe('Default Title');
   });
 
-  it('should return undefined if contentMeta is undefined', () => {
-    const post = {
-      contentMeta: undefined,
-    };
-
-    const result = getPostSmartTitle(post, ContentLanguage.Spanish);
-    expect(result).toBeUndefined();
-  });
-
-  it('should return the English alt title translation if contentLanguage is undefined', () => {
+  it('should return the English alt translated title if no content language is specified', () => {
     const post = {
       contentMeta: {
         alt_title: {
           translations: {
-            [ContentLanguage.English]: 'Smart Title',
+            [ContentLanguage.English]: 'Title in English',
           },
         },
       },
+      title: 'Default Title',
     };
 
-    const result = getPostSmartTitle(post, undefined);
-    expect(result).toBe('Smart Title');
+    const result = getPostSmartTitle(post);
+    expect(result).toBe('Title in English');
+  });
+
+  it('should return the default title if contentMeta is not defined', () => {
+    const post = {
+      title: 'Default Title',
+    };
+
+    const result = getPostSmartTitle(post);
+    expect(result).toBe('Default Title');
   });
 });

--- a/__tests__/notifications/notificationWorkerToWorker.ts
+++ b/__tests__/notifications/notificationWorkerToWorker.ts
@@ -160,9 +160,12 @@ describe('notificationWorkerToWorker', () => {
     expect(notifications[0].attachments).toEqual(
       expect.arrayContaining(attachments.map(({ id }) => id)),
     );
-    avatars.map(({ id }) => id).forEach((id) => {
-      expect(notifications[0].avatars).toContain(id);
-    }
+
+    avatars
+      .map(({ id }) => id)
+      .forEach((id) => {
+        expect(notifications[0].avatars).toContain(id);
+      });
   });
 
   it('should denormalize public properly', async () => {

--- a/__tests__/notifications/notificationWorkerToWorker.ts
+++ b/__tests__/notifications/notificationWorkerToWorker.ts
@@ -160,7 +160,9 @@ describe('notificationWorkerToWorker', () => {
     expect(notifications[0].attachments).toEqual(
       expect.arrayContaining(attachments.map(({ id }) => id)),
     );
-    expect(notifications[0].avatars).toEqual(avatars.map(({ id }) => id));
+    avatars.map(({ id }) => id).forEach((id) => {
+      expect(notifications[0].avatars).toContain(id);
+    }
   });
 
   it('should denormalize public properly', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -24,6 +24,7 @@ import {
   PostReport,
   PostTag,
   PostType,
+  Settings,
   SharePost,
   Source,
   SourceMember,
@@ -31,6 +32,8 @@ import {
   SquadSource,
   UNKNOWN_SOURCE,
   User,
+  UserAction,
+  UserActionType,
   UserPost,
   View,
   WelcomePost,
@@ -81,6 +84,8 @@ import {
 } from '../src/entity/SourcePostModeration';
 import { generateUUID } from '../src/ids';
 import { GQLResponse } from 'mercurius-integration-testing';
+import type { GQLPostSmartTitle } from '../src/schema/posts';
+import { SubscriptionCycles } from '../src/paddle';
 
 jest.mock('../src/common/pubsub', () => ({
   ...(jest.requireActual('../src/common/pubsub') as Record<string, unknown>),
@@ -5924,6 +5929,171 @@ describe('Source post moderation edit/delete', () => {
       expect(post.title).toEqual('New Title');
       expect(post.content).toEqual('New Content');
       expect(post.status).toEqual(SourcePostModerationStatus.Pending);
+    });
+  });
+});
+
+describe('query fetchSmartTitle', () => {
+  const QUERY = /* GraphQL */ `
+    query FetchSmartTitle($id: ID!) {
+      fetchSmartTitle(id: $id) {
+        title
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        contentMeta: {
+          alt_title: {
+            translations: {
+              en: 'Alt Title',
+              de: 'Alt Title DE',
+            },
+          },
+          translate_title: {
+            translations: {
+              de: 'Title DE',
+            },
+          },
+        },
+      },
+    );
+    await con
+      .getRepository(User)
+      .update(
+        { id: '1' },
+        { subscriptionFlags: { cycle: SubscriptionCycles.Yearly } },
+      );
+  });
+
+  it('should throw error when user is not logged in', async () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { id: 'p1' } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should return the original title when clickbait shield is enabled', async () => {
+    loggedUser = '1';
+
+    const res = await client.query<
+      { fetchSmartTitle: GQLPostSmartTitle },
+      { id: string }
+    >(QUERY, {
+      variables: { id: 'p1' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.fetchSmartTitle.title).toEqual('P1');
+  });
+
+  it('should return the original title when clickbait shield is enabled and language is set', async () => {
+    loggedUser = '1';
+    const res = await client.query<
+      { fetchSmartTitle: GQLPostSmartTitle },
+      { id: string }
+    >(QUERY, {
+      variables: { id: 'p1' },
+      headers: { 'content-language': 'de' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.fetchSmartTitle.title).toEqual('Title DE');
+  });
+
+  it('should return the smart title when clickbait shield is disabled', async () => {
+    loggedUser = '1';
+
+    await con
+      .getRepository(Settings)
+      .save({ userId: loggedUser, flags: { clickbaitShieldEnabled: false } });
+
+    const res = await client.query<
+      { fetchSmartTitle: GQLPostSmartTitle },
+      { id: string }
+    >(QUERY, {
+      variables: { id: 'p1' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.fetchSmartTitle.title).toEqual('Alt Title');
+  });
+
+  it('should return the smart title when clickbait shield is disabled and language is set', async () => {
+    loggedUser = '1';
+
+    await con
+      .getRepository(Settings)
+      .save({ userId: loggedUser, flags: { clickbaitShieldEnabled: false } });
+
+    const res = await client.query<
+      { fetchSmartTitle: GQLPostSmartTitle },
+      { id: string }
+    >(QUERY, {
+      variables: { id: 'p1' },
+      headers: { 'content-language': 'de' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.fetchSmartTitle.title).toEqual('Alt Title DE');
+  });
+
+  describe('free user', () => {
+    it('should be able to get the smart title', async () => {
+      loggedUser = '2';
+      const res = await client.query<
+        { fetchSmartTitle: GQLPostSmartTitle },
+        { id: string }
+      >(QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.fetchSmartTitle.title).toEqual('P1');
+    });
+
+    it('should not be able to get the smart title twice', async () => {
+      loggedUser = '2';
+      const res = await client.query<
+        { fetchSmartTitle: GQLPostSmartTitle },
+        { id: string }
+      >(QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.fetchSmartTitle.title).toEqual('P1');
+
+      const res2 = await client.query<
+        { fetchSmartTitle: GQLPostSmartTitle },
+        { id: string }
+      >(QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res2.errors?.length || 0).toEqual(1);
+      expect(res2.errors[0].extensions?.code).toEqual('FORBIDDEN');
+    });
+
+    it('should not be able to get the smart title if they have used free trial', async () => {
+      loggedUser = '2';
+      await con.getRepository(UserAction).save({
+        userId: loggedUser,
+        type: UserActionType.FetchedSmartTitle,
+      });
+
+      const res = await client.query<
+        { fetchSmartTitle: GQLPostSmartTitle },
+        { id: string }
+      >(QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors?.length || 0).toEqual(1);
+      expect(res.errors[0].extensions?.code).toEqual('FORBIDDEN');
     });
   });
 });

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -631,7 +631,7 @@ export const getPostTranslatedTitle = (
   contentLanguage: ContentLanguage,
 ) =>
   post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
-  post.title;
+  (post.title as string);
 
 export const getPostSmartTitle = (
   post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
@@ -639,4 +639,4 @@ export const getPostSmartTitle = (
 ) =>
   post.contentMeta?.alt_title?.translations?.[contentLanguage] ||
   post.contentMeta?.alt_title?.translations?.[ContentLanguage.English] ||
-  post.title;
+  getPostTranslatedTitle(post, contentLanguage);

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -627,16 +627,16 @@ export const findPostImageFromContent = ({
 };
 
 export const getPostTranslatedTitle = (
-  post: Pick<Post, 'title' | 'contentMeta'>,
+  post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
   contentLanguage: ContentLanguage,
 ) =>
   post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
   post.title;
 
 export const getPostSmartTitle = (
-  post: Pick<Post, 'contentMeta'>,
-  contentLanguage: ContentLanguage,
+  post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
+  contentLanguage?: ContentLanguage,
 ) =>
   post.contentMeta?.alt_title?.translations?.[
     contentLanguage ?? ContentLanguage.English
-  ];
+  ] || post.title;

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -635,10 +635,8 @@ export const getPostTranslatedTitle = (
 
 export const getPostSmartTitle = (
   post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
-  contentLanguage?: ContentLanguage,
+  contentLanguage: ContentLanguage,
 ) =>
-  post.contentMeta?.alt_title?.translations?.[
-    contentLanguage ?? ContentLanguage.English
-  ] ||
+  post.contentMeta?.alt_title?.translations?.[contentLanguage] ||
   post.contentMeta?.alt_title?.translations?.[ContentLanguage.English] ||
   post.title;

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -32,6 +32,7 @@ import { downloadJsonFile } from './googleCloud';
 import {
   ContentLanguage,
   type ChangeObject,
+  type I18nRecord,
   type PostCodeSnippetJsonFile,
 } from '../types';
 import { uniqueifyObjectArray } from './utils';
@@ -626,17 +627,31 @@ export const findPostImageFromContent = ({
   return imgTag?.attrGet('src') || undefined;
 };
 
+type PostContentMeta = {
+  alt_title: {
+    translations: I18nRecord;
+  };
+  translate_title: {
+    translations: I18nRecord;
+  };
+};
+
 export const getPostTranslatedTitle = (
   post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
   contentLanguage: ContentLanguage,
 ) =>
-  post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
-  (post.title as string);
+  (post.contentMeta as PostContentMeta)?.translate_title?.translations?.[
+    contentLanguage
+  ] || (post.title as string);
 
 export const getPostSmartTitle = (
   post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
   contentLanguage: ContentLanguage,
 ) =>
-  post.contentMeta?.alt_title?.translations?.[contentLanguage] ||
-  post.contentMeta?.alt_title?.translations?.[ContentLanguage.English] ||
+  (post.contentMeta as PostContentMeta)?.alt_title?.translations?.[
+    contentLanguage
+  ] ||
+  (post.contentMeta as PostContentMeta)?.alt_title?.translations?.[
+    ContentLanguage.English
+  ] ||
   getPostTranslatedTitle(post, contentLanguage);

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -639,4 +639,6 @@ export const getPostSmartTitle = (
 ) =>
   post.contentMeta?.alt_title?.translations?.[
     contentLanguage ?? ContentLanguage.English
-  ] || post.title;
+  ] ||
+  post.contentMeta?.alt_title?.translations?.[ContentLanguage.English] ||
+  post.title;

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -29,7 +29,11 @@ import { createHash } from 'node:crypto';
 import { PostCodeSnippet } from '../entity/posts/PostCodeSnippet';
 import { logger } from '../logger';
 import { downloadJsonFile } from './googleCloud';
-import type { ChangeObject, PostCodeSnippetJsonFile } from '../types';
+import {
+  ContentLanguage,
+  type ChangeObject,
+  type PostCodeSnippetJsonFile,
+} from '../types';
 import { uniqueifyObjectArray } from './utils';
 import {
   SourcePostModeration,
@@ -621,3 +625,18 @@ export const findPostImageFromContent = ({
 
   return imgTag?.attrGet('src') || undefined;
 };
+
+export const getPostTranslatedTitle = (
+  post: Pick<Post, 'title' | 'contentMeta'>,
+  contentLanguage: ContentLanguage,
+) =>
+  post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
+  post.title;
+
+export const getPostSmartTitle = (
+  post: Pick<Post, 'contentMeta'>,
+  contentLanguage: ContentLanguage,
+) =>
+  post.contentMeta?.alt_title?.translations?.[
+    contentLanguage ?? ContentLanguage.English
+  ];

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   PrimaryColumn,
   TableInheritance,
+  type DeepPartial,
 } from 'typeorm';
 import { Source, UNKNOWN_SOURCE } from '../Source';
 import { PostTag } from '../PostTag';
@@ -51,7 +52,7 @@ export type PostContentQuality = Partial<{
   is_ai_probability: number;
 }>;
 
-export type PostContentMeta = Partial<{
+export type PostContentMeta = DeepPartial<{
   alt_title: {
     provider: string;
     translations: I18nRecord;
@@ -60,7 +61,6 @@ export type PostContentMeta = Partial<{
     provider: string;
     translations: I18nRecord;
   };
-  [key: string]: unknown;
 }>;
 
 @Entity()

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -6,7 +6,6 @@ import {
   OneToMany,
   PrimaryColumn,
   TableInheritance,
-  type DeepPartial,
 } from 'typeorm';
 import { Source, UNKNOWN_SOURCE } from '../Source';
 import { PostTag } from '../PostTag';
@@ -14,7 +13,6 @@ import { PostKeyword } from '../PostKeyword';
 import { User } from '../user';
 import { PostRelation } from './PostRelation';
 import type { PostCodeSnippet } from './PostCodeSnippet';
-import type { I18nRecord } from '../../types';
 
 export enum PostType {
   Article = 'article',
@@ -50,17 +48,6 @@ export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;
 
 export type PostContentQuality = Partial<{
   is_ai_probability: number;
-}>;
-
-export type PostContentMeta = DeepPartial<{
-  alt_title: {
-    provider: string;
-    translations: I18nRecord;
-  };
-  translate_title: {
-    provider: string;
-    translations: I18nRecord;
-  };
 }>;
 
 @Entity()
@@ -272,7 +259,7 @@ export class Post {
   slug: string;
 
   @Column({ type: 'jsonb', default: {} })
-  contentMeta: PostContentMeta;
+  contentMeta: object;
 
   @Column({ type: 'jsonb', default: {} })
   contentQuality: PostContentQuality;

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -13,6 +13,7 @@ import { PostKeyword } from '../PostKeyword';
 import { User } from '../user';
 import { PostRelation } from './PostRelation';
 import type { PostCodeSnippet } from './PostCodeSnippet';
+import type { I18nRecord } from '../../types';
 
 export enum PostType {
   Article = 'article',
@@ -48,6 +49,18 @@ export type PostFlagsPublic = Pick<PostFlags, 'private' | 'promoteToPublic'>;
 
 export type PostContentQuality = Partial<{
   is_ai_probability: number;
+}>;
+
+export type PostContentMeta = Partial<{
+  alt_title: {
+    provider: string;
+    translations: I18nRecord;
+  };
+  translate_title: {
+    provider: string;
+    translations: I18nRecord;
+  };
+  [key: string]: unknown;
 }>;
 
 @Entity()
@@ -259,7 +272,7 @@ export class Post {
   slug: string;
 
   @Column({ type: 'jsonb', default: {} })
-  contentMeta: object;
+  contentMeta: PostContentMeta;
 
   @Column({ type: 'jsonb', default: {} })
   contentQuality: PostContentQuality;

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -27,6 +27,7 @@ import { CollectionPost } from './CollectionPost';
 import { checkWithVordr, VordrFilterType } from '../../common/vordr';
 import { AuthContext } from '../../Context';
 import { logger } from '../../logger';
+import { ContentLanguage } from '../../types';
 
 export type PostStats = {
   numPosts: number;
@@ -605,3 +606,18 @@ export const normalizeCollectionPostSources = async ({
 export const getPostVisible = ({ post }: { post: Pick<Post, 'title'> }) => {
   return !!post?.title?.length;
 };
+
+export const getPostTranslatedTitle = (
+  post: Pick<Post, 'title' | 'contentMeta'>,
+  contentLanguage: ContentLanguage,
+) =>
+  post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
+  post.title;
+
+export const getPostSmartTitle = (
+  post: Pick<Post, 'contentMeta'>,
+  contentLanguage: ContentLanguage,
+) =>
+  post.contentMeta?.alt_title?.translations?.[
+    contentLanguage ?? ContentLanguage.English
+  ];

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -27,7 +27,6 @@ import { CollectionPost } from './CollectionPost';
 import { checkWithVordr, VordrFilterType } from '../../common/vordr';
 import { AuthContext } from '../../Context';
 import { logger } from '../../logger';
-import { ContentLanguage } from '../../types';
 
 export type PostStats = {
   numPosts: number;
@@ -606,18 +605,3 @@ export const normalizeCollectionPostSources = async ({
 export const getPostVisible = ({ post }: { post: Pick<Post, 'title'> }) => {
   return !!post?.title?.length;
 };
-
-export const getPostTranslatedTitle = (
-  post: Pick<Post, 'title' | 'contentMeta'>,
-  contentLanguage: ContentLanguage,
-) =>
-  post.contentMeta?.translate_title?.translations?.[contentLanguage] ||
-  post.title;
-
-export const getPostSmartTitle = (
-  post: Pick<Post, 'contentMeta'>,
-  contentLanguage: ContentLanguage,
-) =>
-  post.contentMeta?.alt_title?.translations?.[
-    contentLanguage ?? ContentLanguage.English
-  ];

--- a/src/entity/user/UserAction.ts
+++ b/src/entity/user/UserAction.ts
@@ -10,6 +10,7 @@ export enum UserActionType {
   SquadInvite = 'squad_invite',
   MyFeed = 'my_feed',
   EditWelcomePost = 'edit_welcome_post',
+  FetchedSmartTitle = 'fetched_smart_title',
 }
 
 @Entity()

--- a/src/paddle.ts
+++ b/src/paddle.ts
@@ -1,3 +1,7 @@
+import type { DataSource } from 'typeorm';
+import { User } from './entity';
+import { queryReadReplica } from './common/queryReadReplica';
+
 export enum SubscriptionCycles {
   Monthly = 'monthly',
   Yearly = 'yearly',
@@ -5,3 +9,17 @@ export enum SubscriptionCycles {
 
 export const isPlusMember = (cycle: SubscriptionCycles | undefined): boolean =>
   !!cycle?.length || false;
+
+export const isUserPlusMember = async (
+  con: DataSource,
+  userId?: string,
+): Promise<boolean> => {
+  const { subscriptionFlags } = await queryReadReplica(con, ({ queryRunner }) =>
+    queryRunner.manager.getRepository(User).findOneOrFail({
+      where: { id: userId },
+      select: ['subscriptionFlags'],
+    }),
+  );
+
+  return isPlusMember(subscriptionFlags?.cycle);
+};

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1795,12 +1795,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           throw new ForbiddenError(
             'Free trial has been used! Please upgrade to Plus to continue using this feature.',
           );
-        } else {
-          await ctx.con.getRepository(UserAction).save({
-            userId: ctx.userId,
-            type: UserActionType.FetchedSmartTitle,
-          });
         }
+
+        await ctx.con.getRepository(UserAction).save({
+          userId: ctx.userId,
+          type: UserActionType.FetchedSmartTitle,
+        });
       }
 
       const settings = await queryReadReplica(ctx.con, ({ queryRunner }) =>

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -191,6 +191,10 @@ export type GQLPostNotification = Pick<
   'id' | 'numUpvotes' | 'numComments'
 >;
 
+export type GQLPostSmartTitle = {
+  title: string;
+};
+
 const POST_MODERATION_PAGE_SIZE = 15;
 const POST_MODERATION_LIMIT_FOR_MUTATION = 50;
 const sourcePostModerationPageGenerator =
@@ -1765,7 +1769,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         true,
       );
     },
-    fetchSmartTitle: async (_, { id }: { id: string }, ctx: Context) => {
+    fetchSmartTitle: async (
+      _,
+      { id }: { id: string },
+      ctx: Context,
+    ): Promise<GQLPostSmartTitle> => {
       const post: Pick<Post, 'title' | 'contentMeta'> = await queryReadReplica(
         ctx.con,
         ({ queryRunner }) =>

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -39,6 +39,8 @@ import {
   CreateSourcePostModerationArgs,
   mapCloudinaryUrl,
   validateSourcePostModeration,
+  getPostTranslatedTitle,
+  getPostSmartTitle,
 } from '../common';
 import {
   ArticlePost,
@@ -66,8 +68,6 @@ import {
   SubmitExternalLinkArgs,
   UserAction,
   Settings,
-  getPostTranslatedTitle,
-  getPostSmartTitle,
 } from '../entity';
 import { GQLEmptyResponse, offsetPageGenerator } from './common';
 import {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1769,6 +1769,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         true,
       );
     },
+    /**
+     * Fetches the original title if clickbait shield is enabled,
+     * and the smart title if clickbait shield is disabled.
+     *
+     * This is so that we an query the opposite title based on the user's settings.
+     */
     fetchSmartTitle: async (
       _,
       { id }: { id: string },
@@ -1810,12 +1816,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         }),
       );
 
+      // If the user has clickbait shield enabled, return the original title
       if (settings?.flags?.clickbaitShieldEnabled ?? true) {
         return {
           title: getPostTranslatedTitle(post, ctx.contentLanguage),
         };
       }
 
+      // If the user has clickbait shield disabled, return the smart title
       return {
         title: getPostSmartTitle(post, ctx.contentLanguage),
       };

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1795,16 +1795,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         }
       }
 
-      const {
-        flags: { clickbaitShieldEnabled },
-      } = await queryReadReplica(ctx.con, ({ queryRunner }) =>
-        queryRunner.manager.getRepository(Settings).findOneOrFail({
+      const settings = await queryReadReplica(ctx.con, ({ queryRunner }) =>
+        queryRunner.manager.getRepository(Settings).findOne({
           where: { userId: ctx.userId },
           select: ['flags'],
         }),
       );
 
-      if (clickbaitShieldEnabled ?? true) {
+      if (settings?.flags?.clickbaitShieldEnabled ?? true) {
         return {
           title: getPostTranslatedTitle(post, ctx.contentLanguage),
         };


### PR DESCRIPTION
Created new query to fetch the Smart Title or the original title of a post, based on the settings of the user.

If the user is a free user, we allow them to query one time before we return a forbidden error.

Also added a new post to seeds that has alt title added

TODO:
- [x] Add tests

AS-803