### PR TITLE
feat: add last activity redis solution

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export const fallbackImages = {
     'https://media.daily.dev/image/upload/s--yc7EcfBs--/f_auto,q_auto/v1/public/organization_fallback',
 };
 
+export const USER_LAST_ONLINE_KEY = 'user:lo:';
 export const REDIS_BANNER_KEY = 'boot:latest_banner';
 
 export const DEFAULT_SUBMISSION_LIMIT = '3';

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1249,6 +1249,7 @@ const obj = new GraphORM({
     },
   },
   OrganizationMember: {
+    requiredColumns: ['userId'],
     from: 'ContentPreferenceOrganization',
     additionalQuery: (_, alias, qb) =>
       qb.andWhere(

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -41,6 +41,7 @@ import {
   generateStorageKey,
   REDIS_BANNER_KEY,
   StorageTopic,
+  USER_LAST_ONLINE_KEY,
 } from '../config';
 import {
   ONE_DAY_IN_SECONDS,
@@ -947,6 +948,10 @@ const funnelHandler: RouteHandler = async (req, res) => {
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   const con = await createOrGetConnection();
+
+  fastify.addHook('onResponse', async (req) => {
+    await setRedisObject(`${USER_LAST_ONLINE_KEY}${req.userId}`, Date.now());
+  });
 
   fastify.get('/', async (req, res) => {
     const data = await getBootData(con, req, res);

--- a/src/schema/organizations.ts
+++ b/src/schema/organizations.ts
@@ -53,7 +53,9 @@ import { SubscriptionStatus } from '../common/plus';
 export type GQLOrganizationMember = {
   role: OrganizationMemberRole;
   seatType: ContentPreferenceOrganizationStatus;
+  lastActive: Date;
   user: GQLUser;
+  userId?: string;
 };
 export type GQLOrganization = Omit<
   Organization,
@@ -98,6 +100,11 @@ export const typeDefs = /* GraphQL */ `
     The organization the user is a member of
     """
     organization: Organization
+
+    """
+    The date user was last active
+    """
+    lastActive: DateTime
   }
 
   type Organization {
@@ -1137,6 +1144,20 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         );
         throw err;
       }
+    },
+  },
+  OrganizationMember: {
+    lastActive: async (
+      organizationMember: GQLOrganizationMember,
+      _,
+      ctx: Context,
+    ) => {
+      if (!organizationMember.userId) {
+        return null;
+      }
+      return await ctx.dataLoader.userLastActive.load({
+        userId: organizationMember.userId,
+      });
     },
   },
 });


### PR DESCRIPTION
Added redis write on boot endpoint onResponse handler (to not block)
Then wrote a custom resolver using our dataloader system to read it back to graphQL

For now we'll just return null if redis empty or can't be found.
It seems heavily overkill to re-query in those cases. 