### PR TITLE
fix: require alt title for clickbaitTitleDetected: true

### DIFF
--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -644,14 +644,20 @@ export const getPostTranslatedTitle = (
     contentLanguage
   ] || (post.title as string);
 
+export const getSmartTitle = (
+  contentLanguage: ContentLanguage,
+  translations?: I18nRecord,
+): string | undefined => {
+  return (
+    translations?.[contentLanguage!] ?? translations?.[ContentLanguage.English]
+  );
+};
+
 export const getPostSmartTitle = (
   post: Partial<Pick<Post, 'title' | 'contentMeta'>>,
   contentLanguage: ContentLanguage,
 ) =>
-  (post.contentMeta as PostContentMeta)?.alt_title?.translations?.[
-    contentLanguage
-  ] ||
-  (post.contentMeta as PostContentMeta)?.alt_title?.translations?.[
-    ContentLanguage.English
-  ] ||
-  getPostTranslatedTitle(post, contentLanguage);
+  getSmartTitle(
+    contentLanguage,
+    (post.contentMeta as PostContentMeta)?.alt_title?.translations,
+  ) || getPostTranslatedTitle(post, contentLanguage);


### PR DESCRIPTION
Fixes an edge case when we've detected the title to be clickbait, but we do not have an alternative title for it, so that we don't show the clickbait shield in frontend.