### PR TITLE
feat: funnel boot

### DIFF
--- a/.env
+++ b/.env
@@ -41,6 +41,7 @@ MEILI_ORIGIN=http://localhost:7700/
 SUBMIT_ARTICLE_THRESHOLD=250
 ANALYTICS_URL=http://localhost:5000
 NJORD_ORIGIN=http://njord-transactions-server
+FREYJA_ORIGIN=http://localhost:7800
 
 MEILI_INDEX=dev
 MEILI_TOKEN=dev

--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -54,6 +54,7 @@ config:
     defaultImageUrl: https://res.cloudinary.com/daily-now/image/upload/s--P4t4XyoV--/f_auto/v1722860399/public/Placeholder%2001,https://res.cloudinary.com/daily-now/image/upload/s--VDukGCjf--/f_auto/v1722860399/public/Placeholder%2002,https://res.cloudinary.com/daily-now/image/upload/s--HRgLpUt6--/f_auto/v1722860399/public/Placeholder%2003,https://res.cloudinary.com/daily-now/image/upload/s--foaA6JGU--/f_auto/v1722860399/public/Placeholder%2004,https://res.cloudinary.com/daily-now/image/upload/s--CxzD6vbw--/f_auto/v1722860399/public/Placeholder%2005,https://res.cloudinary.com/daily-now/image/upload/s--ZrL_HSsR--/f_auto/v1722860399/public/Placeholder%2006,https://res.cloudinary.com/daily-now/image/upload/s--1KxV4ohY--/f_auto/v1722860400/public/Placeholder%2007,https://res.cloudinary.com/daily-now/image/upload/s--0_ODbtD2--/f_auto/v1722860399/public/Placeholder%2008,https://res.cloudinary.com/daily-now/image/upload/s--qPvKM23u--/f_auto/v1722860399/public/Placeholder%2009,https://res.cloudinary.com/daily-now/image/upload/s--OHB84bZF--/f_auto/v1722860399/public/Placeholder%2010,https://res.cloudinary.com/daily-now/image/upload/s--2-1xRawN--/f_auto/v1722860399/public/Placeholder%2011,https://res.cloudinary.com/daily-now/image/upload/s--58gMhC4P--/f_auto/v1722860399/public/Placeholder%2012
     digestQueueConcurrency: 1000
     enablePubsub: true
+    freyjaOrigin: http://freyja
     gcloudProject: local
     heimdallOrigin: http://heimdall-api
     jwtAudience: Daily Staging

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -53,6 +53,7 @@ config:
     digestQueueConcurrency: 1000
     experimentationKey:
       secure: AAABADH0xT7H6UeMlZG0fUEGjohQ1dvwcbIgJ3WMI5wfqScub3Qp3nvUDhska0DunbFmvj7IrtH07noRL1lCYg==
+    freyjaOrigin: http://freyja.freyja
     growthbookApiConfigClientKey:
       secure: AAABAJEgS6b8xZv0j06KOawyNMdkTpGmzKs7Ryed5SofiLp3vSTjxhqQuKSVsaHjR5s=
     growthbookClientKey:

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -36,6 +36,16 @@ export const cookies: {
     },
     key: 'da3',
   },
+  funnel: {
+    opts: {
+      maxAge: 1000 * 60 * 30,
+      httpOnly: false,
+      signed: false,
+      secure: false,
+      sameSite: 'lax',
+    },
+    key: 'da4',
+  },
   kratos: {
     key: 'ory_kratos_session',
     opts: {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -39,9 +39,9 @@ export const cookies: {
   funnel: {
     opts: {
       maxAge: 1000 * 60 * 30,
-      httpOnly: false,
+      httpOnly: true,
       signed: false,
-      secure: false,
+      secure: env === 'production',
       sameSite: 'lax',
     },
     key: 'da4',

--- a/src/integrations/freyja/clients.ts
+++ b/src/integrations/freyja/clients.ts
@@ -1,0 +1,62 @@
+import { RequestInit } from 'node-fetch';
+import { IFreyjaClient, type FunnelState } from './types';
+import { GarmrNoopService, IGarmrService, GarmrService } from '../garmr';
+import { fetchOptions as globalFetchOptions } from '../../http';
+import { fetchParse } from '../retry';
+
+export class FreyjaClient implements IFreyjaClient {
+  private readonly fetchOptions: RequestInit;
+  private readonly garmr: IGarmrService;
+
+  constructor(
+    private readonly url: string,
+    options?: {
+      fetchOptions?: RequestInit;
+      garmr?: IGarmrService;
+    },
+  ) {
+    const {
+      fetchOptions = globalFetchOptions,
+      garmr = new GarmrNoopService(),
+    } = options || {};
+
+    this.fetchOptions = fetchOptions;
+    this.garmr = garmr;
+  }
+
+  createSession(
+    userId: string,
+    funnelId: string,
+    version?: number,
+  ): Promise<FunnelState> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/api/sessions`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        body: JSON.stringify({ userId, funnelId, version }),
+      });
+    });
+  }
+
+  getSession(sessionId: string): Promise<FunnelState> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/api/sessions/${sessionId}`, {
+        ...this.fetchOptions,
+        method: 'GET',
+      });
+    });
+  }
+}
+
+const garmrFreyjaService = new GarmrService({
+  service: FreyjaClient.name,
+  breakerOpts: {
+    halfOpenAfter: 5 * 1000,
+    threshold: 0.1,
+    duration: 10 * 1000,
+  },
+});
+
+export const freyjaClient = new FreyjaClient(process.env.FREYJA_ORIGIN!, {
+  garmr: garmrFreyjaService,
+});

--- a/src/integrations/freyja/index.ts
+++ b/src/integrations/freyja/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { FreyjaClient, freyjaClient } from './clients';

--- a/src/integrations/freyja/types.ts
+++ b/src/integrations/freyja/types.ts
@@ -1,0 +1,21 @@
+// Keep the type flexible to allow for future changes
+export type FunnelState = {
+  session: {
+    id: string;
+    currentStep: string;
+    userId: string;
+  } & Record<string, unknown>;
+  funnel: {
+    id: string;
+    version: number;
+  } & Record<string, unknown>;
+};
+
+export interface IFreyjaClient {
+  createSession(
+    userId: string,
+    funnelId: string,
+    version?: number,
+  ): Promise<FunnelState>;
+  getSession(sessionId: string): Promise<FunnelState>;
+}


### PR DESCRIPTION
Introduce a new boot endpoint for web funnels. It's a lean version to optimize for speed.

It calls Freyja to fetch the funnel and has simple logic for the experimentation.