### PR TITLE
feat: add smartTitle as a translatable field

### DIFF
--- a/src/workers/postTranslated.ts
+++ b/src/workers/postTranslated.ts
@@ -22,14 +22,13 @@ export const postTranslated: TypedWorker<'kvasir.v1.post-translated'> = {
         .set({
           translation: () => /*sql*/ `jsonb_set(
           translation,
-          :languages,
+          ARRAY[(:language)],
           COALESCE(translation->:language, '{}'::jsonb) || :translations::jsonb,
           true
         )`,
         })
         .setParameters({
           language,
-          languages: [language],
           translations: JSON.stringify(translations),
         })
         .where('id = :id', { id });

--- a/src/workers/postTranslated.ts
+++ b/src/workers/postTranslated.ts
@@ -15,24 +15,26 @@ export const postTranslated: TypedWorker<'kvasir.v1.post-translated'> = {
     }
 
     try {
-      await con
+      const query = con
         .getRepository(Post)
         .createQueryBuilder()
         .update(Post)
         .set({
-          translation: () => `jsonb_set(
+          translation: () => /*sql*/ `jsonb_set(
           translation,
-          :language,
-          :translations::jsonb,
+          :languages,
+          COALESCE(translation->:language, '{}'::jsonb) || :translations::jsonb,
           true
         )`,
         })
         .setParameters({
-          language: [language],
+          language,
+          languages: [language],
           translations: JSON.stringify(translations),
         })
-        .where('id = :id', { id })
-        .execute();
+        .where('id = :id', { id });
+
+      await query.execute();
 
       logger.debug(
         { id, language, keys: Object.keys(translations) },


### PR DESCRIPTION
Updates the query to not override already existing translations for that language.

AS-968