### PR TITLE
feat: add custom feed for new plus members

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -29,7 +29,11 @@ export const workers: Worker[] = [
   },
   {
     topic: 'user-updated',
-    subscription: 'api.user-updated-plus-subscribed',
+    subscription: 'api.user-updated-plus-subscribed-squad',
+  },
+  {
+    topic: 'user-updated',
+    subscription: 'api.user-updated-plus-subscribed-custom-feed',
   },
   {
     topic: 'user-deleted',

--- a/__tests__/workers/userUpdatedPlusSubscriptionSquad.ts
+++ b/__tests__/workers/userUpdatedPlusSubscriptionSquad.ts
@@ -1,0 +1,169 @@
+import nock from 'nock';
+import worker from '../../src/workers/userUpdatedPlusSubscriptionSquad';
+import { ChangeObject } from '../../src/types';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
+import { User, Source, Feed } from '../../src/entity';
+import { ghostUser, PubSubSchema } from '../../src/common';
+import { typedWorkers } from '../../src/workers';
+import createOrGetConnection from '../../src/db';
+import { DataSource } from 'typeorm';
+import { usersFixture } from '../fixture/user';
+import { SourceMemberRoles } from '../../src/roles';
+import { randomUUID } from 'crypto';
+
+const PLUS_MEMBER_SQUAD_ID = '05862288-bace-4723-9218-d30fab6ae96d';
+
+jest.mock('../../src/common', () => ({
+  ...jest.requireActual('../../src/common'),
+  getShortGenericInviteLink: jest.fn(),
+  resubscribeUser: jest.fn(),
+}));
+
+jest.mock('../../src/cio', () => ({
+  ...(jest.requireActual('../../src/cio') as Record<string, unknown>),
+  cio: { identify: jest.fn() },
+}));
+
+beforeEach(async () => {
+  await con.getRepository(Source).save({
+    id: PLUS_MEMBER_SQUAD_ID,
+    type: 'squad',
+    name: 'plus',
+    handle: 'plus',
+  });
+  await saveFixtures(con, User, usersFixture);
+  await con.getRepository(Feed).save({
+    id: '1',
+    userId: '1',
+  });
+  jest.clearAllMocks();
+  nock.cleanAll();
+});
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+describe('userUpdatedPlusSubscriptionSquad', () => {
+  type ObjectType = Partial<User>;
+  const base: ChangeObject<ObjectType> = {
+    id: '1',
+    username: 'cio',
+    name: 'Customer IO',
+    infoConfirmed: true,
+    createdAt: 1714577744717000,
+    updatedAt: 1714577744717000,
+    bio: 'bio',
+    readme: 'readme',
+    notificationEmail: true,
+    acceptedMarketing: true,
+    followingEmail: true,
+    subscriptionFlags: JSON.stringify({}),
+  };
+
+  it('should be registered', () => {
+    const registeredWorker = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+
+    expect(registeredWorker).toBeDefined();
+  });
+
+  it('should add user to squad', async () => {
+    const newBase = {
+      ...base,
+      subscriptionFlags: JSON.stringify({ subscriptionId: '1234' }),
+    };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: newBase,
+      user: base,
+    } as unknown as PubSubSchema['user-updated']);
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: newBase.id,
+    });
+    expect(sourceMember.role).toEqual(SourceMemberRoles.Member);
+    expect(sourceMember.sourceId).toEqual(PLUS_MEMBER_SQUAD_ID);
+    expect(sourceMember.userId).toEqual(newBase.id);
+  });
+
+  it('should not add user if user is ghost user', async () => {
+    const before: ChangeObject<ObjectType> = { ...base, id: ghostUser.id };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: before,
+      user: before,
+    } as unknown as PubSubSchema['user-updated']);
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+    });
+    expect(sourceMember).toEqual(null);
+  });
+
+  it('should not add user if user is not confirmed', async () => {
+    const before: ChangeObject<ObjectType> = { ...base, infoConfirmed: false };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: before,
+      user: before,
+    } as unknown as PubSubSchema['user-updated']);
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+    });
+    expect(sourceMember).toEqual(null);
+  });
+
+  it('should not add user if flags empty', async () => {
+    const before: ChangeObject<ObjectType> = { ...base, flags: '{}' };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: before,
+      user: before,
+    } as unknown as PubSubSchema['user-updated']);
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+    });
+    expect(sourceMember).toEqual(null);
+  });
+
+  it('should not add user if flags the same', async () => {
+    const before: ChangeObject<ObjectType> = {
+      ...base,
+      flags: '{subscriptionId: "1234"}',
+    };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: before,
+      user: before,
+    } as unknown as PubSubSchema['user-updated']);
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+    });
+    expect(sourceMember).toEqual(null);
+  });
+
+  it('should remove user from squad', async () => {
+    await con.getRepository('SourceMember').save({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+      role: SourceMemberRoles.Member,
+      referralToken: new randomUUID(),
+    });
+    const oldBase = {
+      ...base,
+      subscriptionFlags: JSON.stringify({ subscriptionId: '1234' }),
+    };
+    await expectSuccessfulTypedBackground(worker, {
+      newProfile: base,
+      user: oldBase,
+    } as unknown as PubSubSchema['user-updated']);
+
+    const sourceMember = await con.getRepository('SourceMember').findOneBy({
+      sourceId: PLUS_MEMBER_SQUAD_ID,
+      userId: base.id,
+    });
+    expect(sourceMember).toEqual(null);
+  });
+});

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -11,6 +11,7 @@ type RemoteConfigValue = {
   pricingIds: Record<string, SubscriptionCycles>;
   origins: string[];
   clickbaitTitleProbabilityThreshold: number;
+  plusCustomFeed: boolean;
 };
 
 class RemoteConfig {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -53,7 +53,8 @@ import { vordrPostCommentPrevented } from './vordrPostCommentPrevented';
 import { vordrPostPrevented } from './vordrPostPrevented';
 import { postAddedSlackChannelSendWorker } from './postAddedSlackChannelSend';
 import userCompanyApprovedCio from './userCompanyApprovedCio';
-import userUpdatedPlusSubscription from './userUpdatedPlusSubscription';
+import userUpdatedPlusSubscriptionSquad from './userUpdatedPlusSubscriptionSquad';
+import userUpdatedPlusSubscriptionCustomFeed from './userUpdatedPlusSubscriptionCustomFeed';
 
 export { Worker } from './worker';
 
@@ -110,7 +111,8 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   vordrPostPrevented,
   postAddedSlackChannelSendWorker,
   userCompanyApprovedCio,
-  userUpdatedPlusSubscription,
+  userUpdatedPlusSubscriptionSquad,
+  userUpdatedPlusSubscriptionCustomFeed,
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/src/workers/userUpdatedPlusSubscriptionCustomFeed.ts
+++ b/src/workers/userUpdatedPlusSubscriptionCustomFeed.ts
@@ -1,0 +1,64 @@
+import { ghostUser, isTest } from '../common';
+import { TypedWorker } from './worker';
+import { Feed, User } from '../entity';
+import { queryReadReplica } from '../common/queryReadReplica';
+import { remoteConfig } from '../remoteConfig';
+
+const worker: TypedWorker<'user-updated'> = {
+  subscription: 'api.user-updated-plus-subscribed-custom-feed',
+  handler: async (message, con, log) => {
+    if (!remoteConfig.vars.plusCustomFeed && !isTest) {
+      return;
+    }
+
+    const {
+      data: { newProfile: user, user: oldUser },
+    } = message;
+
+    const beforeFlags = JSON.parse(
+      (oldUser.subscriptionFlags as string) || '{}',
+    ) as User['subscriptionFlags'];
+    const afterFlags = JSON.parse(
+      (user.subscriptionFlags as string) || '{}',
+    ) as User['subscriptionFlags'];
+
+    if (user.id === ghostUser.id || !user.infoConfirmed) {
+      return;
+    }
+
+    if (afterFlags?.subscriptionId === beforeFlags?.subscriptionId) {
+      return;
+    }
+
+    if (afterFlags?.subscriptionId === '' || !afterFlags?.subscriptionId) {
+      return;
+    }
+
+    // Started being plus member create custom feed
+    const cfid = `cf-${user.id}`;
+    const check = await queryReadReplica(con, ({ queryRunner }) => {
+      return queryRunner.manager.getRepository(Feed).findOne({
+        where: {
+          userId: user.id,
+          id: cfid,
+        },
+      });
+    });
+    if (check) {
+      log.info({ userId: user.id }, 'user already has this custom feed');
+      return;
+    }
+
+    await con.getRepository(Feed).save({
+      id: cfid,
+      userId: user.id,
+      flags: {
+        name: 'My new feed',
+        icon: '🤓',
+      },
+    });
+    log.info({ userId: user.id }, 'added custom feed for plus user');
+  },
+};
+
+export default worker;

--- a/src/workers/userUpdatedPlusSubscriptionSquad.ts
+++ b/src/workers/userUpdatedPlusSubscriptionSquad.ts
@@ -7,7 +7,7 @@ import { queryReadReplica } from '../common/queryReadReplica';
 
 const PLUS_MEMBER_SQUAD_ID = '05862288-bace-4723-9218-d30fab6ae96d';
 const worker: TypedWorker<'user-updated'> = {
-  subscription: 'api.user-updated-plus-subscribed',
+  subscription: 'api.user-updated-plus-subscribed-squad',
   handler: async (message, con, log) => {
     const {
       data: { newProfile: user, user: oldUser },


### PR DESCRIPTION
Automatic create custom feed for plus member.
It's behind remoteConfig so it doesn't work until we launch.

AS-834 #done 