### PR TITLE
fix: add updatedAt for enabling query last assigned list effectively

### DIFF
--- a/__tests__/bookmarks.ts
+++ b/__tests__/bookmarks.ts
@@ -148,6 +148,46 @@ describe('mutation addBookmarks', () => {
     expect(actual?.listId).toEqual(listId);
   });
 
+  it('should add new bookmarks to the last updated bookmark list', async () => {
+    loggedUser = '1';
+    const list1 = await con.getRepository(BookmarkList).save({
+      userId: loggedUser,
+      name: 'list1',
+    });
+    const list2 = await con.getRepository(BookmarkList).save({
+      userId: loggedUser,
+      name: 'list2',
+    });
+    await con.getRepository(Bookmark).save([
+      {
+        userId: loggedUser,
+        postId: 'p1',
+        listId: list1.id,
+        createdAt: new Date(now.getTime() - 1000),
+        updatedAt: new Date(now.getTime() - 300),
+      },
+      {
+        userId: loggedUser,
+        postId: 'p2',
+        listId: list2.id,
+        createdAt: new Date(now.getTime() - 500),
+        updatedAt: new Date(now.getTime() - 500),
+      },
+    ]);
+
+    const res = await client.mutate(MUTATION, {
+      variables: { data: { postIds: ['p3'] } },
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.addBookmarks).toHaveLength(1);
+    expect(res.data.addBookmarks[0].list.id).toEqual(list1.id);
+
+    const actual = await con
+      .getRepository(Bookmark)
+      .findOneBy({ postId: 'p3', userId: loggedUser });
+    expect(actual?.listId).toEqual(list1.id);
+  });
+
   it('should ignore conflicts', async () => {
     loggedUser = '1';
     const repo = con.getRepository(Bookmark);

--- a/src/entity/Bookmark.ts
+++ b/src/entity/Bookmark.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import type { BookmarkList } from './BookmarkList';
 import type { Post } from './posts';
 import type { User } from './user';
@@ -34,6 +41,10 @@ export class Bookmark {
   @Column({ default: () => 'now()' })
   @Index('IDX_bookmark_createdAt', { synchronize: false })
   createdAt: Date;
+
+  @UpdateDateColumn()
+  @Index('IDX_bookmark_updatedAt', { synchronize: false })
+  updatedAt: Date;
 
   @ManyToOne('User', {
     lazy: true,

--- a/src/migration/1733932616522-BookmarkUpdatedAt.ts
+++ b/src/migration/1733932616522-BookmarkUpdatedAt.ts
@@ -5,12 +5,11 @@ export class BookmarkUpdatedAt1733932616522 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "bookmark" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
-        await queryRunner.query(`CREATE INDEX "IDX_bookmark_updatedAt" ON "bookmark" ("updatedAt") `);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_bookmark_updatedAt" ON "bookmark" ("updatedAt") `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "bookmark" DROP COLUMN "updatedAt"`);
-        await queryRunner.query(`DROP INDEX IF EXIST "IDX_bookmark_updatedAt"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bookmark_updatedAt"`);
     }
-
 }

--- a/src/migration/1733932616522-BookmarkUpdatedAt.ts
+++ b/src/migration/1733932616522-BookmarkUpdatedAt.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BookmarkUpdatedAt1733932616522 implements MigrationInterface {
+    name = 'BookmarkUpdatedAt1733932616522'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "bookmark" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`CREATE INDEX "IDX_bookmark_updatedAt" ON "bookmark" ("updatedAt") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "bookmark" DROP COLUMN "updatedAt"`);
+        await queryRunner.query(`DROP INDEX IF EXIST "IDX_bookmark_updatedAt"`);
+    }
+
+}

--- a/src/migration/1733932616522-BookmarkUpdatedAt.ts
+++ b/src/migration/1733932616522-BookmarkUpdatedAt.ts
@@ -5,7 +5,7 @@ export class BookmarkUpdatedAt1733932616522 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "bookmark" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
-        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_bookmark_updatedAt" ON "bookmark" ("updatedAt") DESC`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_bookmark_updatedAt" ON "bookmark" ("updatedAt" DESC) `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -343,7 +343,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     ): Promise<GQLBookmark[]> => {
       const lastAddedBookmark = await ctx.con.getRepository(Bookmark).findOne({
         where: { userId: ctx.userId },
-        order: { updatedAt: 'DESC', createdAt: 'DESC' },
+        order: { updatedAt: 'DESC' },
         select: ['listId'],
       });
       const lastUsedListId = lastAddedBookmark?.listId ?? null;

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -343,6 +343,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     ): Promise<GQLBookmark[]> => {
       const lastAddedBookmark = await ctx.con.getRepository(Bookmark).findOne({
         where: { userId: ctx.userId },
+        order: { updatedAt: 'DESC', createdAt: 'DESC' },
         select: ['listId'],
       });
       const lastUsedListId = lastAddedBookmark?.listId ?? null;


### PR DESCRIPTION
I found an edge case when you move a bookmark that isn't the last one saved. 
Adding a `updatedAt` column allows us to keep track of list changes and retrieve the very last used folder.