### PR TITLE
feat: add credits for subscription

### DIFF
--- a/src/common/paddle.ts
+++ b/src/common/paddle.ts
@@ -107,12 +107,19 @@ export const coreProductCustomDataSchema = z.object(
   },
 );
 
-const paddleTransactionSchema = z.object({
+export const paddleTransactionSchema = z.object({
   id: z.string({ message: 'Transaction id is required' }),
   updatedAt: z.preprocess(
     (value) => new Date(value as string),
     z.date({ message: 'Transaction updated at is required' }),
   ),
+  details: z.object({
+    totals: z.object({
+      grandTotal: z.string({
+        message: 'Transaction grand total is required',
+      }),
+    }),
+  }),
   items: z
     .array(
       z.object({

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -22,6 +22,7 @@ type RemoteConfigValue = {
   enableBalance: boolean;
   approvedStoreKitSandboxUsers: string[];
   coreProductId: string;
+  coreModifier: number;
 };
 
 class RemoteConfig {

--- a/src/routes/webhooks/apple.ts
+++ b/src/routes/webhooks/apple.ts
@@ -220,7 +220,11 @@ const handleNotifcationRequest = async (
 
   if (isNullOrUndefined(signedPayload)) {
     logger.error(
-      { body: request.body, provider: SubscriptionProvider.AppleStoreKit },
+      {
+        environment,
+        body: request.body,
+        provider: SubscriptionProvider.AppleStoreKit,
+      },
       "Missing 'signedPayload' in request body",
     );
     return response.status(403).send({ error: 'Invalid Payload' });
@@ -233,7 +237,11 @@ const handleNotifcationRequest = async (
     // Don't proceed any further if it's a test notification
     if (notification.notificationType === NotificationTypeV2.TEST) {
       logger.info(
-        { notification, provider: SubscriptionProvider.AppleStoreKit },
+        {
+          environment,
+          notification,
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
         'Received Test Notification',
       );
       return response.status(200).send({ received: true });
@@ -243,7 +251,11 @@ const handleNotifcationRequest = async (
     // NOTE: When adding support for purchasing cores, we must remove this check as it's not a subscription event
     if (isNullOrUndefined(notification?.data?.signedRenewalInfo)) {
       logger.info(
-        { notification, provider: SubscriptionProvider.AppleStoreKit },
+        {
+          environment,
+          notification,
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
         "Missing 'signedRenewalInfo' in notification data",
       );
       return response.status(400).send({ error: 'Invalid Payload' });
@@ -265,7 +277,11 @@ const handleNotifcationRequest = async (
 
     if (!user) {
       logger.error(
-        { notification, provider: SubscriptionProvider.AppleStoreKit },
+        {
+          environment,
+          notification,
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
         'User not found with matching app account token',
       );
       return response.status(404).send({ error: 'Invalid Payload' });
@@ -277,7 +293,12 @@ const handleNotifcationRequest = async (
       !remoteConfig.vars.approvedStoreKitSandboxUsers?.includes(user.id)
     ) {
       logger.error(
-        { user, provider: SubscriptionProvider.AppleStoreKit },
+        {
+          environment,
+          notification,
+          user,
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
         'User not approved for sandbox',
       );
       return response.status(403).send({ error: 'Invalid Payload' });
@@ -288,6 +309,7 @@ const handleNotifcationRequest = async (
       logger.error(
         {
           user,
+          environment,
           notification,
           provider: SubscriptionProvider.AppleStoreKit,
         },
@@ -331,6 +353,7 @@ const handleNotifcationRequest = async (
       {
         renewalInfo,
         user,
+        environment,
         provider: SubscriptionProvider.AppleStoreKit,
         notification: {
           notificationType: notification.notificationType,
@@ -348,6 +371,7 @@ const handleNotifcationRequest = async (
         {
           err,
           signedPayload,
+          environment,
           provider: SubscriptionProvider.AppleStoreKit,
         },
         'Failed to verify Apple App Store Server Notification',
@@ -358,6 +382,7 @@ const handleNotifcationRequest = async (
         {
           err,
           signedPayload,
+          environment,
           provider: SubscriptionProvider.AppleStoreKit,
         },
         'Failed to process Apple App Store Server Notification',

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -539,9 +539,18 @@ const assignSubscriptionCores = async ({
     return;
   }
 
-  const coresForPayment = Math.floor(
-    remoteConfig.vars?.coreModifier * data.details?.totals?.grandTotal,
-  );
+  const modifier = remoteConfig.vars?.coreModifier || 0.001;
+  const total = parseInt(data.details?.totals?.grandTotal || '0');
+  const coresForPayment = Math.floor(modifier * total);
+
+  if (coresForPayment <= 0) {
+    logger.error(
+      { provider: SubscriptionProvider.Paddle, data },
+      'Cores for payment is less than 0',
+    );
+    return;
+  }
+
   await con.transaction(async (entityManager) => {
     const newTransaction = await entityManager
       .getRepository(UserTransaction)


### PR DESCRIPTION
Add cores to people who complete purchases for plus subscription.
The 1 core value is stores in remoteConfig so we can easily update it.