### PR TITLE
feat: add `appAccountToken` to `UserSubscriptionFlags`

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -130,11 +130,11 @@ const LOGGED_IN_BODY = {
     mastodon: null,
     language: undefined,
     isPlus: false,
-    plusProvider: null,
     defaultFeedId: null,
     flags: {
       showPlusGift: false,
     },
+    subscriptionFlags: {},
   },
   marketingCta: null,
   feeds: [],
@@ -553,46 +553,50 @@ describe('logged in boot', () => {
     expect(res.body.user.defaultFeedId).toBeNull();
   });
 
-  describe('plusProvider', () => {
-    it('should return the correct plus provider when not plus', async () => {
-      mockLoggedIn();
-      const res = await request(app.server)
-        .get(BASE_PATH)
-        .set('Cookie', 'ory_kratos_session=value;')
-        .expect(200);
-      expect(res.body.user.plusProvider).toEqual(null);
-    });
-
-    it('should return the correct plus provider when paddle', async () => {
-      await con.getRepository(User).save({
-        ...usersFixture[0],
-        subscriptionFlags: {
-          provider: SubscriptionProvider.Paddle,
-        },
+  describe('subscriptionFlags', () => {
+    describe('provider flag', () => {
+      it('should not return provider when not set on user', async () => {
+        mockLoggedIn();
+        const res = await request(app.server)
+          .get(BASE_PATH)
+          .set('Cookie', 'ory_kratos_session=value;')
+          .expect(200);
+        expect(res.body.user.subscriptionFlags.provider).toBeUndefined();
       });
-      mockLoggedIn();
-      const res = await request(app.server)
-        .get(BASE_PATH)
-        .set('Cookie', 'ory_kratos_session=value;')
-        .expect(200);
-      expect(res.body.user.plusProvider).toEqual(SubscriptionProvider.Paddle);
-    });
 
-    it('should return the correct plus provider when storekit', async () => {
-      await con.getRepository(User).save({
-        ...usersFixture[0],
-        subscriptionFlags: {
-          provider: SubscriptionProvider.AppleStoreKit,
-        },
+      it('should return the correct plus provider when paddle', async () => {
+        await con.getRepository(User).save({
+          ...usersFixture[0],
+          subscriptionFlags: {
+            provider: SubscriptionProvider.Paddle,
+          },
+        });
+        mockLoggedIn();
+        const res = await request(app.server)
+          .get(BASE_PATH)
+          .set('Cookie', 'ory_kratos_session=value;')
+          .expect(200);
+        expect(res.body.user.subscriptionFlags.provider).toEqual(
+          SubscriptionProvider.Paddle,
+        );
       });
-      mockLoggedIn();
-      const res = await request(app.server)
-        .get(BASE_PATH)
-        .set('Cookie', 'ory_kratos_session=value;')
-        .expect(200);
-      expect(res.body.user.plusProvider).toEqual(
-        SubscriptionProvider.AppleStoreKit,
-      );
+
+      it('should return the correct plus provider when storekit', async () => {
+        await con.getRepository(User).save({
+          ...usersFixture[0],
+          subscriptionFlags: {
+            provider: SubscriptionProvider.AppleStoreKit,
+          },
+        });
+        mockLoggedIn();
+        const res = await request(app.server)
+          .get(BASE_PATH)
+          .set('Cookie', 'ory_kratos_session=value;')
+          .expect(200);
+        expect(res.body.user.subscriptionFlags.provider).toEqual(
+          SubscriptionProvider.AppleStoreKit,
+        );
+      });
     });
   });
 });

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -598,6 +598,34 @@ describe('logged in boot', () => {
         );
       });
     });
+
+    describe('appAccountToken flag', () => {
+      it('should not return appAccountToken when not set on user', async () => {
+        mockLoggedIn();
+        const res = await request(app.server)
+          .get(BASE_PATH)
+          .set('Cookie', 'ory_kratos_session=value;')
+          .expect(200);
+        expect(res.body.user.subscriptionFlags.appAccountToken).toBeUndefined();
+      });
+
+      it('should not return appAccountToken when set on user', async () => {
+        await con.getRepository(User).save({
+          ...usersFixture[0],
+          subscriptionFlags: {
+            appAccountToken: 'b381c50a-b79d-4ec9-9284-973d4d5d767b',
+          },
+        });
+        mockLoggedIn();
+        const res = await request(app.server)
+          .get(BASE_PATH)
+          .set('Cookie', 'ory_kratos_session=value;')
+          .expect(200);
+        expect(res.body.user.subscriptionFlags.appAccountToken).toEqual(
+          'b381c50a-b79d-4ec9-9284-973d4d5d767b',
+        );
+      });
+    });
   });
 });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -6078,3 +6078,44 @@ describe('query getGifterUser', () => {
     expect(res.data.plusGifterUser.image).toBeTruthy();
   });
 });
+
+describe('mutation requestAppAccountToken', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation RequestAppAccountToken {
+      requestAppAccountToken
+    }
+  `;
+
+  it('should throw an error if the user is not logged in', async () => {
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION },
+      'UNAUTHENTICATED',
+    );
+  });
+
+  it('should generate a new app account token if the user does not have one', async () => {
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION);
+    expect(res.errors).toBeFalsy();
+    expect(res.data.requestAppAccountToken).toBeTruthy();
+  });
+
+  it('should return the existing app account token if the user already has one', async () => {
+    loggedUser = '1';
+    await con.getRepository(User).update(
+      { id: loggedUser },
+      {
+        subscriptionFlags: updateSubscriptionFlags({
+          appAccountToken: '77601fd2-0490-44e8-a042-4fd516929715',
+        }),
+      },
+    );
+
+    const res = await client.mutate(MUTATION);
+    expect(res.errors).toBeFalsy();
+    expect(res.data.requestAppAccountToken).toEqual(
+      '77601fd2-0490-44e8-a042-4fd516929715',
+    );
+  });
+});

--- a/src/common/storekit.ts
+++ b/src/common/storekit.ts
@@ -1,0 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const generateAppAccountToken = (): string => {
+  return uuidv4();
+};

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -40,6 +40,9 @@ export type UserSubscriptionFlags = Partial<{
   gifterId?: string;
   giftExpirationDate?: Date;
   provider: SubscriptionProvider;
+
+  // StoreKit flags
+  appAccountToken?: string; // StoreKit app account token (UUID)
 }>;
 
 @Entity()

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -177,6 +177,25 @@ export const excludeProperties = <T, K extends keyof T>(
   return clone;
 };
 
+export const includeProperties = <T, K extends keyof T>(
+  obj: T,
+  properties: K[],
+): Pick<T, K> => {
+  if (!obj) {
+    return obj;
+  }
+
+  const clone = structuredClone(obj);
+  const keys = Object.keys(clone) as K[];
+  keys.forEach((key) => {
+    if (!properties.includes(key)) {
+      delete clone[key];
+    }
+  });
+
+  return clone;
+};
+
 const getSquads = async (
   con: DataSource | QueryRunner,
   userId: string,
@@ -485,7 +504,6 @@ const loggedInBoot = async ({
     }
     const isTeamMember = exp?.a?.team === 1;
     const isPlus = isPlusMember(user.subscriptionFlags?.cycle);
-    const plusProvider = user.subscriptionFlags?.provider || null;
 
     if (isPlus) {
       exp.a.plus = 1;
@@ -515,13 +533,17 @@ const loggedInBoot = async ({
         canSubmitArticle: user.reputation >= submitArticleThreshold,
         isTeamMember,
         isPlus,
-        plusProvider,
         language: user.language || undefined,
         image: mapCloudinaryUrl(user.image),
         cover: mapCloudinaryUrl(user.cover),
         defaultFeedId: isPlus ? user.defaultFeedId : null,
         flags: {
           showPlusGift: Boolean(user?.flags?.showPlusGift),
+        },
+        subscriptionFlags: {
+          ...includeProperties(user.subscriptionFlags!, [
+            'provider',
+          ]),
         },
       },
       visit,

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -543,6 +543,7 @@ const loggedInBoot = async ({
         subscriptionFlags: {
           ...includeProperties(user.subscriptionFlags!, [
             'provider',
+            'appAccountToken',
           ]),
         },
       },


### PR DESCRIPTION
Turns out StoreKit / AppStore is a bit more annoying to work with, I can't set the userId on the transaction, but I can use an `appAccountToken` which must be an UUID.

This is what we will use to associate the App Store transactions with the user (hopefully).