### PR TITLE
fix: try using tags in graphorm queries to look at query insights

### DIFF
--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -10,6 +10,7 @@ import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
 import { Context } from '../Context';
 import { Connection, Edge } from 'graphql-relay';
 import { EntityTarget } from 'typeorm/common/EntityTarget';
+import type { GraphqlPayload } from '../compatibility/utils';
 
 export type QueryBuilder = SelectQueryBuilder<any>;
 
@@ -571,6 +572,9 @@ export class GraphORM {
     let res: any[];
 
     try {
+      builder.queryBuilder.comment(
+        `action='${(ctx.req.body as GraphqlPayload).operationName}'`,
+      );
       res = await builder.queryBuilder.getRawMany();
     } catch (error) {
       throw error;

--- a/src/graphorm/graphorm.ts
+++ b/src/graphorm/graphorm.ts
@@ -573,7 +573,7 @@ export class GraphORM {
 
     try {
       builder.queryBuilder.comment(
-        `action='${(ctx.req.body as GraphqlPayload).operationName}'`,
+        `action='${(ctx?.req?.body as GraphqlPayload)?.operationName}'`,
       );
       res = await builder.queryBuilder.getRawMany();
     } catch (error) {


### PR DESCRIPTION
Adds a SQL comment to the GraphORM queries with the operation name to attempt at getting better query insights in CloudSQL

https://cloud.google.com/sql/docs/postgres/using-query-insights#adding-tags-to-sql-queries