### PR TITLE
fix: feed thresholds under wrong name in config

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -3183,11 +3183,9 @@ describe('function feedToFilters', () => {
       order_by: FeedOrderBy.Downvotes,
       disable_engagement_filter: true,
       min_day_range: 7,
-      thresholds: {
-        min_thresholds: {
-          upvotes: 10,
-          views: 1,
-        },
+      min_thresholds: {
+        upvotes: 10,
+        views: 1,
       },
     });
   });
@@ -3228,10 +3226,8 @@ describe('function feedToFilters', () => {
 
     expect(filters.flags).toEqual({
       disable_engagement_filter: false,
-      thresholds: {
-        min_thresholds: {
-          upvotes: 25,
-        },
+      min_thresholds: {
+        upvotes: 25,
       },
     });
   });

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -595,11 +595,9 @@ describe('FeedUserStateConfigGenerator', () => {
     expect(actual.config.disable_engagement_filter).toBeTruthy();
     expect(actual.config.order_by).toEqual(FeedOrderBy.Downvotes);
     expect(actual.config.min_day_range).toEqual(7);
-    expect(actual.config.thresholds).toEqual({
-      min_thresholds: {
-        upvotes: 10,
-        views: 1,
-      },
+    expect(actual.config.min_thresholds).toEqual({
+      upvotes: 10,
+      views: 1,
     });
   });
 });

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -355,11 +355,9 @@ const feedFlagsToFilters = ({
   }
 
   if (feed.flags.minUpvotes || feed.flags.minViews) {
-    flagFilters.thresholds = {
-      min_thresholds: {
-        upvotes: feed.flags.minUpvotes,
-        views: feed.flags.minViews,
-      },
+    flagFilters.min_thresholds = {
+      upvotes: feed.flags.minUpvotes,
+      views: feed.flags.minViews,
     };
   }
 

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -120,11 +120,9 @@ export const baseFeedConfig: Partial<FeedConfig> = {
 export type FeedFlagsFilters = {
   order_by?: FeedFlags['orderBy'];
   disable_engagement_filter?: FeedFlags['disableEngagementFilter'];
-  thresholds?: {
-    min_thresholds: {
-      upvotes?: FeedFlags['minUpvotes'];
-      views?: FeedFlags['minViews'];
-    };
+  min_thresholds?: {
+    upvotes?: FeedFlags['minUpvotes'];
+    views?: FeedFlags['minViews'];
   };
   min_day_range?: FeedFlags['minDayRange'];
 };


### PR DESCRIPTION
Somehow it ended up being sent under `thesholds`, but `min_thresholds` should be top level.

https://github.com/dailydotdev/daily/issues/1743