### PR TITLE
chore: drop deprecated column `role` from `content_preference` table

### DIFF
--- a/src/migration/1746779086984-DropRoleContentPreference.ts
+++ b/src/migration/1746779086984-DropRoleContentPreference.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropRoleContentPreference1746779086984 implements MigrationInterface {
+  name = 'DropRoleContentPreference1746779086984'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "content_preference" DROP COLUMN "role"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "content_preference" ADD "role" text DEFAULT 'member'`);
+  }
+}


### PR DESCRIPTION
[Omitted from the migration](https://github.com/dailydotdev/daily-api/pull/2377/files#r1829110354) from #2377, but should be safe to drop now