### PR TITLE
fix: re-issue JWT when user is upgraded to plus

### DIFF
--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -484,9 +484,10 @@ const loggedInBoot = async ({
 
     span?.setAttribute(SEMATTRS_DAILY_STAFF, isTeamMember);
 
-    const accessToken = refreshToken
-      ? await setAuthCookie(req, res, userId, roles, isTeamMember, isPlus)
-      : req.accessToken;
+    const accessToken =
+      refreshToken || isPlus !== req.isPlus
+        ? await setAuthCookie(req, res, userId, roles, isTeamMember, isPlus)
+        : req.accessToken;
     return {
       user: {
         ...excludeProperties(user, [


### PR DESCRIPTION
Fixes edge cases where user has upgrade to plus, but can not use the `fetchSmartTitle` on posts because JWT is outdated.
