### PR TITLE
fix: approved edit notification not being sent

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -63,6 +63,7 @@ import {
   SourcePostModeration,
   SourcePostModerationStatus,
 } from '../../src/entity/SourcePostModeration';
+import { randomUUID } from 'crypto';
 
 const userId = '1';
 const commentFixture: Reference<Comment> = {
@@ -1370,9 +1371,17 @@ describe('storeNotificationBundle', () => {
     await con.getRepository(Post).save(postsFixture);
     await con.getRepository(User).save(fixtures);
     const type = NotificationType.SourcePostApproved;
+    const id = randomUUID();
     const ctx: NotificationPostContext = {
       post: postsFixture[0] as Reference<Post>,
       userIds: ['2'],
+      moderated: {
+        id,
+        postId: 'p1',
+        sourceId: 'a',
+        createdById: '2',
+        status: SourcePostModerationStatus.Approved,
+      } as Reference<SourcePostModeration>,
       source: {
         ...sourcesFixture[0],
         type: SourceType.Squad,
@@ -1380,6 +1389,7 @@ describe('storeNotificationBundle', () => {
     };
     const actual = generateNotificationV2(type, ctx);
 
+    expect(actual.notification.uniqueKey).toEqual(id);
     expect(actual.notification.type).toEqual(type);
     expect(actual.userIds).toEqual(['2']);
     expect(actual.notification.public).toEqual(true);

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -165,7 +165,8 @@ export const generateNotificationMap: Record<
   source_post_approved: (builder, ctx: NotificationPostContext) =>
     builder
       .icon(NotificationIcon.Bell)
-      .objectPost(ctx.post, ctx.source, ctx.sharedPost),
+      .objectPost(ctx.post, ctx.source, ctx.sharedPost)
+      .uniqueKey(ctx.moderated?.id ?? ctx.post.id),
   source_post_rejected: (builder, ctx: NotificationPostModerationContext) =>
     builder
       .icon(NotificationIcon.Bell)

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -48,6 +48,7 @@ export type NotificationPostContext<T extends Post = Post> =
     NotificationSourceContext & {
       post: Reference<T>;
       sharedPost?: Reference<Post> | null;
+      moderated?: Reference<SourcePostModeration>;
     };
 
 export type NotificationCommentContext = NotificationPostContext & {

--- a/src/workers/notifications/sourcePostModerationApprovedNotification.ts
+++ b/src/workers/notifications/sourcePostModerationApprovedNotification.ts
@@ -24,6 +24,7 @@ const worker =
       });
       const ctx: NotificationPostContext = {
         ...baseCtx!,
+        moderated: data,
         userIds: [data.createdById],
       };
 


### PR DESCRIPTION
When generating the approved notification, the reference is always the post, which means, the notification has already existed since it was approved the first time.

To set the uniqueness, we should set the key based on the moderation request id.