### PR TITLE
chore: upgrade debezium to v2.4.2.Final

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -436,7 +436,7 @@ const [apps] = deployApplicationSuite(
           ],
     },
     debezium: {
-      version: '2.2.1.Final',
+      version: '2.4.2.Final',
       topicName: debeziumTopicName,
       propsPath: './application.properties',
       propsVars: {

--- a/.infra/package-lock.json
+++ b/.infra/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "api",
       "dependencies": {
-        "@dailydotdev/pulumi-common": "^2.4.2",
+        "@dailydotdev/pulumi-common": "^2.4.3",
         "@pulumi/gcp": "^8.10.2",
         "@pulumi/kubernetes": "^4.19.0",
         "@pulumi/pulumi": "^3.143.0"
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@dailydotdev/pulumi-common": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-2.4.2.tgz",
-      "integrity": "sha512-RD6ATKuUcCYMQDUwoMdpO3KjIDx716QlTZjIhvE3h72LJz6JxiBUS2EE5lXClC9xcKjQi6tlazUol/gcuC/3xQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@dailydotdev/pulumi-common/-/pulumi-common-2.4.3.tgz",
+      "integrity": "sha512-ZQRHbQmhBCQGOzZQaiSVJZBhYNh4JKiikcdXg/I1cgEqlb0eBclNhMclHHGLT76lyusOe7tZHMCVLQiEG1LPyA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@google-cloud/pubsub": "^4.9.0",

--- a/.infra/package.json
+++ b/.infra/package.json
@@ -4,7 +4,7 @@
     "@types/node": "20.12.x"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "^2.4.2",
+    "@dailydotdev/pulumi-common": "^2.4.3",
     "@pulumi/gcp": "^8.10.2",
     "@pulumi/kubernetes": "^4.19.0",
     "@pulumi/pulumi": "^3.143.0"


### PR DESCRIPTION
This aligns us up with Debezium in Mimir.
Also now pulls debezium image from quay.io