### PR TITLE
fix: add better log tracking

### DIFF
--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -5,7 +5,6 @@ import { TypeORMQueryFailedError, TypeOrmError } from '../errors';
 import { isFibonacci } from '../common/fibonacci';
 import { generateStorageKey, StorageKey, StorageTopic } from '../config';
 import { deleteRedisKey } from '../redis';
-import { FastifyLoggerInstance } from 'fastify';
 import { logger } from '../logger';
 
 interface ShouldIncrement {

--- a/src/workers/newView.ts
+++ b/src/workers/newView.ts
@@ -6,6 +6,7 @@ import { isFibonacci } from '../common/fibonacci';
 import { generateStorageKey, StorageKey, StorageTopic } from '../config';
 import { deleteRedisKey } from '../redis';
 import { FastifyLoggerInstance } from 'fastify';
+import { logger } from '../logger';
 
 interface ShouldIncrement {
   currentStreak: number;
@@ -64,13 +65,12 @@ const shouldIncrementStreak = async (
 const incrementReadingStreak = async (
   manager: EntityManager,
   data: DeepPartial<View>,
-  logger: FastifyLoggerInstance,
   messageId: string | undefined,
 ): Promise<boolean> => {
   const { userId, timestamp } = data;
 
   if (!userId) {
-    logger?.warn(
+    logger.warn(
       {
         view: data,
         messageId: messageId,
@@ -192,7 +192,7 @@ const worker: Worker = {
       }
 
       try {
-        await incrementReadingStreak(manager, data, logger, message.messageId);
+        await incrementReadingStreak(manager, data, message.messageId);
       } catch (err) {
         logger.error(
           {


### PR DESCRIPTION
We seemed to always trigger this message regardless of the fail reason.
(might have been added after logs tbh)

So now we only log the user missing when that's the error.
Other cases likely mean user just not eligible for streak.