### PR TITLE
fix: make `coresRole` optional

### DIFF
--- a/__tests__/devcard.ts
+++ b/__tests__/devcard.ts
@@ -261,6 +261,7 @@ describe('query devCard(id)', () => {
     username
     bio
     reputation
+    coresRole
   }
 `;
 
@@ -302,6 +303,7 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/lee',
         reputation: 10,
         username: 'lee',
+        coresRole: null,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Default,
@@ -325,6 +327,7 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/ido',
         reputation: 10,
         username: 'ido',
+        coresRole: null,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Gold,

--- a/__tests__/devcard.ts
+++ b/__tests__/devcard.ts
@@ -261,7 +261,6 @@ describe('query devCard(id)', () => {
     username
     bio
     reputation
-    coresRole
   }
 `;
 
@@ -303,7 +302,6 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/lee',
         reputation: 10,
         username: 'lee',
-        coresRole: 0,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Default,
@@ -327,7 +325,6 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/ido',
         reputation: 10,
         username: 'ido',
-        coresRole: 0,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Gold,

--- a/__tests__/devcard.ts
+++ b/__tests__/devcard.ts
@@ -261,6 +261,7 @@ describe('query devCard(id)', () => {
     username
     bio
     reputation
+    coresRole
   }
 `;
 
@@ -302,6 +303,7 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/lee',
         reputation: 10,
         username: 'lee',
+        coresRole: 0,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Default,
@@ -325,6 +327,7 @@ describe('query devCard(id)', () => {
         permalink: 'http://localhost:5002/ido',
         reputation: 10,
         username: 'ido',
+        coresRole: 0,
       },
       createdAt: expect.any(String),
       theme: DevCardTheme.Gold,

--- a/src/common/devcard.ts
+++ b/src/common/devcard.ts
@@ -127,6 +127,7 @@ export async function getDevCardData(
       'reputation',
       'cover',
       'subscriptionFlags',
+      'coresRole',
     ],
   });
   const [articlesRead, tags, sources] = await Promise.all([

--- a/src/common/devcard.ts
+++ b/src/common/devcard.ts
@@ -127,7 +127,6 @@ export async function getDevCardData(
       'reputation',
       'cover',
       'subscriptionFlags',
-      'coresRole',
     ],
   });
   const [articlesRead, tags, sources] = await Promise.all([

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -461,7 +461,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Role for Cores access
     """
-    coresRole: Int!
+    coresRole: Int
   }
 
   """


### PR DESCRIPTION
In production, the `UserShortInfo` includes `coresRole` on `User`. It was missing in the user query, so it was throwing a `Cannot return null for non-nullable field User.coresRole.` error.

Noticed this because my DevCard GH workflow was throwing errors.