### PR TITLE
feat: Bookmark add and move methods

### DIFF
--- a/src/entity/Bookmark.ts
+++ b/src/entity/Bookmark.ts
@@ -14,7 +14,7 @@ export class Bookmark {
   userId: string;
 
   @Column({ type: 'uuid', nullable: true })
-  listId: string;
+  listId: string | null;
 
   @Column({ type: 'timestamp', nullable: true })
   remindAt: Date;

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -75,6 +75,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Bookmark {
+    postId: ID!
     list: BookmarkList
     createdAt: DateTime
     remindAt: DateTime

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -404,6 +404,11 @@ export const typeDefs = /* GraphQL */ `
       Paginate first
       """
       first: Int
+
+      """
+      Array of supported post types
+      """
+      supportedTypes: [String!]
     ): PostConnection! @auth
 
     """

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,8 @@ export enum UserVoteEntity {
 
 export const maxFeedsPerUser = 10;
 
+export const maxBookmarksPerMutation = 10;
+
 export enum BookmarkListCountLimit {
   Free = 1,
   Plus = 50,


### PR DESCRIPTION
- On bookmark creation: 
  - auto set last folder used from before (if any); 
  - now returns the just-created item;
- Rename `addBookmarkToList` endpoint to `moveBookmark`
