### PR TITLE
chore: adjust when we log warn for gift notification

### DIFF
--- a/src/workers/notifications/userGiftedPlusNotification.ts
+++ b/src/workers/notifications/userGiftedPlusNotification.ts
@@ -36,9 +36,12 @@ const worker = generateTypedNotificationWorker<'user-updated'>({
       (recipient.subscriptionFlags as string) || '{}',
     );
 
+    if (!isGiftedPlus(afterSubscriptionFlags)) {
+      return;
+    }
+
     if (
       isPlusMember(beforeSubscriptionFlags?.cycle) ||
-      !isGiftedPlus(afterSubscriptionFlags) ||
       !afterSubscriptionFlags?.gifterId
     ) {
       logger.warn(


### PR DESCRIPTION
Split condition because `warn` was firing for each user subscription purchase thus spamming a bit too much

We now:
- early return when user is not gifted, basic case where user bought subscription for themself
- warn if user was gifter but was already gifter id is missing