### PR TITLE
fix: log entire error for paddle generic error

### DIFF
--- a/src/common/paddle.ts
+++ b/src/common/paddle.ts
@@ -38,7 +38,7 @@ export const cancelSubscription = async ({
       {
         provider: SubscriptionProvider.Paddle,
         subscriptionId,
-        error: e,
+        err: e,
       },
       'Subscription cancellation failed',
     );

--- a/src/cron/calculateTopReaders.ts
+++ b/src/cron/calculateTopReaders.ts
@@ -133,8 +133,8 @@ export const calculateTopReaders: Cron = {
       logger.info(
         'calculateTopReaders: All done. So long and thanks for all the fish!',
       );
-    } catch (error) {
-      logger.error({ error }, 'Error during calculation of top readers');
+    } catch (err) {
+      logger.error({ err }, 'Error during calculation of top readers');
     }
   },
 };

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -132,17 +132,17 @@ export const updateUserEmail = async (
 
     logger.info(`Updated email for user with ID: ${data.id}`);
     return { status: 'ok', userId: data.id };
-  } catch (error) {
+  } catch (err) {
     logger.error(
       {
         data,
         userId: data.id,
-        error,
+        err,
       },
       'failed to update user email',
     );
 
-    throw error;
+    throw err;
   }
 };
 

--- a/src/routes/webhooks/customerio.ts
+++ b/src/routes/webhooks/customerio.ts
@@ -232,8 +232,8 @@ export const customerio = async (fastify: FastifyInstance): Promise<void> => {
           payload.notification,
         );
         return res.send({ success: true });
-      } catch (error) {
-        logger.error({ error }, 'Error sending generic push');
+      } catch (err) {
+        logger.error({ err }, 'Error sending generic push');
         return res.status(500).send({ success: false });
       }
     },

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -1067,14 +1067,12 @@ export const paddle = async (fastify: FastifyInstance): Promise<void> => {
             );
           }
         } catch (originalError) {
-          const error = originalError as Error;
+          const err = originalError as Error;
 
           logger.error(
             {
+              err,
               provider: SubscriptionProvider.Paddle,
-              err: {
-                message: error.message,
-              },
             },
             'Paddle generic error',
           );

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -47,7 +47,7 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
 
         if (err?.code === TypeOrmError.NULL_VIOLATION) {
           logger.error(
-            { data: messageToJson(message) },
+            { data: messageToJson(message), err },
             'null violation when creating a notification',
           );
           return;
@@ -57,7 +57,7 @@ export function notificationWorkerToWorker(worker: NotificationWorker): Worker {
           err?.constraint === TypeOrmError.USER_CONSTRAINT
         ) {
           logger.error(
-            { data: messageToJson(message) },
+            { data: messageToJson(message), err },
             'user constraint failed when creating a notification',
           );
           return;


### PR DESCRIPTION
Log the entire error, and not just the error message, for better debugging.
Also fixed a few other `logger.error` where it logs to `error` instead