### PR TITLE
feat: transaction value for awards

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -2409,6 +2409,9 @@ describe('query comment awards', () => {
             name
             value
           }
+          awardTransaction {
+            value
+          }
         }
       }
     }
@@ -2551,8 +2554,8 @@ describe('query comment awards', () => {
           productId: '080e0eb0-b366-423b-8d61-eff048b9140b',
           senderId: '3-caq',
           fee: 0,
-          value: 10,
-          valueIncFees: 10,
+          value: 30,
+          valueIncFees: 30,
         },
         {
           processor: UserTransactionProcessor.Njord,
@@ -2595,8 +2598,23 @@ describe('query comment awards', () => {
 
     expect(res.errors).toBeFalsy();
 
-    expect(res.data.awardsTotal.amount).toEqual(30);
+    expect(res.data.awardsTotal.amount).toEqual(50);
     expect(res.data.awards.edges).toMatchObject([
+      {
+        node: {
+          user: {
+            id: '3-caq',
+            name: 'Nimrod',
+          },
+          award: {
+            name: 'Award 2',
+            value: 10,
+          },
+          awardTransaction: {
+            value: 30,
+          },
+        },
+      },
       {
         node: {
           user: {
@@ -2607,17 +2625,8 @@ describe('query comment awards', () => {
             name: 'Award 3',
             value: 20,
           },
-        },
-      },
-      {
-        node: {
-          user: {
-            id: '3-caq',
-            name: 'Nimrod',
-          },
-          award: {
-            name: 'Award 2',
-            value: 10,
+          awardTransaction: {
+            value: 20,
           },
         },
       },

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -7762,6 +7762,9 @@ describe('query post awards', () => {
             name
             value
           }
+          awardTransaction {
+            value
+          }
         }
       }
     }
@@ -7885,8 +7888,8 @@ describe('query post awards', () => {
           productId: '777cfd3d-1359-416b-b52a-e229b230f024',
           senderId: '3-paq',
           fee: 0,
-          value: 10,
-          valueIncFees: 10,
+          value: 50,
+          valueIncFees: 50,
         },
         {
           processor: UserTransactionProcessor.Njord,
@@ -7929,8 +7932,23 @@ describe('query post awards', () => {
 
     expect(res.errors).toBeFalsy();
 
-    expect(res.data.awardsTotal.amount).toEqual(30);
+    expect(res.data.awardsTotal.amount).toEqual(70);
     expect(res.data.awards.edges).toMatchObject([
+      {
+        node: {
+          user: {
+            id: '3-paq',
+            name: 'Nimrod',
+          },
+          award: {
+            name: 'Award 2',
+            value: 10,
+          },
+          awardTransaction: {
+            value: 50,
+          },
+        },
+      },
       {
         node: {
           user: {
@@ -7941,17 +7959,8 @@ describe('query post awards', () => {
             name: 'Award 3',
             value: 20,
           },
-        },
-      },
-      {
-        node: {
-          user: {
-            id: '3-paq',
-            name: 'Nimrod',
-          },
-          award: {
-            name: 'Award 2',
-            value: 10,
+          awardTransaction: {
+            value: 20,
           },
         },
       },

--- a/src/entity/user/UserTransaction.ts
+++ b/src/entity/user/UserTransaction.ts
@@ -49,6 +49,7 @@ export enum UserTransactionProcessor {
 @Index('idx_user_transaction_receiverId_senderId_productId_status', {
   synchronize: false,
 })
+@Index('idx_user_transaction_value_desc', { synchronize: false })
 export class UserTransaction {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -50,7 +50,6 @@ import { isPlusMember } from '../paddle';
 import { remoteConfig } from '../remoteConfig';
 import { whereNotUserBlocked } from '../common/contentPreference';
 import { type GetBalanceResult } from '../common/njord';
-import { Product } from '../entity/Product';
 
 const existsByUserAndPost =
   (entity: string, build?: (queryBuilder: QueryBuilder) => QueryBuilder) =>
@@ -581,13 +580,13 @@ const obj = new GraphORM({
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
               .innerJoin(
-                Product,
-                'awardProduct',
-                `"awardProduct".id = ("${childAlias}".flags->>'awardId')::uuid`,
+                'UserTransaction',
+                'awardUserTransaction',
+                `"awardUserTransaction".id = "${childAlias}"."awardTransactionId"`,
               )
               .where(`"${childAlias}"."postId" = "${parentAlias}".id`)
               .andWhere(`"${childAlias}".flags->>'awardId' is not null`)
-              .orderBy('"awardProduct".value', 'DESC')
+              .orderBy('"awardUserTransaction".value', 'DESC')
               .limit(1);
           },
         },
@@ -846,13 +845,13 @@ const obj = new GraphORM({
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder => {
             return qb
               .innerJoin(
-                Product,
-                'awardProduct',
-                `"awardProduct".id = ("${childAlias}".flags->>'awardId')::uuid`,
+                'UserTransaction',
+                'awardUserTransaction',
+                `"awardUserTransaction".id = "${childAlias}"."awardTransactionId"`,
               )
               .where(`"${childAlias}"."commentId" = "${parentAlias}".id`)
               .andWhere(`"${childAlias}".flags->>'awardId' is not null`)
-              .orderBy('"awardProduct".value', 'DESC')
+              .orderBy('"awardUserTransaction".value', 'DESC')
               .limit(1);
           },
         },
@@ -1151,6 +1150,9 @@ const obj = new GraphORM({
         },
       },
     },
+  },
+  UserTransactionPublic: {
+    from: 'UserTransaction',
   },
 });
 

--- a/src/migration/1747309505414-UserTransactionValueDesc.ts
+++ b/src/migration/1747309505414-UserTransactionValueDesc.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserTransactionValueDesc1747309505414
+  implements MigrationInterface
+{
+  name = 'UserTransactionValueDesc1747309505414';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_user_transaction_value_desc" ON user_transaction ("value" DESC)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_user_transaction_value_desc"`,
+    );
+  }
+}

--- a/src/schema/njord.ts
+++ b/src/schema/njord.ts
@@ -158,6 +158,10 @@ export const typeDefs = /* GraphQL */ `
     count: Int!
   }
 
+  type UserTransactionPublic {
+    value: Int!
+  }
+
   extend type Query {
     """
     List products


### PR DESCRIPTION
Previously the awards listings would use product current value when showing awards, now I added transaction value so that even when product prices change we still show product price at the time of award.