### PR TITLE
refactor: read valid languages from remote config

### DIFF
--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -44,6 +44,7 @@ config:
   api:env:
     accessSecret: topsecret
     analyticsUrl: http://localhost:3000
+    validLanguagesFeatureKey: valid_languages
     cioReportingWebhookSecret: topsecret
     cioWebhookSecret: topsecret
     commentsPrefix: http://webapp.local.com:5002

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -28,6 +28,7 @@ config:
       secure: AAABALdzzBMEk2sKYDjFrWsbsdYJDOvfDfmnOmaj6lvRkds8E6SYw1RNgQ/hpCky9W8BeJXFzu2b0W6jD30KkA==
     analyticsUrl: http://analytics-api
     apiConfigFeatureKey: api-config
+    validLanguagesFeatureKey: valid_languages
     cdcWorkerMaxMessages: 1
     cioApiKey:
       secure: AAABAKsjQ79BKL/Msk8ERCFq7TeKGQ6NnzRcQrOoUzQ7hFEDNdq4uxOcG3w5M5aODolHDw==

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -28,13 +28,13 @@ jest.mock('../src/remoteConfig', () => ({
       rateLimitReputationThreshold: 1,
       pricingIds: { pricingGift: 'yearly' },
     } as typeof remoteConfig.vars,
-  },
-  validLanguages: {
-    en: 'English',
-    es: 'Spanish',
-    fr: 'French',
-    de: 'German',
-    'zh-Hans': 'ChineseSimplified',
+    validLanguages: {
+      en: 'English',
+      es: 'Spanish',
+      fr: 'French',
+      de: 'German',
+      'zh-Hans': 'ChineseSimplified',
+    },
   },
 }));
 

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -27,14 +27,14 @@ jest.mock('../src/remoteConfig', () => ({
       ignoredWorkEmailDomains: ['igored.com', 'ignored.org'],
       rateLimitReputationThreshold: 1,
       pricingIds: { pricingGift: 'yearly' },
-      validLanguages: {
-        en: 'English',
-        es: 'Spanish',
-        fr: 'French',
-        de: 'German',
-        'zh-Hans': 'ChineseSimplified',
-      },
     } as typeof remoteConfig.vars,
+  },
+  validLanguages: {
+    en: 'English',
+    es: 'Spanish',
+    fr: 'French',
+    de: 'German',
+    'zh-Hans': 'ChineseSimplified',
   },
 }));
 

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -10,6 +10,7 @@ import { FastifyRequest, FastifyBaseLogger } from 'fastify';
 import { GraphQLDatabaseLoader } from '@mando75/typeorm-graphql-loader';
 import { Roles } from './roles';
 import { DataLoaderService } from './dataLoaderService';
+import { ContentLanguage } from './types';
 import { remoteConfig } from './remoteConfig';
 
 export class Context {
@@ -17,7 +18,7 @@ export class Context {
   con: DataSource;
   loader: GraphQLDatabaseLoader;
   dataLoader: DataLoaderService;
-  contentLanguage: string | null;
+  contentLanguage: ContentLanguage | null;
 
   constructor(req: FastifyRequest, con: DataSource) {
     this.req = req;
@@ -29,9 +30,9 @@ export class Context {
     const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
 
     this.contentLanguage = validLanguages.includes(
-      contentLanguageHeader as string,
+      contentLanguageHeader as ContentLanguage,
     )
-      ? (contentLanguageHeader as string)
+      ? (contentLanguageHeader as ContentLanguage)
       : null;
   }
 

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -27,7 +27,7 @@ export class Context {
     this.dataLoader = new DataLoaderService({ ctx: this });
 
     const contentLanguageHeader = req.headers['content-language'];
-    const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
+    const validLanguages = Object.keys(remoteConfig.validLanguages || {});
 
     this.contentLanguage = validLanguages.includes(
       contentLanguageHeader as ContentLanguage,

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -10,14 +10,14 @@ import { FastifyRequest, FastifyBaseLogger } from 'fastify';
 import { GraphQLDatabaseLoader } from '@mando75/typeorm-graphql-loader';
 import { Roles } from './roles';
 import { DataLoaderService } from './dataLoaderService';
-import { ContentLanguage, validLanguages } from './types';
+import { remoteConfig } from './remoteConfig';
 
 export class Context {
   req: FastifyRequest;
   con: DataSource;
   loader: GraphQLDatabaseLoader;
   dataLoader: DataLoaderService;
-  contentLanguage: ContentLanguage | null;
+  contentLanguage: string | null;
 
   constructor(req: FastifyRequest, con: DataSource) {
     this.req = req;
@@ -26,11 +26,12 @@ export class Context {
     this.dataLoader = new DataLoaderService({ ctx: this });
 
     const contentLanguageHeader = req.headers['content-language'];
+    const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
 
     this.contentLanguage = validLanguages.includes(
-      contentLanguageHeader as ContentLanguage,
+      contentLanguageHeader as string,
     )
-      ? (contentLanguageHeader as ContentLanguage)
+      ? (contentLanguageHeader as string)
       : null;
   }
 

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -67,7 +67,7 @@ const checkLanguage = (language?: string | null): boolean => {
     return true;
   }
 
-  const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
+  const validLanguages = Object.keys(remoteConfig.validLanguages || {});
   return validLanguages.includes(language as ContentLanguage);
 };
 

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -3,7 +3,7 @@ import {
   UpdateUserFailErrorKeys,
   UserFailErrorKeys,
 } from '../../errors';
-import { ContentLanguage, validLanguages } from '../../types';
+import { ContentLanguage } from '../../types';
 import { DataSource, DeepPartial, EntityManager } from 'typeorm';
 import { FastifyBaseLogger, FastifyRequest } from 'fastify';
 import { counters } from '../../telemetry';
@@ -35,6 +35,7 @@ import { nameRegex, validateRegex, ValidateRegex } from '../../common/object';
 import { logger } from '../../logger';
 import { User } from './User';
 import { Feed } from '../Feed';
+import { remoteConfig } from '../../remoteConfig';
 
 export type AddUserData = Pick<
   User,
@@ -66,6 +67,7 @@ const checkLanguage = (language?: string | null): boolean => {
     return true;
   }
 
+  const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
   return validLanguages.includes(language as ContentLanguage);
 };
 

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -45,7 +45,15 @@ class RemoteConfig {
 
   get vars(): Partial<RemoteConfigValue> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
-      return {};
+      return {
+        validLanguages: {
+          de: 'German',
+          en: 'English',
+          es: 'Spanish',
+          no: 'Norwegian',
+          fr: 'French',
+        },
+      };
     }
 
     if (!this.gb) {

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -16,7 +16,6 @@ type RemoteConfigValue = {
   rateLimitReputationThreshold: number;
   postRateLimit: number;
   commentRateLimit: number;
-  validLanguages: Record<string, string>;
 };
 
 class RemoteConfig {
@@ -45,15 +44,7 @@ class RemoteConfig {
 
   get vars(): Partial<RemoteConfigValue> {
     if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
-      return {
-        validLanguages: {
-          de: 'German',
-          en: 'English',
-          es: 'Spanish',
-          no: 'Norwegian',
-          fr: 'French',
-        },
-      };
+      return {};
     }
 
     if (!this.gb) {
@@ -62,6 +53,35 @@ class RemoteConfig {
 
     const result = this.gb.getFeatureValue(
       process.env.API_CONFIG_FEATURE_KEY,
+      null,
+    );
+
+    if (!result) {
+      logger.error('failed to get remote config');
+
+      return {};
+    }
+
+    return result;
+  }
+
+  get validLanguages(): Record<string, string> {
+    if (!process.env.GROWTHBOOK_API_CONFIG_CLIENT_KEY) {
+      return {
+        de: 'German',
+        en: 'English',
+        es: 'Spanish',
+        no: 'Norwegian',
+        fr: 'French',
+      };
+    }
+
+    if (!this.gb) {
+      throw new Error('remote config not initialized');
+    }
+
+    const result = this.gb.getFeatureValue(
+      process.env.VALID_LANGUAGES_FEATURE_KEY,
       null,
     );
 

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -86,7 +86,7 @@ class RemoteConfig {
     );
 
     if (!result) {
-      logger.error('failed to get remote config');
+      logger.error('failed to get valid languages');
 
       return {};
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,8 +206,6 @@ export enum ContentLanguage {
 
 export type I18nRecord = Partial<Record<ContentLanguage, string>>;
 
-export const validLanguages = Object.values(ContentLanguage);
-
 export type PropsParameters<T extends (props: never) => unknown> = T extends (
   props: infer P,
 ) => unknown

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ declare global {
       SUBMIT_ARTICLE_THRESHOLD: string;
       SLACK_SIGNING_SECRET: string;
       API_CONFIG_FEATURE_KEY: string;
+      VALID_LANGUAGES_FEATURE_KEY: string;
       PADDLE_API_KEY: string;
       PADDLE_WEBHOOK_SECRET: string;
       PADDLE_ENVIRONMENT: string;

--- a/src/workers/postTranslated.ts
+++ b/src/workers/postTranslated.ts
@@ -8,7 +8,7 @@ export const postTranslated: TypedWorker<'kvasir.v1.post-translated'> = {
   handler: async (message, con) => {
     const { id, translations, language } = message.data;
 
-    const validLanguages = Object.keys(remoteConfig.vars.validLanguages || {});
+    const validLanguages = Object.keys(remoteConfig.validLanguages || {});
     if (!validLanguages.includes(language)) {
       logger.error({ id, language }, '[postTranslated]: Invalid language');
       return;


### PR DESCRIPTION
Matches Kvasir so they validate the same languages.