### PR TITLE
fix: rounding up should not be applied

### DIFF
--- a/__tests__/common/paddle/pricing.ts
+++ b/__tests__/common/paddle/pricing.ts
@@ -122,8 +122,8 @@ describe('getPrice', () => {
       divideBy: 30, // Convert monthly to daily price
     });
     expect(result).toEqual({
-      amount: 49.97,
-      formatted: '49,97 kr',
+      amount: 49.96,
+      formatted: '49,96 kr',
     });
   });
 
@@ -132,6 +132,14 @@ describe('getPrice', () => {
     expect(result).toEqual({
       amount: 149.9,
       formatted: 'R$ 149,90',
+    });
+  });
+
+  it('should handle yearly to monthly price conversion with precise rounding', () => {
+    const result = getPrice({ formatted: '$89.99', divideBy: 12 });
+    expect(result).toEqual({
+      amount: 7.49, // Should be 7.49 not 7.50 to preserve original price precision
+      formatted: '$7.49',
     });
   });
 

--- a/src/common/paddle/pricing.ts
+++ b/src/common/paddle/pricing.ts
@@ -226,12 +226,16 @@ export const getPrice = ({
     };
   }
 
-  const dividedAmount = Number((parsed.value / divideBy).toFixed(2));
-  const finalValue = formatter.format(dividedAmount);
+  const dividedAmount = parsed.value / divideBy;
+  // Round to 3 decimal places first to handle floating point precision
+  const roundedAmount = Math.round(dividedAmount * 1000) / 1000;
+  // Then round down to 2 decimal places to preserve the original price's precision
+  const finalAmount = Math.floor(roundedAmount * 100) / 100;
+  const finalValue = formatter.format(finalAmount);
   const updatedFormat = formatted.replace(numericRegex, finalValue);
 
   return {
-    amount: dividedAmount,
+    amount: finalAmount,
     formatted: updatedFormat,
   };
 };


### PR DESCRIPTION
When the value has an example value of 7.49916 - we should not round up to 7.50. We should stay at 7.49.