### PR TITLE
fix: add vordr check to common moderation query

### DIFF
--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -836,6 +836,7 @@ export const getAllModerationItemsAsAdmin = async (
         .where('sm.role IN (:...roles)', {
           roles: [SourceMemberRoles.Admin, SourceMemberRoles.Moderator],
         })
+        .andWhere(`("${builder.alias}"."flags"->>'vordr')::boolean IS NOT TRUE`)
         .andWhere(`"${builder.alias}"."sourceId" = "sm"."sourceId"`)
         .orderBy(`${builder.alias}.updatedAt`, 'DESC')
         .limit(page.limit)


### PR DESCRIPTION
Added vordr check to the common moderation fetch logic, so that it's the same as for just a single squad