### PR TITLE
feat: reduce freeform content change trigger threshold

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1262,9 +1262,7 @@ describe('post', () => {
     const after = {
       ...base,
       type: PostType.Freeform,
-      content: '1'.repeat(
-        FREEFORM_POST_MINIMUM_CONTENT_LENGTH - base.title.length,
-      ),
+      // not setting content, title length should be enough
     };
 
     await expectSuccessfulBackground(
@@ -1288,10 +1286,9 @@ describe('post', () => {
     const after = {
       ...base,
       type: PostType.Freeform,
-      content: '1'.repeat(
-        FREEFORM_POST_MINIMUM_CONTENT_LENGTH - base.title.length - 1,
-      ),
+      content: '',
     };
+    after.title = '';
 
     await expectSuccessfulBackground(
       worker,

--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -1,11 +1,12 @@
 import { ChildEntity, Column } from 'typeorm';
 import { Post, PostType } from './Post';
 
-// Minimun content length required for new posts to trigger content-requested
-export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 5;
+// Minimum content length required for new posts to trigger content-requested
+export const FREEFORM_POST_MINIMUM_CONTENT_LENGTH = 1;
 
-// Minimun content length required for updated posts to trigger content-requested
-export const FREEFORM_POST_MINIMUM_CHANGE_LENGTH = 200;
+// Minimum content length required for updated posts to trigger content-requested
+// it is here to prevent posts processing trigger on non-content related changes
+export const FREEFORM_POST_MINIMUM_CHANGE_LENGTH = 1;
 
 @ChildEntity(PostType.Freeform)
 export class FreeformPost extends Post {


### PR DESCRIPTION
Removing the limits had the effect of unusually high number of posts sent to Yggdrasil. But it did not result in corresponding number of new posts created in database. So I suspect most of updates were sent when freeform post was changed in any way (not just content). 
Now I am trying to leave minimal threshold. I could alternatively check if `len(change) > 0` but decided to keep constants as easy way to change threshold in the future. 

<img width="793" alt="Screenshot 2025-01-13 at 18 17 39" src="https://github.com/user-attachments/assets/e18bafdd-6ba3-493e-9acc-eeae4f31b03c" />
