### PR TITLE
feat: clear title translation when post title is changed (2nd try)

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -926,6 +926,18 @@ describe('translation field', () => {
         },
       });
     });
+
+    it('should not fail when translation does not exist', async () => {
+      expect(
+        (await con.getRepository(ArticlePost).findOneByOrFail({ id: 'p1-tf' }))
+          .translation,
+      ).toEqual({});
+      await clearPostTranslations(con, 'p1-tf', 'title');
+      expect(
+        (await con.getRepository(ArticlePost).findOneByOrFail({ id: 'p1-tf' }))
+          .translation,
+      ).toEqual({});
+    });
   });
 });
 

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -14,6 +14,7 @@ import {
   ArticlePost,
   Bookmark,
   BookmarkList,
+  clearPostTranslations,
   Comment,
   Feed,
   FreeformPost,
@@ -892,6 +893,38 @@ describe('translation field', () => {
     });
     expect(res.data.post.translation).toEqual({
       title: true,
+    });
+  });
+
+  describe('post updated', () => {
+    it('should clear post title translations when title is updated', async () => {
+      await con.getRepository(ArticlePost).update('p1-tf', {
+        translation: {
+          es: {
+            title: 'Hola',
+            body: 'Cuerpo',
+          },
+          de: {
+            title: 'Hallo',
+            body: 'Körper',
+          },
+        },
+      });
+
+      await clearPostTranslations(con, 'p1-tf', 'title');
+
+      const post = await con
+        .getRepository(ArticlePost)
+        .findOneByOrFail({ id: 'p1-tf' });
+
+      expect(post.translation).toEqual({
+        es: {
+          body: 'Cuerpo',
+        },
+        de: {
+          body: 'Körper',
+        },
+      });
     });
   });
 });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -938,6 +938,20 @@ describe('translation field', () => {
           .translation,
       ).toEqual({});
     });
+
+    it('should not fail when translation contains scalar value', async () => {
+      await con.getRepository(ArticlePost).update('p1-tf', {
+        translation: {
+          some: 'value',
+        },
+      });
+
+      await clearPostTranslations(con, 'p1-tf', 'title');
+      expect(
+        (await con.getRepository(ArticlePost).findOneByOrFail({ id: 'p1-tf' }))
+          .translation,
+      ).toEqual({ some: 'value' });
+    });
   });
 });
 

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -54,8 +54,9 @@ export type PostContentQuality = Partial<{
 }>;
 
 export const translateablePostFields = ['title'] as const;
+export type TranslateablePostField = (typeof translateablePostFields)[number];
 export type PostTranslation = {
-  [key in (typeof translateablePostFields)[number]]?: string;
+  [key in TranslateablePostField]?: string;
 };
 
 @Entity()

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -626,7 +626,10 @@ export const clearPostTranslations = async (
       translation: () => /* sql */ `
         COALESCE(
           (
-            SELECT jsonb_object_agg(key, value - :field)
+            SELECT jsonb_object_agg(key, CASE
+                WHEN jsonb_typeof(value) = 'object' AND value ? :field THEN value - :field
+                ELSE value
+              END)
             FROM jsonb_each(translation)
           ),
           '{}'::jsonb

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -623,11 +623,16 @@ export const clearPostTranslations = async (
     .createQueryBuilder()
     .update(Post)
     .set({
-      translation: () => `(
-SELECT jsonb_object_agg(key, value - '${field}')
-FROM jsonb_each(translation)
-)`,
+      translation: () => /* sql */ `
+        COALESCE(
+          (
+            SELECT jsonb_object_agg(key, value - :field)
+            FROM jsonb_each(translation)
+          ),
+          '{}'::jsonb
+        )`,
     })
+    .setParameters({ field })
     .where('id = :id', { id: postId })
     .execute();
 };

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -11,6 +11,7 @@ import {
   Alerts,
   UserTopReader,
   SquadSource,
+  clearPostTranslations,
 } from '../../entity';
 import { messageToJson, Worker } from '../worker';
 import {
@@ -587,6 +588,10 @@ const onPostChange = async (
           { id: data.payload.before!.id },
           { metadataChangedAt: new Date() },
         );
+    }
+
+    if (isChanged(data.payload.before!, data.payload.after!, 'title')) {
+      await clearPostTranslations(con, data.payload.after!.id, 'title');
     }
   } else if (data.payload.op === 'd') {
     await notifyPostBannedOrRemoved(logger, data.payload.before!);


### PR DESCRIPTION
Trying this again... now handles when `translation` is `{}` and when it contains non-object values like `{"key": "value"}`