### PR TITLE
feat: add flags filters for feed config

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -62,7 +62,7 @@ import { usersFixture } from './fixture/user';
 import { base64 } from 'graphql-relay/utils/base64';
 import { maxFeedsPerUser, UserVote } from '../src/types';
 import { SubmissionFailErrorMessage } from '../src/errors';
-import { baseFeedConfig } from '../src/integrations/feed';
+import { baseFeedConfig, FeedConfigName } from '../src/integrations/feed';
 import {
   ContentPreferenceStatus,
   ContentPreferenceType,
@@ -4425,13 +4425,15 @@ describe('query customFeed', () => {
     loggedUser = '1';
 
     nock('http://localhost:6000')
-      .post('/popular', {
+      .post('/feed.json', {
         user_id: '1',
         page_size: 10,
         offset: 0,
         total_pages: 1,
         fresh_page_size: '4',
         allowed_tags: ['webdev', 'html', 'data'],
+        feed_config_name: FeedConfigName.CustomFeedV1,
+        disable_engagement_filter: false,
       })
       .reply(200, {
         data: [{ post_id: 'p1' }, { post_id: 'p4' }],

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -3177,15 +3177,7 @@ describe('function feedToFilters', () => {
     ]);
     const filters = await feedToFilters(con, 'cff1', '1');
 
-    const { order_by, disable_engagement_filter, min_day_range, thresholds } =
-      filters;
-
-    expect({
-      order_by,
-      disable_engagement_filter,
-      min_day_range,
-      thresholds,
-    }).toEqual({
+    expect(filters.flags).toEqual({
       order_by: FeedOrderBy.Downvotes,
       disable_engagement_filter: true,
       min_day_range: 7,
@@ -3211,15 +3203,8 @@ describe('function feedToFilters', () => {
       },
     ]);
     const filters = await feedToFilters(con, 'cff1', '1');
-    const { order_by, disable_engagement_filter, min_day_range, thresholds } =
-      filters;
 
-    expect({
-      order_by,
-      disable_engagement_filter,
-      min_day_range,
-      thresholds,
-    }).toEqual({
+    expect(filters.flags).toEqual({
       disable_engagement_filter: false,
     });
   });
@@ -3238,15 +3223,8 @@ describe('function feedToFilters', () => {
       },
     ]);
     const filters = await feedToFilters(con, 'cff1', '1');
-    const { order_by, disable_engagement_filter, min_day_range, thresholds } =
-      filters;
 
-    expect({
-      order_by,
-      disable_engagement_filter,
-      min_day_range,
-      thresholds,
-    }).toEqual({
+    expect(filters.flags).toEqual({
       disable_engagement_filter: false,
       thresholds: {
         min_thresholds: {

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -18,6 +18,7 @@ import {
   AdvancedSettings,
   Feed,
   FeedAdvancedSettings,
+  FeedOrderBy,
   Keyword,
   PostType,
   postTypes,
@@ -558,6 +559,45 @@ describe('FeedUserStateConfigGenerator', () => {
       user_id: '1',
       page_size: 2,
       offset: 3,
+    });
+  });
+
+  it('should generate config based on flags filters', async () => {
+    await con.getRepository(Feed).save({
+      id: 'cff1',
+      userId: '1',
+      flags: {
+        name: 'Custom feed',
+        orderBy: FeedOrderBy.Downvotes,
+        disableEngagementFilter: true,
+        minDayRange: 7,
+        minUpvotes: 10,
+        minViews: 1,
+      },
+    });
+    const mockClient = mock<ISnotraClient>();
+    mockClient.fetchUserState.mockResolvedValueOnce({
+      personalise: { state: 'personalised' },
+    });
+    const generator: FeedConfigGenerator = new FeedPreferencesConfigGenerator(
+      config,
+      {
+        feedId: 'cff1',
+      },
+    );
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+    });
+    expect(actual.config.disable_engagement_filter).toBeTruthy();
+    expect(actual.config.order_by).toEqual(FeedOrderBy.Downvotes);
+    expect(actual.config.min_day_range).toEqual(7);
+    expect(actual.config.thresholds).toEqual({
+      min_thresholds: {
+        upvotes: 10,
+        views: 1,
+      },
     });
   });
 });

--- a/src/common/feed.ts
+++ b/src/common/feed.ts
@@ -40,7 +40,7 @@ export const feedThresholdMax = 1000;
 export const validateFeedPayload = ({
   name,
   icon,
-  maxDayRange,
+  minDayRange,
   minUpvotes,
   minViews,
 }: Feed['flags']): never | undefined => {
@@ -61,7 +61,7 @@ export const validateFeedPayload = ({
   }
 
   if (
-    [maxDayRange, minUpvotes, minViews].some((item) => {
+    [minDayRange, minUpvotes, minViews].some((item) => {
       if (!item) {
         return false;
       }

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -317,17 +317,21 @@ const sourcesToFilters = ({
   };
 };
 
-const feedFlagsToFilters = ({ feeds }: RawFiltersData): FeedFlagsFilters => {
+const feedFlagsToFilters = ({
+  feeds,
+}: RawFiltersData): {
+  flags?: FeedFlagsFilters;
+} => {
   const feed = feeds?.[0];
   const flagFilters: FeedFlagsFilters = {};
 
   if (!feed) {
-    return flagFilters;
+    return {};
   }
 
   // we set flags only for custom feeds
   if (feed.type !== FeedType.Custom) {
-    return flagFilters;
+    return {};
   }
 
   if (feed.flags.orderBy) {
@@ -349,7 +353,9 @@ const feedFlagsToFilters = ({ feeds }: RawFiltersData): FeedFlagsFilters => {
     };
   }
 
-  return flagFilters;
+  return {
+    flags: flagFilters,
+  };
 };
 
 export const feedToFilters = async (
@@ -637,7 +643,7 @@ export function randomPostsResolver<
  * Feeds builders and resolvers
  */
 
-export type AnonymousFeedFilters = {
+export interface AnonymousFeedFilters {
   includeSources?: string[];
   excludeSources?: string[];
   excludeTypes?: string[];
@@ -649,7 +655,8 @@ export type AnonymousFeedFilters = {
   excludeSourceTypes?: string[];
   followingUsers?: string[];
   followingSources?: string[];
-} & FeedFlagsFilters;
+  flags?: FeedFlagsFilters;
+}
 
 export const anonymousFeedBuilder = (
   ctx: Context,

--- a/src/entity/Feed.ts
+++ b/src/entity/Feed.ts
@@ -11,7 +11,7 @@ export enum FeedOrderBy {
 export type FeedFlags = Partial<{
   name: string;
   orderBy: FeedOrderBy;
-  maxDayRange: number;
+  minDayRange: number;
   minUpvotes: number;
   minViews: number;
   disableEngagementFilter: boolean;
@@ -22,7 +22,7 @@ export type FeedFlagsPublic = Pick<
   FeedFlags,
   | 'name'
   | 'orderBy'
-  | 'maxDayRange'
+  | 'minDayRange'
   | 'minUpvotes'
   | 'minViews'
   | 'disableEngagementFilter'

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -80,7 +80,7 @@ const addFiltersToConfig = ({
   filters: AnonymousFeedFilters;
   opts: Options;
 }): FeedConfigGeneratorResult['config'] => {
-  const baseConfig = { ...config };
+  const baseConfig = { ...config, ...filters.flags };
 
   if (filters.includeTags?.length && opts.includeAllowedTags) {
     baseConfig.allowed_tags = filters.includeTags;

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -62,7 +62,7 @@ export type FeedConfig = {
   config?: {
     [key: string]: unknown;
   };
-};
+} & FeedFlagsFilters;
 
 export type DynamicConfig = Omit<FeedConfig, 'total_pages'>;
 

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -1,4 +1,5 @@
 import { Context } from '../../Context';
+import type { FeedFlags } from '../../entity';
 import { GenericMetadata } from '../lofn';
 
 export type FeedResponse = {
@@ -107,4 +108,16 @@ export type FeedVersion =
 export const baseFeedConfig: Partial<FeedConfig> = {
   source_types: ['machine', 'squad'],
   allowed_languages: ['en'],
+};
+
+export type FeedFlagsFilters = {
+  order_by?: FeedFlags['orderBy'];
+  disable_engagement_filter?: FeedFlags['disableEngagementFilter'];
+  thresholds?: {
+    min_thresholds: {
+      upvotes?: FeedFlags['minUpvotes'];
+      views?: FeedFlags['minViews'];
+    };
+  };
+  min_day_range?: FeedFlags['minDayRange'];
 };

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -15,6 +15,7 @@ export enum FeedConfigName {
   VectorV26 = 'vector_v26',
   VectorV27 = 'vector_v27',
   PostSimilarity = 'post_similarity',
+  CustomFeedV1 = 'custom_feed_v1',
 }
 
 export type FeedProvider = {

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1498,9 +1498,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         ctx.userId
       ) {
         const feedGenerator = new FeedGenerator(
-          popularFeedClient,
+          feedClient,
           new FeedPreferencesConfigGenerator(
-            {},
+            {
+              feed_config_name: FeedConfigName.CustomFeedV1,
+            },
             {
               includeAllowedTags: true,
               includePostTypes: true,
@@ -1511,7 +1513,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
               feedId: feedId,
             },
           ),
-          'popular',
         );
 
         return feedResolverCursor(

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -233,7 +233,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Minimum day range
     """
-    maxDayRange: Int
+    minDayRange: Int
 
     """
     Minimum upvotes
@@ -930,7 +930,7 @@ export const typeDefs = /* GraphQL */ `
       """
       Minimum day range
       """
-      maxDayRange: Int
+      minDayRange: Int
 
       """
       Minimum upvotes
@@ -975,7 +975,7 @@ export const typeDefs = /* GraphQL */ `
       """
       Minimum day range
       """
-      maxDayRange: Int
+      minDayRange: Int
 
       """
       Minimum upvotes


### PR DESCRIPTION
- apply new flags to filters
- send new filters in config generator
- move customFeed query to feed endpoint and custom feed config name (confirmed name with Vas)
- currently not moving to RR because I don't have time to test if any edge cases, will log