### PR TITLE
feat: multi squad moderation

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1294,7 +1294,7 @@ describe('storeNotificationBundle', () => {
     );
     expect(actual.notification.description).toBeFalsy();
     expect(actual.notification.targetUrl).toEqual(
-      'http://localhost:5002/squads/a/moderate',
+      'http://localhost:5002/squads/moderate',
     );
     expect(actual.avatars).toEqual([
       {
@@ -1351,7 +1351,7 @@ describe('storeNotificationBundle', () => {
     );
     expect(actual.notification.description).toEqual('Lacks value.');
     expect(actual.notification.targetUrl).toEqual(
-      'http://localhost:5002/squads/a/moderate',
+      'http://localhost:5002/squads/moderate?handle=a',
     );
     expect(actual.avatars).toEqual([
       {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -6425,10 +6425,11 @@ describe('Source post moderation approve/reject', () => {
   mutation ModerateSourcePost(
     $postIds: [ID]!,
     $status: String,
+    $sourceId: ID,
     $rejectionReason: String,
     $moderatorMessage: String
   ) {
-    moderateSourcePosts(postIds: $postIds, status: $status, rejectionReason: $rejectionReason, moderatorMessage: $moderatorMessage) {
+    moderateSourcePosts(postIds: $postIds, status: $status, sourceId: $sourceId, rejectionReason: $rejectionReason, moderatorMessage: $moderatorMessage) {
       id
       status
     }

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -152,18 +152,33 @@ beforeEach(async () => {
       name: 'Joanna Deer',
     },
   ]);
-  await con.getRepository(SquadSource).save({
-    id: 'm',
-    name: 'Moderated Squad',
-    image: 'http//image.com/m',
-    handle: 'moderatedSquad',
-    type: SourceType.Squad,
-    active: true,
-    private: false,
-    moderationRequired: true,
-    memberPostingRank: sourceRoleRank[SourceMemberRoles.Member],
-    memberInviteRank: sourceRoleRank[SourceMemberRoles.Member],
-  });
+  await con.getRepository(SquadSource).save([
+    {
+      id: 'm',
+      name: 'Moderated Squad',
+      image: 'http//image.com/m',
+      handle: 'moderatedSquad',
+      type: SourceType.Squad,
+      active: true,
+      private: false,
+      moderationRequired: true,
+      memberPostingRank: sourceRoleRank[SourceMemberRoles.Member],
+      memberInviteRank: sourceRoleRank[SourceMemberRoles.Member],
+    },
+    {
+      id: 'm2',
+      name: 'Second Moderated Squad',
+      image: 'http//image.com/m2',
+      handle: 'moderatedSquad2',
+      type: SourceType.Squad,
+      active: true,
+      private: false,
+      moderationRequired: true,
+      memberPostingRank: sourceRoleRank[SourceMemberRoles.Member],
+      memberInviteRank: sourceRoleRank[SourceMemberRoles.Member],
+    },
+  ]);
+
   await con.getRepository(SourceMember).save([
     {
       userId: '3',
@@ -181,6 +196,12 @@ beforeEach(async () => {
       userId: '5',
       sourceId: 'm',
       role: SourceMemberRoles.Member,
+      referralToken: randomUUID(),
+    },
+    {
+      userId: '2',
+      sourceId: 'm2',
+      role: SourceMemberRoles.Moderator,
       referralToken: randomUUID(),
     },
   ]);
@@ -6166,7 +6187,7 @@ describe('query postCodeSnippets', () => {
 });
 
 describe('Source post moderation approve/reject', () => {
-  const [pendingId, rejectedId] = Array.from({ length: 2 }, () =>
+  const [pendingId, pendingId2, rejectedId] = Array.from({ length: 2 }, () =>
     generateUUID(),
   );
   beforeEach(async () => {
@@ -6175,6 +6196,15 @@ describe('Source post moderation approve/reject', () => {
       {
         id: pendingId,
         sourceId: 'm',
+        createdById: '4',
+        title: 'Title',
+        content: 'Content',
+        status: SourcePostModerationStatus.Pending,
+        type: PostType.Article,
+      },
+      {
+        id: pendingId2,
+        sourceId: 'm2',
         createdById: '4',
         title: 'Title',
         content: 'Content',
@@ -6200,11 +6230,10 @@ describe('Source post moderation approve/reject', () => {
   mutation ModerateSourcePost(
     $postIds: [ID]!,
     $status: String,
-    $sourceId: ID!,
     $rejectionReason: String,
     $moderatorMessage: String
   ) {
-    moderateSourcePosts(postIds: $postIds, status: $status, sourceId: $sourceId, rejectionReason: $rejectionReason, moderatorMessage: $moderatorMessage) {
+    moderateSourcePosts(postIds: $postIds, status: $status, rejectionReason: $rejectionReason, moderatorMessage: $moderatorMessage) {
       id
       status
     }
@@ -6218,7 +6247,6 @@ describe('Source post moderation approve/reject', () => {
         mutation: MUTATION,
         variables: {
           postIds: [pendingId],
-          sourceId: 'm',
           status: SourcePostModerationStatus.Approved,
         },
       },
@@ -6234,7 +6262,6 @@ describe('Source post moderation approve/reject', () => {
         mutation: MUTATION,
         variables: {
           postIds: [pendingId],
-          sourceId: 'm',
           status: SourcePostModerationStatus.Approved,
         },
       },
@@ -6250,7 +6277,6 @@ describe('Source post moderation approve/reject', () => {
         mutation: MUTATION,
         variables: {
           postIds: [pendingId],
-          sourceId: 'm',
           status: SourcePostModerationStatus.Approved,
         },
       },
@@ -6266,7 +6292,6 @@ describe('Source post moderation approve/reject', () => {
     }> = await client.mutate(MUTATION, {
       variables: {
         postIds: [pendingId],
-        sourceId: 'm',
         status: SourcePostModerationStatus.Approved,
       },
     });
@@ -6281,6 +6306,38 @@ describe('Source post moderation approve/reject', () => {
     expect(post.moderatedById).toEqual('3');
   });
 
+  it('should not approve posts in sources where user is not moderator', async () => {
+    loggedUser = '2'; // Not moderator of "m" squad, which "pendingId" post belongs to.
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          postIds: [pendingId],
+          status: SourcePostModerationStatus.Approved,
+        },
+      },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should throw error when one or more posts in postIds is from a source where user is not moderator', async () => {
+    loggedUser = '2'; // Not moderator of "m" squad, which "pendingId" post belongs to.
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          postIds: [pendingId, pendingId2],
+          status: SourcePostModerationStatus.Approved,
+        },
+      },
+      'FORBIDDEN',
+    );
+  });
+
   it('should reject pending posts', async () => {
     loggedUser = '3'; // Moderator level
 
@@ -6289,7 +6346,6 @@ describe('Source post moderation approve/reject', () => {
     }> = await client.mutate(MUTATION, {
       variables: {
         postIds: [pendingId],
-        sourceId: 'm',
         status: SourcePostModerationStatus.Rejected,
         rejectionReason: 'Spam',
         moderatorMessage: 'This is spam',
@@ -6317,7 +6373,6 @@ describe('Source post moderation approve/reject', () => {
         mutation: MUTATION,
         variables: {
           postIds: [pendingId],
-          sourceId: 'm',
           status: SourcePostModerationStatus.Rejected,
           moderatorMessage: 'This is spam',
         },
@@ -6335,7 +6390,6 @@ describe('Source post moderation approve/reject', () => {
         mutation: MUTATION,
         variables: {
           postIds: [pendingId],
-          sourceId: 'm',
           status: SourcePostModerationStatus.Rejected,
           rejectionReason: 'Other',
         },
@@ -6352,7 +6406,6 @@ describe('Source post moderation approve/reject', () => {
     }> = await client.mutate(MUTATION, {
       variables: {
         postIds: [pendingId, rejectedId],
-        sourceId: 'm',
         status: SourcePostModerationStatus.Approved,
       },
     });

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -10,10 +10,12 @@ import {
   Post,
   PostOrigin,
   PostType,
+  SourceMember,
   SquadSource,
   User,
   validateCommentary,
   WelcomePost,
+  type Source,
 } from '../entity';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { isValidHttpUrl, standardizeURL } from './links';
@@ -24,7 +26,7 @@ import { GQLPost } from '../schema/posts';
 import { FileUpload } from 'graphql-upload/GraphQLUpload.js';
 import { HttpError, retryFetchParse } from '../integrations/retry';
 import { checkWithVordr, VordrFilterType } from './vordr';
-import { AuthContext } from '../Context';
+import { AuthContext, type Context } from '../Context';
 import { createHash } from 'node:crypto';
 import { PostCodeSnippet } from '../entity/posts/PostCodeSnippet';
 import { logger } from '../logger';
@@ -42,6 +44,37 @@ import {
 } from '../entity/SourcePostModeration';
 import { mapCloudinaryUrl, uploadPostFile, UploadPreset } from './cloudinary';
 import { getMentions } from '../schema/comments';
+import type { ConnectionArguments } from 'graphql-relay';
+import graphorm from '../graphorm';
+import type { GraphQLResolveInfo } from 'graphql';
+import { offsetPageGenerator } from '../schema/common';
+import { SourceMemberRoles } from '../roles';
+import { NotFoundError } from '../errors';
+
+export type SourcePostModerationArgs = ConnectionArguments & {
+  sourceId: string;
+  status: SourcePostModerationStatus[];
+};
+
+export interface GQLSourcePostModeration {
+  id: string;
+  title?: string;
+  content?: string;
+  contentHtml?: string;
+  image?: string;
+  sourceId: string;
+  sharedPostId?: string;
+  status: SourcePostModerationStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  source: Source;
+  post?: Post;
+  postId?: string;
+}
+
+const POST_MODERATION_PAGE_SIZE = 15;
+const sourcePostModerationPageGenerator =
+  offsetPageGenerator<GQLSourcePostModeration>(POST_MODERATION_PAGE_SIZE, 50);
 
 export const defaultImage = {
   urls:
@@ -694,3 +727,146 @@ export const getPostSmartTitle = (
     contentLanguage,
     (post.contentMeta as PostContentMeta)?.alt_title?.translations,
   ) || getPostTranslatedTitle(post, contentLanguage);
+
+export const getModerationItemsAsAdminForSource = async (
+  ctx: Context,
+  info: GraphQLResolveInfo,
+  args: SourcePostModerationArgs,
+) => {
+  const page = sourcePostModerationPageGenerator.connArgsToPage(args);
+  const statuses = Array.from(new Set(args.status));
+
+  return graphorm.queryPaginated<GQLSourcePostModeration>(
+    ctx,
+    info,
+    (nodeSize) =>
+      sourcePostModerationPageGenerator.hasPreviousPage(page, nodeSize),
+    (nodeSize) => sourcePostModerationPageGenerator.hasNextPage(page, nodeSize),
+    (node, index) =>
+      sourcePostModerationPageGenerator.nodeToCursor(page, args, node, index),
+    (builder) => {
+      builder.queryBuilder
+        .where(`"${builder.alias}"."sourceId" = :sourceId`, {
+          sourceId: args.sourceId,
+        })
+        .andWhere(`("${builder.alias}"."flags"->>'vordr')::boolean IS NOT TRUE`)
+        .orderBy(`${builder.alias}.updatedAt`, 'DESC')
+        .limit(page.limit)
+        .offset(page.offset);
+
+      if (statuses.length) {
+        builder.queryBuilder.andWhere(
+          `"${builder.alias}"."status" IN (:...status)`,
+          {
+            status: statuses,
+          },
+        );
+      }
+
+      return builder;
+    },
+    undefined,
+    true,
+  );
+};
+
+export const getModerationItemsByUserForSource = async (
+  ctx: Context,
+  info: GraphQLResolveInfo,
+  args: SourcePostModerationArgs,
+) => {
+  const page = sourcePostModerationPageGenerator.connArgsToPage(args);
+  const { userId } = ctx;
+  const statuses = Array.from(new Set(args.status));
+
+  return graphorm.queryPaginated<GQLSourcePostModeration>(
+    ctx,
+    info,
+    (nodeSize) =>
+      sourcePostModerationPageGenerator.hasPreviousPage(page, nodeSize),
+    (nodeSize) => sourcePostModerationPageGenerator.hasNextPage(page, nodeSize),
+    (node, index) =>
+      sourcePostModerationPageGenerator.nodeToCursor(page, args, node, index),
+    (builder) => {
+      builder.queryBuilder
+        .where(`"${builder.alias}"."sourceId" = :sourceId`, {
+          sourceId: args.sourceId,
+        })
+        .andWhere(`"${builder.alias}"."createdById" = :userId`, {
+          userId,
+        })
+        .orderBy(`${builder.alias}.updatedAt`, 'DESC')
+        .limit(page.limit)
+        .offset(page.offset);
+
+      if (statuses.length) {
+        builder.queryBuilder.andWhere(
+          `"${builder.alias}"."status" IN (:...status)`,
+          {
+            status: statuses,
+          },
+        );
+      }
+
+      return builder;
+    },
+    undefined,
+    true,
+  );
+};
+
+export const getAllModerationItemsAsAdmin = async (
+  ctx: Context,
+  info: GraphQLResolveInfo,
+  args: SourcePostModerationArgs,
+) => {
+  const page = sourcePostModerationPageGenerator.connArgsToPage(args);
+  const { userId } = ctx;
+  const statuses = Array.from(new Set(args.status));
+
+  const userModeratorSources = await ctx.con
+    .getRepository(SourceMember)
+    .createQueryBuilder('member')
+    .select('member.sourceId')
+    .where('member.userId = :userId', { userId })
+    .andWhere('member.role IN (:...roles)', {
+      roles: [SourceMemberRoles.Admin, SourceMemberRoles.Moderator],
+    })
+    .getMany();
+
+  const sourceIds = userModeratorSources.map((source) => source.sourceId);
+  if (!sourceIds.length)
+    throw new NotFoundError('Not moderator of any sources');
+
+  return graphorm.queryPaginated<GQLSourcePostModeration>(
+    ctx,
+    info,
+    (nodeSize) =>
+      sourcePostModerationPageGenerator.hasPreviousPage(page, nodeSize),
+    (nodeSize) => sourcePostModerationPageGenerator.hasNextPage(page, nodeSize),
+    (node, index) =>
+      sourcePostModerationPageGenerator.nodeToCursor(page, args, node, index),
+    (builder) => {
+      builder.queryBuilder
+        .where(`"${builder.alias}"."sourceId" IN (:...sourceIds)`, {
+          sourceIds,
+        })
+        .orderBy(`${builder.alias}.updatedAt`, 'DESC')
+        .limit(page.limit)
+        .offset(page.offset);
+
+      if (statuses.length) {
+        builder.queryBuilder.andWhere(
+          `"${builder.alias}"."status" IN (:...status)`,
+          {
+            status: statuses,
+          },
+        );
+      }
+
+      return builder;
+    },
+    undefined,
+    true,
+  );
+};

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -212,9 +212,11 @@ export class NotificationBuilder {
     });
   }
 
-  targetSourceModeration(source: Reference<Source>): NotificationBuilder {
+  targetSourceModeration(source?: Reference<Source>): NotificationBuilder {
     return this.enrichNotification({
-      targetUrl: `${getSourceLink(source)}/moderate`,
+      targetUrl: source
+        ? `${process.env.COMMENTS_PREFIX}/squads/moderate?handle=${source.handle}`
+        : `${process.env.COMMENTS_PREFIX}/squads/moderate`,
     });
   }
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -180,7 +180,7 @@ export const generateNotificationMap: Record<
       .avatarSource(ctx.source)
       .avatarUser(ctx.user)
       .referencePostModeration(ctx.post)
-      .targetSourceModeration(ctx.source),
+      .targetSourceModeration(),
   community_picks_failed: (builder, ctx: NotificationSubmissionContext) =>
     builder.systemNotification().referenceSubmission(ctx.submission),
   community_picks_succeeded: (builder, ctx: NotificationPostContext) =>

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1225,6 +1225,10 @@ export const typeDefs = /* GraphQL */ `
       """
       status: String
       """
+      Source to moderate the post in
+      """
+      sourceId: ID!
+      """
       Rejection reason for the post
       """
       rejectionReason: String

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1227,7 +1227,7 @@ export const typeDefs = /* GraphQL */ `
       """
       Source to moderate the post in
       """
-      sourceId: ID!
+      sourceId: ID
       """
       Rejection reason for the post
       """

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -997,9 +997,12 @@ export const canModeratePosts = async (
 
   const sourceIds = Array.from(new Set(posts.map((p) => p.sourceId)));
 
-  const memberships = await ctx.con.getRepository(SourceMember).findBy({
-    sourceId: In(sourceIds),
-    userId: ctx.userId,
+  const memberships = await ctx.con.getRepository(SourceMember).find({
+    where: {
+      sourceId: In(sourceIds),
+      userId: ctx.userId,
+    },
+    select: ['role'],
   });
 
   if (!memberships.length || memberships.length !== sourceIds.length) {

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -982,6 +982,35 @@ export const canAccessSource = async (
   return hasPermissionCheck(source, member, permission, validateRankAgainst);
 };
 
+export const canModeratePosts = async (
+  ctx: Context,
+  moderationIds: string[],
+): Promise<boolean> => {
+  const posts = await ctx.con.getRepository(SourcePostModeration).find({
+    where: { id: In(moderationIds) },
+    select: ['sourceId'],
+  });
+
+  if (!posts.length) {
+    return false;
+  }
+
+  const sourceIds = Array.from(new Set(posts.map((p) => p.sourceId)));
+
+  const memberships = await ctx.con.getRepository(SourceMember).findBy({
+    sourceId: In(sourceIds),
+    userId: ctx.userId,
+  });
+
+  if (!memberships.length || memberships.length !== sourceIds.length) {
+    return false;
+  }
+
+  return memberships.every(
+    (m) => sourceRoleRank[m.role] >= sourceRoleRank.moderator,
+  );
+};
+
 export const isPrivilegedMember = async (
   ctx: Context,
   sourceId: string,


### PR DESCRIPTION
Enables a moderator to view moderation items from multiple squads at once, as well as bulk approve for multiple squads at once.