### PR TITLE
feat: adjust transaction processing

### DIFF
--- a/src/common/paddle/index.ts
+++ b/src/common/paddle/index.ts
@@ -5,8 +5,8 @@ import {
   type Subscription,
   type TransactionCompletedEvent,
   type TransactionCreatedEvent,
+  type TransactionPaidEvent,
   TransactionPaymentFailedEvent,
-  type TransactionReadyEvent,
   type TransactionUpdatedEvent,
 } from '@paddle/paddle-node-sdk';
 import { logger } from '../../logger';
@@ -137,7 +137,7 @@ export const isCoreTransaction = ({
   event:
     | TransactionCreatedEvent
     | TransactionUpdatedEvent
-    | TransactionReadyEvent
+    | TransactionPaidEvent
     | TransactionCompletedEvent
     | TransactionPaymentFailedEvent;
 }): boolean => {
@@ -155,7 +155,7 @@ export const getPaddleTransactionData = ({
   event:
     | TransactionCreatedEvent
     | TransactionUpdatedEvent
-    | TransactionReadyEvent
+    | TransactionPaidEvent
     | TransactionCompletedEvent
     | TransactionPaymentFailedEvent;
 }): z.infer<typeof paddleTransactionSchema> => {

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -8,9 +8,9 @@ import {
   type SubscriptionCreatedEvent,
   type SubscriptionUpdatedEvent,
   type TransactionPaymentFailedEvent,
-  type TransactionReadyEvent,
   type TransactionUpdatedEvent,
   type TransactionPayoutTotalsNotification,
+  type TransactionPaidEvent,
 } from '@paddle/paddle-node-sdk';
 import createOrGetConnection from '../../db';
 import {
@@ -857,10 +857,10 @@ export const processTransactionCreated = async ({
   }
 };
 
-export const processTransactionReady = async ({
+export const processTransactionPaid = async ({
   event,
 }: {
-  event: TransactionReadyEvent;
+  event: TransactionPaidEvent;
 }) => {
   if (isCoreTransaction({ event })) {
     const transactionData = getPaddleTransactionData({ event });
@@ -989,8 +989,9 @@ export const processTransactionUpdated = async ({
 
       switch (event.data.status) {
         case 'draft':
-          return UserTransactionStatus.Created;
         case 'ready':
+          return UserTransactionStatus.Created;
+        case 'billed':
           return UserTransactionStatus.Processing;
         default:
           return undefined;
@@ -1049,8 +1050,8 @@ export const paddle = async (fastify: FastifyInstance): Promise<void> => {
                 });
 
                 break;
-              case EventName.TransactionReady:
-                await processTransactionReady({
+              case EventName.TransactionPaid:
+                await processTransactionPaid({
                   event: eventData,
                 });
 

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -880,7 +880,10 @@ export const processTransactionPaid = async ({
         event,
         transaction,
         nextStatus,
-        validStatus: [UserTransactionStatus.Created],
+        validStatus: [
+          UserTransactionStatus.Created,
+          UserTransactionStatus.Processing,
+        ],
         data: transactionData,
       })
     ) {


### PR DESCRIPTION
With one-step checkout `transaction.ready` happens immediately so most transaction would end up in processing/pending state even though user maybe did not even interact with checkout. This keeps transaction in `created` state until user actually tries to pay and then we start processing.