### PR TITLE
feat: expose translation field on Post

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -855,7 +855,7 @@ describe('translation field', () => {
   it('should return false for fields when content-language header is not set', async () => {
     const res = await client.query(QUERY);
     expect(res.data.post.translation).toEqual({
-      title: false,
+      title: null,
     });
   });
 
@@ -873,7 +873,7 @@ describe('translation field', () => {
       },
     });
     expect(res.data.post.translation).toEqual({
-      title: false,
+      title: null,
     });
   });
 

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -823,6 +823,61 @@ describe('type field', () => {
   });
 });
 
+describe('translation field', () => {
+  const QUERY = /* GraphQL */ `
+    {
+      post(id: "p1") {
+        translation {
+          title
+        }
+      }
+    }
+  `;
+
+  it('should return false for fields when content-language header is not set', async () => {
+    const res = await client.query(QUERY);
+    expect(res.data.post.translation).toEqual({
+      title: false,
+    });
+  });
+
+  it('should return false for fields when translation does not exist', async () => {
+    await con.getRepository(ArticlePost).update('p1', {
+      translation: {
+        es: {
+          title: 'Hola',
+        },
+      },
+    });
+    const res = await client.query(QUERY, {
+      headers: {
+        'content-language': 'de',
+      },
+    });
+    expect(res.data.post.translation).toEqual({
+      title: false,
+    });
+  });
+
+  it('should return true for fields when translation does exist', async () => {
+    await con.getRepository(ArticlePost).update('p1', {
+      translation: {
+        es: {
+          title: 'Hola',
+        },
+      },
+    });
+    const res = await client.query(QUERY, {
+      headers: {
+        'content-language': 'es',
+      },
+    });
+    expect(res.data.post.translation).toEqual({
+      title: true,
+    });
+  });
+});
+
 describe('freeformPost type', () => {
   const QUERY = `{
     post(id: "ff") {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -824,9 +824,27 @@ describe('type field', () => {
 });
 
 describe('translation field', () => {
+  beforeEach(async () => {
+    await saveFixtures(con, ArticlePost, [
+      {
+        id: 'p1-tf',
+        shortId: 'sp1-tf',
+        title: 'P1-tf',
+        url: 'http://p1-tf.com',
+        canonicalUrl: 'http://p1-tfc.com',
+        image: 'https://daily.dev/image.jpg',
+        score: 1,
+        sourceId: 'a',
+        tagsStr: 'javascript,webdev',
+        type: PostType.Article,
+        contentCuration: ['c1', 'c2'],
+      },
+    ]);
+  });
+
   const QUERY = /* GraphQL */ `
     {
-      post(id: "p1") {
+      post(id: "p1-tf") {
         translation {
           title
         }
@@ -842,7 +860,7 @@ describe('translation field', () => {
   });
 
   it('should return false for fields when translation does not exist', async () => {
-    await con.getRepository(ArticlePost).update('p1', {
+    await con.getRepository(ArticlePost).update('p1-tf', {
       translation: {
         es: {
           title: 'Hola',
@@ -860,7 +878,7 @@ describe('translation field', () => {
   });
 
   it('should return true for fields when translation does exist', async () => {
-    await con.getRepository(ArticlePost).update('p1', {
+    await con.getRepository(ArticlePost).update('p1-tf', {
       translation: {
         es: {
           title: 'Hola',

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -53,9 +53,10 @@ export type PostContentQuality = Partial<{
   manual_clickbait_probability: number;
 }>;
 
-export type PostTranslation = Partial<{
-  title: string;
-}>;
+export const translateablePostFields = ['title'] as const;
+export type PostTranslation = {
+  [key in (typeof translateablePostFields)[number]]?: string;
+};
 
 @Entity()
 @Index('IDX_post_id_sourceid', ['id', 'sourceId'])

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -497,13 +497,15 @@ const obj = new GraphORM({
         transform: (
           translations: Partial<Record<ContentLanguage, PostTranslation>>,
           ctx: Context,
-        ): Record<keyof PostTranslation, boolean> => {
-          const translation = ctx.contentLanguage
-            ? translations[ctx.contentLanguage]
-            : {};
+        ): Partial<Record<keyof PostTranslation, boolean>> => {
+          if (!ctx.contentLanguage || !translations[ctx.contentLanguage]) {
+            return {};
+          }
+
+          const translation = translations[ctx.contentLanguage]!;
           return translateablePostFields.reduce(
             (acc: Record<string, boolean>, field) => {
-              acc[field] = !!translation?.[field];
+              acc[field] = !!translation[field];
               return acc;
             },
             {},

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -16,6 +16,8 @@ import {
   SettingsFlagsPublic,
   UserStats,
   UserSubscriptionFlags,
+  type PostTranslation,
+  translateablePostFields,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -29,7 +31,7 @@ import { base64, domainOnly, getSmartTitle, transformDate } from '../common';
 import { GQLComment } from '../schema/comments';
 import { GQLUserPost } from '../schema/posts';
 import { UserComment } from '../entity/user/UserComment';
-import { type I18nRecord, UserVote } from '../types';
+import { type ContentLanguage, type I18nRecord, UserVote } from '../types';
 import { whereVordrFilter } from '../common/vordr';
 import { UserCompany, Post } from '../entity';
 import {
@@ -490,6 +492,24 @@ const obj = new GraphORM({
       title: createSmartTitleField({
         field: 'title',
       }),
+      translation: {
+        jsonType: true,
+        transform: (
+          translations: Partial<Record<ContentLanguage, PostTranslation>>,
+          ctx: Context,
+        ): Record<keyof PostTranslation, boolean> => {
+          const translation = ctx.contentLanguage
+            ? translations[ctx.contentLanguage]
+            : {};
+          return translateablePostFields.reduce(
+            (acc: Record<string, boolean>, field) => {
+              acc[field] = !!translation?.[field];
+              return acc;
+            },
+            {},
+          );
+        },
+      },
     },
   },
   SourceCategory: {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -498,11 +498,14 @@ const obj = new GraphORM({
           translations: Partial<Record<ContentLanguage, PostTranslation>>,
           ctx: Context,
         ): Partial<Record<keyof PostTranslation, boolean>> => {
-          if (!ctx.contentLanguage || !translations[ctx.contentLanguage]) {
+          const translation = ctx.contentLanguage
+            ? translations[ctx.contentLanguage]
+            : undefined;
+
+          if (!translation) {
             return {};
           }
 
-          const translation = translations[ctx.contentLanguage]!;
           return translateablePostFields.reduce(
             (acc: Record<string, boolean>, field) => {
               acc[field] = !!translation[field];

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -68,6 +68,7 @@ import {
   SubmitExternalLinkArgs,
   UserAction,
   Settings,
+  type PostTranslation,
 } from '../entity';
 import { GQLEmptyResponse, offsetPageGenerator } from './common';
 import {
@@ -174,6 +175,7 @@ export interface GQLPost {
   flags?: PostFlagsPublic;
   userState?: GQLUserPost;
   slug?: string;
+  translations?: Partial<Record<keyof PostTranslation, boolean>>;
 }
 
 interface PinPostArgs {
@@ -408,6 +410,10 @@ export const typeDefs = /* GraphQL */ `
     user: User!
 
     post: Post!
+  }
+
+  type PostTranslation {
+    title: Boolean
   }
 
   """
@@ -658,6 +664,11 @@ export const typeDefs = /* GraphQL */ `
     Whether the post title is detected as clickbait
     """
     clickbaitTitleDetected: Boolean
+
+    """
+    List of available translations for the post
+    """
+    translation: PostTranslation
   }
 
   type PostConnection {


### PR DESCRIPTION
Expose `translation` field on `Post`. It returns an object containing keys of what translations are available. Currently we only return `title`, but it can be extended in the future.