### PR TITLE
fix: check sub state before cancel

### DIFF
--- a/src/common/paddle/index.ts
+++ b/src/common/paddle/index.ts
@@ -63,8 +63,22 @@ type CancelSubscriptionProps = {
 };
 export const cancelSubscription = async ({
   subscriptionId,
-}: CancelSubscriptionProps): Promise<Subscription | undefined> => {
+}: CancelSubscriptionProps): Promise<Subscription> => {
   try {
+    const subscription = await paddleInstance.subscriptions.get(subscriptionId);
+
+    if (subscription.status === 'canceled') {
+      logger.info(
+        {
+          provider: SubscriptionProvider.Paddle,
+          subscriptionId,
+        },
+        'Subscription already canceled',
+      );
+
+      return subscription;
+    }
+
     return await paddleInstance.subscriptions.cancel(subscriptionId, {
       effectiveFrom: null,
     });


### PR DESCRIPTION
Sub cancelation during user deletion sometimes fails due to sub being in locked/canceled state. While I did not find how to detect that locked state I did add a check for canceled state so we avoid canceling if already canceled by user. Added logging so we can monitor.

AS-1034