### PR TITLE
chore: update pulumi-common

### DIFF
--- a/.infra/.gitignore
+++ b/.infra/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /node_modules/
+.env

--- a/.infra/package.json
+++ b/.infra/package.json
@@ -7,7 +7,7 @@
     "@types/node": "22.13.x"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "^2.6.0",
+    "@dailydotdev/pulumi-common": "github:dailydotdev/pulumi-common#8080d374d878d03a06c37361d50dd85a226e4f54",
     "@pulumi/gcp": "^8.19.1",
     "@pulumi/kubernetes": "^4.21.1",
     "@pulumi/pulumi": "^3.150.0"

--- a/.infra/pnpm-lock.yaml
+++ b/.infra/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@dailydotdev/pulumi-common':
-        specifier: ^2.6.0
-        version: 2.6.0(encoding@0.1.13)
+        specifier: github:dailydotdev/pulumi-common#8080d374d878d03a06c37361d50dd85a226e4f54
+        version: https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54(encoding@0.1.13)
       '@pulumi/gcp':
         specifier: ^8.19.1
         version: 8.19.1
@@ -27,8 +27,9 @@ importers:
 
 packages:
 
-  '@dailydotdev/pulumi-common@2.6.0':
-    resolution: {integrity: sha512-21GxhefOgT83WtiyjqB9WoDuK6zjEF3P/8a62tQ3HDOs0IPNWyc09+Qv1nrfOzEOiBO+SujKW8EK/kWw+5rl9g==}
+  '@dailydotdev/pulumi-common@https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54':
+    resolution: {tarball: https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54}
+    version: 2.6.2
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -1551,7 +1552,7 @@ packages:
 
 snapshots:
 
-  '@dailydotdev/pulumi-common@2.6.0(encoding@0.1.13)':
+  '@dailydotdev/pulumi-common@https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54(encoding@0.1.13)':
     dependencies:
       '@google-cloud/pubsub': 4.10.0(encoding@0.1.13)
       '@pulumi/gcp': 8.19.1

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,7 +6,13 @@ docker_build(
   'api-image',
   context='.',
   dockerfile='./Dockerfile.dev',
-  ignore=['./node_modules', './.infra', '__tests__', './seeds', './build'],
+  ignore=[
+    './node_modules',
+    './.infra',
+    '__tests__',
+    './seeds',
+    './build',
+  ],
   live_update=[
     sync('./src', '/opt/app/src'),
     sync('./bin', '/opt/app/bin'),
@@ -20,18 +26,27 @@ pulumi_resource(
   'api',
   stack='adhoc',
   dir='.infra/',
-  deps=['.infra/index.ts', '.infra/workers.ts', '.infra/.env'],
+  deps=[
+    '.infra/index.ts',
+    '.infra/workers.ts',
+    '.infra/.env',
+  ],
   image_deps=['api-image'],
   image_configs=['image'],
 )
 
 # Add a button to API to run pulumi up
 cmd_button(
-  name="pulumi_up",
-  resource="api",
-  text="Run pulumi up",
-  icon_name="arrow_circle_up",
+  name='pulumi_up',
+  resource='api',
+  text='Run pulumi up',
+  icon_name='arrow_circle_up',
   requires_confirmation=True,
-  dir="./.infra",
-  argv=["pulumi", "up", "--stack", "adhoc", "--yes", "--skip-preview"],
+  dir='./.infra',
+  argv=[
+    'pulumi', 'up',
+    '--stack', 'adhoc',
+    '--yes',
+    '--skip-preview',
+  ],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,5 @@
 load('ext://pulumi', 'pulumi_resource')
+load('ext://uibutton', 'cmd_button', 'location')
 update_settings(k8s_upsert_timeout_secs=300)
 
 docker_build(
@@ -22,4 +23,15 @@ pulumi_resource(
   deps=['.infra/index.ts', '.infra/workers.ts'],
   image_deps=['api-image'],
   image_configs=['image'],
+)
+
+# Add a button to API to run pulumi up
+cmd_button(
+  name="pulumi_up",
+  resource="api",
+  text="Run pulumi up",
+  icon_name="arrow_circle_up",
+  requires_confirmation=True,
+  dir="./.infra",
+  argv=["pulumi", "up", "--stack", "adhoc", "--yes", "--skip-preview"],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -20,7 +20,7 @@ pulumi_resource(
   'api',
   stack='adhoc',
   dir='.infra/',
-  deps=['.infra/index.ts', '.infra/workers.ts'],
+  deps=['.infra/index.ts', '.infra/workers.ts', '.infra/.env'],
   image_deps=['api-image'],
   image_configs=['image'],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -37,7 +37,7 @@ pulumi_resource(
 
 # Add a button to API to run pulumi up
 cmd_button(
-  name='pulumi_up',
+  name='api_pulumi_up',
   resource='api',
   text='Run pulumi up',
   icon_name='arrow_circle_up',


### PR DESCRIPTION
Temporarily from git because unable to publish new version at the moment :fml:

New in this version, is that it can now read secrets from a local `.env` file inside `.infra` directory. That way you can manipulate env variables without adding them to pulumi config and accidentally committing it.

Also new, if it detects a change in the `.env` or pulumi config, it will re-deploy the pods so that it has the new env variables loaded. Unfortunately, only the `.env` changes will automagically trigger pulumi update, as detecting change in the pulumi config will just cause infinite loops (because of image tag).

But for that, I added a new button to Tilt, that triggers pulumi up from Tilt :)
![image](https://github.com/user-attachments/assets/d76ea1ce-2269-4215-ad23-8671e906e07a)
