### PR TITLE
fix: mimir pagination works differently

### DIFF
--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -171,10 +171,7 @@ export const meiliOffsetGenerator = <
   },
   nodeToCursor: (page, { ids }, node): string =>
     offsetToCursor(page.offset + ids.findIndex((postId) => postId === node.id)),
-  hasNextPage: (page): boolean => {
-    console.log('page', page.current, page.limit, page.current! < page.limit);
-    return page.current! < page.limit;
-  },
+  hasNextPage: (page): boolean => page.current! < page.limit,
   hasPreviousPage: (page): boolean => page.offset > 0,
 });
 

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -171,7 +171,10 @@ export const meiliOffsetGenerator = <
   },
   nodeToCursor: (page, { ids }, node): string =>
     offsetToCursor(page.offset + ids.findIndex((postId) => postId === node.id)),
-  hasNextPage: (page): boolean => page.current! < page.limit,
+  hasNextPage: (page): boolean => {
+    console.log('page', page.current, page.limit, page.current! < page.limit);
+    return page.current! < page.limit;
+  },
   hasPreviousPage: (page): boolean => page.offset > 0,
 });
 

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -416,6 +416,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         });
 
         const mimirSearchRes = await mimirClient.search(searchReq);
+        console.log(
+          'search',
+          mimirSearchRes.result.map((x) => x.postId),
+          mimirSearchRes.result.length,
+        );
+
         const res = await meiliSearchResolver(
           source,
           {
@@ -424,8 +430,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             pagination: {
               limit,
               offset,
-              total: mimirSearchRes.result.length,
-              current: offset + mimirSearchRes.result.length,
+              total: limit + 1,
+              current: mimirSearchRes.result.length,
             },
           },
           ctx,

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -416,11 +416,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         });
 
         const mimirSearchRes = await mimirClient.search(searchReq);
-        console.log(
-          'search',
-          mimirSearchRes.result.map((x) => x.postId),
-          mimirSearchRes.result.length,
-        );
 
         const res = await meiliSearchResolver(
           source,


### PR DESCRIPTION
Since we don't know total, we need to evaluate page to page.
But since we reuse the meiei one for now I adjusted it a bit hacky to start with.