### PR TITLE
feat: add grouped argument so we can extract grouped dates

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -602,7 +602,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type ReadHistory {
-    date: DateTime!
+    date: String!
     reads: Int!
   }
 
@@ -796,7 +796,16 @@ export const typeDefs = /* GraphQL */ `
     """
     Get a heatmap of reads per day in a given time frame.
     """
-    userReadHistory(id: ID!, after: String!, before: String!): [ReadHistory]
+    userReadHistory(
+      id: ID!
+      after: String!
+      before: String!
+
+      """
+      Group by day stamp yyyy-MM-dd
+      """
+      grouped: Boolean
+    ): [ReadHistory]
     """
     Get the number of articles the user read
     """
@@ -1105,16 +1114,28 @@ export const getUserReadHistory = async ({
   userId,
   after,
   before,
+  grouped,
 }: {
   con: DataSource;
   userId: string;
   after: Date;
   before: Date;
+  grouped?: boolean;
 }) => {
-  return con
+  const readHistoryQuery = con
     .getRepository(ActiveView)
-    .createQueryBuilder('view')
-    .select('view.timestamp', 'date')
+    .createQueryBuilder('view');
+
+  if (grouped) {
+    readHistoryQuery.select(
+      `date_trunc('day', view.timestamp)::date::text`,
+      'date',
+    );
+  } else {
+    readHistoryQuery.select('view.timestamp', 'date');
+  }
+
+  return readHistoryQuery
     .addSelect(`count(*) AS "reads"`)
     .innerJoin(User, 'user', 'user.id = view.userId')
     .where('view.userId = :userId', { userId })
@@ -1130,6 +1151,7 @@ interface ReadingHistyoryArgs {
   after: string;
   before: string;
   limit?: number;
+  grouped?: boolean;
 }
 
 interface userStreakProfileArgs {
@@ -1443,7 +1465,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     },
     userReadHistory: async (
       source,
-      { id, after, before }: ReadingHistyoryArgs,
+      { id, after, before, grouped }: ReadingHistyoryArgs,
       ctx: Context,
     ): Promise<GQLReadingRankHistory[]> =>
       getUserReadHistory({
@@ -1451,6 +1473,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         userId: id,
         after: new Date(after),
         before: new Date(before),
+        grouped,
       }),
     userStreak: async (
       _,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1132,7 +1132,11 @@ export const getUserReadHistory = async ({
       'date',
     );
   } else {
-    readHistoryQuery.select('view.timestamp', 'date');
+    // format to ISO 8601 because we can't use DateTime of gql due to grouped format
+    readHistoryQuery.select(
+      `to_char(view.timestamp, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`,
+      'date',
+    );
   }
 
   return readHistoryQuery

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1128,7 +1128,7 @@ export const getUserReadHistory = async ({
 
   if (grouped) {
     readHistoryQuery.select(
-      `date_trunc('day', view.timestamp)::date::text`,
+      `date_trunc('day', ${timestampAtTimezone})::date::text`,
       'date',
     );
   } else {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1133,10 +1133,13 @@ export const getUserReadHistory = async ({
     );
   } else {
     // format to ISO 8601 because we can't use DateTime of gql due to grouped format
-    readHistoryQuery.select(
-      `to_char(view.timestamp, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`,
-      'date',
-    );
+    readHistoryQuery
+      .select(
+        `to_char(view.timestamp, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`,
+        'date',
+      )
+      // limit to 30 events for ungrouped views, reading streak
+      .limit(30);
   }
 
   return readHistoryQuery


### PR DESCRIPTION
fixes calendar heatmap [thread](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1737040404925759)

- for reading streaks we needed exact times with time portion of date so that we can accurately know when did user read occur, which conflicted with a way we return read history currently
- this adds a `grouped` param which for now allows us to retain that functionality for calendar heatmap
- heatmap will again return dates in user's timezone to preserve heatmap logic, we can look into adjusting that in the future but for now its ok

Frontend PR https://github.com/dailydotdev/apps/pull/4073