### PR TITLE
fix: escape post translated JSON

### DIFF
--- a/__tests__/workers/postTranslated.ts
+++ b/__tests__/workers/postTranslated.ts
@@ -51,6 +51,28 @@ describe('postTranslated', () => {
     });
   });
 
+  it('should handle titles with special characters', async () => {
+    expect(
+      (await con.getRepository(Post).findOneByOrFail({ id: 'p1' })).translation,
+    ).toEqual({});
+
+    await expectSuccessfulTypedBackground(worker, {
+      id: 'p1',
+      language: ContentLanguage.German,
+      translations: {
+        title: `new title #"!#%&/()=?'"\`\\ƒ∂∞€€é∂ßä`,
+      },
+    });
+
+    expect(
+      (await con.getRepository(Post).findOneByOrFail({ id: 'p1' })).translation,
+    ).toEqual({
+      de: {
+        title: `new title #"!#%&/()=?'"\`\\ƒ∂∞€€é∂ßä`,
+      },
+    });
+  });
+
   it('should not update post translation if language is invalid', async () => {
     expect(
       (await con.getRepository(Post).findOneByOrFail({ id: 'p1' })).translation,

--- a/src/workers/postTranslated.ts
+++ b/src/workers/postTranslated.ts
@@ -22,10 +22,14 @@ export const postTranslated: TypedWorker<'kvasir.v1.post-translated'> = {
         .set({
           translation: () => `jsonb_set(
           translation,
-          '{${language}}',
-          '${JSON.stringify(translations)}'::jsonb,
+          :language,
+          :translations::jsonb,
           true
         )`,
+        })
+        .setParameters({
+          language: [language],
+          translations: JSON.stringify(translations),
         })
         .where('id = :id', { id })
         .execute();


### PR DESCRIPTION
During the demo, I noticed that it didn't store translations where the translated title contained `'`, because it wasn't getting escaped properly 🙈 