### PR TITLE
feat: expose translation field on fetch smart title

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -6906,6 +6906,10 @@ describe('query fetchSmartTitle', () => {
     query FetchSmartTitle($id: ID!) {
       fetchSmartTitle(id: $id) {
         title
+        translation {
+          title
+          smartTitle
+        }
       }
     }
   `;
@@ -7171,6 +7175,25 @@ describe('query fetchSmartTitle', () => {
 
       expect(res.errors?.length || 0).toEqual(1);
       expect(res.errors[0].extensions?.code).toEqual('FORBIDDEN');
+    });
+
+    it('should return translate field', async () => {
+      loggedUser = '1';
+      isPlus = true;
+      const res = await client.query<
+        { fetchSmartTitle: GQLPostSmartTitle },
+        { id: string }
+      >(QUERY, {
+        variables: { id: 'p1' },
+        headers: { 'content-language': 'de' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.fetchSmartTitle.title).toEqual('Title DE');
+      expect(res.data.fetchSmartTitle.translation).toEqual({
+        title: true,
+        smartTitle: false,
+      });
     });
   });
 });

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -13,9 +13,11 @@ import {
   Source,
   SourceMember,
   SquadSource,
+  translateablePostFields,
   User,
   validateCommentary,
   WelcomePost,
+  type PostTranslation,
 } from '../entity';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { isValidHttpUrl, standardizeURL } from './links';
@@ -862,5 +864,29 @@ export const getAllModerationItemsAsAdmin = async (
     },
     undefined,
     true,
+  );
+};
+
+export const getTranslationRecord = ({
+  translations,
+  contentLanguage,
+}: {
+  translations: Partial<Record<ContentLanguage, PostTranslation>>;
+  contentLanguage: ContentLanguage | null;
+}) => {
+  const translation = contentLanguage
+    ? translations[contentLanguage]
+    : undefined;
+
+  if (!translation) {
+    return {};
+  }
+
+  return translateablePostFields.reduce(
+    (acc: Record<string, boolean>, field) => {
+      acc[field] = !!translation[field];
+      return acc;
+    },
+    {},
   );
 };

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -17,7 +17,6 @@ import {
   UserStats,
   UserSubscriptionFlags,
   type PostTranslation,
-  translateablePostFields,
 } from '../entity';
 import {
   SourceMemberRoles,
@@ -27,7 +26,13 @@ import {
 } from '../roles';
 
 import { Context } from '../Context';
-import { base64, domainOnly, getSmartTitle, transformDate } from '../common';
+import {
+  base64,
+  domainOnly,
+  getSmartTitle,
+  getTranslationRecord,
+  transformDate,
+} from '../common';
 import { GQLComment } from '../schema/comments';
 import { GQLUserPost } from '../schema/posts';
 import { UserComment } from '../entity/user/UserComment';
@@ -501,21 +506,10 @@ const obj = new GraphORM({
           translations: Partial<Record<ContentLanguage, PostTranslation>>,
           ctx: Context,
         ): Partial<Record<keyof PostTranslation, boolean>> => {
-          const translation = ctx.contentLanguage
-            ? translations[ctx.contentLanguage]
-            : undefined;
-
-          if (!translation) {
-            return {};
-          }
-
-          return translateablePostFields.reduce(
-            (acc: Record<string, boolean>, field) => {
-              acc[field] = !!translation[field];
-              return acc;
-            },
-            {},
-          );
+          return getTranslationRecord({
+            translations,
+            contentLanguage: ctx.contentLanguage,
+          });
         },
       },
     },


### PR DESCRIPTION
- when smart title is fetched we want to know if it was translated as well
- exposed the same `translation` field