### PR TITLE
feat: add userId to subscription custom data on creation

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -149,6 +149,11 @@ jest.mock('../src/common/paddle/index.ts', () => ({
     unknown
   >),
   cancelSubscription: jest.fn(),
+  paddleInstance: {
+    subscriptions: {
+      update: jest.fn().mockResolvedValue({}),
+    },
+  },
 }));
 
 jest.mock('../src/common/mailing.ts', () => ({

--- a/src/common/paddle/index.ts
+++ b/src/common/paddle/index.ts
@@ -379,14 +379,19 @@ export const logPaddleAnalyticsEvent = async (
   }
 
   const { data, occurredAt, eventId } = event;
-  const customData = data.customData as { user_id: string };
+  const customData = data.customData as {
+    user_id: string;
+    tracking_id?: string;
+  };
   const userId = await getUserId({
     userId: customData?.user_id,
     subscriptionId:
       ('subscriptionId' in data && data.subscriptionId) || data.id,
   });
 
-  if (!userId) {
+  const analyticsId = userId || customData?.tracking_id;
+
+  if (!analyticsId) {
     return;
   }
 
@@ -396,7 +401,7 @@ export const logPaddleAnalyticsEvent = async (
       event_timestamp: new Date(occurredAt),
       event_id: eventId,
       app_platform: 'api',
-      user_id: userId,
+      user_id: analyticsId,
       extra: JSON.stringify(getAnalyticsExtra(data)),
       target_type: isPurchaseType(PurchaseType.Cores, event)
         ? TargetType.Credits

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -395,33 +395,6 @@ export const addClaimableItemsToUser = async (
       },
     );
 
-    await Promise.allSettled([
-      sendAnalyticsEvent([
-        {
-          event_name: AnalyticsEventName.ClaimSubscription,
-          event_timestamp: new Date(),
-          user_id: body.id,
-          app_platform: 'api',
-          target_type: TargetType.Plus,
-        },
-      ]).catch((error) => {
-        logger.warn(
-          { error },
-          'Failed to send analytics event for claimed subscription',
-        );
-      }),
-      identifyAnonymousFunnelSubscription({
-        cio,
-        email: body.email,
-        claimedSub: true,
-      }).catch((error) => {
-        logger.warn(
-          { error },
-          'Failed to identify anonymous funnel subscription',
-        );
-      }),
-    ]);
-
     await con.transaction(async (em) => {
       await em.getRepository(ClaimableItem).update(subscription.id, {
         claimedById: body.id,
@@ -432,6 +405,33 @@ export const addClaimableItemsToUser = async (
       });
     });
   }
+
+  await Promise.allSettled([
+    sendAnalyticsEvent([
+      {
+        event_name: AnalyticsEventName.ClaimSubscription,
+        event_timestamp: new Date(),
+        user_id: body.id,
+        app_platform: 'api',
+        target_type: TargetType.Plus,
+      },
+    ]).catch((error) => {
+      logger.warn(
+        { error },
+        'Failed to send analytics event for claimed subscription',
+      );
+    }),
+    identifyAnonymousFunnelSubscription({
+      cio,
+      email: body.email,
+      claimedSub: true,
+    }).catch((error) => {
+      logger.warn(
+        { error },
+        'Failed to identify anonymous funnel subscription',
+      );
+    }),
+  ]);
 };
 
 export const validateUserUpdate = async (

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -44,6 +44,12 @@ import { DeletedUser } from './DeletedUser';
 import { ClaimableItem } from '../ClaimableItem';
 import { cio, identifyAnonymousFunnelSubscription } from '../../cio';
 import { getGeo } from '../../common/geo';
+import {
+  AnalyticsEventName,
+  sendAnalyticsEvent,
+  TargetType,
+} from '../../integrations/analytics';
+import { paddleInstance } from '../../common/paddle';
 
 export type AddUserData = Pick<
   User,
@@ -380,6 +386,42 @@ export const addClaimableItemsToUser = async (
     .findOneBy({ email: body.email, claimedById: IsNull() });
 
   if (subscription) {
+    await paddleInstance.subscriptions.update(
+      subscription.flags.subscriptionId!,
+      {
+        customData: {
+          user_id: body.id,
+        },
+      },
+    );
+
+    await Promise.allSettled([
+      sendAnalyticsEvent([
+        {
+          event_name: AnalyticsEventName.ClaimSubscription,
+          event_timestamp: new Date(),
+          user_id: body.id,
+          app_platform: 'api',
+          target_type: TargetType.Plus,
+        },
+      ]).catch((error) => {
+        logger.warn(
+          { error },
+          'Failed to send analytics event for claimed subscription',
+        );
+      }),
+      identifyAnonymousFunnelSubscription({
+        cio,
+        email: body.email,
+        claimedSub: true,
+      }).catch((error) => {
+        logger.warn(
+          { error },
+          'Failed to identify anonymous funnel subscription',
+        );
+      }),
+    ]);
+
     await con.transaction(async (em) => {
       await em.getRepository(ClaimableItem).update(subscription.id, {
         claimedById: body.id,
@@ -388,12 +430,6 @@ export const addClaimableItemsToUser = async (
       await em.getRepository(User).update(body.id, {
         subscriptionFlags: subscription.flags as UserSubscriptionFlags,
       });
-    });
-
-    await identifyAnonymousFunnelSubscription({
-      cio,
-      email: body.email,
-      claimedSub: true,
     });
   }
 };

--- a/src/integrations/analytics.ts
+++ b/src/integrations/analytics.ts
@@ -19,6 +19,7 @@ export enum AnalyticsEventName {
   ChangeBillingCycle = 'change billing cycle',
   CancelSubscription = 'cancel subscription',
   ReceivePayment = 'receive payment',
+  ClaimSubscription = 'claim subscription',
 }
 
 export async function sendAnalyticsEvent<T extends AnalyticsEvent>(


### PR DESCRIPTION
When claiming a subscription, we now add the userId to the subscriptions customdata, so that it gets properly updated on change events, i.e cancelling the sub.

Also added a log event to claiming a sub

[REF](https://dailydotdev.slack.com/archives/C02E2C3C13R/p1748340567666399?thread_ts=1748324078.181229&cid=C02E2C3C13R)