### PR TITLE
refactor: use dataloader for storing user settings per request

### DIFF
--- a/src/dataLoaderService.ts
+++ b/src/dataLoaderService.ts
@@ -1,7 +1,7 @@
 import DataLoader, { BatchLoadFn } from 'dataloader';
 import { Context } from './Context';
 import { getShortUrl } from './common';
-import { SourceMember } from './entity';
+import { Settings, SourceMember } from './entity';
 import { GQLSource } from './schema/sources';
 
 export const defaultCacheKeyFn = <K extends object | string>(key: K) => {
@@ -51,6 +51,15 @@ export class DataLoaderService {
     }
 
     return this.loaders[type] as DataLoader<K, V>;
+  }
+
+  get userSettings() {
+    return this.getLoader<{ userId: string }, Settings>({
+      type: 'userSettings',
+      loadFn: async ({ userId }) =>
+        this.ctx.con.getRepository(Settings).findOneBy({ userId }),
+      cacheKeyFn: ({ userId }) => defaultCacheKeyFn({ userId }),
+    });
   }
 
   get shortUrl() {

--- a/src/dataLoaderService.ts
+++ b/src/dataLoaderService.ts
@@ -56,8 +56,13 @@ export class DataLoaderService {
   get userSettings() {
     return this.getLoader<{ userId: string }, Settings>({
       type: 'userSettings',
-      loadFn: async ({ userId }) =>
-        this.ctx.con.getRepository(Settings).findOneBy({ userId }),
+      loadFn: async ({ userId }) => {
+        if (!userId) {
+          return null;
+        }
+
+        return this.ctx.con.getRepository(Settings).findOneBy({ userId });
+      },
       cacheKeyFn: ({ userId }) => defaultCacheKeyFn({ userId }),
     });
   }

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -83,9 +83,8 @@ const createSmartTitleField = ({ field }: { field: string }): GraphORMField => {
     select: field,
     transform: async (value: string, ctx: Context, parent) => {
       const typedParent = parent as {
-        ['i18nTitle']: I18nRecord;
-        ['smartTitle']: I18nRecord;
-        clickbaitShieldEnabled?: boolean;
+        i18nTitle: I18nRecord;
+        smartTitle: I18nRecord;
         clickbaitProbability?: string;
         [key: string]: unknown;
       };

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -16,7 +16,6 @@ import {
   SettingsFlagsPublic,
   UserStats,
   UserSubscriptionFlags,
-  Settings,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -82,7 +81,7 @@ const checkIfTitleIsClickbait = (value?: string): boolean => {
 const createSmartTitleField = ({ field }: { field: string }): GraphORMField => {
   return {
     select: field,
-    transform: (value: string, ctx: Context, parent): string => {
+    transform: async (value: string, ctx: Context, parent) => {
       const typedParent = parent as {
         ['i18nTitle']: I18nRecord;
         ['smartTitle']: I18nRecord;
@@ -91,12 +90,16 @@ const createSmartTitleField = ({ field }: { field: string }): GraphORMField => {
         [key: string]: unknown;
       };
 
+      const settings = await ctx.dataLoader.userSettings.load({
+        userId: ctx.userId!,
+      });
+
       const i18nValue = typedParent.i18nTitle?.[ctx.contentLanguage];
       const altValue =
         typedParent.smartTitle?.[ctx.contentLanguage] ||
         typedParent.smartTitle?.[ContentLanguage.English];
       const clickbaitShieldEnabled =
-        typedParent?.clickbaitShieldEnabled ?? true;
+        settings?.flags?.clickbaitShieldEnabled ?? true;
 
       const clickbaitTitleDetected = checkIfTitleIsClickbait(
         typedParent.clickbaitProbability,
@@ -271,24 +274,10 @@ const obj = new GraphORM({
     },
   },
   Post: {
-    additionalQuery: (ctx, alias, qb) => {
-      qb = qb
+    additionalQuery: (ctx, alias, qb) =>
+      qb
         .andWhere(`"${alias}"."deleted" = false`)
-        .andWhere(`"${alias}"."visible" = true`);
-
-      if (ctx.userId && ctx.isPlus) {
-        qb = qb
-          .innerJoin(Settings, 's', 's."userId" = :userId', {
-            userId: ctx.userId,
-          })
-          .addSelect(
-            `"s"."flags"->'clickbaitShieldEnabled'`,
-            'clickbaitShieldEnabled',
-          );
-      }
-
-      return qb;
-    },
+        .andWhere(`"${alias}"."visible" = true`),
     requiredColumns: [
       'id',
       'shortId',

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1783,60 +1783,58 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       _,
       { id }: { id: string },
       ctx: Context,
-    ): Promise<GQLPostSmartTitle> => {
-      const post: Pick<Post, 'title' | 'contentMeta'> = await queryReadReplica(
-        ctx.con,
-        ({ queryRunner }) =>
-          queryRunner.manager.getRepository(Post).findOneOrFail({
+    ): Promise<GQLPostSmartTitle> =>
+      queryReadReplica(ctx.con, async ({ queryRunner }) => {
+        const post: Pick<Post, 'title' | 'contentMeta'> =
+          await queryRunner.manager.getRepository(Post).findOneOrFail({
             where: { id },
             select: ['title', 'contentMeta'],
-          }),
-      );
+          });
 
-      if (!ctx.isPlus) {
-        const hasUsedFreeTrial = await ctx.con
-          .getRepository(UserAction)
-          .findOneBy({
+        if (!ctx.isPlus) {
+          const hasUsedFreeTrial = await ctx.con
+            .getRepository(UserAction)
+            .findOneBy({
+              userId: ctx.userId,
+              type: UserActionType.FetchedSmartTitle,
+            });
+
+          if (hasUsedFreeTrial) {
+            throw new ForbiddenError(
+              'Free trial has been used! Please upgrade to Plus to continue using this feature.',
+            );
+          }
+
+          await ctx.con.getRepository(UserAction).save({
             userId: ctx.userId,
             type: UserActionType.FetchedSmartTitle,
           });
 
-        if (hasUsedFreeTrial) {
-          throw new ForbiddenError(
-            'Free trial has been used! Please upgrade to Plus to continue using this feature.',
-          );
+          // We always want to return the smart title for non-plus users who have not used the free trial, as it is part of the try before you buy experience
+          return {
+            title: getPostSmartTitle(post, ctx.contentLanguage),
+          };
         }
 
-        await ctx.con.getRepository(UserAction).save({
-          userId: ctx.userId,
-          type: UserActionType.FetchedSmartTitle,
-        });
+        const settings = await queryRunner.manager
+          .getRepository(Settings)
+          .findOne({
+            where: { userId: ctx.userId },
+            select: ['flags'],
+          });
 
-        // We always want to return the smart title for non-plus users who have not used the free trial, as it is part of the try before you buy experience
+        // If the user has clickbait shield enabled, return the original title
+        if (settings?.flags?.clickbaitShieldEnabled ?? true) {
+          return {
+            title: getPostTranslatedTitle(post, ctx.contentLanguage),
+          };
+        }
+
+        // If the user has clickbait shield disabled, return the smart title
         return {
           title: getPostSmartTitle(post, ctx.contentLanguage),
         };
-      }
-
-      const settings = await queryReadReplica(ctx.con, ({ queryRunner }) =>
-        queryRunner.manager.getRepository(Settings).findOne({
-          where: { userId: ctx.userId },
-          select: ['flags'],
-        }),
-      );
-
-      // If the user has clickbait shield enabled, return the original title
-      if (settings?.flags?.clickbaitShieldEnabled ?? true) {
-        return {
-          title: getPostTranslatedTitle(post, ctx.contentLanguage),
-        };
-      }
-
-      // If the user has clickbait shield disabled, return the smart title
-      return {
-        title: getPostSmartTitle(post, ctx.contentLanguage),
-      };
-    },
+      }),
   },
   Mutation: {
     createSourcePostModeration: async (


### PR DESCRIPTION
Should reduce the need for querying user settings too many times in post queries

AS-813