### PR TITLE
feat: correctly type product ids as partial

### DIFF
--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -27,7 +27,7 @@ type RemoteConfigValue = {
   kvasirRequirePlus: boolean;
   paddleIps: string[];
   paddleTestDiscountIds: string[];
-  paddleProductIds: Record<PurchaseType, string>;
+  paddleProductIds: Partial<Record<PurchaseType, string>>;
 };
 
 class RemoteConfig {


### PR DESCRIPTION
So that type checking works when accessing and fallbacks are required in code.