### PR TITLE
refactor: pricing preview to add locale option

### DIFF
--- a/__tests__/paddle.ts
+++ b/__tests__/paddle.ts
@@ -371,8 +371,8 @@ describe('plus pricing metadata', () => {
 
 describe('plus pricing preview', () => {
   const QUERY = /* GraphQL */ `
-    query PricingPreview($type: PricingType) {
-      pricingPreview(type: $type) {
+    query PricingPreview($type: PricingType, $locale: String) {
+      pricingPreview(type: $type, locale: $locale) {
         metadata {
           appsId
           title
@@ -561,6 +561,31 @@ describe('plus pricing preview', () => {
     expect(setRedisObjectWithExpirySpy).toHaveBeenCalledTimes(1);
 
     expect(result).toEqual(result2);
+  });
+
+  it('should format prices according to locale', async () => {
+    loggedUser = 'whp-1';
+    const result = await client.query(QUERY, {
+      variables: {
+        type: PricingType.Plus,
+        locale: 'de-DE',
+      },
+    });
+    expect(result.data.pricingPreview).toHaveLength(1);
+    const preview = result.data.pricingPreview[0];
+    expect(preview.price.formatted).toMatch(/€\d+,\d+/); // German format with € and comma
+  });
+
+  it('should use default locale when not specified', async () => {
+    loggedUser = 'whp-1';
+    const result = await client.query(QUERY, {
+      variables: {
+        type: PricingType.Plus,
+      },
+    });
+    expect(result.data.pricingPreview).toHaveLength(1);
+    const preview = result.data.pricingPreview[0];
+    expect(preview.price.formatted).toMatch(/\$\d+\.\d+/); // Default USD format
   });
 });
 

--- a/__tests__/paddle.ts
+++ b/__tests__/paddle.ts
@@ -674,7 +674,7 @@ describe('plus pricing preview', () => {
 
     jest
       .spyOn(paddleInstance.pricingPreview, 'preview')
-      .mockResolvedValue(mockPreview as any);
+      .mockResolvedValue(mockPreview as never);
 
     const result = await client.query(QUERY, {
       variables: {

--- a/src/schema/paddle.ts
+++ b/src/schema/paddle.ts
@@ -131,10 +131,7 @@ export const typeDefs = /* GraphQL */ `
     pricePreviews: PricePreviews! @auth
     corePricePreviews: PricePreviews! @auth
     pricingMetadata(type: PricingType): [ProductPricingMetadata!]! @auth
-    pricingPreview(
-      type: PricingType
-      locale: String
-    ): [ProductPricingPreview!]! @auth
+    pricingPreview(type: PricingType, locale: String): [ProductPricingPreview!]!
   }
 
   ${toGQLEnum(PricingType, 'PricingType')}

--- a/src/schema/paddle.ts
+++ b/src/schema/paddle.ts
@@ -131,7 +131,10 @@ export const typeDefs = /* GraphQL */ `
     pricePreviews: PricePreviews! @auth
     corePricePreviews: PricePreviews! @auth
     pricingMetadata(type: PricingType): [ProductPricingMetadata!]! @auth
-    pricingPreview(type: PricingType): [ProductPricingPreview!]! @auth
+    pricingPreview(
+      type: PricingType
+      locale: String
+    ): [ProductPricingPreview!]! @auth
   }
 
   ${toGQLEnum(PricingType, 'PricingType')}
@@ -275,6 +278,7 @@ export interface GQLCustomData {
 
 interface PaddlePricingPreviewArgs {
   type?: PricingType;
+  locale?: string;
 }
 
 export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
@@ -389,7 +393,7 @@ export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
     ): Promise<BasePricingMetadata[]> => getPricingMetadata(ctx, type),
     pricingPreview: async (
       _,
-      { type = PricingType.Plus }: PaddlePricingPreviewArgs,
+      { type = PricingType.Plus, locale }: PaddlePricingPreviewArgs,
       ctx,
     ): Promise<BasePricingPreview[]> => {
       const metadata = await getPricingMetadata(ctx, type);
@@ -416,7 +420,7 @@ export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
         return {
           metadata: meta,
           priceId: item.price.id,
-          price: getProductPrice(item),
+          price: getProductPrice(item, locale),
           currency: {
             code: preview.currencyCode,
             symbol: removeNumbers(item.formattedTotals.total),


### PR DESCRIPTION
Add a `locale` param for requesting the pricing preview.