### PR TITLE
feat: rate limiting based on reputation

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -943,17 +943,17 @@ describe('mutation commentOnPost', () => {
       expect(await getRedisObject(redisKey)).toEqual('1');
     });
 
-    it('should rate limit creating posts to 10 per hour', async () => {
+    it('should rate limit commenting to 100 per hour', async () => {
       loggedUser = '1';
 
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < 100; i++) {
         const res = await client.mutate(MUTATION, {
           variables,
         });
 
         expect(res.errors).toBeFalsy();
       }
-      expect(await getRedisObject(redisKey)).toEqual('20');
+      expect(await getRedisObject(redisKey)).toEqual('100');
 
       await testMutationErrorCode(
         client,
@@ -1189,17 +1189,17 @@ describe('mutation commentOnComment', () => {
       expect(await getRedisObject(redisKey)).toEqual('1');
     });
 
-    it('should rate limit creating posts to 10 per hour', async () => {
+    it('should rate limit commenting to 100 per hour', async () => {
       loggedUser = '1';
 
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < 100; i++) {
         const res = await client.mutate(MUTATION, {
           variables,
         });
 
         expect(res.errors).toBeFalsy();
       }
-      expect(await getRedisObject(redisKey)).toEqual('20');
+      expect(await getRedisObject(redisKey)).toEqual('100');
 
       await testMutationErrorCode(
         client,

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -21,6 +21,7 @@ jest.mock('../src/remoteConfig', () => ({
       vordrWords: ['vordrwillcatchyou', 'andvordrwillhavefun'],
       vordrIps: ['192.0.2.0/24', '198.51.100.0/24', '203.0.113.0/24'],
       ignoredWorkEmailDomains: ['igored.com', 'ignored.org'],
+      rateLimitReputationThreshold: 10,
     } as typeof remoteConfig.vars,
   },
 }));

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -21,7 +21,7 @@ jest.mock('../src/remoteConfig', () => ({
       vordrWords: ['vordrwillcatchyou', 'andvordrwillhavefun'],
       vordrIps: ['192.0.2.0/24', '198.51.100.0/24', '203.0.113.0/24'],
       ignoredWorkEmailDomains: ['igored.com', 'ignored.org'],
-      rateLimitReputationThreshold: 10,
+      rateLimitReputationThreshold: 1,
     } as typeof remoteConfig.vars,
   },
 }));

--- a/src/common/rateLimit.ts
+++ b/src/common/rateLimit.ts
@@ -1,0 +1,85 @@
+import { DataSource, EntityManager, MoreThan } from 'typeorm';
+import { Comment, Post, User } from '../entity';
+import { remoteConfig } from '../remoteConfig';
+import { subDays } from 'date-fns';
+import { GraphQLError } from 'graphql/index';
+
+export class RateLimitError extends GraphQLError {
+  extensions = {};
+  message = '';
+
+  constructor({
+    msBeforeNextReset = 0,
+    message,
+  }: {
+    msBeforeNextReset?: number;
+    message?: string;
+  }) {
+    const seconds = (msBeforeNextReset / 1000).toFixed(0);
+    message = message ?? `Too many requests, please try again in ${seconds}s`;
+    super(message);
+
+    this.message = message;
+    this.extensions = { code: 'RATE_LIMITED' };
+  }
+}
+
+const ensureReputationBasedRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+  count: Promise<number>,
+  countThreshold: number,
+  errorMessage: string,
+): Promise<void> => {
+  const [user, countValue] = await Promise.all([
+    con
+      .getRepository(User)
+      .findOneOrFail({ select: ['id', 'reputation'], where: { id: userId } }),
+    count,
+  ]);
+
+  if (
+    remoteConfig.vars?.rateLimitReputationThreshold &&
+    user.reputation > remoteConfig.vars.rateLimitReputationThreshold
+  ) {
+    return;
+  }
+
+  if (countValue >= countThreshold) {
+    throw new RateLimitError({
+      message: errorMessage,
+    });
+  }
+};
+
+export const ensurePostRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+): Promise<void> => {
+  return ensureReputationBasedRateLimit(
+    con,
+    userId,
+    con.getRepository(Post).countBy({
+      authorId: userId,
+      createdAt: MoreThan(subDays(new Date(), 1)),
+    }),
+    remoteConfig.vars?.postRateLimit ?? 0,
+    `Take a break. You already posted enough`,
+  );
+};
+
+export const ensureCommentRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+): Promise<void> => {
+  return ensureReputationBasedRateLimit(
+    con,
+    userId,
+    con.getRepository(Comment).countBy({
+      userId: userId,
+      createdAt: MoreThan(subDays(new Date(), 1)),
+    }),
+    remoteConfig.vars?.commentRateLimit ?? 0,
+    `Take a break. You already commented enough`,
+  );
+};

--- a/src/directive/rateLimit.ts
+++ b/src/directive/rateLimit.ts
@@ -213,7 +213,7 @@ export const ensureCommentRateLimit = async (
       userId: userId,
       createdAt: MoreThan(subDays(new Date(), 1)),
     }),
-    remoteConfig.vars?.postRateLimit ?? 0,
+    remoteConfig.vars?.commentRateLimit ?? 0,
     `Take a break. You already commented enough`,
   );
 };

--- a/src/directive/rateLimit.ts
+++ b/src/directive/rateLimit.ts
@@ -9,16 +9,13 @@ import {
   IRateLimiterRedisOptions,
   RateLimiterRedis,
 } from 'rate-limiter-flexible';
-import { GraphQLError, GraphQLSchema } from 'graphql';
+import { GraphQLSchema } from 'graphql';
 import { singleRedisClient } from '../redis';
 import { Context } from '../Context';
 import { logger } from '../logger';
 import { WATERCOOLER_ID } from '../common';
 import { counters } from '../telemetry';
-import { DataSource, EntityManager, MoreThan } from 'typeorm';
-import { Comment, Post, User } from '../entity';
-import { subDays } from 'date-fns';
-import { remoteConfig } from '../remoteConfig';
+import { RateLimitError } from '../common/rateLimit';
 
 export const highRateLimitedSquads = [WATERCOOLER_ID];
 
@@ -67,26 +64,6 @@ const keyGenerator: RateLimitKeyGenerator<Context> = (
     }
   }
 };
-
-class RateLimitError extends GraphQLError {
-  extensions = {};
-  message = '';
-
-  constructor({
-    msBeforeNextReset = 0,
-    message,
-  }: {
-    msBeforeNextReset?: number;
-    message?: string;
-  }) {
-    const seconds = (msBeforeNextReset / 1000).toFixed(0);
-    message = message ?? `Too many requests, please try again in ${seconds}s`;
-    super(message);
-
-    this.message = message;
-    this.extensions = { code: 'RATE_LIMITED' };
-  }
-}
 
 export const onLimit: RateLimitOnLimit<Context> = (
   resource,
@@ -157,63 +134,3 @@ export const rateLimitTypeDefs = [
   rateLimitDirectiveTypeDefs,
   highRateLimitTypeDefs,
 ];
-
-const ensureReputationBasedRateLimit = async (
-  con: DataSource | EntityManager,
-  userId: string,
-  count: Promise<number>,
-  countThreshold: number,
-  errorMessage: string,
-): Promise<void> => {
-  const [user, countValue] = await Promise.all([
-    con
-      .getRepository(User)
-      .findOneOrFail({ select: ['id', 'reputation'], where: { id: userId } }),
-    count,
-  ]);
-
-  if (
-    remoteConfig.vars?.rateLimitReputationThreshold &&
-    user.reputation > remoteConfig.vars.rateLimitReputationThreshold
-  ) {
-    return;
-  }
-
-  if (countValue >= countThreshold) {
-    throw new RateLimitError({
-      message: errorMessage,
-    });
-  }
-};
-
-export const ensurePostRateLimit = async (
-  con: DataSource | EntityManager,
-  userId: string,
-): Promise<void> => {
-  return ensureReputationBasedRateLimit(
-    con,
-    userId,
-    con.getRepository(Post).countBy({
-      authorId: userId,
-      createdAt: MoreThan(subDays(new Date(), 1)),
-    }),
-    remoteConfig.vars?.postRateLimit ?? 0,
-    `Take a break. You already posted enough`,
-  );
-};
-
-export const ensureCommentRateLimit = async (
-  con: DataSource | EntityManager,
-  userId: string,
-): Promise<void> => {
-  return ensureReputationBasedRateLimit(
-    con,
-    userId,
-    con.getRepository(Comment).countBy({
-      userId: userId,
-      createdAt: MoreThan(subDays(new Date(), 1)),
-    }),
-    remoteConfig.vars?.commentRateLimit ?? 0,
-    `Take a break. You already commented enough`,
-  );
-};

--- a/src/directive/rateLimit.ts
+++ b/src/directive/rateLimit.ts
@@ -15,6 +15,10 @@ import { Context } from '../Context';
 import { logger } from '../logger';
 import { WATERCOOLER_ID } from '../common';
 import { counters } from '../telemetry';
+import { DataSource, EntityManager, MoreThan } from 'typeorm';
+import { Comment, Post, User } from '../entity';
+import { subDays } from 'date-fns';
+import { remoteConfig } from '../remoteConfig';
 
 export const highRateLimitedSquads = [WATERCOOLER_ID];
 
@@ -153,3 +157,63 @@ export const rateLimitTypeDefs = [
   rateLimitDirectiveTypeDefs,
   highRateLimitTypeDefs,
 ];
+
+const ensureReputationBasedRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+  count: Promise<number>,
+  countThreshold: number,
+  errorMessage: string,
+): Promise<void> => {
+  const [user, countValue] = await Promise.all([
+    con
+      .getRepository(User)
+      .findOneOrFail({ select: ['id', 'reputation'], where: { id: userId } }),
+    count,
+  ]);
+
+  if (
+    remoteConfig.vars?.rateLimitReputationThreshold &&
+    user.reputation > remoteConfig.vars.rateLimitReputationThreshold
+  ) {
+    return;
+  }
+
+  if (countValue >= countThreshold) {
+    throw new RateLimitError({
+      message: errorMessage,
+    });
+  }
+};
+
+export const ensurePostRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+): Promise<void> => {
+  return ensureReputationBasedRateLimit(
+    con,
+    userId,
+    con.getRepository(Post).countBy({
+      authorId: userId,
+      createdAt: MoreThan(subDays(new Date(), 1)),
+    }),
+    remoteConfig.vars?.postRateLimit ?? 0,
+    `Take a break. You already posted enough`,
+  );
+};
+
+export const ensureCommentRateLimit = async (
+  con: DataSource | EntityManager,
+  userId: string,
+): Promise<void> => {
+  return ensureReputationBasedRateLimit(
+    con,
+    userId,
+    con.getRepository(Comment).countBy({
+      userId: userId,
+      createdAt: MoreThan(subDays(new Date(), 1)),
+    }),
+    remoteConfig.vars?.postRateLimit ?? 0,
+    `Take a break. You already commented enough`,
+  );
+};

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -43,9 +43,7 @@ class RemoteConfig {
 
   get vars(): Partial<RemoteConfigValue> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
-      return {
-        rateLimitReputationThreshold: 10,
-      };
+      return {};
     }
 
     if (!this.gb) {

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -14,6 +14,7 @@ type RemoteConfigValue = {
   plusCustomFeed: boolean;
   rateLimitReputationThreshold: number;
   postRateLimit: number;
+  commentRateLimit: number;
 };
 
 class RemoteConfig {

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -12,6 +12,8 @@ type RemoteConfigValue = {
   origins: string[];
   clickbaitTitleProbabilityThreshold: number;
   plusCustomFeed: boolean;
+  rateLimitReputationThreshold: number;
+  postRateLimit: number;
 };
 
 class RemoteConfig {
@@ -40,7 +42,9 @@ class RemoteConfig {
 
   get vars(): Partial<RemoteConfigValue> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
-      return {};
+      return {
+        rateLimitReputationThreshold: 10,
+      };
     }
 
     if (!this.gb) {

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -52,6 +52,7 @@ import {
 import { reportComment } from '../common/reporting';
 import { ReportReason } from '../entity/common';
 import { toGQLEnum } from '../common/utils';
+import { ensureCommentRateLimit } from '../directive/rateLimit';
 
 export interface GQLComment {
   id: string;
@@ -363,7 +364,7 @@ export const typeDefs = /* GraphQL */ `
       Content of the comment
       """
       content: String!
-    ): Comment @auth @rateLimit(limit: 20, duration: 3600)
+    ): Comment @auth @rateLimit(limit: 100, duration: 3600)
 
     """
     Comment on a comment
@@ -377,7 +378,7 @@ export const typeDefs = /* GraphQL */ `
       Content of the comment
       """
       content: String!
-    ): Comment @auth @rateLimit(limit: 20, duration: 3600)
+    ): Comment @auth @rateLimit(limit: 100, duration: 3600)
 
     """
     Edit comment
@@ -795,6 +796,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLComment> => {
       validateComment(ctx, content);
+      await ensureCommentRateLimit(ctx.con, ctx.userId);
 
       try {
         const post = await ctx.con
@@ -843,6 +845,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLComment> => {
       validateComment(ctx, content);
+      await ensureCommentRateLimit(ctx.con, ctx.userId);
 
       try {
         const comment = await ctx.con.transaction(async (entityManager) => {

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -52,7 +52,7 @@ import {
 import { reportComment } from '../common/reporting';
 import { ReportReason } from '../entity/common';
 import { toGQLEnum } from '../common/utils';
-import { ensureCommentRateLimit } from '../directive/rateLimit';
+import { ensureCommentRateLimit } from '../common/rateLimit';
 
 export interface GQLComment {
   id: string;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -110,7 +110,7 @@ import { logger } from '../logger';
 import { Source } from '@dailydotdev/schema';
 import { queryReadReplica } from '../common/queryReadReplica';
 import { remoteConfig } from '../remoteConfig';
-import { ensurePostRateLimit } from '../directive/rateLimit';
+import { ensurePostRateLimit } from '../common/rateLimit';
 
 export interface GQLSourcePostModeration {
   id: string;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -110,6 +110,7 @@ import { logger } from '../logger';
 import { Source } from '@dailydotdev/schema';
 import { queryReadReplica } from '../common/queryReadReplica';
 import { remoteConfig } from '../remoteConfig';
+import { ensurePostRateLimit } from '../directive/rateLimit';
 
 export interface GQLSourcePostModeration {
   id: string;
@@ -1027,10 +1028,7 @@ export const typeDefs = /* GraphQL */ `
       Content of the post
       """
       content: String
-    ): Post!
-      @auth
-      @rateLimit(limit: 10, duration: 3600)
-      @highRateLimit(limit: 1, duration: 600)
+    ): Post! @auth @highRateLimit(limit: 1, duration: 60)
 
     """
     To allow user to edit posts
@@ -1173,10 +1171,7 @@ export const typeDefs = /* GraphQL */ `
       Commentary for the share
       """
       commentary: String
-    ): EmptyResponse
-      @auth
-      @rateLimit(limit: 10, duration: 3600)
-      @highRateLimit(limit: 1, duration: 600)
+    ): EmptyResponse @auth @highRateLimit(limit: 1, duration: 60)
 
     """
     Share post to source
@@ -1194,10 +1189,7 @@ export const typeDefs = /* GraphQL */ `
       Source to share the post to
       """
       sourceId: ID!
-    ): Post
-      @auth
-      @rateLimit(limit: 10, duration: 3600)
-      @highRateLimit(limit: 1, duration: 600)
+    ): Post @auth @highRateLimit(limit: 1, duration: 60)
 
     """
     Update share type post
@@ -2077,9 +2069,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         throw new ValidationError('Title can not be an empty string!');
       }
 
+      await Promise.all([
+        ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
+        ensurePostRateLimit(ctx.con, ctx.userId),
+      ]);
       await con.transaction(async (manager) => {
-        await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
-
         const mentions = await getMentions(manager, content, userId, sourceId);
         const contentHtml = markdown.render(content, { mentions });
         const params: CreatePost = {
@@ -2274,8 +2268,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       { sourceId, commentary, url, title, image }: SubmitExternalLinkArgs,
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
+      await Promise.all([
+        ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
+        ensurePostRateLimit(ctx.con, ctx.userId),
+      ]);
       await ctx.con.transaction(async (manager) => {
-        await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
         const cleanUrl = standardizeURL(url);
         if (!isValidHttpUrl(cleanUrl)) {
           throw new ValidationError('URL is not valid');
@@ -2327,8 +2324,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
-      await ctx.con.getRepository(Post).findOneByOrFail({ id });
-      await ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post);
+      await Promise.all([
+        ctx.con.getRepository(Post).findOneByOrFail({ id }),
+        ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
+        ensurePostRateLimit(ctx.con, ctx.userId),
+      ]);
 
       const newPost = await createSharePost({
         con: ctx.con,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1028,7 +1028,7 @@ export const typeDefs = /* GraphQL */ `
       Content of the post
       """
       content: String
-    ): Post! @auth @highRateLimit(limit: 1, duration: 60)
+    ): Post! @auth @rateLimit(limit: 1, duration: 60)
 
     """
     To allow user to edit posts
@@ -1171,7 +1171,7 @@ export const typeDefs = /* GraphQL */ `
       Commentary for the share
       """
       commentary: String
-    ): EmptyResponse @auth @highRateLimit(limit: 1, duration: 60)
+    ): EmptyResponse @auth @rateLimit(limit: 1, duration: 60)
 
     """
     Share post to source
@@ -1189,7 +1189,7 @@ export const typeDefs = /* GraphQL */ `
       Source to share the post to
       """
       sourceId: ID!
-    ): Post @auth @highRateLimit(limit: 1, duration: 60)
+    ): Post @auth @rateLimit(limit: 1, duration: 60)
 
     """
     Update share type post


### PR DESCRIPTION
Rate limit also affects our power users and I'd like to avoid that. Hence, introducing reputation based rate limiting. It will allow us to set stricter limits to new accounts with low reputation to deal with the spam