### PR TITLE
fix: onboarding funnel session cookies

### DIFF
--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -830,7 +830,14 @@ const getFunnel = async (
     query.id,
     query.v ? Number(query.v) : undefined,
   );
-  setCookie(req, res, 'funnel', funnel.session.id);
+
+  const getCookieKeyFromFeatureKey = (featureKey: string) => {
+    return Object.entries(funnelBoots).find(
+      ([, value]) => value.featureKey === featureKey,
+    )?.[0];
+  };
+  const cookieKey = getCookieKeyFromFeatureKey(featureKey) || 'funnel';
+  setCookie(req, res, cookieKey, funnel.session.id);
 
   return funnel;
 };

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -832,11 +832,17 @@ const getFunnel = async (
   );
 
   const getCookieKeyFromFeatureKey = (featureKey: string) => {
-    return Object.entries(funnelBoots).find(
-      ([, value]) => value.featureKey === featureKey,
-    )?.[0];
+    return Object.entries(funnelBoots).reduce(
+      (acc, [funnelKey, funnelConfig]) => {
+        if (funnelConfig.featureKey === featureKey) {
+          return funnelKey;
+        }
+        return acc;
+      },
+      'funnel',
+    );
   };
-  const cookieKey = getCookieKeyFromFeatureKey(featureKey) || 'funnel';
+  const cookieKey = getCookieKeyFromFeatureKey(featureKey);
   setCookie(req, res, cookieKey, funnel.session.id);
 
   return funnel;
@@ -914,7 +920,7 @@ type FunnelBootConfig = {
 };
 
 const funnelBoots = {
-  paid: {
+  funnel: {
     featureKey: 'web_funnel_id',
     cookieKey: cookies.funnel.key,
   } satisfies FunnelBootConfig,
@@ -927,7 +933,7 @@ const funnelBoots = {
 /**
  * Handles incoming requests for funnel-related boot endpoints.
  * This function retrieves the funnel data for a specific funnel type, identified by the `id` parameter.
- * If not provided, it defaults to the 'paid' funnel configuration from {funnelBoots}.
+ * If not provided, it defaults to the 'funnel' funnel configuration from {funnelBoots}.
  *
  * @type {RouteHandler}
  * @param {Request} req
@@ -936,7 +942,7 @@ const funnelBoots = {
  */
 const funnelHandler: RouteHandler = async (req, res) => {
   const con = await createOrGetConnection();
-  const { id = 'paid' } = req.params as { id: keyof typeof funnelBoots };
+  const { id = 'funnel' } = req.params as { id: keyof typeof funnelBoots };
 
   if (id in funnelBoots) {
     const funnel = funnelBoots[id];


### PR DESCRIPTION
Onboarding funnels weren't keeping the sessionId. Just added a way to set the right one. 