### PR TITLE
feat: add new `translation` column to `Post`

### DIFF
--- a/__tests__/workers/__snapshots__/postUpdated.ts.snap
+++ b/__tests__/workers/__snapshots__/postUpdated.ts.snap
@@ -47,6 +47,7 @@ Object {
   "title": "Title",
   "titleHtml": null,
   "toc": null,
+  "translation": Object {},
   "trending": null,
   "type": "article",
   "upvotes": 0,

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -13,6 +13,7 @@ import { PostKeyword } from '../PostKeyword';
 import { User } from '../user';
 import { PostRelation } from './PostRelation';
 import type { PostCodeSnippet } from './PostCodeSnippet';
+import type { I18nRecord } from '../../types';
 
 export enum PostType {
   Article = 'article',
@@ -50,6 +51,10 @@ export type PostContentQuality = Partial<{
   is_ai_probability: number;
   is_clickbait_probability: number;
   manual_clickbait_probability: number;
+}>;
+
+export type PostTranslation = Partial<{
+  title: I18nRecord;
 }>;
 
 @Entity()
@@ -265,6 +270,9 @@ export class Post {
 
   @Column({ type: 'jsonb', default: {} })
   contentQuality: PostContentQuality;
+
+  @Column({ type: 'jsonb', default: {} })
+  translation: PostTranslation;
 
   @OneToMany(
     'PostCodeSnippet',

--- a/src/migration/1736519518183-PostTranslations.ts
+++ b/src/migration/1736519518183-PostTranslations.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class PostTranslations1736519518183 implements MigrationInterface {
+  name = 'PostTranslations1736519518183'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post" ADD "translation" jsonb NOT NULL DEFAULT '{}'`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "post" DROP COLUMN "translation"`);
+  }
+}


### PR DESCRIPTION
Adds new `translation` column to `Post`.

```js
{
	// First implementation only has title
	"title": {
		"es": "Titulo",
		"no": "Tittel",
	},

	// Future expansion to other fields:
	"summary": {
		"es": "Sumario",
		"no": "Sammendrag",
	}
}
```


AS-921