### PR TITLE
fix: thread notifications

### DIFF
--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -1521,17 +1521,17 @@ it('should add comment mention notification', async () => {
       commentUserId: '2',
     },
   });
-  expect(actual.length).toEqual(1);
-  expect(actual[0].type).toEqual(NotificationType.CommentMention);
-  expect(actual[0].ctx.userIds).toEqual(['1']);
-  expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
-  expect((actual[0].ctx as NotificationPostContext).source.id).toEqual('a');
-  expect((actual[0].ctx as NotificationCommentContext).comment.id).toEqual(
+  expect(actual?.length).toEqual(1);
+  expect(actual?.[0].type).toEqual(NotificationType.CommentMention);
+  expect(actual?.[0].ctx.userIds).toEqual(['1']);
+  expect((actual?.[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+  expect((actual?.[0].ctx as NotificationPostContext).source.id).toEqual('a');
+  expect((actual?.[0].ctx as NotificationCommentContext).comment.id).toEqual(
     'c1',
   );
-  expect((actual[0].ctx as NotificationCommenterContext).commenter.id).toEqual(
-    '2',
-  );
+  expect(
+    (actual?.[0].ctx as NotificationCommenterContext).commenter.id,
+  ).toEqual('2');
 });
 
 it('should not add comment mention notification when you mentioned the author', async () => {
@@ -1589,7 +1589,7 @@ it('should not add comment mention notification when you mentioned the parent co
   expect(actual).toBeFalsy();
 });
 
-it('should not add comment mention notification when you mentioned someone in the same thread', async () => {
+it('should add comment mention notification when you mentioned someone in the same thread', async () => {
   const mentionedUserId = '3';
   await con.getRepository(Comment).save([
     {
@@ -1617,7 +1617,17 @@ it('should not add comment mention notification when you mentioned someone in th
       mentionedUserId,
     },
   });
-  expect(actual).toBeFalsy();
+  expect(actual?.length).toEqual(1);
+  expect(actual?.[0].type).toEqual(NotificationType.CommentMention);
+  expect(actual?.[0].ctx.userIds).toEqual([mentionedUserId]);
+  expect((actual?.[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+  expect((actual?.[0].ctx as NotificationPostContext).source.id).toEqual('a');
+  expect((actual?.[0].ctx as NotificationCommentContext).comment.id).toEqual(
+    'c2',
+  );
+  expect(
+    (actual?.[0].ctx as NotificationCommenterContext).commenter.id,
+  ).toEqual('1');
 });
 
 describe('comment reply worker', () => {

--- a/__tests__/workers/notifications/commentMention.ts
+++ b/__tests__/workers/notifications/commentMention.ts
@@ -6,7 +6,6 @@ import createOrGetConnection from '../../../src/db';
 import {
   Comment,
   CommentMention,
-  NotificationPreferenceComment,
   Post,
   Source,
   User,
@@ -15,10 +14,6 @@ import { badUsersFixture, sourcesFixture, usersFixture } from '../../fixture';
 import { postsFixture } from '../../fixture/post';
 import { workers } from '../../../src/workers';
 import { invokeNotificationWorker, saveFixtures } from '../../helpers';
-import {
-  NotificationPreferenceStatus,
-  NotificationType,
-} from '../../../src/notifications/common';
 
 let con: DataSource;
 
@@ -40,21 +35,6 @@ beforeEach(async () => {
       content: 'comment',
       contentHtml: '<p>comment</p>',
       flags: { vordr: true },
-    },
-    {
-      id: 'c2',
-      postId: 'p1',
-      userId: '1',
-      content: 'comment',
-      contentHtml: '<p>comment</p>',
-    },
-    {
-      id: 'c3',
-      postId: 'p1',
-      userId: '2',
-      content: 'comment',
-      contentHtml: '<p>comment</p>',
-      parentId: 'c2',
     },
   ]);
   await saveFixtures(con, CommentMention, [
@@ -78,7 +58,7 @@ describe('commentMention', () => {
   it('should not send notification when the comment is prevented by vordr', async () => {
     const payload: Data = {
       commentMention: {
-        commentId: 'c1',
+        commentId: 'c2',
         commentByUserId: '1',
         mentionedUserId: '2',
       },
@@ -90,82 +70,5 @@ describe('commentMention', () => {
     );
 
     expect(result).toBeUndefined();
-  });
-
-  it('should not send notification when the parent commenter is mentioned', async () => {
-    const payload: Data = {
-      commentMention: {
-        commentId: 'c3',
-        commentByUserId: '2',
-        mentionedUserId: '1',
-      },
-    };
-
-    const result = await invokeNotificationWorker(
-      worker,
-      payload as unknown as Record<string, unknown>,
-    );
-
-    expect(result).toBeUndefined();
-  });
-
-  it('should not send notification when the author is mentioned', async () => {
-    await con.getRepository(Post).update('p1', { authorId: '3' });
-    const payload: Data = {
-      commentMention: {
-        commentId: 'c2',
-        commentByUserId: '1',
-        mentionedUserId: '3',
-      },
-    };
-
-    const result = await invokeNotificationWorker(
-      worker,
-      payload as unknown as Record<string, unknown>,
-    );
-
-    expect(result).toBeUndefined();
-  });
-
-  it('should not send notification when the user muted the thread', async () => {
-    await con.getRepository(NotificationPreferenceComment).save({
-      userId: '3',
-      referenceId: 'c2',
-      notificationType: NotificationType.CommentReply,
-      status: NotificationPreferenceStatus.Muted,
-    });
-    const payload: Data = {
-      commentMention: {
-        commentId: 'c3',
-        commentByUserId: '2',
-        mentionedUserId: '3',
-      },
-    };
-
-    const result = await invokeNotificationWorker(
-      worker,
-      payload as unknown as Record<string, unknown>,
-    );
-
-    expect(result).toBeUndefined();
-  });
-
-  it('should send notification to mentioned user', async () => {
-    const payload: Data = {
-      commentMention: {
-        commentId: 'c3',
-        commentByUserId: '2',
-        mentionedUserId: '3',
-      },
-    };
-
-    const result = await invokeNotificationWorker(
-      worker,
-      payload as unknown as Record<string, unknown>,
-    );
-
-    expect(result?.length).toEqual(1);
-    expect(result?.[0].ctx.userIds).toEqual(['3']);
-    expect(result?.[0].type).toEqual(NotificationType.CommentMention);
   });
 });

--- a/src/workers/notifications/commentReply.ts
+++ b/src/workers/notifications/commentReply.ts
@@ -7,6 +7,7 @@ import {
 import { NotificationCommenterContext } from '../../notifications';
 import {
   commentReplyNotificationTypes,
+  NotificationPreferenceStatus,
   NotificationType,
 } from '../../notifications/common';
 import { NotificationWorker } from './worker';
@@ -27,10 +28,7 @@ const worker: NotificationWorker = {
       where: { id: data.childCommentId },
       relations: ['parent', 'user'],
     });
-    if (!comment) {
-      return;
-    }
-    if (comment.flags?.vordr) {
+    if (!comment || comment.flags?.vordr) {
       return;
     }
     const postCtx = await buildPostContext(con, comment.postId);
@@ -47,6 +45,7 @@ const worker: NotificationWorker = {
       .findBy({
         referenceId: In([comment.id, parent.id]),
         notificationType: In(commentReplyNotificationTypes),
+        status: NotificationPreferenceStatus.Muted,
       });
 
     const ctx: Omit<NotificationCommenterContext, 'userIds'> = {


### PR DESCRIPTION
Send notifications to mentioned users even if they are part of the thread since we send a reply notification only to the parent commenter. We also respect mute settings now

MI-604 #done