### PR TITLE
feat: add `plusProvider` to boot

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -129,6 +129,7 @@ const LOGGED_IN_BODY = {
     mastodon: null,
     language: undefined,
     isPlus: false,
+    plusProvider: null,
     defaultFeedId: null,
     flags: {
       showPlusGift: false,

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -555,10 +555,6 @@ describe('logged in boot', () => {
 
   describe('plusProvider', () => {
     it('should return the correct plus provider when not plus', async () => {
-      // await con.getRepository(User).save({
-      //   ...usersFixture[0],
-      //   plusProvider: 'stripe',
-      // });
       mockLoggedIn();
       const res = await request(app.server)
         .get(BASE_PATH)

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -29,6 +29,7 @@ import {
   SourceType,
   SQUAD_IMAGE_PLACEHOLDER,
   SquadSource,
+  SubscriptionProvider,
   User,
   UserMarketingCta,
   UserNotification,
@@ -550,6 +551,53 @@ describe('logged in boot', () => {
       .set('Cookie', 'ory_kratos_session=value;')
       .expect(200);
     expect(res.body.user.defaultFeedId).toBeNull();
+  });
+
+  describe('plusProvider', () => {
+    it('should return the correct plus provider when not plus', async () => {
+      // await con.getRepository(User).save({
+      //   ...usersFixture[0],
+      //   plusProvider: 'stripe',
+      // });
+      mockLoggedIn();
+      const res = await request(app.server)
+        .get(BASE_PATH)
+        .set('Cookie', 'ory_kratos_session=value;')
+        .expect(200);
+      expect(res.body.user.plusProvider).toEqual(null);
+    });
+
+    it('should return the correct plus provider when paddle', async () => {
+      await con.getRepository(User).save({
+        ...usersFixture[0],
+        subscriptionFlags: {
+          provider: SubscriptionProvider.Paddle,
+        },
+      });
+      mockLoggedIn();
+      const res = await request(app.server)
+        .get(BASE_PATH)
+        .set('Cookie', 'ory_kratos_session=value;')
+        .expect(200);
+      expect(res.body.user.plusProvider).toEqual(SubscriptionProvider.Paddle);
+    });
+
+    it('should return the correct plus provider when storekit', async () => {
+      await con.getRepository(User).save({
+        ...usersFixture[0],
+        subscriptionFlags: {
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
+      });
+      mockLoggedIn();
+      const res = await request(app.server)
+        .get(BASE_PATH)
+        .set('Cookie', 'ory_kratos_session=value;')
+        .expect(200);
+      expect(res.body.user.plusProvider).toEqual(
+        SubscriptionProvider.AppleStoreKit,
+      );
+    });
   });
 });
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -485,6 +485,7 @@ const loggedInBoot = async ({
     }
     const isTeamMember = exp?.a?.team === 1;
     const isPlus = isPlusMember(user.subscriptionFlags?.cycle);
+    const plusProvider = user.subscriptionFlags?.provider || null;
 
     if (isPlus) {
       exp.a.plus = 1;
@@ -514,6 +515,7 @@ const loggedInBoot = async ({
         canSubmitArticle: user.reputation >= submitArticleThreshold,
         isTeamMember,
         isPlus,
+        plusProvider,
         language: user.language || undefined,
         image: mapCloudinaryUrl(user.image),
         cover: mapCloudinaryUrl(user.cover),


### PR DESCRIPTION
Exposes the plus provider in boot. Need to use it in webapp to determine what plus to show in app