### PR TITLE
fix: uniform value for the subscription cycle

### DIFF
--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -65,7 +65,15 @@ type PaddleSubscriptionEvent =
 const extractSubscriptionCycle = (
   items: PaddleSubscriptionEvent['data']['items'],
 ) => {
-  return items?.[0]?.price?.billingCycle?.interval;
+  const cycle = items?.[0]?.price?.billingCycle?.interval;
+
+  if (!cycle) {
+    return undefined;
+  }
+
+  return cycle === 'year'
+    ? SubscriptionCycles.Yearly
+    : SubscriptionCycles.Monthly;
 };
 
 export const updateUserSubscription = async ({
@@ -186,7 +194,7 @@ const planChanged = async ({ data }: SubscriptionUpdatedEvent) => {
 };
 
 interface AnalyticsExtra {
-  cycle: string;
+  cycle: SubscriptionCycles;
   cost: number;
   currency: string;
   payment: string;


### PR DESCRIPTION
The value returned by Paddle event is `year`. We've been using `yearly` since then. To make them consistent from the past, we are going to keep using `yearly`.

I will run a manual update to around 15 records once this is merged.