### PR TITLE
fix: some icons don't pass folder validation

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -176,10 +176,21 @@ export function isNumber(value: string | number): boolean {
   return !isNaN(Number(value.toString()));
 }
 
-const emojiMatch = /^(\p{Emoji_Presentation})$/gu;
-
-export const isOneEmoji = (text: string): boolean => {
-  return emojiMatch.test(text);
+export const VALID_FOLDER_EMOJIS = [
+  `🐹`,
+  '🐍',
+  '☕️',
+  '🔥',
+  '📦',
+  '⚙️',
+  '🐙',
+  '🐳',
+  '💡',
+  '📜',
+  '🚀',
+];
+export const isOneValidEmoji = (text: string): boolean => {
+  return VALID_FOLDER_EMOJIS.includes(text);
 };
 
 export const validateWorkEmailDomain = (domain: string): boolean => {

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -17,7 +17,7 @@ import {
   FeedArgs,
   feedResolver,
   getCursorFromAfter,
-  isOneEmoji,
+  isOneValidEmoji,
   Ranking,
 } from '../common';
 import { In, SelectQueryBuilder } from 'typeorm';
@@ -407,7 +407,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       { name, icon }: Record<'name' | 'icon', string>,
       ctx: AuthContext,
     ): Promise<GQLBookmarkList> => {
-      const isValidIcon = !icon || isOneEmoji(icon);
+      const isValidIcon = !icon || isOneValidEmoji(icon);
       if (!isValidIcon || !name.length) {
         throw new ValidationError('Invalid icon or name');
       }


### PR DESCRIPTION
Looks like the regex didn't work for some icons. 
Since we are allowing only a strict amount of emojis changes the check for this subset.