### PR TITLE
fix: improve DX by adding liveness probe to API pod

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -222,6 +222,7 @@ if (isAdhocEnv) {
       maxReplicas: 15,
       limits: apiLimits,
       requests: apiRequests,
+      livenessProbe,
       metric: { type: 'memory_cpu', cpu: 70 },
       ports: [
         { containerPort: 3000, name: 'http' },


### PR DESCRIPTION
Adds the liveness probe to the API pod in adhoc environment, so that it'll restart it when the API has crashed for some reason.

Because we're using nodemon in adhoc environment, the pod doesn't really crash when API crashes, because nodemon is still running.