### PR TITLE
fix: don't show shared post deleted on feed

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -108,6 +108,10 @@ export const workers: Worker[] = [
     subscription: 'api.post-deleted-comments-cleanup',
   },
   {
+    topic: 'post-banned-or-removed',
+    subscription: 'api.post-deleted-shared-post-cleanup',
+  },
+  {
     topic: 'pub-request',
     subscription: 'pub-request-rep',
   },
@@ -323,8 +327,8 @@ export const workers: Worker[] = [
   },
   {
     topic: 'kvasir.v1.post-translated',
-    subscription: 'api.post-translated'
-  }
+    subscription: 'api.post-translated',
+  },
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/__tests__/workers/postDeletedSharedPostCleanup.ts
+++ b/__tests__/workers/postDeletedSharedPostCleanup.ts
@@ -1,0 +1,49 @@
+import { expectSuccessfulBackground, saveFixtures } from '../helpers';
+import worker from '../../src/workers/postDeletedSharedPostCleanup';
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { Post, SharePost, Source } from '../../src/entity';
+import { postsFixture, sharedPostsFixture } from '../fixture/post';
+import { sourcesFixture } from '../fixture';
+
+let con: DataSource;
+beforeEach(async () => {
+  con = await createOrGetConnection();
+  jest.resetAllMocks();
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(
+    con,
+    Post,
+    postsFixture.map((item) => {
+      return {
+        ...item,
+        id: `pdspc-${item.id}`,
+        deleted: true,
+      };
+    }),
+  );
+  await saveFixtures(
+    con,
+    SharePost,
+    sharedPostsFixture.map((item) => {
+      return {
+        ...item,
+        id: `pdspc-${item.id}`,
+        sharedPostId: `pdspc-p1`,
+      };
+    }),
+  );
+});
+
+it('should set shared post to not show on feed if post gets deleted', async () => {
+  await expectSuccessfulBackground(worker, {
+    post: {
+      id: 'pdspc-p1',
+    },
+  });
+  const sharedPost = await con.getRepository(SharePost).findOneBy({
+    id: 'pdspc-squadP1',
+  });
+  expect(sharedPost?.showOnFeed).toBe(false);
+  expect(sharedPost?.flags?.showOnFeed).toEqual(false);
+});

--- a/__tests__/workers/postDeletedSharedPostCleanup.ts
+++ b/__tests__/workers/postDeletedSharedPostCleanup.ts
@@ -5,7 +5,7 @@ import createOrGetConnection from '../../src/db';
 import { Post, SharePost, Source } from '../../src/entity';
 import { postsFixture, sharedPostsFixture } from '../fixture/post';
 import { sourcesFixture } from '../fixture';
-import { typedWorkers, workers } from '../../src/workers';
+import { workers } from '../../src/workers';
 
 let con: DataSource;
 beforeEach(async () => {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -56,6 +56,7 @@ import userCompanyApprovedCio from './userCompanyApprovedCio';
 import userUpdatedPlusSubscriptionSquad from './userUpdatedPlusSubscriptionSquad';
 import userUpdatedPlusSubscriptionCustomFeed from './userUpdatedPlusSubscriptionCustomFeed';
 import { postTranslated } from './postTranslated';
+import postDeletedSharedPostCleanup from './postDeletedSharedPostCleanup';
 
 export { Worker } from './worker';
 
@@ -74,6 +75,7 @@ export const workers: Worker[] = [
   postUpvotedRedis,
   postBannedRep,
   postDeletedCommentsCleanup,
+  postDeletedSharedPostCleanup,
   usernameChanged,
   updateComments,
   newNotificationRealTime,

--- a/src/workers/postDeletedSharedPostCleanup.ts
+++ b/src/workers/postDeletedSharedPostCleanup.ts
@@ -16,7 +16,6 @@ const worker: Worker = {
     const databasePost = await con
       .getRepository(Post)
       .findOneBy({ id: post?.id });
-    console.log('del: ', databasePost?.deleted);
     if (!databasePost || !databasePost?.deleted) {
       return logger.info(
         {

--- a/src/workers/postDeletedSharedPostCleanup.ts
+++ b/src/workers/postDeletedSharedPostCleanup.ts
@@ -1,0 +1,55 @@
+import { messageToJson, Worker } from './worker';
+import { Post, SharePost } from '../entity/';
+import { ChangeObject } from '../types';
+import { updateFlagsStatement } from '../common';
+
+interface Data {
+  post: ChangeObject<Post>;
+}
+
+const worker: Worker = {
+  subscription: 'api.post-deleted-shared-post-cleanup',
+  handler: async (message, con, logger): Promise<void> => {
+    const data: Data = messageToJson(message);
+    const { post } = data;
+
+    const databasePost = await con
+      .getRepository(Post)
+      .findOneBy({ id: post?.id });
+    console.log('del: ', databasePost?.deleted);
+    if (!databasePost || !databasePost?.deleted) {
+      return logger.info(
+        {
+          data,
+          messageId: message.messageId,
+        },
+        'failed to cleanup shared post due to post deletion error',
+      );
+    }
+    
+    await con
+      .getRepository(SharePost)
+      .createQueryBuilder()
+      .update()
+      .where({
+        sharedPostId: post.id,
+      })
+      .set({
+        showOnFeed: false,
+        flags: updateFlagsStatement<Post>({
+          showOnFeed: false,
+        }),
+      })
+      .execute();
+
+    logger.info(
+      {
+        data,
+        messageId: message.messageId,
+      },
+      'set shared post to not show on feed due to post deletion',
+    );
+  },
+};
+
+export default worker;

--- a/src/workers/postDeletedSharedPostCleanup.ts
+++ b/src/workers/postDeletedSharedPostCleanup.ts
@@ -26,7 +26,7 @@ const worker: Worker = {
         'failed to cleanup shared post due to post deletion error',
       );
     }
-    
+
     await con
       .getRepository(SharePost)
       .createQueryBuilder()


### PR DESCRIPTION
We decided not to show shared post that have deleted reference on feed anymore.
Luckily `showOnFeed` handles all feed types for us.

To retro fix I suggest we simply run a manual query. (Probably very few hits anyway)