### PR TITLE
fix: send transaction id instead of app transaction id

### DIFF
--- a/src/common/apple/purchase.ts
+++ b/src/common/apple/purchase.ts
@@ -70,7 +70,7 @@ export const notifyNewStoreKitPurchase = async ({
       fields: [
         {
           type: 'mrkdwn',
-          text: concatTextToNewline('*Transaction ID:*', data.appTransactionId),
+          text: concatTextToNewline('*Transaction ID:*', data.transactionId),
         },
         {
           type: 'mrkdwn',

--- a/src/common/apple/subscription.ts
+++ b/src/common/apple/subscription.ts
@@ -87,7 +87,10 @@ export const notifyNewStoreKitSubscription = async (
       fields: [
         {
           type: 'mrkdwn',
-          text: concatTextToNewline('*Transaction ID:*', data.appTransactionId),
+          text: concatTextToNewline(
+            '*Transaction ID:*',
+            data.originalTransactionId,
+          ),
         },
         {
           type: 'mrkdwn',

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -92,7 +92,7 @@ export const logAppleAnalyticsEvent = async (
     {
       event_name: eventName,
       event_timestamp: new Date(transactionInfo?.signedDate || ''),
-      event_id: transactionInfo.appTransactionId,
+      event_id: transactionInfo.transactionId,
       app_platform: 'api',
       user_id: user.id,
       extra: JSON.stringify(extra),


### PR DESCRIPTION
It was probably just s typo since first implementation of apple payment, `appTransactionId` is unique id for app install, not current transaction. Not really broke anything since it was only for notifications. 