### PR TITLE
fix: suggestions should keep same logic as posts

### DIFF
--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -346,6 +346,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         .where('post.id IN (:...ids)', {
           ids: hits.length ? hits.map((x) => x.post_id) : ['nosuchid'],
         })
+        .andWhere('post.deleted = FALSE')
+        .andWhere('post.private = FALSE')
         .andWhere('post.title IS NOT NULL')
         .orderBy(`array_position(array[${idsStr}], post.id)`);
       if (ctx.userId) {


### PR DESCRIPTION
I saw the suggestion one didn't filter out deleted/private posts.
It should as they not accesible for the masses.

Then it's also inline with the actual post page.