### PR TITLE
fix: id maps property can be nullable

### DIFF
--- a/src/schema/paddle.ts
+++ b/src/schema/paddle.ts
@@ -156,11 +156,11 @@ export const typeDefs = /* GraphQL */ `
     """
     Paddle platform ID
     """
-    paddle: String!
+    paddle: String
     """
     iOS platform ID
     """
-    ios: String!
+    ios: String
   }
 
   """


### PR DESCRIPTION
As discussed from this PR, the id for iOS can be nullable: https://github.com/dailydotdev/daily-api/pull/2741#discussion_r2032691102

We can probably say the same for Paddle, if we intend to promote something similar to gifting in iOS but implemented differently.