### PR TITLE
chore: install pulumi-common from npm

### DIFF
--- a/.infra/package.json
+++ b/.infra/package.json
@@ -7,7 +7,7 @@
     "@types/node": "22.13.x"
   },
   "dependencies": {
-    "@dailydotdev/pulumi-common": "github:dailydotdev/pulumi-common#8080d374d878d03a06c37361d50dd85a226e4f54",
+    "@dailydotdev/pulumi-common": "^2.7.0",
     "@pulumi/gcp": "^8.19.1",
     "@pulumi/kubernetes": "^4.21.1",
     "@pulumi/pulumi": "^3.150.0"

--- a/.infra/pnpm-lock.yaml
+++ b/.infra/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@dailydotdev/pulumi-common':
-        specifier: github:dailydotdev/pulumi-common#8080d374d878d03a06c37361d50dd85a226e4f54
-        version: https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54(encoding@0.1.13)
+        specifier: ^2.7.0
+        version: 2.7.0(encoding@0.1.13)
       '@pulumi/gcp':
         specifier: ^8.19.1
         version: 8.19.1
@@ -27,9 +27,8 @@ importers:
 
 packages:
 
-  '@dailydotdev/pulumi-common@https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54':
-    resolution: {tarball: https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54}
-    version: 2.6.2
+  '@dailydotdev/pulumi-common@2.7.0':
+    resolution: {integrity: sha512-eJKXBHVuy+x7ck9kg8hTxHX6ebf+u90eG1aVF4se/V7l6R5YQhZfI3xDEAV+Mbbck8oY9M9d6l8urhzWO7AbZQ==}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -1552,7 +1551,7 @@ packages:
 
 snapshots:
 
-  '@dailydotdev/pulumi-common@https://codeload.github.com/dailydotdev/pulumi-common/tar.gz/8080d374d878d03a06c37361d50dd85a226e4f54(encoding@0.1.13)':
+  '@dailydotdev/pulumi-common@2.7.0(encoding@0.1.13)':
     dependencies:
       '@google-cloud/pubsub': 4.10.0(encoding@0.1.13)
       '@pulumi/gcp': 8.19.1


### PR DESCRIPTION
This pull request updates the dependency versions for `@dailydotdev/pulumi-common` in the `.infra` package files. The most important changes are:

Dependency updates:

* [`.infra/package.json`](diffhunk://#diff-37e1ff10ed9cd0f932c497ce8c56ac4d56c676c48934656bae2fe84582684c10L10-R10): Updated the `@dailydotdev/pulumi-common` dependency from a specific GitHub commit to version `^2.7.0`.
* [`.infra/pnpm-lock.yaml`](diffhunk://#diff-5c2618ceb30b389b2fafabaf477a1adf2abcbd2a211d4a7efb01f62336288db6L12-R13): Updated the `@dailydotdev/pulumi-common` dependency specifier from a specific GitHub commit to version `^2.7.0`.
* [`.infra/pnpm-lock.yaml`](diffhunk://#diff-5c2618ceb30b389b2fafabaf477a1adf2abcbd2a211d4a7efb01f62336288db6L30-R31): Updated the `@dailydotdev/pulumi-common` package resolution from a specific GitHub commit tarball to version `2.7.0` with the corresponding integrity hash.
* [`.infra/pnpm-lock.yaml`](diffhunk://#diff-5c2618ceb30b389b2fafabaf477a1adf2abcbd2a211d4a7efb01f62336288db6L1555-R1554): Updated the snapshot for `@dailydotdev/pulumi-common` to version `2.7.0`.