### PR TITLE
fix: not filtering by userId on bookmark save

### DIFF
--- a/__tests__/bookmarks.ts
+++ b/__tests__/bookmarks.ts
@@ -223,9 +223,7 @@ describe('mutation addBookmarks', () => {
         .findOneBy({ postId: 'p2', userId: loggedUser });
       expect(actual?.listId).toBeFalsy();
     });
-  });
 
-  describe('plus user', () => {
     it('should add new bookmarks to the last used list', async () => {
       loggedUser = '5';
       isPlus = true;
@@ -278,6 +276,13 @@ describe('mutation addBookmarks', () => {
           userId: loggedUser,
           postId: 'p2',
           listId: list2.id,
+          createdAt: new Date(now.getTime() - 500),
+          updatedAt: new Date(now.getTime() - 500),
+        },
+        {
+          userId: '2',
+          postId: 'p3',
+          listId: null,
           createdAt: new Date(now.getTime() - 500),
           updatedAt: new Date(now.getTime() - 500),
         },

--- a/src/schema/bookmarks.ts
+++ b/src/schema/bookmarks.ts
@@ -374,8 +374,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       return await graphorm.query<GQLBookmark>(ctx, info, (builder) => ({
         ...builder,
         queryBuilder: builder.queryBuilder.where(
-          `"${builder.alias}"."postId" IN (:...postIds)`,
-          { postIds: data.postIds },
+          `"${builder.alias}"."postId" IN (:...postIds) AND "${builder.alias}"."userId" = :userId`,
+          { postIds: data.postIds, userId: ctx.userId },
         ),
       }));
     },


### PR DESCRIPTION
Currently is not filtering by userId, so the toast will show the first bookmark result (maybe not from this user). 
This is only for the return query, not the update/logic applied before.