### PR TITLE
fix(dx): install ping and curl in dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,10 @@ ADD https://www.apple.com/certificateauthority/AppleRootCA-G2.cer /usr/local/sha
 ADD https://www.apple.com/certificateauthority/AppleRootCA-G3.cer /usr/local/share/ca-certificates/AppleRootCA-G3.cer
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates \
+    && apt-get install -y \
+      ca-certificates \
+      iputils-ping \
+      curl \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Minor DX improvement where we install utils like `ping` and `curl` in the dev image, so it's available in the container when running in adhoc. So we don't have to manually install it.