### PR TITLE
chore: docker dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM node:22.13-bookworm-slim
 RUN apt-get update \
     && apt-get install -y ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
missed updating dev image version