### PR TITLE
fix: paddle transaction management for gifting

### DIFF
--- a/src/paddle.ts
+++ b/src/paddle.ts
@@ -6,7 +6,7 @@ export enum SubscriptionCycles {
 }
 
 // one year
-export const subscriptionGiftDuration = 31557600000;
+export const plusGiftDuration = 31557600000;
 
 export const isPlusMember = (cycle: SubscriptionCycles | undefined): boolean =>
   !!cycle?.length || false;


### PR DESCRIPTION
One-time payments are not considered subscriptions in Paddle's dictionary, so we must handle the event for gifting within the TransactionCompleted. Events are as below:

![Screenshot 2025-02-08 at 12 38 33 PM](https://github.com/user-attachments/assets/4926a82c-0017-4a09-bb80-5500fa96c104)

Test cases still check out.