### PR TITLE
fix: deleting an account with gifted subscription

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -4059,6 +4059,27 @@ describe('mutation deleteUser', () => {
     expect(userOne).toEqual(null);
   });
 
+  it('should not call cancel subscription for gifted subscription', async () => {
+    loggedUser = '1';
+
+    await con.getRepository(User).update(
+      { id: '1' },
+      {
+        subscriptionFlags: updateSubscriptionFlags({
+          subscriptionId: '123',
+          provider: SubscriptionProvider.Paddle,
+          giftExpirationDate: new Date(Date.now() + 86400000), // 1 day from now
+        }),
+      },
+    );
+
+    await client.mutate(MUTATION);
+
+    expect(cancelSubscription).not.toHaveBeenCalled();
+    const userOne = await con.getRepository(User).findOneBy({ id: '1' });
+    expect(userOne).toEqual(null);
+  });
+
   describe('when user has a storekit subscription', () => {
     beforeEach(async () => {
       await saveFixtures(con, User, [

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -47,16 +47,20 @@ export const deleteUser = async (
       }
 
       if (subscriptionFlags?.provider === SubscriptionProvider.Paddle) {
-        await cancelSubscription({
-          subscriptionId: subscriptionFlags.subscriptionId,
-        });
+        const isGifted = !!subscriptionFlags.giftExpirationDate;
+        // gifted subscription is a one-time payment hence not considered subscription in Paddle's terms
+        if (!isGifted) {
+          await cancelSubscription({
+            subscriptionId: subscriptionFlags.subscriptionId,
+          });
+        }
         logger.info(
           {
             provider: SubscriptionProvider.Paddle,
             userId,
             subscriptionId: subscriptionFlags.subscriptionId,
           },
-          'Subscription cancelled user deletion',
+          `Subscription${isGifted ? ' (gifted)' : ''} cancelled user deletion`,
         );
       }
     }

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -58,9 +58,10 @@ export const deleteUser = async (
           {
             provider: SubscriptionProvider.Paddle,
             userId,
+            isGifted,
             subscriptionId: subscriptionFlags.subscriptionId,
           },
-          `Subscription${isGifted ? ' (gifted)' : ''} cancelled user deletion`,
+          'Subscription cancelled user deletion',
         );
       }
     }


### PR DESCRIPTION
From Paddle's side of things, there is no subscription ID for gifted Plus membership. Hence we get an error that the subscription is not found and the process causes to throw an error.