### PR TITLE
chore: adjust ws memory limit and split into r/l

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -136,11 +136,14 @@ const apiLimits: pulumi.Input<{ memory: string }> = {
   memory: `${memory}Mi`,
 };
 
-const wsMemory = 2048;
+const wsMemory = 1280;
+const wsRequests: pulumi.Input<{ cpu: string; memory: string }> = {
+  cpu: '300',
+  memory: '800Mi',
+};
 const wsLimits: pulumi.Input<{
   [key: string]: pulumi.Input<string>;
 }> = {
-  cpu: '300m',
   memory: `${wsMemory}Mi`,
 };
 
@@ -342,6 +345,7 @@ if (isAdhocEnv) {
       minReplicas: 3,
       maxReplicas: 10,
       limits: wsLimits,
+      requests: wsRequests,
       readinessProbe,
       livenessProbe,
       metric: { type: 'memory_cpu', cpu: 85 },


### PR DESCRIPTION
Decrease the ws memory limit to 1.25 GiB, and request 800 MiB memory
![image](https://github.com/user-attachments/assets/67cc255d-c836-4c4d-a0f2-bf7a2bf54487)
