### PR TITLE
fix: use master for award mutation queries

### DIFF
--- a/src/workers/transactions/userReceivedAward.ts
+++ b/src/workers/transactions/userReceivedAward.ts
@@ -1,5 +1,4 @@
 import { env } from 'node:process';
-import { queryReadReplica } from '../../common/queryReadReplica';
 import { UserPost } from '../../entity';
 import { UserComment } from '../../entity/user/UserComment';
 import {
@@ -12,66 +11,63 @@ import { generateTypedNotificationWorker } from '../notifications/worker';
 export const userReceivedAward =
   generateTypedNotificationWorker<'api.v1.user-transaction'>({
     subscription: 'api.user-received-award',
-    handler: async (data, con, logger) =>
-      queryReadReplica(con, async ({ queryRunner }) => {
-        const transaction = await queryRunner.manager
-          .getRepository(UserTransaction)
-          .findOne({
-            where: { id: data.transaction.id },
-            relations: {
-              sender: true,
-              receiver: true,
-            },
-          });
+    handler: async (data, con, logger) => {
+      const transaction = await con.getRepository(UserTransaction).findOne({
+        where: { id: data.transaction.id },
+        relations: {
+          sender: true,
+          receiver: true,
+        },
+      });
 
-        if (!transaction) {
-          logger.error(
-            { transactionId: data.transaction.id },
-            'Transaction not found',
-          );
-          return;
-        }
+      if (!transaction) {
+        logger.error(
+          { transactionId: data.transaction.id },
+          'Transaction not found',
+        );
+        return;
+      }
 
-        if (!transaction.productId) {
-          return;
-        }
+      if (!transaction.productId) {
+        return;
+      }
 
-        if (transaction.processor !== UserTransactionProcessor.Njord) {
-          return;
-        }
+      if (transaction.processor !== UserTransactionProcessor.Njord) {
+        return;
+      }
 
-        const sender = await transaction.sender;
-        const receiver = await transaction.receiver;
+      const sender = await transaction.sender;
+      const receiver = await transaction.receiver;
 
-        const [userPost, userComment] = await Promise.all([
-          queryRunner.manager.getRepository(UserPost).findOneBy({
-            awardTransactionId: transaction.id,
-          }),
-          queryRunner.manager.getRepository(UserComment).findOneBy({
-            awardTransactionId: transaction.id,
-          }),
-        ]);
+      const [userPost, userComment] = await Promise.all([
+        con.manager.getRepository(UserPost).findOneBy({
+          awardTransactionId: transaction.id,
+        }),
+        con.manager.getRepository(UserComment).findOneBy({
+          awardTransactionId: transaction.id,
+        }),
+      ]);
 
-        let targetUrl = `/${receiver.username}`;
+      let targetUrl = `/${receiver.username}`;
 
-        if (userPost) {
-          targetUrl = `/posts/${userPost.postId}`;
-        } else if (userComment) {
-          const comment = await userComment.comment;
-          targetUrl = `/posts/${comment.postId}#c-${userComment.commentId}`;
-        }
+      if (userPost) {
+        targetUrl = `/posts/${userPost.postId}`;
+      } else if (userComment) {
+        const comment = await userComment.comment;
+        targetUrl = `/posts/${comment.postId}#c-${userComment.commentId}`;
+      }
 
-        return [
-          {
-            type: NotificationType.UserReceivedAward,
-            ctx: {
-              userIds: [transaction.receiverId],
-              transaction,
-              sender,
-              receiver,
-              targetUrl: `${env.COMMENTS_PREFIX}${targetUrl}`,
-            },
+      return [
+        {
+          type: NotificationType.UserReceivedAward,
+          ctx: {
+            userIds: [transaction.receiverId],
+            transaction,
+            sender,
+            receiver,
+            targetUrl: `${env.COMMENTS_PREFIX}${targetUrl}`,
           },
-        ];
-      }),
+        },
+      ];
+    },
   });


### PR DESCRIPTION
- got little carried away with read replica, which can be outdated during multiple mutations, so moving everything to master
- also moved worker since cdc also listens for master changes