### PR TITLE
feat: cores iap

### DIFF
--- a/__tests__/routes/webhooks/apple.ts
+++ b/__tests__/routes/webhooks/apple.ts
@@ -106,7 +106,7 @@ describe('POST /webhooks/apple/notifications', () => {
           transactionId: '23456',
           originalTransactionId: '12345',
           webOrderLineItemId: '34343',
-          bundleId: 'com.example',
+          bundleId: 'dev.fylla',
           productId: 'annual',
           subscriptionGroupIdentifier: '55555',
           purchaseDate: 1698148900000,
@@ -228,6 +228,9 @@ describe('POST /webhooks/apple/notifications', () => {
         signedPayload: signedPayload({
           notificationType: NotificationTypeV2.SUBSCRIBED,
           data: {
+            signedTransactionInfo: {
+              productId: 'non-existing',
+            },
             signedRenewalInfo: {
               autoRenewProductId: 'non-existing',
             },
@@ -244,6 +247,9 @@ describe('POST /webhooks/apple/notifications', () => {
         signedPayload: signedPayload({
           notificationType: NotificationTypeV2.SUBSCRIBED,
           data: {
+            signedTransactionInfo: {
+              appAccountToken: 'non-existing',
+            },
             signedRenewalInfo: {
               appAccountToken: 'non-existing',
             },
@@ -370,6 +376,9 @@ describe('POST /webhooks/apple/notifications', () => {
         signedPayload: signedPayload({
           notificationType: NotificationTypeV2.SUBSCRIBED,
           data: {
+            signedTransactionInfo: {
+              appAccountToken: '4b1d83a3-163e-4434-a502-96fb2a516a51',
+            },
             signedRenewalInfo: {
               appAccountToken: '4b1d83a3-163e-4434-a502-96fb2a516a51',
             },

--- a/__tests__/routes/webhooks/apple.ts
+++ b/__tests__/routes/webhooks/apple.ts
@@ -450,6 +450,8 @@ describe('POST /webhooks/apple/notifications', () => {
     });
 
     it('should purchase cores', async () => {
+      const purchaseCoresSpy = jest.spyOn(njordCommon, 'purchaseCores');
+
       await request(app.server)
         .post('/webhooks/apple/notifications')
         .send({
@@ -467,6 +469,8 @@ describe('POST /webhooks/apple/notifications', () => {
           }),
         })
         .expect(200);
+
+      expect(purchaseCoresSpy).toHaveBeenCalledTimes(1);
 
       const userTransaction = await getTransactionForProviderId({
         con,
@@ -493,6 +497,8 @@ describe('POST /webhooks/apple/notifications', () => {
     });
 
     it('transaction completed throw if user coresRole is none', async () => {
+      const purchaseCoresSpy = jest.spyOn(njordCommon, 'purchaseCores');
+
       await request(app.server)
         .post('/webhooks/apple/notifications')
         .send({
@@ -510,9 +516,19 @@ describe('POST /webhooks/apple/notifications', () => {
           }),
         })
         .expect(500);
+
+      expect(purchaseCoresSpy).toHaveBeenCalledTimes(0);
+
+      const userTransaction = await getTransactionForProviderId({
+        con,
+        providerId: '220698',
+      });
+      expect(userTransaction).toBeNull();
     });
 
     it('transaction completed throw if user coresRole is readonly', async () => {
+      const purchaseCoresSpy = jest.spyOn(njordCommon, 'purchaseCores');
+
       await request(app.server)
         .post('/webhooks/apple/notifications')
         .send({
@@ -530,6 +546,14 @@ describe('POST /webhooks/apple/notifications', () => {
           }),
         })
         .expect(500);
+
+      expect(purchaseCoresSpy).toHaveBeenCalledTimes(0);
+
+      const userTransaction = await getTransactionForProviderId({
+        con,
+        providerId: '220698',
+      });
+      expect(userTransaction).toBeNull();
     });
   });
 });

--- a/__tests__/routes/webhooks/apple.ts
+++ b/__tests__/routes/webhooks/apple.ts
@@ -76,7 +76,7 @@ beforeAll(async () => {
 afterAll(() => app.close());
 
 beforeEach(async () => {
-  jest.resetAllMocks();
+  jest.clearAllMocks();
   nock.cleanAll();
   await deleteRedisKey(StorageKey.OpenExchangeRates);
 
@@ -560,7 +560,7 @@ describe('POST /webhooks/apple/notifications', () => {
       expect(userTransaction).toBeNull();
     });
 
-    it('should error cores purchase on njord error', async () => {
+    it('should error purchase on njord error', async () => {
       jest.spyOn(njordCommon, 'getNjordClient').mockImplementation(() =>
         createClient(
           Credits,
@@ -584,7 +584,7 @@ describe('POST /webhooks/apple/notifications', () => {
                 quantity: 1,
                 type: 'Consumable',
                 appAccountToken: '18138f83-b4d3-456a-831f-1f3f7bcbb0bd',
-                transactionId: '220698',
+                transactionId: '200166',
               },
             },
           }),
@@ -595,7 +595,7 @@ describe('POST /webhooks/apple/notifications', () => {
 
       const userTransaction = await getTransactionForProviderId({
         con,
-        providerId: '220698',
+        providerId: '200166',
       });
 
       expect(userTransaction).toEqual({
@@ -603,7 +603,7 @@ describe('POST /webhooks/apple/notifications', () => {
         createdAt: expect.any(Date),
         fee: 0,
         flags: {
-          providerId: '220698',
+          providerId: '200166',
           error: 'Insufficient Cores balance.',
         },
         processor: UserTransactionProcessor.AppleStoreKit,

--- a/src/common/apple/purchase.ts
+++ b/src/common/apple/purchase.ts
@@ -1,0 +1,70 @@
+import type {
+  Environment,
+  JWSTransactionDecodedPayload,
+  ResponseBodyV2DecodedPayload,
+} from '@apple/app-store-server-library';
+import type { User } from '../../entity/user/User';
+import { getAppleTransactionType } from './utils';
+import { AppleTransactionType } from './types';
+import {
+  UserTransaction,
+  UserTransactionProcessor,
+  UserTransactionStatus,
+} from '../../entity/user/UserTransaction';
+import createOrGetConnection from '../../db';
+
+export const isCorePurchaseApple = ({
+  decodedInfo,
+}: {
+  decodedInfo: JWSTransactionDecodedPayload;
+}) => {
+  return (
+    getAppleTransactionType({ decodedInfo }) ===
+      AppleTransactionType.Consumable &&
+    !!decodedInfo.productId?.startsWith('cores_')
+  );
+};
+
+export const handleCoresPurchase = async ({
+  decodedInfo,
+  user,
+}: {
+  decodedInfo: JWSTransactionDecodedPayload;
+  user: User;
+  environment: Environment;
+  notification: ResponseBodyV2DecodedPayload;
+}): Promise<UserTransaction> => {
+  if (!decodedInfo.transactionId) {
+    throw new Error('Missing transactionId in decodedInfo');
+  }
+
+  if (!decodedInfo.productId) {
+    throw new Error('Missing productId in decodedInfo');
+  }
+
+  const con = await createOrGetConnection();
+
+  // TODO feat/cores-iap load from api metadata/new endpoint
+  const coresValue = Number(decodedInfo.productId.match(/\d+/)?.[0]);
+
+  const payload = con.getRepository(UserTransaction).create({
+    processor: UserTransactionProcessor.AppleStoreKit,
+    receiverId: user.id,
+    status: UserTransactionStatus.Success,
+    productId: null, // no product user is buying cores directly
+    senderId: null, // no sender, user is buying cores
+    value: coresValue,
+    valueIncFees: coresValue,
+    fee: 0, // no fee when buying cores
+    request: {},
+    flags: {
+      providerId: decodedInfo.transactionId,
+    },
+  });
+
+  const userTransaction = await con
+    .getRepository(UserTransaction)
+    .save(payload);
+
+  return userTransaction;
+};

--- a/src/common/apple/purchase.ts
+++ b/src/common/apple/purchase.ts
@@ -14,38 +14,38 @@ import {
 import createOrGetConnection from '../../db';
 
 export const isCorePurchaseApple = ({
-  decodedInfo,
+  transactionInfo,
 }: {
-  decodedInfo: JWSTransactionDecodedPayload;
+  transactionInfo: JWSTransactionDecodedPayload;
 }) => {
   return (
-    getAppleTransactionType({ decodedInfo }) ===
+    getAppleTransactionType({ transactionInfo }) ===
       AppleTransactionType.Consumable &&
-    !!decodedInfo.productId?.startsWith('cores_')
+    !!transactionInfo.productId?.startsWith('cores_')
   );
 };
 
 export const handleCoresPurchase = async ({
-  decodedInfo,
+  transactionInfo,
   user,
 }: {
-  decodedInfo: JWSTransactionDecodedPayload;
+  transactionInfo: JWSTransactionDecodedPayload;
   user: User;
   environment: Environment;
   notification: ResponseBodyV2DecodedPayload;
 }): Promise<UserTransaction> => {
-  if (!decodedInfo.transactionId) {
-    throw new Error('Missing transactionId in decodedInfo');
+  if (!transactionInfo.transactionId) {
+    throw new Error('Missing transactionId in transactionInfo');
   }
 
-  if (!decodedInfo.productId) {
-    throw new Error('Missing productId in decodedInfo');
+  if (!transactionInfo.productId) {
+    throw new Error('Missing productId in transactionInfo');
   }
 
   const con = await createOrGetConnection();
 
   // TODO feat/cores-iap load from api metadata/new endpoint
-  const coresValue = Number(decodedInfo.productId.match(/\d+/)?.[0]);
+  const coresValue = Number(transactionInfo.productId.match(/\d+/)?.[0]);
 
   const payload = con.getRepository(UserTransaction).create({
     processor: UserTransactionProcessor.AppleStoreKit,
@@ -58,7 +58,7 @@ export const handleCoresPurchase = async ({
     fee: 0, // no fee when buying cores
     request: {},
     flags: {
-      providerId: decodedInfo.transactionId,
+      providerId: transactionInfo.transactionId,
     },
   });
 

--- a/src/common/apple/subscription.ts
+++ b/src/common/apple/subscription.ts
@@ -1,0 +1,141 @@
+import {
+  NotificationTypeV2,
+  Subtype,
+  type Environment,
+  type JWSRenewalInfoDecodedPayload,
+  type ResponseBodyV2DecodedPayload,
+} from '@apple/app-store-server-library';
+import { logger } from '../../logger';
+import {
+  SubscriptionProvider,
+  UserSubscriptionStatus,
+  type User,
+  type UserSubscriptionFlags,
+} from '../../entity/user/User';
+import { convertCurrencyToUSD } from '../../integrations/openExchangeRates';
+import { updateStoreKitUserSubscription } from '../../plusSubscription';
+import { isNullOrUndefined } from '../object';
+import {
+  getAnalyticsEventFromAppleNotification,
+  logAppleAnalyticsEvent,
+} from './utils';
+import { notifyNewStoreKitSubscription } from '../../routes/webhooks/apple';
+import { productIdToCycle } from './types';
+
+const getSubscriptionStatus = (
+  notificationType: ResponseBodyV2DecodedPayload['notificationType'],
+  subtype?: ResponseBodyV2DecodedPayload['subtype'],
+): UserSubscriptionStatus => {
+  switch (notificationType) {
+    case NotificationTypeV2.SUBSCRIBED:
+    case NotificationTypeV2.DID_RENEW:
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_PREF: // Upgrade/Downgrade
+    case NotificationTypeV2.REFUND_REVERSED:
+      return UserSubscriptionStatus.Active;
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS: // Disable/Enable Auto-Renew
+      return subtype === Subtype.AUTO_RENEW_ENABLED
+        ? UserSubscriptionStatus.Active
+        : UserSubscriptionStatus.Cancelled;
+    case NotificationTypeV2.DID_FAIL_TO_RENEW:
+      // When user fails to renew and there is no grace period
+      if (isNullOrUndefined(subtype)) {
+        return UserSubscriptionStatus.Cancelled;
+      }
+    case NotificationTypeV2.GRACE_PERIOD_EXPIRED:
+      return UserSubscriptionStatus.Cancelled;
+    case NotificationTypeV2.REFUND:
+    case NotificationTypeV2.EXPIRED:
+    case NotificationTypeV2.REVOKE: // We don't support Family Sharing, but to be on the safe side
+      return UserSubscriptionStatus.Expired;
+    default:
+      logger.error(
+        {
+          notificationType,
+          subtype,
+          provider: SubscriptionProvider.AppleStoreKit,
+        },
+        'Unknown notification type',
+      );
+      throw new Error('Unknown notification type');
+  }
+};
+
+const renewalInfoToSubscriptionFlags = (
+  data: JWSRenewalInfoDecodedPayload,
+): UserSubscriptionFlags => {
+  const cycle =
+    productIdToCycle[data.autoRenewProductId as keyof typeof productIdToCycle];
+
+  if (isNullOrUndefined(cycle)) {
+    logger.error(
+      { data, provider: SubscriptionProvider.AppleStoreKit },
+      'Invalid auto renew product ID',
+    );
+    throw new Error('Invalid auto renew product ID');
+  }
+
+  return {
+    cycle,
+    subscriptionId: data.originalTransactionId,
+    createdAt: new Date(data.recentSubscriptionStartDate!),
+    expiresAt: new Date(data.renewalDate!),
+    provider: SubscriptionProvider.AppleStoreKit,
+  };
+};
+
+export const handleAppleSubscription = async ({
+  decodedInfo,
+  user,
+  environment,
+  notification,
+}: {
+  decodedInfo: JWSRenewalInfoDecodedPayload;
+  user: User;
+  environment: Environment;
+  notification: ResponseBodyV2DecodedPayload;
+}) => {
+  // Prevent double subscription
+  if (user.subscriptionFlags?.provider === SubscriptionProvider.Paddle) {
+    logger.error(
+      {
+        user,
+        environment,
+        notification,
+        provider: SubscriptionProvider.AppleStoreKit,
+      },
+      'User already has a Paddle subscription',
+    );
+    throw new Error('User already has a Paddle subscription');
+  }
+
+  const subscriptionStatus = getSubscriptionStatus(
+    notification.notificationType,
+    notification.subtype,
+  );
+
+  const subscriptionFlags = renewalInfoToSubscriptionFlags(decodedInfo);
+
+  await updateStoreKitUserSubscription({
+    userId: user.id,
+    status: subscriptionStatus,
+    data: subscriptionFlags,
+  });
+
+  const currencyInUSD = await convertCurrencyToUSD(
+    (decodedInfo.renewalPrice || 0) / 1000,
+    decodedInfo.currency || 'USD',
+  );
+
+  const eventName = getAnalyticsEventFromAppleNotification(
+    notification.notificationType,
+    notification.subtype,
+  );
+
+  if (eventName) {
+    await logAppleAnalyticsEvent(decodedInfo, eventName, user, currencyInUSD);
+  }
+
+  if (notification.notificationType === NotificationTypeV2.SUBSCRIBED) {
+    await notifyNewStoreKitSubscription(decodedInfo, user, currencyInUSD);
+  }
+};

--- a/src/common/apple/subscription.ts
+++ b/src/common/apple/subscription.ts
@@ -65,7 +65,7 @@ const getSubscriptionStatus = (
 
 export const notifyNewStoreKitSubscription = async (
   data: JWSRenewalInfoDecodedPayload,
-  user: User,
+  user: Pick<User, 'id' | 'subscriptionFlags' | 'coresRole'>,
   currencyInUSD: number,
 ) => {
   if (isTest) {
@@ -188,7 +188,7 @@ export const handleAppleSubscription = async ({
 }: {
   transactionInfo: JWSTransactionDecodedPayload;
   renewalInfo: JWSRenewalInfoDecodedPayload;
-  user: User;
+  user: Pick<User, 'id' | 'subscriptionFlags' | 'coresRole'>;
   environment: Environment;
   notification: ResponseBodyV2DecodedPayload;
 }) => {

--- a/src/common/apple/types.ts
+++ b/src/common/apple/types.ts
@@ -1,0 +1,58 @@
+import { Environment } from '@apple/app-store-server-library';
+import { env } from 'node:process';
+import { isTest } from '../utils';
+import { SubscriptionCycles } from '../../paddle';
+
+export const certificatesToLoad = isTest
+  ? ['__tests__/fixture/testCA.der']
+  : [
+      '/usr/local/share/ca-certificates/AppleIncRootCertificate.cer',
+      '/usr/local/share/ca-certificates/AppleRootCA-G2.cer',
+      '/usr/local/share/ca-certificates/AppleRootCA-G3.cer',
+    ];
+
+const getVerifierEnvironment = (): Environment => {
+  switch (env.NODE_ENV) {
+    case 'production':
+      return Environment.PRODUCTION;
+    case 'development':
+      return Environment.SANDBOX;
+    case 'test':
+      return Environment.LOCAL_TESTING;
+    default:
+      throw new Error("Invalid 'NODE_ENV' value");
+  }
+};
+
+export const bundleId = isTest ? 'dev.fylla' : env.APPLE_APP_BUNDLE_ID;
+export const appAppleId = parseInt(env.APPLE_APP_APPLE_ID);
+export const appleEnableOnlineChecks = true;
+export const appleEnvironment = getVerifierEnvironment();
+
+export const allowedIPs = [
+  '127.0.0.1/24',
+  '192.168.0.0/16',
+  '172.16.0.0/12',
+  '10.0.0.0/8',
+
+  // Production IPs. These are the IPs that Apple uses to send notifications.
+  // https://developer.apple.com/documentation/appstoreservernotifications/enabling-app-store-server-notifications#Configure-an-allow-list
+  '17.0.0.0/8',
+];
+
+export interface AppleNotificationRequest {
+  signedPayload: string;
+}
+
+export const productIdToCycle = {
+  annualSpecial: SubscriptionCycles.Yearly,
+  annual: SubscriptionCycles.Yearly,
+  monthly: SubscriptionCycles.Monthly,
+};
+
+export enum AppleTransactionType {
+  AutoRenewableSubscription = 'Auto-Renewable Subscription',
+  NonConsumable = 'Non-Consumable',
+  Consumable = 'Consumable',
+  NonRenewingSubscription = 'Non-Renewing Subscription',
+}

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -1,0 +1,149 @@
+import {
+  NotificationTypeV2,
+  Subtype,
+  type Environment,
+  type JWSRenewalInfoDecodedPayload,
+  type JWSTransactionDecodedPayload,
+  type ResponseBodyV2DecodedPayload,
+  type SignedDataVerifier,
+} from '@apple/app-store-server-library';
+import { logger } from '../../logger';
+import { SubscriptionProvider, type User } from '../../entity/user/User';
+import { isNullOrUndefined } from '../object';
+import {
+  AnalyticsEventName,
+  sendAnalyticsEvent,
+} from '../../integrations/analytics';
+import {
+  AppleTransactionType,
+  certificatesToLoad,
+  productIdToCycle,
+} from './types';
+import { readFile } from 'fs/promises';
+import { isTest } from '../utils';
+
+export const verifyAndDecodeAppleSignedData = async ({
+  notification,
+  environment,
+  verifier,
+}: {
+  notification: ResponseBodyV2DecodedPayload;
+  environment: Environment;
+  verifier: SignedDataVerifier;
+}) => {
+  if (!isNullOrUndefined(notification.data?.signedRenewalInfo)) {
+    return await verifier.verifyAndDecodeTransaction(
+      notification.data.signedRenewalInfo,
+    );
+  }
+
+  if (!isNullOrUndefined(notification.data?.signedTransactionInfo)) {
+    return await verifier.verifyAndDecodeTransaction(
+      notification.data.signedTransactionInfo,
+    );
+  }
+
+  logger.info(
+    {
+      environment,
+      notification,
+      provider: SubscriptionProvider.AppleStoreKit,
+    },
+    'Missing signed data in notification data',
+  );
+
+  return null;
+};
+
+export const logAppleAnalyticsEvent = async (
+  data: JWSRenewalInfoDecodedPayload,
+  eventName: AnalyticsEventName,
+  user: User,
+  currencyInUSD: number,
+) => {
+  if (!data || isTest) {
+    return;
+  }
+
+  const cycle =
+    productIdToCycle[data?.autoRenewProductId as keyof typeof productIdToCycle];
+  const cost = data?.renewalPrice;
+
+  const extra = {
+    payment: SubscriptionProvider.AppleStoreKit,
+    cycle,
+    cost: currencyInUSD,
+    currency: 'USD',
+    localCost: cost ? cost / 1000 : undefined,
+    localCurrency: data?.currency,
+    payout: {
+      total: currencyInUSD * 100,
+      grandTotal: currencyInUSD * 100,
+      currencyCode: 'USD',
+    },
+  };
+
+  await sendAnalyticsEvent([
+    {
+      event_name: eventName,
+      event_timestamp: new Date(data?.signedDate || ''),
+      event_id: data.appTransactionId,
+      app_platform: 'api',
+      user_id: user.id,
+      extra: JSON.stringify(extra),
+    },
+  ]);
+};
+
+export const getAnalyticsEventFromAppleNotification = (
+  notificationType: ResponseBodyV2DecodedPayload['notificationType'],
+  subtype?: ResponseBodyV2DecodedPayload['subtype'],
+): AnalyticsEventName | null => {
+  switch (notificationType) {
+    case NotificationTypeV2.SUBSCRIBED:
+    case NotificationTypeV2.DID_RENEW:
+    case NotificationTypeV2.ONE_TIME_CHARGE:
+      return AnalyticsEventName.ReceivePayment;
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_PREF:
+      return AnalyticsEventName.ChangeBillingCycle;
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS: // Disable/Enable Auto-Renew
+      return subtype === Subtype.AUTO_RENEW_ENABLED
+        ? null
+        : AnalyticsEventName.CancelSubscription;
+    case NotificationTypeV2.DID_FAIL_TO_RENEW:
+      // When user fails to renew and there is no grace period
+      if (isNullOrUndefined(subtype)) {
+        return AnalyticsEventName.CancelSubscription;
+      }
+    default:
+      return null;
+  }
+};
+
+export const loadAppleRootCAs = async (): Promise<Buffer[]> => {
+  const appleRootCAs: Buffer[] = await Promise.all(
+    certificatesToLoad.map(async (certPath) => await readFile(certPath)),
+  );
+
+  logger.debug(`Loaded ${appleRootCAs.length} Apple's Root CAs`);
+  return appleRootCAs;
+};
+
+export const getAppleTransactionType = ({
+  decodedInfo,
+}: {
+  decodedInfo: JWSTransactionDecodedPayload;
+}): AppleTransactionType | null => {
+  switch (decodedInfo.type) {
+    case 'Auto-Renewable Subscription':
+      return AppleTransactionType.AutoRenewableSubscription;
+    case 'Non-Consumable':
+      return AppleTransactionType.NonConsumable;
+    case 'Consumable':
+      return AppleTransactionType.Consumable;
+    case 'Non-Renewing Subscription':
+      return AppleTransactionType.NonRenewingSubscription;
+    default:
+      return null;
+  }
+};

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -58,7 +58,7 @@ export const logAppleAnalyticsEvent = async (
   transactionInfo: JWSTransactionDecodedPayload,
   renewalInfo: JWSRenewalInfoDecodedPayload,
   eventName: AnalyticsEventName,
-  user: User,
+  user: Pick<User, 'id' | 'subscriptionFlags' | 'coresRole'>,
   currencyInUSD: number,
 ) => {
   if (!transactionInfo || isTest) {

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -24,7 +24,6 @@ import { isTest } from '../utils';
 
 export const verifyAndDecodeAppleSignedData = async ({
   notification,
-  environment,
   verifier,
 }: {
   notification: ResponseBodyV2DecodedPayload;
@@ -48,15 +47,6 @@ export const verifyAndDecodeAppleSignedData = async ({
       notification.data.signedTransactionInfo,
     );
   }
-
-  logger.info(
-    {
-      environment,
-      notification,
-      provider: SubscriptionProvider.AppleStoreKit,
-    },
-    'Missing signed data in notification data',
-  );
 
   return {
     transactionInfo,

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -13,6 +13,7 @@ import { isNullOrUndefined } from '../object';
 import {
   AnalyticsEventName,
   sendAnalyticsEvent,
+  TargetType,
 } from '../../integrations/analytics';
 import {
   AppleTransactionType,
@@ -21,6 +22,7 @@ import {
 } from './types';
 import { readFile } from 'fs/promises';
 import { isTest } from '../utils';
+import { isCorePurchaseApple } from './purchase';
 
 export const verifyAndDecodeAppleSignedData = async ({
   notification,
@@ -56,7 +58,7 @@ export const verifyAndDecodeAppleSignedData = async ({
 
 export const logAppleAnalyticsEvent = async (
   transactionInfo: JWSTransactionDecodedPayload,
-  renewalInfo: JWSRenewalInfoDecodedPayload,
+  renewalInfo: JWSRenewalInfoDecodedPayload | undefined,
   eventName: AnalyticsEventName,
   user: Pick<User, 'id' | 'subscriptionFlags' | 'coresRole'>,
   currencyInUSD: number,
@@ -93,6 +95,9 @@ export const logAppleAnalyticsEvent = async (
       app_platform: 'api',
       user_id: user.id,
       extra: JSON.stringify(extra),
+      target_type: isCorePurchaseApple({ transactionInfo })
+        ? TargetType.Credits
+        : TargetType.Plus,
     },
   ]);
 };

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -70,3 +70,8 @@ export async function sendExperimentAllocationEvent<
     { retries: 3 },
   );
 }
+
+export enum TargetType {
+  Plus = 'plus',
+  Credits = 'credits',
+}

--- a/src/routes/webhooks/apple.ts
+++ b/src/routes/webhooks/apple.ts
@@ -81,14 +81,15 @@ const handleNotifcationRequest = async (
     }
 
     const con = await createOrGetConnection();
-    const user = await con.getRepository(User).findOne({
-      select: ['id', 'subscriptionFlags'],
-      where: {
-        subscriptionFlags: JsonContains({
-          appAccountToken: transactionInfo.appAccountToken,
-        }),
-      },
-    });
+    const user: Pick<User, 'id' | 'subscriptionFlags' | 'coresRole'> | null =
+      await con.getRepository(User).findOne({
+        select: ['id', 'subscriptionFlags', 'coresRole'],
+        where: {
+          subscriptionFlags: JsonContains({
+            appAccountToken: transactionInfo.appAccountToken,
+          }),
+        },
+      });
 
     if (!user) {
       logger.error(

--- a/src/routes/webhooks/apple.ts
+++ b/src/routes/webhooks/apple.ts
@@ -1,217 +1,39 @@
-import { readFile } from 'node:fs/promises';
-import { env } from 'node:process';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { logger } from '../../logger';
 import {
   Environment,
   NotificationTypeV2,
   SignedDataVerifier,
-  Subtype,
   VerificationException,
   type JWSRenewalInfoDecodedPayload,
-  type ResponseBodyV2DecodedPayload,
 } from '@apple/app-store-server-library';
 import { concatTextToNewline, isTest, webhooks } from '../../common';
 import { isInSubnet } from 'is-in-subnet';
 import { isNullOrUndefined } from '../../common/object';
 import createOrGetConnection from '../../db';
-import {
-  UserSubscriptionStatus,
-  SubscriptionProvider,
-  User,
-  type UserSubscriptionFlags,
-} from '../../entity';
+import { SubscriptionProvider, User } from '../../entity';
 import { JsonContains } from 'typeorm';
-import { SubscriptionCycles } from '../../paddle';
-import { updateStoreKitUserSubscription } from '../../plusSubscription';
-import {
-  AnalyticsEventName,
-  sendAnalyticsEvent,
-} from '../../integrations/analytics';
 import type { Block, KnownBlock } from '@slack/web-api';
 import { remoteConfig } from '../../remoteConfig';
-import { convertCurrencyToUSD } from '../../integrations/openExchangeRates';
-
-const certificatesToLoad = isTest
-  ? ['__tests__/fixture/testCA.der']
-  : [
-      '/usr/local/share/ca-certificates/AppleIncRootCertificate.cer',
-      '/usr/local/share/ca-certificates/AppleRootCA-G2.cer',
-      '/usr/local/share/ca-certificates/AppleRootCA-G3.cer',
-    ];
-
-const loadAppleRootCAs = async (): Promise<Buffer[]> => {
-  const appleRootCAs: Buffer[] = await Promise.all(
-    certificatesToLoad.map(async (certPath) => await readFile(certPath)),
-  );
-
-  logger.debug(`Loaded ${appleRootCAs.length} Apple's Root CAs`);
-  return appleRootCAs;
-};
-
-const getVerifierEnvironment = (): Environment => {
-  switch (env.NODE_ENV) {
-    case 'production':
-      return Environment.PRODUCTION;
-    case 'development':
-      return Environment.SANDBOX;
-    case 'test':
-      return Environment.LOCAL_TESTING;
-    default:
-      throw new Error("Invalid 'NODE_ENV' value");
-  }
-};
-
-const bundleId = isTest ? 'dev.fylla' : env.APPLE_APP_BUNDLE_ID;
-const appAppleId = parseInt(env.APPLE_APP_APPLE_ID);
-const enableOnlineChecks = true;
-const environment = getVerifierEnvironment();
-
-const allowedIPs = [
-  '127.0.0.1/24',
-  '192.168.0.0/16',
-  '172.16.0.0/12',
-  '10.0.0.0/8',
-
-  // Production IPs. These are the IPs that Apple uses to send notifications.
-  // https://developer.apple.com/documentation/appstoreservernotifications/enabling-app-store-server-notifications#Configure-an-allow-list
-  '17.0.0.0/8',
-];
-
-interface AppleNotificationRequest {
-  signedPayload: string;
-}
-
-const productIdToCycle = {
-  annualSpecial: SubscriptionCycles.Yearly,
-  annual: SubscriptionCycles.Yearly,
-  monthly: SubscriptionCycles.Monthly,
-};
-
-const renewalInfoToSubscriptionFlags = (
-  data: JWSRenewalInfoDecodedPayload,
-): UserSubscriptionFlags => {
-  const cycle =
-    productIdToCycle[data.autoRenewProductId as keyof typeof productIdToCycle];
-
-  if (isNullOrUndefined(cycle)) {
-    logger.error(
-      { data, provider: SubscriptionProvider.AppleStoreKit },
-      'Invalid auto renew product ID',
-    );
-    throw new Error('Invalid auto renew product ID');
-  }
-
-  return {
-    cycle,
-    subscriptionId: data.originalTransactionId,
-    createdAt: new Date(data.recentSubscriptionStartDate!),
-    expiresAt: new Date(data.renewalDate!),
-    provider: SubscriptionProvider.AppleStoreKit,
-  };
-};
-
-const getSubscriptionStatus = (
-  notificationType: ResponseBodyV2DecodedPayload['notificationType'],
-  subtype?: ResponseBodyV2DecodedPayload['subtype'],
-): UserSubscriptionStatus => {
-  switch (notificationType) {
-    case NotificationTypeV2.SUBSCRIBED:
-    case NotificationTypeV2.DID_RENEW:
-    case NotificationTypeV2.DID_CHANGE_RENEWAL_PREF: // Upgrade/Downgrade
-    case NotificationTypeV2.REFUND_REVERSED:
-      return UserSubscriptionStatus.Active;
-    case NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS: // Disable/Enable Auto-Renew
-      return subtype === Subtype.AUTO_RENEW_ENABLED
-        ? UserSubscriptionStatus.Active
-        : UserSubscriptionStatus.Cancelled;
-    case NotificationTypeV2.DID_FAIL_TO_RENEW:
-      // When user fails to renew and there is no grace period
-      if (isNullOrUndefined(subtype)) {
-        return UserSubscriptionStatus.Cancelled;
-      }
-    case NotificationTypeV2.GRACE_PERIOD_EXPIRED:
-      return UserSubscriptionStatus.Cancelled;
-    case NotificationTypeV2.REFUND:
-    case NotificationTypeV2.EXPIRED:
-    case NotificationTypeV2.REVOKE: // We don't support Family Sharing, but to be on the safe side
-      return UserSubscriptionStatus.Expired;
-    default:
-      logger.error(
-        {
-          notificationType,
-          subtype,
-          provider: SubscriptionProvider.AppleStoreKit,
-        },
-        'Unknown notification type',
-      );
-      throw new Error('Unknown notification type');
-  }
-};
-
-const getSubscriptionAnalyticsEvent = (
-  notificationType: ResponseBodyV2DecodedPayload['notificationType'],
-  subtype?: ResponseBodyV2DecodedPayload['subtype'],
-): AnalyticsEventName | null => {
-  switch (notificationType) {
-    case NotificationTypeV2.SUBSCRIBED:
-    case NotificationTypeV2.DID_RENEW:
-      return AnalyticsEventName.ReceivePayment;
-    case NotificationTypeV2.DID_CHANGE_RENEWAL_PREF:
-      return AnalyticsEventName.ChangeBillingCycle;
-    case NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS: // Disable/Enable Auto-Renew
-      return subtype === Subtype.AUTO_RENEW_ENABLED
-        ? null
-        : AnalyticsEventName.CancelSubscription;
-    case NotificationTypeV2.DID_FAIL_TO_RENEW:
-      // When user fails to renew and there is no grace period
-      if (isNullOrUndefined(subtype)) {
-        return AnalyticsEventName.CancelSubscription;
-      }
-    default:
-      return null;
-  }
-};
-
-export const logAppleAnalyticsEvent = async (
-  data: JWSRenewalInfoDecodedPayload,
-  eventName: AnalyticsEventName,
-  user: User,
-  currencyInUSD: number,
-) => {
-  if (!data || isTest) {
-    return;
-  }
-
-  const cycle =
-    productIdToCycle[data?.autoRenewProductId as keyof typeof productIdToCycle];
-  const cost = data?.renewalPrice;
-
-  const extra = {
-    payment: SubscriptionProvider.AppleStoreKit,
-    cycle,
-    cost: currencyInUSD,
-    currency: 'USD',
-    localCost: cost ? cost / 1000 : undefined,
-    localCurrency: data?.currency,
-    payout: {
-      total: currencyInUSD * 100,
-      grandTotal: currencyInUSD * 100,
-      currencyCode: 'USD',
-    },
-  };
-
-  await sendAnalyticsEvent([
-    {
-      event_name: eventName,
-      event_timestamp: new Date(data?.signedDate || ''),
-      event_id: data.appTransactionId,
-      app_platform: 'api',
-      user_id: user.id,
-      extra: JSON.stringify(extra),
-    },
-  ]);
-};
+import {
+  getAppleTransactionType,
+  verifyAndDecodeAppleSignedData,
+} from '../../common/apple/utils';
+import {
+  allowedIPs,
+  appAppleId,
+  bundleId,
+  appleEnableOnlineChecks,
+  appleEnvironment,
+  type AppleNotificationRequest,
+  AppleTransactionType,
+} from '../../common/apple/types';
+import {
+  handleCoresPurchase,
+  isCorePurchaseApple,
+} from '../../common/apple/purchase';
+import { handleAppleSubscription } from '../../common/apple/subscription';
+import { loadAppleRootCAs } from '../../common/apple/utils';
 
 const handleNotifcationRequest = async (
   verifier: SignedDataVerifier,
@@ -250,30 +72,22 @@ const handleNotifcationRequest = async (
       return response.status(200).send({ received: true });
     }
 
-    // Check if the event is a subscription event
-    // NOTE: When adding support for purchasing cores, we must remove this check as it's not a subscription event
-    if (isNullOrUndefined(notification?.data?.signedRenewalInfo)) {
-      logger.info(
-        {
-          environment,
-          notification,
-          provider: SubscriptionProvider.AppleStoreKit,
-        },
-        "Missing 'signedRenewalInfo' in notification data",
-      );
+    const decodedInfo = await verifyAndDecodeAppleSignedData({
+      notification,
+      environment,
+      verifier,
+    });
+
+    if (!decodedInfo) {
       return response.status(400).send({ error: 'Invalid Payload' });
     }
-
-    const renewalInfo = await verifier.verifyAndDecodeRenewalInfo(
-      notification.data.signedRenewalInfo!,
-    );
 
     const con = await createOrGetConnection();
     const user = await con.getRepository(User).findOne({
       select: ['id', 'subscriptionFlags'],
       where: {
         subscriptionFlags: JsonContains({
-          appAccountToken: renewalInfo.appAccountToken,
+          appAccountToken: decodedInfo.appAccountToken,
         }),
       },
     });
@@ -307,54 +121,34 @@ const handleNotifcationRequest = async (
       return response.status(403).send({ error: 'Invalid Payload' });
     }
 
-    // Prevent double subscription
-    if (user.subscriptionFlags?.provider === SubscriptionProvider.Paddle) {
-      logger.error(
-        {
+    switch (getAppleTransactionType({ decodedInfo })) {
+      case AppleTransactionType.Consumable:
+        if (isCorePurchaseApple({ decodedInfo })) {
+          await handleCoresPurchase({
+            decodedInfo,
+            user,
+            environment,
+            notification,
+          });
+        } else {
+          throw new Error('Unsupported Apple Consumable transaction type');
+        }
+        break;
+      case AppleTransactionType.AutoRenewableSubscription:
+        await handleAppleSubscription({
+          decodedInfo,
           user,
           environment,
           notification,
-          provider: SubscriptionProvider.AppleStoreKit,
-        },
-        'User already has a Paddle subscription',
-      );
-      throw new Error('User already has a Paddle subscription');
-    }
-
-    const subscriptionStatus = getSubscriptionStatus(
-      notification.notificationType,
-      notification.subtype,
-    );
-
-    const eventName = getSubscriptionAnalyticsEvent(
-      notification.notificationType,
-      notification.subtype,
-    );
-
-    const subscriptionFlags = renewalInfoToSubscriptionFlags(renewalInfo);
-
-    await updateStoreKitUserSubscription({
-      userId: user.id,
-      status: subscriptionStatus,
-      data: subscriptionFlags,
-    });
-
-    const currencyInUSD = await convertCurrencyToUSD(
-      (renewalInfo.renewalPrice || 0) / 1000,
-      renewalInfo.currency || 'USD',
-    );
-
-    if (eventName) {
-      await logAppleAnalyticsEvent(renewalInfo, eventName, user, currencyInUSD);
-    }
-
-    if (notification.notificationType === NotificationTypeV2.SUBSCRIBED) {
-      await notifyNewStoreKitSubscription(renewalInfo, user, currencyInUSD);
+        });
+        break;
+      default:
+        throw new Error('Unsupported Apple transaction type');
     }
 
     logger.info(
       {
-        renewalInfo,
+        decodedInfo,
         user,
         environment,
         provider: SubscriptionProvider.AppleStoreKit,
@@ -509,13 +303,18 @@ export const apple = async (fastify: FastifyInstance): Promise<void> => {
     ) => {
       const verifier = new SignedDataVerifier(
         appleRootCAs,
-        enableOnlineChecks,
-        environment,
+        appleEnableOnlineChecks,
+        appleEnvironment,
         bundleId,
         appAppleId,
       );
 
-      await handleNotifcationRequest(verifier, request, response, environment);
+      await handleNotifcationRequest(
+        verifier,
+        request,
+        response,
+        appleEnvironment,
+      );
     },
   );
 
@@ -527,7 +326,7 @@ export const apple = async (fastify: FastifyInstance): Promise<void> => {
     ) => {
       const verifier = new SignedDataVerifier(
         appleRootCAs,
-        enableOnlineChecks,
+        appleEnableOnlineChecks,
         Environment.SANDBOX,
         bundleId,
         appAppleId,

--- a/src/routes/webhooks/paddle.ts
+++ b/src/routes/webhooks/paddle.ts
@@ -29,6 +29,7 @@ import { logger } from '../../logger';
 import {
   AnalyticsEventName,
   sendAnalyticsEvent,
+  TargetType,
 } from '../../integrations/analytics';
 import { JsonContains, type DataSource, type EntityManager } from 'typeorm';
 import {
@@ -278,7 +279,9 @@ const logPaddleAnalyticsEvent = async (
       app_platform: 'api',
       user_id: userId,
       extra: JSON.stringify(getAnalyticsExtra(data)),
-      target_type: isCoreTransaction({ event }) ? 'credits' : 'plus',
+      target_type: isCoreTransaction({ event })
+        ? TargetType.Credits
+        : TargetType.Plus,
     },
   ]);
 };


### PR DESCRIPTION
- support for IAP and one time purchases
- refactor apple webhooks file to common to split and reuse common logic
- will work on adding mores tests for IAP flow in next PR after some sandbox testing e2e if needed