### PR TITLE
fix: funnel return 500 when userId is read

### DIFF
--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -769,7 +769,7 @@ const resolveDynamicFunnelId = (userId: string): string => {
 
 // Fetches the funnel data from Freyja
 const getFunnel = async (req: FastifyRequest, res: FastifyReply) => {
-  const userId = req?.userId || req?.trackingId;
+  const userId = req.userId || req.trackingId;
   const query = req.query as { id?: string; v?: string };
   const sessionId = req.cookies[cookies.funnel.key];
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -769,7 +769,7 @@ const resolveDynamicFunnelId = (userId: string): string => {
 
 // Fetches the funnel data from Freyja
 const getFunnel = async (req: FastifyRequest, res: FastifyReply) => {
-  const userId = req.userId || req.trackingId;
+  const userId = req?.userId || req?.trackingId;
   const query = req.query as { id?: string; v?: string };
   const sessionId = req.cookies[cookies.funnel.key];
 
@@ -780,7 +780,7 @@ const getFunnel = async (req: FastifyRequest, res: FastifyReply) => {
   // If the session id is set, we should use it to fetch the funnel data
   if (sessionId) {
     const sessionFunnel = await freyjaClient.getSession(sessionId);
-    if (sessionFunnel?.session.userId === userId) {
+    if (sessionFunnel?.session?.userId === userId) {
       return sessionFunnel;
     }
   }


### PR DESCRIPTION
Add optional chaining to userId and session checks in funnel data retrieval

| Cloud | Vercel |
|--------|--------|
| <img width="1211" alt="image" src="https://github.com/user-attachments/assets/b4138808-2b09-4f02-a069-93ba6f40924b" /> | <img width="1211" alt="image" src="https://github.com/user-attachments/assets/531f229a-97dc-4c7b-8f91-aefbb48d91a1" /> | 


