### PR TITLE
feat: clear title translation when post title is changed

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -14,6 +14,7 @@ import {
   ArticlePost,
   Bookmark,
   BookmarkList,
+  clearPostTranslations,
   Comment,
   Feed,
   FreeformPost,
@@ -892,6 +893,38 @@ describe('translation field', () => {
     });
     expect(res.data.post.translation).toEqual({
       title: true,
+    });
+  });
+
+  describe('post updated', () => {
+    it('should clear post title translations when title is updated', async () => {
+      await con.getRepository(ArticlePost).update('p1-tf', {
+        translation: {
+          es: {
+            title: 'Hola',
+            body: 'Cuerpo',
+          },
+          de: {
+            title: 'Hallo',
+            body: 'Körper',
+          },
+        },
+      });
+
+      await clearPostTranslations(con, 'p1-tf', 'title');
+
+      const post = await con
+        .getRepository(ArticlePost)
+        .findOneByOrFail({ id: 'p1-tf' });
+
+      expect(post.translation).toEqual({
+        es: {
+          body: 'Cuerpo',
+        },
+        de: {
+          body: 'Körper',
+        },
+      });
     });
   });
 });

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -54,8 +54,9 @@ export type PostContentQuality = Partial<{
 }>;
 
 export const translateablePostFields = ['title'] as const;
+export type TranslateablePostField = (typeof translateablePostFields)[number];
 export type PostTranslation = {
-  [key in (typeof translateablePostFields)[number]]?: string;
+  [key in TranslateablePostField]?: string;
 };
 
 @Entity()

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -11,6 +11,7 @@ import {
   Alerts,
   UserTopReader,
   SquadSource,
+  clearPostTranslations,
 } from '../../entity';
 import { messageToJson, Worker } from '../worker';
 import {
@@ -587,6 +588,10 @@ const onPostChange = async (
           { id: data.payload.before!.id },
           { metadataChangedAt: new Date() },
         );
+    }
+
+    if (isChanged(data.payload.before!, data.payload.after!, 'title')) {
+      await clearPostTranslations(con, data.payload.after!.id, 'title');
     }
   } else if (data.payload.op === 'd') {
     await notifyPostBannedOrRemoved(logger, data.payload.before!);


### PR DESCRIPTION
When a post title is changed, we want to clear out the translation, so that we can fetch translation for the new title.