### PR TITLE
fix: read-only from GCS

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -354,6 +354,7 @@ if (isAdhocEnv) {
         {
           name: 'geoip-data',
           mountPath: '/usr/share/geoip',
+          readOnly: true,
         },
       ]
     },


### PR DESCRIPTION
To ensure we don't accidentally break GeoIP db