### PR TITLE
feat: move workers queries to read replica 1

### DIFF
--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -11,6 +11,7 @@ import {
   ObjectLiteral,
   QueryBuilder,
   SelectQueryBuilder,
+  type EntityManager,
 } from 'typeorm';
 import { Connection, ConnectionArguments } from 'graphql-relay';
 import { IFieldResolver } from '@graphql-tools/utils';
@@ -80,7 +81,7 @@ export const whereKeyword = (
 };
 
 const rawFilterSelect = <T extends ObjectLiteral>(
-  con: DataSource,
+  con: DataSource | EntityManager,
   name: string,
   func: (qb: QueryBuilder<T>) => QueryBuilder<T>,
 ): QueryBuilder<T> =>
@@ -104,7 +105,7 @@ type RawFiltersData = {
 };
 
 const getRawFiltersData = async (
-  con: DataSource,
+  con: DataSource | EntityManager,
   feedId: string,
   userId: string,
 ): Promise<RawFiltersData | undefined> => {
@@ -307,7 +308,7 @@ const sourcesToFilters = ({
 };
 
 export const feedToFilters = async (
-  con: DataSource,
+  con: DataSource | EntityManager,
   feedId?: string,
   userId?: string,
 ): Promise<AnonymousFeedFilters> => {

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -232,7 +232,7 @@ export const getPersonalizedDigestEmailPayload = async ({
   previousSendDate: Date;
   feature: PersonalizedDigestFeatureConfig;
 }): Promise<SendEmailRequestWithTemplate | undefined> => {
-  const feedConfig = await await queryReadReplica(con, ({ queryRunner }) => {
+  const feedConfig = await queryReadReplica(con, ({ queryRunner }) => {
     return feedToFilters(
       queryRunner.manager,
       personalizedDigest.userId,

--- a/src/workers/notifications/articleAnalytics.ts
+++ b/src/workers/notifications/articleAnalytics.ts
@@ -2,6 +2,7 @@ import { messageToJson } from '../worker';
 import { NotificationWorker } from './worker';
 import { buildPostContext, uniquePostOwners } from './utils';
 import { NotificationType } from '../../notifications/common';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 interface Data {
   postId: string;
@@ -11,7 +12,10 @@ const worker: NotificationWorker = {
   subscription: 'api.article-analytics-notification',
   handler: async (message, con) => {
     const data: Data = messageToJson(message);
-    const ctx = await buildPostContext(con, data.postId);
+    const ctx = await queryReadReplica(con, ({ queryRunner }) => {
+      return buildPostContext(queryRunner.manager, data.postId);
+    });
+
     if (!ctx) {
       return;
     }

--- a/src/workers/notifications/collectionUpdated.ts
+++ b/src/workers/notifications/collectionUpdated.ts
@@ -15,6 +15,7 @@ import {
   NotificationPreferenceStatus,
   NotificationType,
 } from '../../notifications/common';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 interface Data {
   post: ChangeObject<Post>;
@@ -25,34 +26,44 @@ export const collectionUpdated: NotificationWorker = {
   handler: async (message, con) => {
     const data: Data = messageToJson(message);
 
-    const baseCtx = await buildPostContext(con, data.post.id);
+    const baseCtx = await queryReadReplica(con, ({ queryRunner }) => {
+      return buildPostContext(queryRunner.manager, data.post.id);
+    });
+
     if (!baseCtx) {
       return;
     }
+
     const { post } = baseCtx;
 
     if (post.type !== PostType.Collection) {
       return;
     }
 
-    const sources = await getAllSourcesBaseQuery({
+    const [sources, members] = await queryReadReplica(
       con,
-      postId: post.id,
-      relationType: PostRelationType.Collection,
-    })
-      .select(
-        's.id as id, s."name" as name, s."image" as image, count(s."id") OVER() AS total, s."handle" as handle',
-      )
-      .limit(3)
-      .getRawMany<Source & { total: number }>();
+      ({ queryRunner }) => {
+        return Promise.all([
+          getAllSourcesBaseQuery({
+            con: queryRunner.manager,
+            postId: post.id,
+            relationType: PostRelationType.Collection,
+          })
+            .select(
+              's.id as id, s."name" as name, s."image" as image, count(s."id") OVER() AS total, s."handle" as handle',
+            )
+            .limit(3)
+            .getRawMany<Source & { total: number }>(),
+          queryRunner.manager.getRepository(NotificationPreferencePost).findBy({
+            notificationType: NotificationType.CollectionUpdated,
+            referenceId: post.id,
+            status: NotificationPreferenceStatus.Subscribed,
+          }),
+        ]);
+      },
+    );
 
     const numTotalAvatars = sources[0]?.total || 0;
-
-    const members = await con.getRepository(NotificationPreferencePost).findBy({
-      notificationType: NotificationType.CollectionUpdated,
-      referenceId: post.id,
-      status: NotificationPreferenceStatus.Subscribed,
-    });
 
     return [
       {

--- a/src/workers/notifications/sourcePostModerationApprovedNotification.ts
+++ b/src/workers/notifications/sourcePostModerationApprovedNotification.ts
@@ -3,6 +3,7 @@ import { NotificationType } from '../../notifications/common';
 import { NotificationPostContext } from '../../notifications';
 import { buildPostContext } from './utils';
 import { SourcePostModerationStatus } from '../../entity/SourcePostModeration';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 const worker =
   generateTypedNotificationWorker<'api.v1.source-post-moderation-approved'>({
@@ -12,11 +13,15 @@ const worker =
         return;
       }
 
-      if (!data?.postId) {
+      const postId = data?.postId;
+
+      if (!postId) {
         return;
       }
 
-      const baseCtx = await buildPostContext(con, data.postId);
+      const baseCtx = await queryReadReplica(con, ({ queryRunner }) => {
+        return buildPostContext(queryRunner.manager, postId);
+      });
       const ctx: NotificationPostContext = {
         ...baseCtx!,
         userIds: [data.createdById],

--- a/src/workers/notifications/sourcePostModerationRejectedNotification.ts
+++ b/src/workers/notifications/sourcePostModerationRejectedNotification.ts
@@ -5,6 +5,7 @@ import { SourcePostModerationStatus } from '../../entity/SourcePostModeration';
 import { getPostModerationContext } from './utils';
 import { logger } from '../../logger';
 import { TypeORMQueryFailedError } from '../../errors';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 const worker =
   generateTypedNotificationWorker<'api.v1.source-post-moderation-rejected'>({
@@ -15,7 +16,9 @@ const worker =
       }
 
       try {
-        const moderationCtx = await getPostModerationContext(con, post);
+        const moderationCtx = await queryReadReplica(con, ({ queryRunner }) => {
+          return getPostModerationContext(queryRunner.manager, post);
+        });
         const ctx: NotificationPostModerationContext = {
           ...moderationCtx,
           userIds: [post.createdById],

--- a/src/workers/notifications/sourceRequest.ts
+++ b/src/workers/notifications/sourceRequest.ts
@@ -5,6 +5,7 @@ import { NotificationType } from '../../notifications/common';
 import { NotificationWorker } from './worker';
 import { NotificationReason } from '../../common';
 import { ChangeObject } from '../../types';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 type Data = {
   reason: NotificationReason;
@@ -21,9 +22,11 @@ const worker: NotificationWorker = {
     };
     switch (data.reason) {
       case NotificationReason.Publish: {
-        const source = await con
-          .getRepository(Source)
-          .findOneBy({ id: data.sourceRequest.sourceId });
+        const source = await queryReadReplica(con, ({ queryRunner }) => {
+          return queryRunner.manager
+            .getRepository(Source)
+            .findOneBy({ id: data.sourceRequest.sourceId });
+        });
         return [
           { type: NotificationType.SourceApproved, ctx: { ...ctx, source } },
         ];

--- a/src/workers/notifications/squadFeaturedUpdated.ts
+++ b/src/workers/notifications/squadFeaturedUpdated.ts
@@ -4,6 +4,7 @@ import { NotificationSourceContext } from '../../notifications';
 import { SourceMemberRoles } from '../../roles';
 import { SourceMember } from '../../entity';
 import { In } from 'typeorm';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 const toNotify = [SourceMemberRoles.Admin, SourceMemberRoles.Moderator];
 
@@ -15,9 +16,11 @@ const worker = generateTypedNotificationWorker<'api.v1.squad-featured-updated'>(
         return undefined;
       }
 
-      const users = await con.getRepository(SourceMember).findBy({
-        sourceId: squad.id,
-        role: In(toNotify),
+      const users = await queryReadReplica(con, ({ queryRunner }) => {
+        return queryRunner.manager.getRepository(SourceMember).findBy({
+          sourceId: squad.id,
+          role: In(toNotify),
+        });
       });
 
       if (!users.length) {

--- a/src/workers/notifications/squadPublicRequestNotification.ts
+++ b/src/workers/notifications/squadPublicRequestNotification.ts
@@ -11,6 +11,7 @@ import {
   SquadPublicRequest,
   SquadPublicRequestStatus,
 } from '../../entity';
+import { queryReadReplica } from '../../common/queryReadReplica';
 
 interface Data {
   request: ChangeObject<SquadPublicRequest>;
@@ -33,7 +34,11 @@ const worker: NotificationWorker = {
       sourceId,
       messageId: message.messageId,
     };
-    const source = await con.getRepository(Source).findOneBy({ id: sourceId });
+    const source = await queryReadReplica(con, ({ queryRunner }) => {
+      return queryRunner.manager
+        .getRepository(Source)
+        .findOneBy({ id: sourceId });
+    });
 
     if (!source) {
       logger.info(logDetails, 'source does not exist');

--- a/src/workers/notifications/utils.ts
+++ b/src/workers/notifications/utils.ts
@@ -63,7 +63,7 @@ export const getSubscribedMembers = (
 };
 
 export const buildPostContext = async (
-  con: DataSource,
+  con: DataSource | EntityManager,
   postId: string,
 ): Promise<Omit<NotificationPostContext, 'userIds'> | null> => {
   const post = await con


### PR DESCRIPTION
Moved workers:
- digest generation
- all workers not needing real time data (upvotes, rep, notification with counts)

Did not move any worker that needs to write or live data as well. Some of them I implemented but in testing realized they would return stale data since RR would be out of date. 

We could move rest of the real time workers if we moved CDC to RR, see [here](https://dailydotdev.slack.com/archives/C03C3JZPRU4/p1733484456135089), but something to be evaluated separate. 