### PR TITLE
test: price formatter with the original test cases

### DIFF
--- a/__tests__/common/paddle/pricing.ts
+++ b/__tests__/common/paddle/pricing.ts
@@ -107,6 +107,34 @@ describe('getPrice', () => {
     });
   });
 
+  it('should handle Indian Rupee format', () => {
+    const result = getPrice({ formatted: '₹49.97', locale: 'en-IN' });
+    expect(result).toEqual({
+      amount: 49.97,
+      formatted: '₹49.97',
+    });
+  });
+
+  it('should handle Swedish Krona format with symbol after amount', () => {
+    const result = getPrice({
+      formatted: '1499,00 kr',
+      locale: 'sv-SE',
+      divideBy: 30, // Convert monthly to daily price
+    });
+    expect(result).toEqual({
+      amount: 49.97,
+      formatted: '49,97 kr',
+    });
+  });
+
+  it('should handle Brazilian Real format with specific spacing', () => {
+    const result = getPrice({ formatted: 'R$ 149,90', locale: 'pt-BR' });
+    expect(result).toEqual({
+      amount: 149.9,
+      formatted: 'R$ 149,90',
+    });
+  });
+
   // we have not covered the case where there are multiple spaces within the format and negative values
 });
 


### PR DESCRIPTION
As Ido asked, since we moved the formatter logic from the apps repo to API repo, we should cover the tests that were from the original code. Basically the ones that are currency-specific.

Even though we already covered a wide coverage of the cases, it shouldn't hurt to add more so I've committed more 🚀 

Referenced original tests: https://github.com/dailydotdev/apps/blob/df596ba2d619272f6b386cc25ad5b765ee9636d1/packages/shared/src/features/payment/hooks/usePricingCycleConverter.spec.ts