### PR TITLE
fix: set correct memory limit for ws hpa

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -138,7 +138,7 @@ const apiLimits: pulumi.Input<{ memory: string }> = {
 
 const wsMemory = 1280;
 const wsRequests: pulumi.Input<{ cpu: string; memory: string }> = {
-  cpu: '300',
+  cpu: '300m',
   memory: '800Mi',
 };
 const wsLimits: pulumi.Input<{

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -348,7 +348,7 @@ if (isAdhocEnv) {
       requests: wsRequests,
       readinessProbe,
       livenessProbe,
-      metric: { type: 'memory_cpu', cpu: 85 },
+      metric: { type: 'memory_cpu', cpu: 85, memory: 130 },
       disableLifecycle: true,
       spot: { enabled: true },
       ...vols,


### PR DESCRIPTION
- set HPA to trigger at 130% of requested memory (~80% of limit)
- and don't request 300 cores (instead of 0.3 core)

Expect pulumi to fail, as I force applied fix