### PR TITLE
feat: fetch our price metadata when getting price previews

### DIFF
--- a/__tests__/paddle.ts
+++ b/__tests__/paddle.ts
@@ -7,7 +7,7 @@ import {
   type GraphQLTestingState,
   type GraphQLTestClient,
 } from './helpers';
-import { User } from '../src/entity';
+import { ExperimentVariantType, User } from '../src/entity';
 import {
   PurchaseType,
   SubscriptionProvider,
@@ -714,8 +714,16 @@ describe('plus pricing preview', () => {
 
 describe('pricing preview by ids', () => {
   const QUERY = /* GraphQL */ `
-    query PricingPreviewByIds($ids: [String]!, $locale: String) {
-      pricingPreviewByIds(ids: $ids, locale: $locale) {
+    query PricingPreviewByIds(
+      $ids: [String]!
+      $locale: String
+      $loadMetadata: Boolean
+    ) {
+      pricingPreviewByIds(
+        ids: $ids
+        locale: $locale
+        loadMetadata: $loadMetadata
+      ) {
         priceId
         price {
           amount
@@ -737,6 +745,12 @@ describe('pricing preview by ids', () => {
         trialPeriod {
           interval
           frequency
+        }
+        metadata {
+          title
+          caption {
+            copy
+          }
         }
       }
     }
@@ -830,6 +844,7 @@ describe('pricing preview by ids', () => {
     expect(monthlyPreview?.duration).toBe('monthly');
     expect(monthlyPreview?.trialPeriod?.interval).toBe('day');
     expect(monthlyPreview?.trialPeriod?.frequency).toBe(14);
+    expect(monthlyPreview?.metadata).toBeNull();
 
     const yearlyPreview = result.data?.pricingPreviewByIds.find(
       (p) => p.priceId === 'pri_yearly',
@@ -844,6 +859,7 @@ describe('pricing preview by ids', () => {
     expect(yearlyPreview?.currency.symbol).toBe('$');
     expect(yearlyPreview?.duration).toBe('yearly');
     expect(yearlyPreview?.trialPeriod).toBeNull();
+    expect(yearlyPreview?.metadata).toBeNull();
   });
 
   it('should throw error when no ids are provided', async () => {
@@ -931,6 +947,125 @@ describe('pricing preview by ids', () => {
     expect(getRedisObjectSpy).toHaveBeenCalledTimes(2);
     expect(setRedisObjectWithExpirySpy).toHaveBeenCalledTimes(1);
     expect(result).toEqual(result2);
+  });
+
+  it('should return metadata when requested', async () => {
+    loggedUser = 'whp-1';
+    await con.getRepository(ExperimentVariant).save([
+      {
+        feature: 'featureKey1',
+        variant: 'featureVariant1',
+        type: ExperimentVariantType.ProductPricing,
+        value: JSON.stringify([
+          {
+            idMap: {
+              paddle: 'pri_monthly',
+            },
+            title: 'Plus Subscription',
+            caption: {
+              copy: 'Get access to exclusive features',
+            },
+          },
+        ]),
+      },
+      {
+        feature: 'featureKey2',
+        variant: 'featureVariant2',
+        type: ExperimentVariantType.ProductPricing,
+        value: JSON.stringify([
+          {
+            idMap: {
+              paddle: 'pri_yearly',
+            },
+            title: 'Variant Plus Subscription',
+            caption: {
+              copy: '50% off',
+            },
+          },
+        ]),
+      },
+    ]);
+
+    const result = await client.query(QUERY, {
+      variables: {
+        ids: ['pri_monthly', 'pri_yearly'],
+        loadMetadata: true,
+      },
+    });
+
+    expect(result.errors).toBeFalsy();
+    expect(result.data?.pricingPreviewByIds).toHaveLength(2);
+
+    const monthlyPreview = result.data?.pricingPreviewByIds.find(
+      (p) => p.priceId === 'pri_monthly',
+    );
+
+    expect(monthlyPreview?.metadata).toMatchObject({
+      title: 'Plus Subscription',
+      caption: {
+        copy: 'Get access to exclusive features',
+      },
+    });
+
+    const yearlyPreview = result.data?.pricingPreviewByIds.find(
+      (p) => p.priceId === 'pri_yearly',
+    );
+
+    expect(yearlyPreview?.metadata).toMatchObject({
+      title: 'Variant Plus Subscription',
+      caption: {
+        copy: '50% off',
+      },
+    });
+  });
+
+  it('should return null metadata when price id is not found', async () => {
+    loggedUser = 'whp-1';
+    await con.getRepository(ExperimentVariant).save([
+      {
+        feature: 'featureKey1',
+        variant: 'featureVariant1',
+        type: ExperimentVariantType.ProductPricing,
+        value: JSON.stringify([
+          {
+            idMap: {
+              paddle: 'pri_monthly',
+            },
+            title: 'Plus Subscription',
+            caption: {
+              copy: 'Get access to exclusive features',
+            },
+          },
+        ]),
+      },
+    ]);
+
+    const result = await client.query(QUERY, {
+      variables: {
+        ids: ['pri_monthly', 'pri_yearly'],
+        loadMetadata: true,
+      },
+    });
+
+    expect(result.errors).toBeFalsy();
+    expect(result.data?.pricingPreviewByIds).toHaveLength(2);
+
+    const monthlyPreview = result.data?.pricingPreviewByIds.find(
+      (p) => p.priceId === 'pri_monthly',
+    );
+
+    expect(monthlyPreview?.metadata).toMatchObject({
+      title: 'Plus Subscription',
+      caption: {
+        copy: 'Get access to exclusive features',
+      },
+    });
+
+    const yearlyPreview = result.data?.pricingPreviewByIds.find(
+      (p) => p.priceId === 'pri_yearly',
+    );
+
+    expect(yearlyPreview?.metadata).toBeNull();
   });
 });
 

--- a/__tests__/paddle.ts
+++ b/__tests__/paddle.ts
@@ -7,7 +7,7 @@ import {
   type GraphQLTestingState,
   type GraphQLTestClient,
 } from './helpers';
-import { ExperimentVariantType, User } from '../src/entity';
+import { ExperimentVariant, ExperimentVariantType, User } from '../src/entity';
 import {
   PurchaseType,
   SubscriptionProvider,
@@ -31,7 +31,6 @@ import { logger } from '../src/logger';
 import { paddleInstance, type PaddleCustomData } from '../src/common/paddle';
 import * as redisFile from '../src/redis';
 import { ioRedisPool } from '../src/redis';
-import { ExperimentVariant } from '../src/entity';
 import {
   PLUS_FEATURE_KEY,
   DEFAULT_PLUS_METADATA,
@@ -354,11 +353,13 @@ describe('plus pricing metadata', () => {
         feature: PLUS_FEATURE_KEY,
         variant: DEFAULT_PLUS_METADATA,
         value: JSON.stringify(mockPlusMetadata),
+        type: ExperimentVariantType.ProductPricing,
       },
       {
         feature: CORES_FEATURE_KEY,
         variant: DEFAULT_CORES_METADATA,
         value: JSON.stringify(mockCoresMetadata),
+        type: ExperimentVariantType.ProductPricing,
       },
     ]);
   });
@@ -510,6 +511,7 @@ describe('plus pricing preview', () => {
         feature: PLUS_FEATURE_KEY,
         variant: DEFAULT_PLUS_METADATA,
         value: JSON.stringify(mockMetadata),
+        type: ExperimentVariantType.ProductPricing,
       },
     ]);
 

--- a/__tests__/routes/webhooks/apple.ts
+++ b/__tests__/routes/webhooks/apple.ts
@@ -6,7 +6,11 @@ import type { DataSource } from 'typeorm';
 import { generateKeyPairSync, type ECKeyPairOptions } from 'crypto';
 import { sign } from 'jsonwebtoken';
 import createOrGetConnection from '../../../src/db';
-import { ExperimentVariant, User } from '../../../src/entity';
+import {
+  ExperimentVariant,
+  ExperimentVariantType,
+  User,
+} from '../../../src/entity';
 import {
   createMockNjordErrorTransport,
   createMockNjordTransport,
@@ -465,6 +469,7 @@ describe('POST /webhooks/apple/notifications', () => {
               coresValue: 100,
             },
           ]),
+          type: ExperimentVariantType.ProductPricing,
         },
       ]);
     });

--- a/src/common/paddle/pricing.ts
+++ b/src/common/paddle/pricing.ts
@@ -168,12 +168,12 @@ export const getPricingMetadata = async (
 
 export const getPricingMetadataByPriceIds = async (
   ctx: AuthContext,
-  ids: string[],
+  pricingIds: string[],
 ): Promise<Record<string, BasePricingMetadata>> => {
   // Because we disable escaping, we need to ensure that the ids are valid
   // strings, just to be safe.
-  const pricingIds = z.array(z.string()).safeParse(ids);
-  if (pricingIds.error) {
+  const parsedPricingIds = z.array(z.string()).safeParse(pricingIds);
+  if (parsedPricingIds.error) {
     return {};
   }
 
@@ -183,8 +183,8 @@ export const getPricingMetadataByPriceIds = async (
     .from(ExperimentVariant, 'ev')
     .addFrom('jsonb_array_elements(ev.value::jsonb)', 'item')
     .disableEscaping()
-    .where("item -> 'idMap' ->> 'paddle' IN (:...pricingIds)", {
-      pricingIds: pricingIds.data,
+    .where("item -> 'idMap' ->> 'paddle' IN (:...ids)", {
+      ids: parsedPricingIds.data,
     })
     .andWhere('ev.type = :type', {
       type: ExperimentVariantType.ProductPricing,

--- a/src/entity/ExperimentVariant.ts
+++ b/src/entity/ExperimentVariant.ts
@@ -1,5 +1,9 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
+export enum ExperimentVariantType {
+  ProductPricing = 'productPricing',
+}
+
 @Entity()
 export class ExperimentVariant {
   @PrimaryColumn({ type: 'text' })
@@ -13,4 +17,7 @@ export class ExperimentVariant {
 
   @Column({ type: 'text', default: null })
   value: string;
+
+  @Column({ type: 'text' })
+  type: ExperimentVariantType;
 }

--- a/src/migration/1748371994832-ExperimentVariationType.ts
+++ b/src/migration/1748371994832-ExperimentVariationType.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ExperimentVariationType1748371994832 implements MigrationInterface {
+  name = 'ExperimentVariationType1748371994832'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "experiment_variant" ADD "type" text`);
+    await queryRunner.query(`UPDATE "experiment_variant" SET "type" = 'productPricing' WHERE "type" IS NULL`);
+    await queryRunner.query(`ALTER TABLE "experiment_variant" ALTER COLUMN "type" SET NOT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "experiment_variant" DROP COLUMN "type"`);
+  }
+}

--- a/src/schema/paddle.ts
+++ b/src/schema/paddle.ts
@@ -1,6 +1,7 @@
 import {
   getPricingDuration,
   getPricingMetadata,
+  getPricingMetadataByPriceIds,
   getProductPrice,
 } from './../common/paddle/pricing';
 import type { CountryCode } from '@paddle/paddle-node-sdk';
@@ -135,8 +136,19 @@ export const typeDefs = /* GraphQL */ `
     pricingMetadata(type: PricingType): [ProductPricingMetadata!]! @auth
     pricingPreview(type: PricingType, locale: String): [ProductPricingPreview!]!
     pricingPreviewByIds(
+      """
+      The IDs of the prices to preview
+      """
       ids: [String]!
+
+      """
+      The locale to use for formatting prices
+      """
       locale: String
+      """
+      Load metadata for the pricing previews
+      """
+      loadMetadata: Boolean
     ): [BaseProductPricingPreview!]!
   }
 
@@ -265,6 +277,11 @@ export const typeDefs = /* GraphQL */ `
     Trial period information
     """
     trialPeriod: TrialPeriod
+
+    """
+    Price metadata information
+    """
+    metadata: ProductPricingMetadata
   }
 
   """
@@ -311,6 +328,7 @@ interface PaddlePricingPreviewArgs {
 interface PaddlePricingPreviewByIdsArgs {
   ids: string[];
   locale?: string;
+  loadMetadata?: boolean;
 }
 
 type BasePricingWithoutMetadata = Omit<BasePricingPreview, 'metadata'>;
@@ -468,12 +486,16 @@ export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
     },
     pricingPreviewByIds: async (
       _,
-      { ids, locale }: PaddlePricingPreviewByIdsArgs,
+      { ids, locale, loadMetadata }: PaddlePricingPreviewByIdsArgs,
       ctx,
     ): Promise<BasePricingWithoutMetadata[]> => {
       if (!ids.length) {
         throw new ValidationError('No ids provided');
       }
+
+      const priceMetadata: Record<string, BasePricingMetadata> = loadMetadata
+        ? await getPricingMetadataByPriceIds(ctx, ids)
+        : {};
 
       const preview = await getPlusPricePreview(ctx, ids);
       const pricing = preview.details.lineItems.map((item) => ({
@@ -485,6 +507,7 @@ export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
           code: preview.currencyCode,
           symbol: removeNumbers(item.formattedTotals.total),
         },
+        metadata: priceMetadata?.[item.price.id],
       }));
 
       if (!pricing.length) {

--- a/src/schema/paddle.ts
+++ b/src/schema/paddle.ts
@@ -507,7 +507,7 @@ export const resolvers: IResolvers<unknown, AuthContext> = traceResolvers<
           code: preview.currencyCode,
           symbol: removeNumbers(item.formattedTotals.total),
         },
-        metadata: priceMetadata?.[item.price.id],
+        metadata: priceMetadata?.[item.price.id] ?? null,
       }));
 
       if (!pricing.length) {


### PR DESCRIPTION
Need to be able to get the metadata we have for prices too, and can't rely on `PricingPreview` if it returns an experiment variation with a price ID that doesn't match what the organization is subscribed with