### PR TITLE
fix: new feature for shared post

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -2289,6 +2289,56 @@ describe('mutation sharePost', () => {
     expect(post.title).toEqual('My comment');
   });
 
+  it('should share sharedPost to squad if title was provided', async () => {
+    await con.getRepository(SharePost).save({
+      id: 'sp-1',
+      shortId: 'sp-1',
+      sourceId: 's1',
+      title: 'Some special title',
+      type: PostType.Share,
+      sharedPostId: 'p1',
+    });
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        sourceId: 's1',
+        id: 'sp-1',
+        commentary: 'My comment',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const newId = res.data.sharePost.id;
+    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    expect(post.authorId).toEqual('1');
+    expect(post.sharedPostId).toEqual('sp-1');
+    expect(post.title).toEqual('My comment');
+  });
+
+  it('should share sharedPost to squad but link to original article if no title was provided', async () => {
+    await con.getRepository(SharePost).save({
+      id: 'sp-2',
+      shortId: 'sp-2',
+      sourceId: 's1',
+      title: null,
+      type: PostType.Share,
+      sharedPostId: 'p1',
+    });
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        sourceId: 's1',
+        id: 'sp-2',
+        commentary: 'My comment',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const newId = res.data.sharePost.id;
+    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    expect(post.authorId).toEqual('1');
+    expect(post.sharedPostId).toEqual('p1');
+    expect(post.title).toEqual('My comment');
+  });
+
   it('should share to squad and increment squad flags total posts', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, { variables });

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -354,8 +354,7 @@ interface CreateSharePostArgs {
 }
 
 export const determineSharedPostId = (post: Post | SharePost): string => {
-  if (post.type === PostType.Share) {
-    if (!post.title) {
+  if (post.type === PostType.Share && !post.title) {
       return post instanceof SharePost ? post.sharedPostId : post.id;
     }
   }

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -14,8 +14,9 @@ import { ArticlePost } from './ArticlePost';
 import {
   Post,
   PostOrigin,
-  translateablePostFields,
+  PostType,
   type TranslateablePostField,
+  translateablePostFields,
 } from './Post';
 import { MAX_COMMENTARY_LENGTH, SharePost } from './SharePost';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
@@ -351,6 +352,16 @@ interface CreateSharePostArgs {
   ctx?: AuthContext;
   args: SharePostArgs;
 }
+
+export const determineSharedPostId = (post: Post | SharePost): string => {
+  if (post.type === PostType.Share) {
+    if (!post.title) {
+      return post instanceof SharePost ? post.sharedPostId : post.id;
+    }
+  }
+
+  return post.id;
+};
 
 export const createSharePost = async ({
   con,

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -355,7 +355,9 @@ interface CreateSharePostArgs {
 
 export const determineSharedPostId = (post: Post | SharePost): string => {
   if (post.type === PostType.Share && !post.title) {
-    return post instanceof SharePost ? post.sharedPostId : post.id;
+    if (post instanceof SharePost) {
+      return post.sharedPostId;
+    }
   }
 
   return post.id;

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -355,8 +355,7 @@ interface CreateSharePostArgs {
 
 export const determineSharedPostId = (post: Post | SharePost): string => {
   if (post.type === PostType.Share && !post.title) {
-      return post instanceof SharePost ? post.sharedPostId : post.id;
-    }
+    return post instanceof SharePost ? post.sharedPostId : post.id;
   }
 
   return post.id;

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2345,7 +2345,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
-      const [post]: [post: Post] = await Promise.all([
+      const [post, __, ___] = await Promise.all([
         ctx.con.getRepository(Post).findOneByOrFail({ id }),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
         ensurePostRateLimit(ctx.con, ctx.userId),

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2345,6 +2345,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [post, __, ___] = await Promise.all([
         ctx.con.getRepository(Post).findOneByOrFail({ id }),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2351,9 +2351,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLPost> => {
       const [post] = await Promise.all([
-        ctx.con.getRepository(Post).findOneByOrFail({ id }),
+        ctx.con
+          .createQueryBuilder()
+          .select(['post.id', 'post.title', 'post.type', 'post.sharedPostId'])
+          .from(Post, 'post')
+          .where('post.id = :id', { id })
+          .getOneOrFail(),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        // ensurePostRateLimit(ctx.con, ctx.userId),
       ]);
 
       const sharedPostId = determineSharedPostId(post);

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2345,9 +2345,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [post, __, ___] = await Promise.all([
-        ctx.con.getRepository(Post).findOneByOrFail({ id }),
+      const [post] = await Promise.all([
+        ctx.con.getRepository(Post).findOneOrFail({ where: { id } }),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
         ensurePostRateLimit(ctx.con, ctx.userId),
       ]);

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2346,7 +2346,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLPost> => {
       const [post] = await Promise.all([
-        ctx.con.getRepository(Post).findOneOrFail({ where: { id } }),
+        ctx.con.getRepository(Post).findOneByOrFail({ id }),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
         ensurePostRateLimit(ctx.con, ctx.userId),
       ]);

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -69,6 +69,7 @@ import {
   UserAction,
   Settings,
   type PostTranslation,
+  determineSharedPostId,
 } from '../entity';
 import { GQLEmptyResponse, offsetPageGenerator } from './common';
 import {
@@ -2344,11 +2345,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
-      await Promise.all([
+      const [post]: [post: Post] = await Promise.all([
         ctx.con.getRepository(Post).findOneByOrFail({ id }),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
         ensurePostRateLimit(ctx.con, ctx.userId),
       ]);
+
+      const sharedPostId = determineSharedPostId(post);
 
       const newPost = await createSharePost({
         con: ctx.con,
@@ -2356,7 +2359,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         args: {
           authorId: ctx.userId,
           sourceId,
-          postId: id,
+          postId: sharedPostId,
           commentary,
         },
       });

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2358,7 +2358,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           .where('post.id = :id', { id })
           .getOneOrFail(),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
-        // ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId),
       ]);
 
       const sharedPostId = determineSharedPostId(post);


### PR DESCRIPTION
New flow that will always share 1 up only.

If 1 up is a shared post with commentary we re-share that.
If 1 up is a shared post with no commentary we share it's parent.
if 1 up is some other post we just share that.