### PR TITLE
chore: cleanup commented out @fastify/websocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@fastify/helmet": "^13.0.1",
         "@fastify/http-proxy": "^11.0.0",
         "@fastify/rate-limit": "^10.2.1",
-        "@fastify/websocket": "^11.0.1",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/opentelemetry-resource-util": "^2.4.0",
         "@google-cloud/pubsub": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@fastify/helmet": "^13.0.1",
     "@fastify/http-proxy": "^11.0.0",
     "@fastify/rate-limit": "^10.2.1",
-    "@fastify/websocket": "^11.0.1",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/opentelemetry-resource-util": "^2.4.0",
     "@google-cloud/pubsub": "^4.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import MercuriusGQLUpload from 'mercurius-upload';
 import MercuriusCache from 'mercurius-cache';
 import proxy, { type FastifyHttpProxyOptions } from '@fastify/http-proxy';
 import { NoSchemaIntrospectionCustomRule } from 'graphql';
-// import fastifyWebsocket from '@fastify/websocket';
 
 import './config';
 
@@ -150,13 +149,6 @@ export default async function app(
     res.type('application/health+json');
     res.send(stringifyHealthCheck({ status: 'ok' }));
   });
-
-  // app.register(fastifyWebsocket, {
-  //   options: {
-  //     maxPayload: 1048576,
-  //     verifyClient: (info, next) => next(true),
-  //   },
-  // });
 
   app.register(MercuriusGQLUpload, {
     maxFileSize: 1024 * 1024 * 20,


### PR DESCRIPTION
It has been commented out for almost 3 years https://github.com/dailydotdev/daily-api/pull/855, so I think we can safely remove it