### PR TITLE
Revert "hotfix: adjust private and temporal memory limits"

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -152,10 +152,10 @@ const bgRequests: pulumi.Input<{ cpu: string; memory: string }> = {
   memory: '256Mi',
 };
 
-const temporalLimits: pulumi.Input<{ memory: string }> = { memory: '256Mi' };
+const temporalLimits: pulumi.Input<{ memory: string }> = { memory: '320Mi' };
 const temporalRequests: pulumi.Input<{ cpu: string; memory: string }> = {
-  cpu: '50m',
-  memory: '150Mi',
+  cpu: '10m',
+  memory: '256Mi',
 };
 
 const initialDelaySeconds = 20;
@@ -427,9 +427,12 @@ if (isAdhocEnv) {
       env: [{ name: 'ENABLE_PRIVATE_ROUTES', value: 'true' }, ...commonEnv, ...jwtEnv],
       minReplicas: 2,
       maxReplicas: 2,
+      requests: {
+        memory: '192Mi',
+        cpu: '10m',
+      },
       limits: {
         memory: '256Mi',
-        cpu: '25m',
       },
       readinessProbe,
       livenessProbe,


### PR DESCRIPTION
This reverts commit 2747cc44189b2c1fb26b77b3c99ff6892bb8d873.

Memory is back down since we load the smaller db and only in some parts of api.