### PR TITLE
fix: skadi response can be empty

### DIFF
--- a/__tests__/common/personalizedDigest.ts
+++ b/__tests__/common/personalizedDigest.ts
@@ -1,0 +1,98 @@
+import type { DataSource } from 'typeorm';
+import { getEmailAd } from '../../src/common/personalizedDigest';
+import createOrGetConnection from '../../src/db';
+import { saveFixtures } from '../helpers';
+import { User } from '../../src/entity/user/User';
+import { usersFixture } from '../fixture/user';
+import nock from 'nock';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+describe('getEmailAd', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    nock.cleanAll();
+
+    await saveFixtures(
+      con,
+      User,
+      usersFixture.map((user) => {
+        return {
+          ...user,
+          id: `${user.id}-cgea`,
+          username: `${user.username}-cgea`,
+        };
+      }),
+    );
+  });
+
+  it('should return ad', async () => {
+    nock('http://localhost:8080')
+      .post('/private', {
+        placement: 'default_digest',
+        metadata: { USERID: '1-cgea' },
+      })
+      .reply(200, {
+        type: 'ad',
+        value: {
+          digest: {
+            call_to_action: 'Click now!',
+            company_logo: ' https://daily.dev/image',
+            company_name: 'WE',
+            image: 'https://daily.dev/image',
+            link: 'https://daily.dev/ad',
+            title: 'Ad title',
+            type: 'dynamic_ad',
+          },
+        },
+        pixels: [],
+      });
+
+    const user = await con.getRepository(User).findOneByOrFail({
+      id: '1-cgea',
+    });
+
+    const ad = await getEmailAd({
+      user,
+      feature: {
+        templateId: '75',
+      },
+    });
+
+    expect(ad).toEqual({
+      call_to_action: 'Click now!',
+      company_logo: ' https://daily.dev/image',
+      company_name: 'WE',
+      image: 'https://daily.dev/image',
+      link: 'https://daily.dev/ad',
+      title: 'Ad title',
+      type: 'dynamic_ad',
+    });
+  });
+
+  it('should return null if no ad available', async () => {
+    nock('http://localhost:8080')
+      .post('/private', {
+        placement: 'default_digest',
+        metadata: { USERID: '2-cgea' },
+      })
+      .reply(200, {});
+
+    const user = await con.getRepository(User).findOneByOrFail({
+      id: '2-cgea',
+    });
+
+    const ad = await getEmailAd({
+      user,
+      feature: {
+        templateId: '75',
+      },
+    });
+
+    expect(ad).toBeNull();
+  });
+});

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -127,12 +127,12 @@ type CIOSkadiAd = {
   type: string;
 } & SkadiAd;
 
-const getEmailAd = async ({
+export const getEmailAd = async ({
   user,
   feature,
 }: {
   user: User;
-  feature: PersonalizedDigestFeatureConfig;
+  feature: Pick<PersonalizedDigestFeatureConfig, 'templateId'>;
 }): Promise<CIOSkadiAd | null> => {
   // TODO: Temporary hardcode 75 check
   if (
@@ -146,7 +146,11 @@ const getEmailAd = async ({
     USERID: user.id,
   });
 
-  const digestAd = ad.value.digest;
+  const digestAd = ad.value?.digest;
+
+  if (!digestAd) {
+    return null;
+  }
 
   return {
     type: 'dynamic_ad',

--- a/src/integrations/skadi/types.ts
+++ b/src/integrations/skadi/types.ts
@@ -7,13 +7,13 @@ export type SkadiAd = {
   company_logo: string;
   call_to_action: string;
 };
-export type SkadiResponse = {
+export type SkadiResponse = Partial<{
   type: string;
   value: {
     digest: SkadiAd;
   };
   pixels: string[];
-};
+}>;
 
 export interface ISkadiClient {
   getAd(


### PR DESCRIPTION
Skadi response can be `{}` when no ad is available.