### PR TITLE
feat: new private endpoint for Kvasir

### DIFF
--- a/__tests__/routes/private/kvasir.ts
+++ b/__tests__/routes/private/kvasir.ts
@@ -109,6 +109,24 @@ describe('POST /p/kvasir/posts', () => {
     expect(res.body.error).toHaveProperty('name', 'ZodError');
   });
 
+  it('should validate postIds does not exceed maximum length', async () => {
+    const longPostIds = Array.from({ length: 101 }, (_, i) => `p${i + 1}`);
+
+    const res = await authorizeRequest(
+      request(app.server)
+        .post('/p/kvasir/posts')
+        .send({ postIds: longPostIds }),
+    );
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.error).toHaveProperty('name', 'ZodError');
+    expect(res.body.error.issues[0]).toMatchObject({
+      code: 'too_big',
+      maximum: 100,
+      type: 'array',
+    });
+  });
+
   it('should return public posts', async () => {
     const res = await authorizeRequest(
       request(app.server).post('/p/kvasir/posts').send({ postIds }),

--- a/__tests__/routes/private/kvasir.ts
+++ b/__tests__/routes/private/kvasir.ts
@@ -82,10 +82,20 @@ describe('POST /p/kvasir/posts', () => {
     ]);
   });
 
-  it('should require authentication', async () => {
+  it('should require service token', async () => {
     const res = await request(app.server)
       .post('/p/kvasir/posts')
       .send({ postIds });
+
+    expect(res.statusCode).toEqual(404);
+    expect(res.body).toMatchObject({});
+  });
+
+  it('should require authentication', async () => {
+    const res = await request(app.server)
+      .post('/p/kvasir/posts')
+      .send({ postIds })
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`);
 
     expect(res.statusCode).toEqual(401);
     expect(res.body).toMatchObject({ error: 'Unauthorized' });

--- a/__tests__/routes/private/kvasir.ts
+++ b/__tests__/routes/private/kvasir.ts
@@ -91,9 +91,18 @@ describe('POST /p/kvasir/posts', () => {
     expect(res.body).toMatchObject({ error: 'Unauthorized' });
   });
 
-  it('should validate input', async () => {
+  it('should validate input has postIds', async () => {
     const res = await authorizeRequest(
       request(app.server).post('/p/kvasir/posts').send({ invalid: 'data' }),
+    );
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.error).toHaveProperty('name', 'ZodError');
+  });
+
+  it('should validate postIds is not empty', async () => {
+    const res = await authorizeRequest(
+      request(app.server).post('/p/kvasir/posts').send({ postIds: [] }),
     );
 
     expect(res.statusCode).toEqual(400);

--- a/__tests__/routes/private/kvasir.ts
+++ b/__tests__/routes/private/kvasir.ts
@@ -1,0 +1,152 @@
+import appFunc from '../../../src';
+import { FastifyInstance } from 'fastify';
+import request from 'supertest';
+
+import type { DataSource } from 'typeorm';
+import createOrGetConnection from '../../../src/db';
+import { Post, Source, SourceMember, User } from '../../../src/entity';
+import { SourceMemberRoles } from '../../../src/roles';
+import { randomUUID } from 'node:crypto';
+import { authorizeRequest, saveFixtures } from '../../helpers';
+import { usersFixture } from '../../fixture/user';
+
+let app: FastifyInstance;
+let con: DataSource;
+
+beforeAll(async () => {
+  app = await appFunc();
+  con = await createOrGetConnection();
+  return app.ready();
+});
+
+afterAll(() => app.close());
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+});
+
+describe('POST /p/kvasir/posts', () => {
+  const postIds = ['p1', 'p2', 'p3', 'p4'];
+  const userId = '1';
+
+  beforeEach(async () => {
+    await con.getRepository(Source).save([
+      { id: 's1', handle: 's1', name: 'Public Source', private: false },
+      { id: 's2', handle: 's2', name: 'Private Source', private: true },
+    ]);
+
+    await con.getRepository(Post).save([
+      {
+        id: 'p1',
+        title: 'Public post',
+        sourceId: 's1',
+        deleted: false,
+        visible: true,
+        shortId: 'sh1',
+      },
+      {
+        id: 'p2',
+        title: 'Private post',
+        sourceId: 's2',
+        deleted: false,
+        visible: true,
+        shortId: 'sh2',
+      },
+      {
+        id: 'p3',
+        title: 'Deleted post',
+        sourceId: 's1',
+        deleted: true,
+        visible: true,
+        shortId: 'sh3',
+      },
+      {
+        id: 'p4',
+        title: 'Invisible post',
+        sourceId: 's1',
+        deleted: false,
+        visible: false,
+        shortId: 'sh4',
+      },
+    ]);
+
+    await saveFixtures(con, User, usersFixture);
+
+    await con.getRepository(SourceMember).save([
+      {
+        sourceId: 's2',
+        userId,
+        role: SourceMemberRoles.Member,
+        referralToken: randomUUID(),
+      },
+    ]);
+  });
+
+  it('should require authentication', async () => {
+    const res = await request(app.server)
+      .post('/p/kvasir/posts')
+      .send({ postIds });
+
+    expect(res.statusCode).toEqual(401);
+    expect(res.body).toMatchObject({ error: 'Unauthorized' });
+  });
+
+  it('should validate input', async () => {
+    const res = await authorizeRequest(
+      request(app.server).post('/p/kvasir/posts').send({ invalid: 'data' }),
+    );
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.error).toHaveProperty('name', 'ZodError');
+  });
+
+  it('should return public posts', async () => {
+    const res = await authorizeRequest(
+      request(app.server).post('/p/kvasir/posts').send({ postIds }),
+
+      '2',
+    );
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toEqual('p1');
+  });
+
+  it('should return private posts when user is a member', async () => {
+    const res = await authorizeRequest(
+      request(app.server)
+        .post('/p/kvasir/posts')
+        .send({ postIds: ['p2'] }),
+    );
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toEqual('p2');
+  });
+
+  it('should not return private posts when user is blocked', async () => {
+    await con
+      .getRepository(SourceMember)
+      .update({ sourceId: 's2', userId }, { role: SourceMemberRoles.Blocked });
+
+    const res = await authorizeRequest(
+      request(app.server)
+        .post('/p/kvasir/posts')
+        .send({ postIds: ['p2'] }),
+    );
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it('should not return deleted or invisible posts', async () => {
+    const res = await authorizeRequest(
+      request(app.server)
+        .post('/p/kvasir/posts')
+        .send({ postIds: ['p3', 'p4'] }),
+    );
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toHaveLength(0);
+  });
+});

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -13,6 +13,7 @@ import {
   updateUserEmail,
 } from '../entity/user/utils';
 import { queryReadReplica } from '../common/queryReadReplica';
+import { kvasir } from './private/kvasir';
 
 interface SearchUsername {
   search: string;
@@ -173,4 +174,6 @@ export default async function (fastify: FastifyInstance): Promise<void> {
       completedAt: action?.completedAt,
     });
   });
+
+  fastify.register(kvasir, { prefix: '/kvasir' });
 }

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -7,7 +7,14 @@ import { SourceMemberRoles } from '../../roles';
 import { z } from 'zod';
 
 const postsSchema = z.object({
-  postIds: z.array(z.string()).min(1),
+  postIds: z
+    .array(z.string())
+    .min(1, {
+      message: 'No posts to translate',
+    })
+    .max(100, {
+      message: 'Too many posts to translate',
+    }),
 });
 
 export const kvasir = async (fastify: FastifyInstance): Promise<void> => {

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -7,7 +7,7 @@ import { SourceMemberRoles } from '../../roles';
 import { z } from 'zod';
 
 const postsSchema = z.object({
-  postIds: z.array(z.string()),
+  postIds: z.array(z.string()).min(1),
 });
 
 export const kvasir = async (fastify: FastifyInstance): Promise<void> => {

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -19,7 +19,7 @@ export const kvasir = async (fastify: FastifyInstance): Promise<void> => {
 
   fastify.post<{
     Body: {
-      postIds?: Array<Post['id']>;
+      postIds: Array<Post['id']>;
     };
   }>('/posts', async (request, response): Promise<Array<Post>> => {
     const con = await createOrGetConnection();

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -10,7 +10,7 @@ const postsSchema = z.object({
   postIds: z
     .array(z.string())
     .min(1, {
-      message: 'No posts to translate',
+      message: 'No posts provided',
     })
     .max(100, {
       message: 'Too many posts to translate',

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from 'fastify';
+import { Post, Source, SourceMember } from '../../entity';
+import createOrGetConnection from '../../db';
+import { queryReadReplica } from '../../common/queryReadReplica';
+import { Brackets } from 'typeorm';
+import { SourceMemberRoles } from '../../roles';
+import { z } from 'zod';
+
+const postsSchema = z.object({
+  postIds: z.array(z.string()),
+});
+
+export const kvasir = async (fastify: FastifyInstance): Promise<void> => {
+  fastify.addHook('preHandler', async (req, res) => {
+    if (!req.userId) {
+      return res.code(401).send({ error: 'Unauthorized' });
+    }
+  });
+
+  fastify.post<{
+    Body: {
+      postIds?: Array<Post['id']>;
+    };
+  }>('/posts', async (request, response): Promise<Array<Post>> => {
+    const con = await createOrGetConnection();
+
+    return queryReadReplica(con, async ({ queryRunner }) => {
+      const body = postsSchema.safeParse(request.body);
+
+      if (body.error) {
+        request.log.error(body.error);
+        return response.code(400).send({
+          error: body.error,
+        });
+      }
+
+      const postIds = body.data.postIds;
+
+      return await queryRunner.manager
+        .createQueryBuilder(Post, 'post')
+        .select('post')
+        .leftJoin(Source, 'source', 'post.sourceId = source.id')
+        .leftJoin(
+          SourceMember,
+          'sm',
+          'sm.sourceId = source.id AND sm.userId = :userId',
+          { userId: request.userId },
+        )
+        .where('post.id IN (:...postIds)', { postIds })
+        .andWhere('post.deleted = false')
+        .andWhere('post.visible = true')
+        .andWhere(
+          new Brackets((qb) => {
+            qb.where('source.private = false').orWhere(
+              'sm.userId IS NOT NULL AND sm.role != :blockedRole',
+              { blockedRole: SourceMemberRoles.Blocked },
+            );
+          }),
+        )
+        .getMany();
+    });
+  });
+};

--- a/src/routes/private/kvasir.ts
+++ b/src/routes/private/kvasir.ts
@@ -19,6 +19,10 @@ const postsSchema = z.object({
 
 export const kvasir = async (fastify: FastifyInstance): Promise<void> => {
   fastify.addHook('preHandler', async (req, res) => {
+    if (!req.service) {
+      return res.status(404).send();
+    }
+
     if (!req.userId) {
       return res.code(401).send({ error: 'Unauthorized' });
     }


### PR DESCRIPTION
Creates a new endpoint that Kvasir will call to fetch posts, and it will only return the posts that the user has access to.

Kvasir calls the endpoint by emulating being the user, where it forwards the users auth token as the da3 cookie in the request.

https://github.com/dailydotdev/kvasir/pull/15

### Jira ticket
AS-1002