### PR TITLE
feat: add new type column to Feed entity

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -3267,6 +3267,30 @@ describe('slug field', () => {
   });
 });
 
+describe('type field', () => {
+  it('should set the type to main when feed ID matches user ID', async () => {
+    await con.getRepository(Feed).save({
+      id: '1',
+      userId: '1',
+    });
+
+    const feed = await con.getRepository(Feed).findOneByOrFail({ id: '1' });
+    expect(feed.type).toEqual('main');
+  });
+
+  it('should set the type to custom when feed ID does not match user ID', async () => {
+    await con.getRepository(Feed).save({
+      id: 'something-else',
+      userId: '1',
+    });
+
+    const feed = await con
+      .getRepository(Feed)
+      .findOneByOrFail({ id: 'something-else' });
+    expect(feed.type).toEqual('custom');
+  });
+});
+
 describe('query feedList', () => {
   const QUERY = `{
     feedList {

--- a/src/entity/Feed.ts
+++ b/src/entity/Feed.ts
@@ -7,7 +7,10 @@ export type FeedFlags = Partial<{
 
 export type FeedFlagsPublic = Pick<FeedFlags, 'name'>;
 
-export type FeedType = 'main' | 'custom';
+export enum FeedType {
+  Main = 'main',
+  Custom = 'custom',
+}
 
 @Entity()
 @Index('IDX_feed_id_user_id', ['id', 'userId'], { unique: true })

--- a/src/entity/Feed.ts
+++ b/src/entity/Feed.ts
@@ -7,6 +7,8 @@ export type FeedFlags = Partial<{
 
 export type FeedFlagsPublic = Pick<FeedFlags, 'name'>;
 
+export type FeedType = 'main' | 'custom';
+
 @Entity()
 @Index('IDX_feed_id_user_id', ['id', 'userId'], { unique: true })
 export class Feed {
@@ -34,6 +36,17 @@ export class Feed {
   })
   @Index('IDX_feed_slug', { unique: true })
   slug: string;
+
+  @Column({
+    type: 'text',
+    update: false,
+    insert: false,
+    nullable: false,
+    unique: false,
+    generatedType: 'STORED',
+    asExpression: `CASE WHEN "id" = "userId" THEN 'main' ELSE 'custom' END`,
+  })
+  type: FeedType;
 
   @ManyToOne('User', {
     lazy: true,

--- a/src/migration/1734071060646-FeedTypeColumn.ts
+++ b/src/migration/1734071060646-FeedTypeColumn.ts
@@ -5,9 +5,11 @@ export class FeedTypeColumn1734071060646 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "feed" ADD "type" text GENERATED ALWAYS AS (CASE WHEN "id" = "userId" THEN 'main' ELSE 'custom' END) STORED NOT NULL`);
+    await queryRunner.query(`INSERT INTO "public"."typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES ($1, $2, $3, $4, $5, $6)`, ["api","public","feed","GENERATED_COLUMN","type","CASE WHEN \"id\" = \"userId\" THEN 'main' ELSE 'custom' END"]);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "public"."typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "database" = $3 AND "schema" = $4 AND "table" = $5`, ["GENERATED_COLUMN","type","api","public","feed"]);
     await queryRunner.query(`ALTER TABLE "feed" DROP COLUMN "type"`);
   }
 }

--- a/src/migration/1734071060646-FeedTypeColumn.ts
+++ b/src/migration/1734071060646-FeedTypeColumn.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FeedTypeColumn1734071060646 implements MigrationInterface {
+  name = 'FeedTypeColumn1734071060646'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "feed" ADD "type" text GENERATED ALWAYS AS (CASE WHEN "id" = "userId" THEN 'main' ELSE 'custom' END) STORED NOT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "feed" DROP COLUMN "type"`);
+  }
+}


### PR DESCRIPTION
Creates a new generated column `type` on `Feed` entity which is `main` when feed.id equals feed.userId, otherwise it is `custom`.

AS-837