### PR TITLE
fix: parse `appAppleId` as int

### DIFF
--- a/src/routes/webhooks/apple.ts
+++ b/src/routes/webhooks/apple.ts
@@ -56,7 +56,7 @@ const getVerifierEnvironment = (): Environment => {
 };
 
 const bundleId = isTest ? 'dev.fylla' : env.APPLE_APP_BUNDLE_ID;
-const appAppleId = env.APPLE_APP_APPLE_ID;
+const appAppleId = parseInt(env.APPLE_APP_APPLE_ID);
 const enableOnlineChecks = true;
 const environment = getVerifierEnvironment();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ declare global {
       SLACK_TRANSACTIONS_WEBHOOK: string;
       NJORD_ORIGIN: string;
 
-      APPLE_APP_APPLE_ID?: number;
+      APPLE_APP_APPLE_ID: string;
       APPLE_APP_BUNDLE_ID: string;
     }
   }


### PR DESCRIPTION
:fml:

Error didn't occur in sandbox, because there it doesn't care about the `appAppleId` :triggered: