### PR TITLE
fix: assign nested comment correctly after award

### DIFF
--- a/src/common/njord.ts
+++ b/src/common/njord.ts
@@ -590,7 +590,7 @@ export const awardComment = async (
   const [product, comment, userComment] = await queryReadReplica<
     [
       Pick<Product, 'id' | 'type'>,
-      Pick<Comment, 'id' | 'userId' | 'postId' | 'post'>,
+      Pick<Comment, 'id' | 'userId' | 'postId' | 'post' | 'parentId'>,
       Pick<UserComment, 'awardTransactionId'> | null,
     ]
   >(ctx.con, async ({ queryRunner }) => {
@@ -602,7 +602,7 @@ export const awardComment = async (
         },
       }),
       queryRunner.manager.getRepository(Comment).findOneOrFail({
-        select: ['id', 'userId', 'postId'],
+        select: ['id', 'userId', 'postId', 'parentId'],
         where: {
           id: props.entityId,
         },
@@ -670,7 +670,7 @@ export const awardComment = async (
         const newComment = entityManager.getRepository(Comment).create({
           id: await generateShortId(),
           postId: comment.postId,
-          parentId: comment.id,
+          parentId: comment.parentId || comment.id,
           userId: ctx.userId,
           content: note,
           awardTransactionId: transaction.id,


### PR DESCRIPTION
- award comment would not be visible due to being assigned to nested comment,  which is what we don't support
- now it assigns to parent comment as we do for other nested comments