### PR TITLE
fix: types in posts test

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -76,6 +76,7 @@ import { rateLimiterName } from '../src/directive/rateLimit';
 import { badUsersFixture, usersFixture } from './fixture/user';
 import { PostCodeSnippet } from '../src/entity/posts/PostCodeSnippet';
 import {
+  PostModerationReason,
   SourcePostModeration,
   SourcePostModerationStatus,
 } from '../src/entity/SourcePostModeration';
@@ -930,11 +931,11 @@ describe('translation field', () => {
         translation: {
           es: {
             title: 'Hola',
-            body: 'Cuerpo',
+            summary: 'Cuerpo',
           },
           de: {
             title: 'Hallo',
-            body: 'Körper',
+            summary: 'Körper',
           },
         },
       });
@@ -947,10 +948,10 @@ describe('translation field', () => {
 
       expect(post.translation).toEqual({
         es: {
-          body: 'Cuerpo',
+          summary: 'Cuerpo',
         },
         de: {
-          body: 'Körper',
+          summary: 'Körper',
         },
       });
     });
@@ -970,6 +971,7 @@ describe('translation field', () => {
     it('should not fail when translation contains scalar value', async () => {
       await con.getRepository(ArticlePost).update('p1-tf', {
         translation: {
+          // @ts-expect-error we're testing against scalar value
           some: 'value',
         },
       });
@@ -1041,7 +1043,7 @@ describe('welcomePost type', () => {
   });
 
   it('should add welcome post with showOnFeed as false by default', async () => {
-    const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+    const source = await con.getRepository(Source).findOneByOrFail({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '1');
     expect(post.showOnFeed).toEqual(false);
     expect(post.flags.showOnFeed).toEqual(false);
@@ -1049,17 +1051,17 @@ describe('welcomePost type', () => {
 
   it('should add welcome post and increment squad total posts', async () => {
     const repo = con.getRepository(Source);
-    const sourceToCount = await repo.findOneBy({ id: 'a' });
+    const sourceToCount = await repo.findOneByOrFail({ id: 'a' });
     expect(sourceToCount.flags.totalPosts).toEqual(3);
     const posts = await con.getRepository(Post).countBy({ sourceId: 'a' });
     expect(posts).toEqual(3);
     await repo.update({ id: 'a' }, { type: SourceType.Squad });
-    const source = await repo.findOneBy({ id: 'a' });
+    const source = await repo.findOneByOrFail({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '1');
     expect(post.showOnFeed).toEqual(false);
     expect(post.flags.showOnFeed).toEqual(false);
 
-    const updatedSource = await repo.findOneBy({ id: 'a' });
+    const updatedSource = await repo.findOneByOrFail({ id: 'a' });
     expect(updatedSource.flags.totalPosts).toEqual(posts + 1);
   });
 
@@ -1067,12 +1069,12 @@ describe('welcomePost type', () => {
     const repo = con.getRepository(Source);
     const posts = await con.getRepository(Post).countBy({ sourceId: 'a' });
     expect(posts).toEqual(3);
-    const source = await repo.findOneBy({ id: 'a' });
+    const source = await repo.findOneByOrFail({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '1');
     expect(post.showOnFeed).toEqual(false);
     expect(post.flags.showOnFeed).toEqual(false);
 
-    const updatedSource = await repo.findOneBy({ id: 'a' });
+    const updatedSource = await repo.findOneByOrFail({ id: 'a' });
     expect(updatedSource.flags.totalPosts).toEqual(posts + 1);
   });
 });
@@ -1838,7 +1840,7 @@ describe('mutation deletePost', () => {
   const verifyPostDeleted = async (id: string, user: string) => {
     const res = await client.mutate(MUTATION, { variables: { id } });
     expect(res.errors).toBeFalsy();
-    const actual = await con.getRepository(Post).findOneBy({ id });
+    const actual = await con.getRepository(Post).findOneByOrFail({ id });
     expect(actual.deleted).toBeTruthy();
     expect(actual.flags.deleted).toBeTruthy();
     expect(actual.flags.deletedBy).toBe(user);
@@ -1846,7 +1848,7 @@ describe('mutation deletePost', () => {
 
   it('should allow member to delete their own freeform post', async () => {
     loggedUser = '2';
-    const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+    const source = await con.getRepository(Source).findOneByOrFail({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '2');
     await con
       .getRepository(Post)
@@ -1862,7 +1864,7 @@ describe('mutation deletePost', () => {
       role: SourceMemberRoles.Moderator,
       referralToken: randomUUID(),
     });
-    const source = await con.getRepository(Source).findOneBy({ id: 'a' });
+    const source = await con.getRepository(Source).findOneByOrFail({ id: 'a' });
     const post = await createSquadWelcomePost(con, source, '2');
     await verifyPostDeleted(post.id, loggedUser);
     await con
@@ -1951,7 +1953,7 @@ describe('mutation banPost', () => {
     roles = [Roles.Moderator];
     const res = await client.mutate(MUTATION, { variables: { id: 'p1' } });
     expect(res.errors).toBeFalsy();
-    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
     expect(post.banned).toEqual(true);
     expect(post.flags.banned).toEqual(true);
   });
@@ -2323,7 +2325,9 @@ describe('mutation sharePost', () => {
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toEqual('My comment');
@@ -2348,7 +2352,9 @@ describe('mutation sharePost', () => {
     });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('sp-1');
     expect(post.title).toEqual('My comment');
@@ -2373,7 +2379,9 @@ describe('mutation sharePost', () => {
     });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toEqual('My comment');
@@ -2384,7 +2392,9 @@ describe('mutation sharePost', () => {
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     const source = await post.source;
     expect(source.flags.totalPosts).toEqual(1);
   });
@@ -2396,7 +2406,9 @@ describe('mutation sharePost', () => {
     });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toEqual('My comment');
@@ -2409,7 +2421,9 @@ describe('mutation sharePost', () => {
     });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toBeNull();
@@ -2424,13 +2438,13 @@ describe('mutation sharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: res.data.sharePost.id });
+      .findOneByOrFail({ id: res.data.sharePost.id });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.titleHtml).toMatchSnapshot();
     const mentions = await con
       .getRepository(PostMention)
-      .findOneBy({ mentionedUserId: '2', mentionedByUserId: '1' });
+      .findOneByOrFail({ mentionedUserId: '2', mentionedByUserId: '1' });
     expect(mentions).toBeTruthy();
   });
 
@@ -2443,7 +2457,7 @@ describe('mutation sharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: res.data.sharePost.id });
+      .findOneByOrFail({ id: res.data.sharePost.id });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.titleHtml).toMatch(
@@ -2512,7 +2526,9 @@ describe('mutation sharePost', () => {
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toEqual('My comment');
@@ -2533,7 +2549,9 @@ describe('mutation sharePost', () => {
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
     const newId = res.data.sharePost.id;
-    const post = await con.getRepository(SharePost).findOneBy({ id: newId });
+    const post = await con
+      .getRepository(SharePost)
+      .findOneByOrFail({ id: newId });
     expect(post.authorId).toEqual('1');
     expect(post.sharedPostId).toEqual('p1');
     expect(post.title).toEqual('My comment');
@@ -2677,7 +2695,7 @@ describe('mutation editSharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: variables.id });
+      .findOneByOrFail({ id: variables.id });
     expect(post.title).toEqual('My comment');
   });
 
@@ -2689,7 +2707,7 @@ describe('mutation editSharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: variables.id });
+      .findOneByOrFail({ id: variables.id });
     expect(post.title).toBeNull();
   });
 
@@ -2702,7 +2720,7 @@ describe('mutation editSharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: variables.id });
+      .findOneByOrFail({ id: variables.id });
     expect(post.authorId).toEqual('1');
     expect(post.titleHtml).toMatchSnapshot();
     const mentions = await con
@@ -2720,7 +2738,7 @@ describe('mutation editSharePost', () => {
     expect(res.errors).toBeFalsy();
     const post = await con
       .getRepository(SharePost)
-      .findOneBy({ id: variables.id });
+      .findOneByOrFail({ id: variables.id });
     expect(post.titleHtml).toMatch(
       markdown.utils.escapeHtml(
         `<style>html { color: red !important; }</style>`,
@@ -2893,7 +2911,7 @@ describe('mutation submitExternalLink', () => {
     expect(res.errors).toBeFalsy();
     const articlePost = await con
       .getRepository(ArticlePost)
-      .findOneBy({ url: variables.url });
+      .findOneByOrFail({ url: variables.url });
     expect(articlePost.url).toEqual('https://daily.dev');
     expect(articlePost.visible).toEqual(visible);
 
@@ -2904,7 +2922,7 @@ describe('mutation submitExternalLink', () => {
 
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost.id });
+      .findOneByOrFail({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
     expect(sharedPost.visible).toEqual(visible);
@@ -3008,7 +3026,7 @@ describe('mutation submitExternalLink', () => {
     expect(res.errors).toBeFalsy();
     const youtubePost = await con
       .getRepository(YouTubePost)
-      .findOneBy({ url: 'https://youtu.be/T_AbQGe7fuU' });
+      .findOneByOrFail({ url: 'https://youtu.be/T_AbQGe7fuU' });
     expect(youtubePost.url).toEqual('https://youtu.be/T_AbQGe7fuU');
     expect(youtubePost.visible).toEqual(true);
     expect(youtubePost.id).toEqual('yt1');
@@ -3017,7 +3035,7 @@ describe('mutation submitExternalLink', () => {
 
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: youtubePost.id });
+      .findOneByOrFail({ sharedPostId: youtubePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
     expect(sharedPost.visible).toEqual(true);
@@ -3031,7 +3049,7 @@ describe('mutation submitExternalLink', () => {
     expect(res.errors).toBeFalsy();
     const articlePost = await con
       .getRepository(ArticlePost)
-      .findOneBy({ url: 'http://p6.com' });
+      .findOneByOrFail({ url: 'http://p6.com' });
     expect(articlePost.url).toEqual('http://p6.com');
     expect(articlePost.visible).toEqual(true);
     expect(articlePost.id).toEqual('p6');
@@ -3040,7 +3058,7 @@ describe('mutation submitExternalLink', () => {
 
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost.id });
+      .findOneByOrFail({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toBeNull();
     expect(sharedPost.visible).toEqual(true);
@@ -3118,7 +3136,7 @@ describe('mutation submitExternalLink', () => {
     expect(res.errors).toBeFalsy();
     const articlePost = await con
       .getRepository(ArticlePost)
-      .findOneBy({ url: 'http://p6.com' });
+      .findOneByOrFail({ url: 'http://p6.com' });
     expect(articlePost.url).toEqual('http://p6.com');
     expect(articlePost.visible).toEqual(true);
     expect(articlePost.id).toEqual('p6');
@@ -3127,7 +3145,7 @@ describe('mutation submitExternalLink', () => {
 
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost.id });
+      .findOneByOrFail({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
     expect(sharedPost.visible).toEqual(true);
@@ -3151,7 +3169,7 @@ describe('mutation submitExternalLink', () => {
     expect(res.errors).toBeFalsy();
     const articlePost = await con
       .getRepository(ArticlePost)
-      .findOneBy({ url: 'http://p6.com' });
+      .findOneByOrFail({ url: 'http://p6.com' });
     expect(articlePost.url).toEqual('http://p6.com');
     expect(articlePost.visible).toEqual(true);
     expect(articlePost.id).toEqual('p6');
@@ -3160,7 +3178,7 @@ describe('mutation submitExternalLink', () => {
 
     const sharedPost = await con
       .getRepository(SharePost)
-      .findOneBy({ sharedPostId: articlePost.id });
+      .findOneByOrFail({ sharedPostId: articlePost.id });
     expect(sharedPost.authorId).toEqual('1');
     expect(sharedPost.title).toEqual('My comment');
     expect(sharedPost.visible).toEqual(true);
@@ -3506,7 +3524,7 @@ describe('mutation checkLinkPreview', () => {
     const url = 'http://p1c.com';
     const foundPost = await con
       .getRepository(ArticlePost)
-      .findOneBy({ canonicalUrl: url });
+      .findOneByOrFail({ canonicalUrl: url });
     const res = await client.mutate(MUTATION, { variables: { url } });
     expect(res.data.checkLinkPreview).toBeTruthy();
     expect(res.data.checkLinkPreview.id).toEqual(foundPost.id);
@@ -3515,7 +3533,9 @@ describe('mutation checkLinkPreview', () => {
   it('should return post by url', async () => {
     loggedUser = '1';
     const url = 'http://p1.com';
-    const foundPost = await con.getRepository(ArticlePost).findOneBy({ url });
+    const foundPost = await con
+      .getRepository(ArticlePost)
+      .findOneByOrFail({ url });
     const res = await client.mutate(MUTATION, { variables: { url } });
     expect(res.data.checkLinkPreview).toBeTruthy();
     expect(res.data.checkLinkPreview.id).toEqual(foundPost.id);
@@ -4733,7 +4753,7 @@ describe('mutation promoteToPublic', () => {
       variables: params,
     });
 
-    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
     const sixDays = new Date();
     sixDays.setDate(sixDays.getDate() + 6);
     const timeToSeconds = Math.floor(sixDays.valueOf() / 1000);
@@ -4787,7 +4807,7 @@ describe('mutation demoteFromPublic', () => {
       variables: params,
     });
 
-    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
     expect(post.flags.promoteToPublic).toEqual(null);
   });
 });
@@ -4831,7 +4851,7 @@ describe('mutation updatePinPost', () => {
       .getRepository(SourceMember)
       .update({ userId: '1' }, { role: SourceMemberRoles.Admin });
 
-    const getPost = () => con.getRepository(Post).findOneBy({ id: 'p1' });
+    const getPost = () => con.getRepository(Post).findOneByOrFail({ id: 'p1' });
 
     const unpinned = await getPost();
     expect(unpinned.pinnedAt).toBeNull();
@@ -4921,6 +4941,7 @@ describe('mutation swapPinnedPosts', () => {
     it('should throw a validation error if posts are not pinned', async () => {
       loggedUser = '1';
 
+      // @ts-expect-error pinnedAt default value is null
       await con.getRepository(Post).update({ id: 'p1' }, { pinnedAt: null });
 
       return testMutationError(
@@ -4988,7 +5009,7 @@ describe('mutation swapPinnedPosts', () => {
       // to assert that the first pinned post pinnedAt timestamp is changed
       const firstPostBefore = await con
         .getRepository(Post)
-        .findOneBy({ id: 'p2' });
+        .findOneByOrFail({ id: 'p2' });
 
       await client.mutate(MUTATION, {
         variables: { id: 'p3', swapWithId: 'p1' },
@@ -4996,10 +5017,10 @@ describe('mutation swapPinnedPosts', () => {
 
       const firstPostAfter = await con
         .getRepository(Post)
-        .findOneBy({ id: 'p2' });
+        .findOneByOrFail({ id: 'p2' });
 
-      expect(firstPostAfter.pinnedAt.getTime()).toEqual(
-        firstPostBefore.pinnedAt.getTime() + 1000,
+      expect(firstPostAfter.pinnedAt?.getTime()).toEqual(
+        (firstPostBefore.pinnedAt?.getTime() as number) + 1000,
       );
     });
 
@@ -5020,7 +5041,7 @@ describe('mutation swapPinnedPosts', () => {
 
       const firstPostBefore = await con
         .getRepository(Post)
-        .findOneBy({ id: 'p2' });
+        .findOneByOrFail({ id: 'p2' });
 
       await client.mutate(MUTATION, {
         variables: { id: 'p3', swapWithId: 'p1' },
@@ -5028,10 +5049,10 @@ describe('mutation swapPinnedPosts', () => {
 
       const firstPostAfter = await con
         .getRepository(Post)
-        .findOneBy({ id: 'p2' });
+        .findOneByOrFail({ id: 'p2' });
 
-      expect(firstPostAfter.pinnedAt.getTime()).toEqual(
-        firstPostBefore.pinnedAt.getTime(),
+      expect(firstPostAfter.pinnedAt?.getTime()).toEqual(
+        firstPostBefore.pinnedAt?.getTime(),
       );
     });
   });
@@ -5147,8 +5168,8 @@ describe('posts flags field', () => {
   });
 
   it('should contain all default values in db query', async () => {
-    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
-    expect(post?.flags).toEqual({
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+    expect(post.flags).toEqual({
       sentAnalyticsReport: true,
       visible: true,
       showOnFeed: true,
@@ -6816,7 +6837,7 @@ describe('Source post moderation approve/reject', () => {
     await saveSquadFixtures();
     await con.getRepository(SourcePostModeration).save([
       {
-        id: pendingId,
+        id: pendingId as string,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
@@ -6825,7 +6846,7 @@ describe('Source post moderation approve/reject', () => {
         type: PostType.Article,
       },
       {
-        id: pendingId2,
+        id: pendingId2 as string,
         sourceId: 'm2',
         createdById: '4',
         title: 'Title',
@@ -6834,13 +6855,13 @@ describe('Source post moderation approve/reject', () => {
         type: PostType.Article,
       },
       {
-        id: rejectedId,
+        id: rejectedId as string,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
         content: 'Content',
         status: SourcePostModerationStatus.Rejected,
-        rejectionReason: 'Spam',
+        rejectionReason: PostModerationReason.Spam,
         moderatorMessage: 'This is spam',
         type: PostType.Article,
         moderatedById: '3',
@@ -7058,7 +7079,7 @@ describe('Source post moderation edit/delete', () => {
     ]);
     await con.getRepository(SourcePostModeration).save([
       {
-        id: pendingId,
+        id: pendingId as string,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
@@ -7067,13 +7088,13 @@ describe('Source post moderation edit/delete', () => {
         type: PostType.Share,
       },
       {
-        id: rejectedId,
+        id: rejectedId as string,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
         content: 'Content',
         status: SourcePostModerationStatus.Rejected,
-        rejectionReason: 'Spam',
+        rejectionReason: PostModerationReason.Spam,
         moderatorMessage: 'This is spam',
         type: PostType.Share,
         moderatedById: '3',

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -6837,7 +6837,7 @@ describe('Source post moderation approve/reject', () => {
     await saveSquadFixtures();
     await con.getRepository(SourcePostModeration).save([
       {
-        id: pendingId as string,
+        id: pendingId,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
@@ -6846,7 +6846,7 @@ describe('Source post moderation approve/reject', () => {
         type: PostType.Article,
       },
       {
-        id: pendingId2 as string,
+        id: pendingId2,
         sourceId: 'm2',
         createdById: '4',
         title: 'Title',
@@ -6855,7 +6855,7 @@ describe('Source post moderation approve/reject', () => {
         type: PostType.Article,
       },
       {
-        id: rejectedId as string,
+        id: rejectedId,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
@@ -7079,7 +7079,7 @@ describe('Source post moderation edit/delete', () => {
     ]);
     await con.getRepository(SourcePostModeration).save([
       {
-        id: pendingId as string,
+        id: pendingId,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',
@@ -7088,7 +7088,7 @@ describe('Source post moderation edit/delete', () => {
         type: PostType.Share,
       },
       {
-        id: rejectedId as string,
+        id: rejectedId,
         sourceId: 'm',
         createdById: '4',
         title: 'Title',


### PR DESCRIPTION
Just solves some typing errors in the posts test. Leftovers from when I tried to get Claude to fix the test but explicitly told it to ignore TS errors, and it fixed TS errors instead and ignored test errors.