### PR TITLE
fix: only count followers/following based on main feed type

### DIFF
--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -40,9 +40,11 @@ type FollowEntity = ({
 type UnFollowEntity = ({
   ctx,
   id,
+  feedId,
 }: {
   ctx: AuthContext;
   id: string;
+  feedId: string;
 }) => Promise<void>;
 
 type BlockEntity = ({
@@ -145,13 +147,13 @@ const followUser: FollowEntity = async ({ ctx, id, status, feedId }) => {
   });
 };
 
-const unfollowUser: UnFollowEntity = async ({ ctx, id }) => {
+const unfollowUser: UnFollowEntity = async ({ ctx, id, feedId }) => {
   await ctx.con.transaction(async (entityManager) => {
     const repository = entityManager.getRepository(ContentPreferenceUser);
 
     await repository.delete({
       userId: ctx.userId,
-      feedId: ctx.userId,
+      feedId,
       referenceId: id,
     });
 
@@ -189,30 +191,30 @@ const followKeyword: FollowEntity = async ({ ctx, id, status, feedId }) => {
   });
 };
 
-const unfollowKeyword: UnFollowEntity = async ({ ctx, id }) => {
+const unfollowKeyword: UnFollowEntity = async ({ ctx, id, feedId }) => {
   await ctx.con.transaction(async (entityManager) => {
     const repository = entityManager.getRepository(ContentPreferenceKeyword);
 
     await repository.delete({
       userId: ctx.userId,
-      feedId: ctx.userId,
+      feedId,
       referenceId: id,
     });
 
     // TODO follow phase 3 remove when backward compatibility is done
     await entityManager.getRepository(FeedTag).delete({
-      feedId: ctx.userId,
+      feedId,
       tag: id,
     });
   });
 };
 
-const unfollowWord: UnFollowEntity = async ({ ctx, id }) => {
+const unfollowWord: UnFollowEntity = async ({ ctx, id, feedId }) => {
   const repository = ctx.getRepository(ContentPreferenceWord);
 
   await repository.delete({
     userId: ctx.userId,
-    feedId: ctx.userId,
+    feedId,
     referenceId: id,
   });
 };
@@ -261,13 +263,13 @@ const followSource: FollowEntity = async ({ ctx, id, status, feedId }) => {
   });
 };
 
-const unfollowSource: UnFollowEntity = async ({ ctx, id }) => {
+const unfollowSource: UnFollowEntity = async ({ ctx, id, feedId }) => {
   await ctx.con.transaction(async (entityManager) => {
     const repository = entityManager.getRepository(ContentPreferenceSource);
 
     await repository.delete({
       userId: ctx.userId,
-      feedId: ctx.userId,
+      feedId,
       referenceId: id,
     });
 
@@ -281,7 +283,7 @@ const unfollowSource: UnFollowEntity = async ({ ctx, id }) => {
     });
 
     await entityManager.getRepository(FeedSource).delete({
-      feedId: ctx.userId,
+      feedId,
       sourceId: id,
     });
   });
@@ -452,20 +454,22 @@ export const unfollowEntity = ({
   ctx,
   id,
   entity,
+  feedId,
 }: {
   ctx: AuthContext;
   id: string;
   entity: ContentPreferenceType;
+  feedId: string;
 }): Promise<void> => {
   switch (entity) {
     case ContentPreferenceType.User:
-      return unfollowUser({ ctx, id });
+      return unfollowUser({ ctx, id, feedId });
     case ContentPreferenceType.Keyword:
-      return unfollowKeyword({ ctx, id });
+      return unfollowKeyword({ ctx, id, feedId });
     case ContentPreferenceType.Source:
-      return unfollowSource({ ctx, id });
+      return unfollowSource({ ctx, id, feedId });
     case ContentPreferenceType.Word:
-      return unfollowWord({ ctx, id });
+      return unfollowWord({ ctx, id, feedId });
     default:
       throw new Error('Entity not supported');
   }

--- a/src/common/contentPreference.ts
+++ b/src/common/contentPreference.ts
@@ -506,11 +506,13 @@ export const unblockEntity = async ({
   ctx,
   id,
   entity,
+  feedId,
 }: {
   ctx: AuthContext;
   id: string;
   entity: ContentPreferenceType;
+  feedId: string;
 }): Promise<void> => {
   // currently unblock is just like unfollow, eg. remove everything from db
-  return unfollowEntity({ ctx, id, entity });
+  return unfollowEntity({ ctx, id, entity, feedId });
 };

--- a/src/entity/Feed.ts
+++ b/src/entity/Feed.ts
@@ -7,6 +7,11 @@ export type FeedFlags = Partial<{
 
 export type FeedFlagsPublic = Pick<FeedFlags, 'name'>;
 
+export enum FeedType {
+  Main = 'main',
+  Custom = 'custom',
+}
+
 @Entity()
 @Index('IDX_feed_id_user_id', ['id', 'userId'], { unique: true })
 export class Feed {
@@ -34,6 +39,17 @@ export class Feed {
   })
   @Index('IDX_feed_slug', { unique: true })
   slug: string;
+
+  @Column({
+    type: 'text',
+    update: false,
+    insert: false,
+    nullable: false,
+    unique: false,
+    generatedType: 'STORED',
+    asExpression: `CASE WHEN "id" = "userId" THEN 'main' ELSE 'custom' END`,
+  })
+  type: FeedType;
 
   @ManyToOne('User', {
     lazy: true,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -30,6 +30,7 @@ import {
   Alerts,
   reputationReasonAmount,
   ConnectionManager,
+  FeedType,
 } from '../entity';
 import {
   AuthenticationError,
@@ -1323,6 +1324,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               ContentPreferenceStatus.Follow,
               ContentPreferenceStatus.Subscribed,
             ]),
+            feed: {
+              type: FeedType.Main,
+            },
           }),
           ctx.con.getRepository(ContentPreferenceUser).countBy({
             referenceId: id,
@@ -1330,6 +1334,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               ContentPreferenceStatus.Follow,
               ContentPreferenceStatus.Subscribed,
             ]),
+            feed: {
+              type: FeedType.Main,
+            },
           }),
         ]);
       return {


### PR DESCRIPTION
Fixes issue where the Following/ Followers stats also selects when I follow users in custom feeds, by checking where feed type is `main`.

This includes the changes from https://github.com/dailydotdev/daily-api/pull/2537, but will be rebased after that has been merged.