### PR TITLE
fix: missing type from the slack message

### DIFF
--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -277,11 +277,12 @@ const notifyNewPaddleTransaction = async ({
 }: {
   event: TransactionCompletedEvent;
 }) => {
-  const { user_id, gifter_id } = (data?.customData ?? {}) as PaddleCustomData;
+  const { customData, subscriptionId } = data ?? {};
+  const { user_id, gifter_id } = (customData ?? {}) as PaddleCustomData;
   const purchasedById = gifter_id ?? user_id;
   const subscriptionForId = await getUserId({
     userId: user_id,
-    subscriptionId: 'subscriptionId' in data && data.subscriptionId,
+    subscriptionId,
   });
   const con = await createOrGetConnection();
   const flags = (


### PR DESCRIPTION
Issue: the `type` is missing from the Slack message. Basically the cycle.

![Screenshot 2025-04-02 at 10 12 56 PM](https://github.com/user-attachments/assets/b4e31982-b583-4344-8df6-9232fd5e7f0c)

Root cause: the const `flags` is defaulting to `null` value when the transaction is not gifting. We should now always fetch it to get the basis of the cycle that the subscribed user is in.

Checked any other place. This is the only one where we default to `null` based on certain conditions.