### PR TITLE
chore: move private route files

### DIFF
--- a/__tests__/routes/private/rpc.ts
+++ b/__tests__/routes/private/rpc.ts
@@ -1,18 +1,23 @@
-import { saveFixtures } from './helpers';
-import { ArticlePost, Source, SourceRequest, SourceType } from '../src/entity';
-import { sourcesFixture } from './fixture/source';
+import { saveFixtures } from '../../helpers';
+import {
+  ArticlePost,
+  Source,
+  SourceRequest,
+  SourceType,
+} from '../../../src/entity';
+import { sourcesFixture } from '../../fixture/source';
 import { DataSource } from 'typeorm';
-import createOrGetConnection from '../src/db';
+import createOrGetConnection from '../../../src/db';
 import { PostService, SourceRequestService } from '@dailydotdev/schema';
 import {
   CallOptions,
   Code,
   ConnectError,
-  createPromiseClient,
+  createClient,
   createRouterTransport,
 } from '@connectrpc/connect';
-import privateRpc from '../src/routes/privateRpc';
-import { baseRpcContext } from '../src/common/connectRpc';
+import privateRpc from '../../../src/routes/private/rpc';
+import { baseRpcContext } from '../../../src/common/connectRpc';
 
 let con: DataSource;
 
@@ -60,7 +65,7 @@ const defaultClientAuthOptions: CallOptions = {
 };
 
 describe('PostService', () => {
-  const mockClient = createPromiseClient(PostService, mockTransport);
+  const mockClient = createClient(PostService, mockTransport);
   it('should return not found when not authorized', async () => {
     baseRpcContext.defaultValue = {
       service: false,
@@ -269,7 +274,7 @@ describe('PostService', () => {
 });
 
 describe('SourceRequestService', () => {
-  const mockClient = createPromiseClient(SourceRequestService, mockTransport);
+  const mockClient = createClient(SourceRequestService, mockTransport);
   it('should return not found when not authorized', async () => {
     baseRpcContext.defaultValue = {
       service: false,

--- a/__tests__/routes/private/snotra.ts
+++ b/__tests__/routes/private/snotra.ts
@@ -1,13 +1,13 @@
-import appFunc from '../src';
+import appFunc from '../../../src';
 import { FastifyInstance } from 'fastify';
-import { saveFixtures } from './helpers';
-import { Keyword, Post, Source } from '../src/entity';
-import { sourcesFixture } from './fixture/source';
+import { saveFixtures } from '../../helpers';
+import { Keyword, Post, Source } from '../../../src/entity';
+import { sourcesFixture } from '../../fixture/source';
 import request from 'supertest';
 import { DataSource } from 'typeorm';
-import createOrGetConnection from '../src/db';
-import { postsFixture } from './fixture/post';
-import { keywordsFixture } from './fixture/keywords';
+import createOrGetConnection from '../../../src/db';
+import { postsFixture } from '../../fixture/post';
+import { keywordsFixture } from '../../fixture/keywords';
 
 let app: FastifyInstance;
 let con: DataSource;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,7 +5,6 @@ import alerts from './alerts';
 import redirector from './redirector';
 import devcards from './devcards';
 import privateRoutes from './private';
-import privateSnotraRoutes from './privateSnotra';
 import whoami from './whoami';
 import notifications from './notifications';
 import boot from './boot';
@@ -29,7 +28,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(devcards, { prefix: '/devcards' });
   if (process.env.ENABLE_PRIVATE_ROUTES === 'true') {
     fastify.register(privateRoutes, { prefix: '/p' });
-    fastify.register(privateSnotraRoutes, { prefix: '/p/snotra' });
   }
   fastify.register(whoami, { prefix: '/whoami' });
   fastify.register(boot, { prefix: '/boot' });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -19,8 +19,6 @@ import createOrGetConnection from '../db';
 import { UserPersonalizedDigest, UserPersonalizedDigestType } from '../entity';
 import { notifyGeneratePersonalizedDigest } from '../common';
 import { PersonalizedDigestFeatureConfig } from '../growthbook';
-import privateRpc from './privateRpc';
-import { connectRpcPlugin } from '../common/connectRpc';
 import integrations from './integrations';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
@@ -32,10 +30,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
   if (process.env.ENABLE_PRIVATE_ROUTES === 'true') {
     fastify.register(privateRoutes, { prefix: '/p' });
     fastify.register(privateSnotraRoutes, { prefix: '/p/snotra' });
-    fastify.register(connectRpcPlugin, {
-      routes: privateRpc,
-      prefix: '/p/rpc',
-    });
   }
   fastify.register(whoami, { prefix: '/whoami' });
   fastify.register(boot, { prefix: '/boot' });

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -14,6 +14,7 @@ import {
 } from '../entity/user/utils';
 import { queryReadReplica } from '../common/queryReadReplica';
 
+import snotra from './private/snotra';
 import rpc from './private/rpc';
 import { connectRpcPlugin } from '../common/connectRpc';
 
@@ -177,6 +178,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     });
   });
 
+  fastify.register(snotra, { prefix: '/snotra' });
   fastify.register(connectRpcPlugin, {
     routes: rpc,
     prefix: '/rpc',

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -14,6 +14,9 @@ import {
 } from '../entity/user/utils';
 import { queryReadReplica } from '../common/queryReadReplica';
 
+import rpc from './private/rpc';
+import { connectRpcPlugin } from '../common/connectRpc';
+
 interface SearchUsername {
   search: string;
 }
@@ -172,5 +175,10 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       found: !!action,
       completedAt: action?.completedAt,
     });
+  });
+
+  fastify.register(connectRpcPlugin, {
+    routes: rpc,
+    prefix: '/rpc',
   });
 }

--- a/src/routes/private/rpc.ts
+++ b/src/routes/private/rpc.ts
@@ -1,10 +1,10 @@
 import { Code, ConnectError, ConnectRouter } from '@connectrpc/connect';
-import { TypeOrmError, TypeORMQueryFailedError } from '../errors';
-import { ArticlePost, SourceRequest } from '../entity';
-import { generateShortId } from '../ids';
-import createOrGetConnection from '../db';
-import { isValidHttpUrl, standardizeURL } from '../common/links';
-import { baseRpcContext } from '../common/connectRpc';
+import { TypeOrmError, TypeORMQueryFailedError } from '../../errors';
+import { ArticlePost, SourceRequest } from '../../entity';
+import { generateShortId } from '../../ids';
+import createOrGetConnection from '../../db';
+import { isValidHttpUrl, standardizeURL } from '../../common/links';
+import { baseRpcContext } from '../../common/connectRpc';
 import {
   CreatePostRequest,
   CreatePostResponse,
@@ -12,7 +12,7 @@ import {
   PostService,
 } from '@dailydotdev/schema';
 import { DataSource, FindOptionsWhere } from 'typeorm';
-import { logger } from '../logger';
+import { logger } from '../../logger';
 
 const getDuplicatePost = async ({
   req,

--- a/src/routes/private/snotra.ts
+++ b/src/routes/private/snotra.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import createOrGetConnection from '../db';
-import { Keyword, Source, Post } from '../entity';
+import createOrGetConnection from '../../db';
+import { Keyword, Source, Post } from '../../entity';
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get('/all_tags', async (req, res) => {


### PR DESCRIPTION
Moves the private route files for RPC and snotra into `routes/private`