### PR TITLE
refactor: skadi boost client

### DIFF
--- a/.env
+++ b/.env
@@ -44,7 +44,7 @@ ANALYTICS_URL=http://localhost:5000
 NJORD_ORIGIN=http://njord-transactions-server
 FREYJA_ORIGIN=http://localhost:7800
 SKADI_ORIGIN=http://localhost:8080
-SKADI_API_ORIGIN=http://localhost:8090
+SKADI_API_ORIGIN=http://skadi-api-server.local.svc.cluster.local
 MIMIR_ORIGIN=http://localhost:7600
 
 MEILI_INDEX=dev

--- a/.env
+++ b/.env
@@ -44,6 +44,7 @@ ANALYTICS_URL=http://localhost:5000
 NJORD_ORIGIN=http://njord-transactions-server
 FREYJA_ORIGIN=http://localhost:7800
 SKADI_ORIGIN=http://localhost:8080
+SKADI_API_ORIGIN=http://localhost:8090
 MIMIR_ORIGIN=http://localhost:7600
 
 MEILI_INDEX=dev

--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -95,4 +95,3 @@ config:
   api:temporal:
     chain: ''
     key: ''
-  api:image: api-image:tilt-e5bbadab09197923

--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -38,9 +38,9 @@ config:
       6S+tkxhzAgWZNOhtqvSTFxKH9c51/jTCLDrPvHNlzNoeqhvaowUmvOrRoT1TZ8hs
       7QIDAQAB
       -----END PUBLIC KEY-----
-  api:debeziumDbPass: '12345'
+  api:debeziumDbPass: "12345"
   api:debeziumDbUser: postgres
-  api:enablePersonalizedDigest: 'false'
+  api:enablePersonalizedDigest: "false"
   api:env:
     accessSecret: topsecret
     analyticsUrl: http://localhost:3000

--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -38,9 +38,9 @@ config:
       6S+tkxhzAgWZNOhtqvSTFxKH9c51/jTCLDrPvHNlzNoeqhvaowUmvOrRoT1TZ8hs
       7QIDAQAB
       -----END PUBLIC KEY-----
-  api:debeziumDbPass: "12345"
+  api:debeziumDbPass: '12345'
   api:debeziumDbUser: postgres
-  api:enablePersonalizedDigest: "false"
+  api:enablePersonalizedDigest: 'false'
   api:env:
     accessSecret: topsecret
     analyticsUrl: http://localhost:3000
@@ -54,6 +54,7 @@ config:
     defaultImageUrl: https://res.cloudinary.com/daily-now/image/upload/s--P4t4XyoV--/f_auto/v1722860399/public/Placeholder%2001,https://res.cloudinary.com/daily-now/image/upload/s--VDukGCjf--/f_auto/v1722860399/public/Placeholder%2002,https://res.cloudinary.com/daily-now/image/upload/s--HRgLpUt6--/f_auto/v1722860399/public/Placeholder%2003,https://res.cloudinary.com/daily-now/image/upload/s--foaA6JGU--/f_auto/v1722860399/public/Placeholder%2004,https://res.cloudinary.com/daily-now/image/upload/s--CxzD6vbw--/f_auto/v1722860399/public/Placeholder%2005,https://res.cloudinary.com/daily-now/image/upload/s--ZrL_HSsR--/f_auto/v1722860399/public/Placeholder%2006,https://res.cloudinary.com/daily-now/image/upload/s--1KxV4ohY--/f_auto/v1722860400/public/Placeholder%2007,https://res.cloudinary.com/daily-now/image/upload/s--0_ODbtD2--/f_auto/v1722860399/public/Placeholder%2008,https://res.cloudinary.com/daily-now/image/upload/s--qPvKM23u--/f_auto/v1722860399/public/Placeholder%2009,https://res.cloudinary.com/daily-now/image/upload/s--OHB84bZF--/f_auto/v1722860399/public/Placeholder%2010,https://res.cloudinary.com/daily-now/image/upload/s--2-1xRawN--/f_auto/v1722860399/public/Placeholder%2011,https://res.cloudinary.com/daily-now/image/upload/s--58gMhC4P--/f_auto/v1722860399/public/Placeholder%2012
     digestQueueConcurrency: 1000
     enablePubsub: true
+    skadiApiOrigin: http://skadi-api-server.local.svc.cluster.local
     freyjaOrigin: http://freyja
     gcloudProject: local
     heimdallOrigin: http://heimdall-api
@@ -94,3 +95,4 @@ config:
   api:temporal:
     chain: ''
     key: ''
+  api:image: api-image:tilt-e5bbadab09197923

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -6,7 +6,7 @@ config:
       secure: AAABAGND38ZY4hSe1YR2RTh/JyY3g3pBsK8Ovm4FCs6Et4ihLMPkAvZUKDy+T6N1Wg1OEmO3q9JMeB3dNGZ3ptLDTEDZ8bpAh7FBBMuZGxeC81i1XwzCNAMPzKwm2m3ZJkSSWRdxkEp8m+0qfpiPCscYGpeKCmRJUZqDHuMUl1S+kMAK4CQn+xdCtDLhI+9EqujfNyyGXaPzw1UkEMAF7RZs5GSWvoTOWIwN5N4TC7Uwi3dZq2COQcGJ2RdjCFDtbq3uDoq7kLsgQsCxG02hJnjzxlbRzpm+CVq6Alkj1v0FgpzY7kdX2xpBnjNz9Rd7ILOYni6PMcvF+uM1FJRnUxcZMExM8sS7Lm14CPdi/IjTRXvu7ie+FNmRbotEypb2fBLHLxrcrn4EtB/6ihTFfg2mCOMY3I74laKihU3hjpUR3YpVS3Eio+cEYB5SBdxIexA2Ff7TIyJe6dY3VwoeB9Ln3VqU4KtWEvOIKArZK+lR4GL1qmlEFshB8OvjHoLBnBWoMKXSXkyO9kTaQUEPRjyrxKgLLkRVHsp04aTW95VZQRkykUvzGGAFkUwiTKeC4/SPPkOpbl41dHfQL2lWGvMlfuwoi0lDwM1vbM/XEmASjVghvReZYE9/qnY09VnI1E8=
   api:clickhouseSync:
     keys:
-      slot.name: 'clickhouse_sync'
+      slot.name: "clickhouse_sync"
     vars:
       clickhouse_database:
         secure: AAABAFXhGil+ZGIYbGEIU71Q2eQslzMjGAkeeW0LumXI3GA=
@@ -22,7 +22,7 @@ config:
     secure: AAABAHdC/62trKcIoEduX+v3nBKj/KJ1XDNPRwwEwqcq33TLhqLrVq9oJfFsq/aX
   api:debeziumDbUser:
     secure: AAABAO0E/09gCux4t78RzYaMt9h+ZVFXNo6KS9mwLuKX11/HvmX7sg==
-  api:enablePersonalizedDigest: 'true'
+  api:enablePersonalizedDigest: "true"
   api:env:
     accessSecret:
       secure: AAABALdzzBMEk2sKYDjFrWsbsdYJDOvfDfmnOmaj6lvRkds8E6SYw1RNgQ/hpCky9W8BeJXFzu2b0W6jD30KkA==

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -6,7 +6,7 @@ config:
       secure: AAABAGND38ZY4hSe1YR2RTh/JyY3g3pBsK8Ovm4FCs6Et4ihLMPkAvZUKDy+T6N1Wg1OEmO3q9JMeB3dNGZ3ptLDTEDZ8bpAh7FBBMuZGxeC81i1XwzCNAMPzKwm2m3ZJkSSWRdxkEp8m+0qfpiPCscYGpeKCmRJUZqDHuMUl1S+kMAK4CQn+xdCtDLhI+9EqujfNyyGXaPzw1UkEMAF7RZs5GSWvoTOWIwN5N4TC7Uwi3dZq2COQcGJ2RdjCFDtbq3uDoq7kLsgQsCxG02hJnjzxlbRzpm+CVq6Alkj1v0FgpzY7kdX2xpBnjNz9Rd7ILOYni6PMcvF+uM1FJRnUxcZMExM8sS7Lm14CPdi/IjTRXvu7ie+FNmRbotEypb2fBLHLxrcrn4EtB/6ihTFfg2mCOMY3I74laKihU3hjpUR3YpVS3Eio+cEYB5SBdxIexA2Ff7TIyJe6dY3VwoeB9Ln3VqU4KtWEvOIKArZK+lR4GL1qmlEFshB8OvjHoLBnBWoMKXSXkyO9kTaQUEPRjyrxKgLLkRVHsp04aTW95VZQRkykUvzGGAFkUwiTKeC4/SPPkOpbl41dHfQL2lWGvMlfuwoi0lDwM1vbM/XEmASjVghvReZYE9/qnY09VnI1E8=
   api:clickhouseSync:
     keys:
-      slot.name: "clickhouse_sync"
+      slot.name: 'clickhouse_sync'
     vars:
       clickhouse_database:
         secure: AAABAFXhGil+ZGIYbGEIU71Q2eQslzMjGAkeeW0LumXI3GA=
@@ -22,7 +22,7 @@ config:
     secure: AAABAHdC/62trKcIoEduX+v3nBKj/KJ1XDNPRwwEwqcq33TLhqLrVq9oJfFsq/aX
   api:debeziumDbUser:
     secure: AAABAO0E/09gCux4t78RzYaMt9h+ZVFXNo6KS9mwLuKX11/HvmX7sg==
-  api:enablePersonalizedDigest: "true"
+  api:enablePersonalizedDigest: 'true'
   api:env:
     accessSecret:
       secure: AAABALdzzBMEk2sKYDjFrWsbsdYJDOvfDfmnOmaj6lvRkds8E6SYw1RNgQ/hpCky9W8BeJXFzu2b0W6jD30KkA==
@@ -53,6 +53,7 @@ config:
     digestQueueConcurrency: 1000
     experimentationKey:
       secure: AAABADH0xT7H6UeMlZG0fUEGjohQ1dvwcbIgJ3WMI5wfqScub3Qp3nvUDhska0DunbFmvj7IrtH07noRL1lCYg==
+    skadiApiOrigin: http://skadi-api-server.daily.svc.cluster.local
     freyjaOrigin: http://freyja.freyja
     growthbookApiConfigClientKey:
       secure: AAABAJEgS6b8xZv0j06KOawyNMdkTpGmzKs7Ryed5SofiLp3vSTjxhqQuKSVsaHjR5s=

--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -2278,10 +2278,8 @@ describe('query boostEstimatedReach', () => {
   const QUERY = `
     query BoostEstimatedReach($postId: ID!, $duration: Int!, $budget: Int!) {
       boostEstimatedReach(postId: $postId, duration: $duration, budget: $budget) {
-        estimatedReach {
-          min
-          max
-        }
+        min
+        max
       }
     }
   `;

--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -2390,12 +2390,11 @@ describe('query boostEstimatedReach', () => {
   it('should the response returned by skadi client', async () => {
     loggedUser = '1';
 
-    // Mock the skadi client to return estimated reach
+    // Mock the skadi client to return impressions
     (skadiApiClient.estimatePostBoostReach as jest.Mock).mockResolvedValue({
-      estimatedReach: {
-        min: 80,
-        max: 120,
-      },
+      impressions: 100,
+      clicks: 10,
+      users: 50,
     });
 
     const res = await client.query(QUERY, {
@@ -2404,8 +2403,8 @@ describe('query boostEstimatedReach', () => {
 
     expect(res.errors).toBeFalsy();
     expect(res.data.boostEstimatedReach.estimatedReach).toEqual({
-      max: 120,
-      min: 80,
+      max: 108, // 100 + (100 * 0.08) = 108
+      min: 92, // 100 - (100 * 0.08) = 92
     });
 
     // Verify the skadi client was called with correct parameters

--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -2046,7 +2046,7 @@ describe('mutation startPostBoost', () => {
     expect(skadiApiClient.startPostCampaign).toHaveBeenCalledWith({
       postId: 'p1',
       userId: '1',
-      duration: 1,
+      durationInDays: 1,
       budget: 10, // Converted from cores to USD (1000 cores = 10 USD)
     });
 
@@ -2400,7 +2400,7 @@ describe('query boostEstimatedReach', () => {
     });
 
     expect(res.errors).toBeFalsy();
-    expect(res.data.boostEstimatedReach.estimatedReach).toEqual({
+    expect(res.data.boostEstimatedReach).toEqual({
       max: 108, // 100 + (100 * 0.08) = 108
       min: 92, // 100 - (100 * 0.08) = 92
     });
@@ -2409,7 +2409,7 @@ describe('query boostEstimatedReach', () => {
     expect(skadiApiClient.estimatePostBoostReach).toHaveBeenCalledWith({
       postId: 'p1',
       userId: '1',
-      duration: 1,
+      durationInDays: 1,
       budget: 1000,
     });
   });

--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -39,7 +39,7 @@ import { randomUUID } from 'crypto';
 import { deleteKeysByPattern, ioRedisPool } from '../../../src/redis';
 import { rateLimiterName } from '../../../src/directive/rateLimit';
 import { badUsersFixture } from '../../fixture/user';
-import { skadiBoostClient } from '../../../src/integrations/skadi/clients';
+import { skadiApiClient } from '../../../src/integrations/skadi/api/clients';
 import { pickImageUrl } from '../../../src/common/post';
 import { updateFlagsStatement } from '../../../src/common';
 import { UserTransaction } from '../../../src/entity/user/UserTransaction';
@@ -54,9 +54,9 @@ jest.mock('../../../src/common/pubsub', () => ({
   notifyContentRequested: jest.fn(),
 }));
 
-// Mock the skadiBoostClient
-jest.mock('../../../src/integrations/skadi/clients', () => ({
-  skadiBoostClient: {
+// Mock the skadiApiClient
+jest.mock('../../../src/integrations/skadi/api/clients', () => ({
+  skadiApiClient: {
     getCampaignById: jest.fn(),
     estimatePostBoostReach: jest.fn(),
     startPostCampaign: jest.fn(),
@@ -258,7 +258,7 @@ describe('query postCampaignById', () => {
     loggedUser = '1';
 
     // Mock the skadi client to return the share post campaign
-    (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
       campaignId: 'mock-campaign-id',
       postId: 'p1',
       status: 'active',
@@ -333,7 +333,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the share post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'share-campaign-id',
           postId: 'share-post-1',
           status: 'active',
@@ -392,7 +392,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the share post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'share-campaign-id-2',
           postId: 'share-post-2',
           status: 'active',
@@ -451,7 +451,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the share post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'share-campaign-id-3',
           postId: 'share-post-3',
           status: 'active',
@@ -498,7 +498,7 @@ describe('query postCampaignById', () => {
         } as unknown as Partial<FreeformPost>);
 
         // Mock the skadi client to return the freeform post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'freeform-campaign-id',
           postId: freeformPost.id,
           status: 'active',
@@ -544,7 +544,7 @@ describe('query postCampaignById', () => {
         } as unknown as Partial<FreeformPost>);
 
         // Mock the skadi client to return the freeform post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'freeform-campaign-id-2',
           postId: freeformPost.id,
           status: 'active',
@@ -600,7 +600,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the article post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'article-campaign-id',
           postId: articlePost.id,
           status: 'active',
@@ -646,7 +646,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the article post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'article-campaign-id-2',
           postId: articlePost.id,
           status: 'active',
@@ -702,7 +702,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the welcome post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'welcome-campaign-id',
           postId: welcomePost.id,
           status: 'active',
@@ -749,7 +749,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the collection post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'collection-campaign-id',
           postId: collectionPost.id,
           status: 'active',
@@ -797,7 +797,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the YouTube post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'youtube-campaign-id',
           postId: youtubePost.id,
           status: 'active',
@@ -859,7 +859,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the share post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'share-campaign-no-image',
           postId: sharePost.id,
           status: 'active',
@@ -913,7 +913,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'null-title-campaign',
           postId: nullTitlePost.id,
           status: 'active',
@@ -958,7 +958,7 @@ describe('query postCampaignById', () => {
         });
 
         // Mock the skadi client to return the post campaign
-        (skadiBoostClient.getCampaignById as jest.Mock).mockResolvedValue({
+        (skadiApiClient.getCampaignById as jest.Mock).mockResolvedValue({
           campaignId: 'undefined-title-campaign',
           postId: undefinedTitlePost.id,
           status: 'active',
@@ -1046,7 +1046,7 @@ describe('query postCampaigns', () => {
     loggedUser = '1';
 
     // Mock the skadi client to return empty campaigns
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [],
       impressions: 0,
       clicks: 0,
@@ -1110,7 +1110,7 @@ describe('query postCampaigns', () => {
     ]);
 
     // Mock the skadi client to return campaigns
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [
         {
           campaignId: 'campaign-1',
@@ -1223,7 +1223,7 @@ describe('query postCampaigns', () => {
     });
 
     // Mock the skadi client to return campaigns
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [
         {
           campaignId: 'campaign-3',
@@ -1292,7 +1292,7 @@ describe('query postCampaigns', () => {
     await con.getRepository(ArticlePost).save(posts);
 
     // Mock the skadi client to return campaigns for first page (limit 2)
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValueOnce({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValueOnce({
       promotedPosts: posts.slice(0, 2).map((post, index) => ({
         campaignId: `campaign-${index + 1}`,
         postId: post.id,
@@ -1311,7 +1311,7 @@ describe('query postCampaigns', () => {
     });
 
     // Mock the skadi client to return campaigns for second page (offset 2, limit 2)
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValueOnce({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValueOnce({
       promotedPosts: posts.slice(2, 4).map((post, index) => ({
         campaignId: `campaign-${index + 3}`,
         postId: post.id,
@@ -1362,7 +1362,7 @@ describe('query postCampaigns', () => {
     expect(res2.data.postCampaigns.stats).toBeNull(); // No stats on subsequent requests
 
     // Verify that the correct offset was sent to Skadi for the second request
-    expect(skadiBoostClient.getCampaigns).toHaveBeenCalledWith({
+    expect(skadiApiClient.getCampaigns).toHaveBeenCalledWith({
       userId: '1',
       offset: 2, // cursorToOffset('YXJyYXljb25uZWN0aW9uOjI=') = 2
       limit: 2,
@@ -1433,7 +1433,7 @@ describe('query postCampaigns', () => {
     });
 
     // Mock the skadi client to return campaigns for different post types
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [
         {
           campaignId: 'campaign-1',
@@ -1547,7 +1547,7 @@ describe('query postCampaigns', () => {
     });
 
     // Mock the skadi client to return campaigns with zero values
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [
         {
           campaignId: 'campaign-zero',
@@ -1610,7 +1610,7 @@ describe('query postCampaigns', () => {
     });
 
     // Mock the skadi client to return campaigns with decimal USD amounts
-    (skadiBoostClient.getCampaigns as jest.Mock).mockResolvedValue({
+    (skadiApiClient.getCampaigns as jest.Mock).mockResolvedValue({
       promotedPosts: [
         {
           campaignId: 'campaign-decimal',
@@ -1781,7 +1781,7 @@ describe('mutation startPostBoost', () => {
     );
 
     // Mock skadi client to throw an error
-    (skadiBoostClient.startPostCampaign as jest.Mock).mockRejectedValue(
+    (skadiApiClient.startPostCampaign as jest.Mock).mockRejectedValue(
       new Error('Skadi service unavailable'),
     );
 
@@ -1827,7 +1827,7 @@ describe('mutation startPostBoost', () => {
     );
 
     // Mock skadi client to succeed but transfer to fail
-    (skadiBoostClient.startPostCampaign as jest.Mock).mockResolvedValue({
+    (skadiApiClient.startPostCampaign as jest.Mock).mockResolvedValue({
       campaignId: 'mock-campaign-id',
     });
 
@@ -2021,7 +2021,7 @@ describe('mutation startPostBoost', () => {
     );
 
     // Mock skadi client to succeed
-    (skadiBoostClient.startPostCampaign as jest.Mock).mockResolvedValue({
+    (skadiApiClient.startPostCampaign as jest.Mock).mockResolvedValue({
       campaignId: 'mock-campaign-id',
     });
 
@@ -2043,7 +2043,7 @@ describe('mutation startPostBoost', () => {
     expect(post?.flags?.campaignId).toBe('mock-campaign-id');
 
     // Verify the skadi client was called with correct parameters
-    expect(skadiBoostClient.startPostCampaign).toHaveBeenCalledWith({
+    expect(skadiApiClient.startPostCampaign).toHaveBeenCalledWith({
       postId: 'p1',
       userId: '1',
       duration: 1,
@@ -2066,7 +2066,7 @@ describe('mutation startPostBoost', () => {
     );
 
     // Mock skadi client to throw an error
-    (skadiBoostClient.startPostCampaign as jest.Mock).mockRejectedValue(
+    (skadiApiClient.startPostCampaign as jest.Mock).mockRejectedValue(
       new Error('Skadi service unavailable'),
     );
 
@@ -2171,7 +2171,7 @@ describe('mutation cancelPostBoost', () => {
     loggedUser = '1';
 
     // Mock skadi client to succeed
-    (skadiBoostClient.cancelPostCampaign as jest.Mock).mockResolvedValue({
+    (skadiApiClient.cancelPostCampaign as jest.Mock).mockResolvedValue({
       success: true,
     });
 
@@ -2257,7 +2257,7 @@ describe('mutation cancelPostBoost', () => {
     );
 
     // Mock skadi client to succeed
-    (skadiBoostClient.cancelPostCampaign as jest.Mock).mockResolvedValue({
+    (skadiApiClient.cancelPostCampaign as jest.Mock).mockResolvedValue({
       success: true,
     });
 
@@ -2391,7 +2391,7 @@ describe('query boostEstimatedReach', () => {
     loggedUser = '1';
 
     // Mock the skadi client to return estimated reach
-    (skadiBoostClient.estimatePostBoostReach as jest.Mock).mockResolvedValue({
+    (skadiApiClient.estimatePostBoostReach as jest.Mock).mockResolvedValue({
       estimatedReach: {
         min: 80,
         max: 120,
@@ -2409,7 +2409,7 @@ describe('query boostEstimatedReach', () => {
     });
 
     // Verify the skadi client was called with correct parameters
-    expect(skadiBoostClient.estimatePostBoostReach).toHaveBeenCalledWith({
+    expect(skadiApiClient.estimatePostBoostReach).toHaveBeenCalledWith({
       postId: 'p1',
       userId: '1',
       duration: 1,

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -1,0 +1,148 @@
+import { RequestInit } from 'node-fetch';
+import {
+  ISkadiApiClient,
+  type GetCampaignByIdProps,
+  type GetCampaignsProps,
+  type PostBoostReach,
+  type PromotedPost,
+  type PromotedPostList,
+} from './types';
+import { GarmrNoopService, IGarmrService, GarmrService } from '../../garmr';
+import { fetchOptions as globalFetchOptions } from '../../../http';
+import { fetchParse } from '../../retry';
+
+export class SkadiApiClient implements ISkadiApiClient {
+  private readonly fetchOptions: RequestInit;
+  private readonly garmr: IGarmrService;
+
+  constructor(
+    private readonly url: string,
+    options?: {
+      fetchOptions?: RequestInit;
+      garmr?: IGarmrService;
+    },
+  ) {
+    const {
+      fetchOptions = globalFetchOptions,
+      garmr = new GarmrNoopService(),
+    } = options || {};
+
+    this.fetchOptions = fetchOptions;
+    this.garmr = garmr;
+  }
+
+  startPostCampaign({
+    postId,
+    userId,
+    duration,
+    budget,
+  }: {
+    postId: string;
+    userId: string;
+    duration: number;
+    budget: number;
+  }): Promise<{ campaignId: string }> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/promote/post/create`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ postId, userId, duration, budget }),
+      });
+    });
+  }
+
+  cancelPostCampaign({
+    postId,
+    userId,
+  }: {
+    postId: string;
+    userId: string;
+  }): Promise<{ success: boolean }> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/promote/post/cancel`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ postId, userId }),
+      });
+    });
+  }
+
+  estimatePostBoostReach({
+    postId,
+    userId,
+    duration,
+    budget,
+  }: {
+    postId: string;
+    userId: string;
+    duration: number;
+    budget: number;
+  }): Promise<PostBoostReach> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/promote/post/reach`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ postId, userId, duration, budget }),
+      });
+    });
+  }
+
+  getCampaignById({
+    campaignId,
+    userId,
+  }: GetCampaignByIdProps): Promise<PromotedPost> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/promote/post/get`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ campaignId, userId }),
+      });
+    });
+  }
+
+  getCampaigns({
+    limit,
+    offset,
+    userId,
+  }: GetCampaignsProps): Promise<PromotedPostList> {
+    return this.garmr.execute(() => {
+      return fetchParse(`${this.url}/promote/post/list`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ limit, offset, userId }),
+      });
+    });
+  }
+}
+
+const garmBoostService = new GarmrService({
+  service: SkadiApiClient.name,
+  breakerOpts: {
+    halfOpenAfter: 5 * 1000,
+    threshold: 0.1,
+    duration: 10 * 1000,
+  },
+  retryOpts: {
+    maxAttempts: 1,
+  },
+});
+
+export const skadiBoostClient = new SkadiApiClient(
+  process.env.SKADI_API_ORIGIN,
+  { garmr: garmBoostService },
+);

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -10,6 +10,7 @@ import {
 import { GarmrNoopService, IGarmrService, GarmrService } from '../../garmr';
 import { fetchOptions as globalFetchOptions } from '../../../http';
 import { fetchParse } from '../../retry';
+import { ONE_DAY_IN_SECONDS } from '../../../common';
 
 export class SkadiApiClient implements ISkadiApiClient {
   private readonly fetchOptions: RequestInit;
@@ -34,12 +35,12 @@ export class SkadiApiClient implements ISkadiApiClient {
   startPostCampaign({
     postId,
     userId,
-    duration,
+    durationInDays,
     budget,
   }: {
     postId: string;
     userId: string;
-    duration: number;
+    durationInDays: number;
     budget: number;
   }): Promise<{ campaignId: string }> {
     return this.garmr.execute(() => {
@@ -49,7 +50,12 @@ export class SkadiApiClient implements ISkadiApiClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ postId, userId, duration, budget }),
+        body: JSON.stringify({
+          post_id: postId,
+          user_id: userId,
+          duration: durationInDays * ONE_DAY_IN_SECONDS,
+          budget,
+        }),
       });
     });
   }
@@ -76,12 +82,12 @@ export class SkadiApiClient implements ISkadiApiClient {
   estimatePostBoostReach({
     postId,
     userId,
-    duration,
+    durationInDays,
     budget,
   }: {
     postId: string;
     userId: string;
-    duration: number;
+    durationInDays: number;
     budget: number;
   }): Promise<PostEstimatedReach> {
     return this.garmr.execute(() => {
@@ -91,7 +97,12 @@ export class SkadiApiClient implements ISkadiApiClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ postId, userId, duration, budget }),
+        body: JSON.stringify({
+          postId,
+          userId,
+          duration: durationInDays * ONE_DAY_IN_SECONDS,
+          budget,
+        }),
       });
     });
   }

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -3,7 +3,7 @@ import {
   ISkadiApiClient,
   type GetCampaignByIdProps,
   type GetCampaignsProps,
-  type PostBoostReach,
+  type PostEstimatedReach,
   type PromotedPost,
   type PromotedPostList,
 } from './types';
@@ -83,7 +83,7 @@ export class SkadiApiClient implements ISkadiApiClient {
     userId: string;
     duration: number;
     budget: number;
-  }): Promise<PostBoostReach> {
+  }): Promise<PostEstimatedReach> {
     return this.garmr.execute(() => {
       return fetchParse(`${this.url}/promote/post/reach`, {
         ...this.fetchOptions,

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -74,7 +74,7 @@ export class SkadiApiClient implements ISkadiApiClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ postId, userId }),
+        body: JSON.stringify({ post_id: postId, user_id: userId }),
       });
     });
   }
@@ -98,8 +98,8 @@ export class SkadiApiClient implements ISkadiApiClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          postId,
-          userId,
+          post_id: postId,
+          user_id: userId,
           duration: durationInDays * ONE_DAY_IN_SECONDS,
           budget,
         }),
@@ -118,7 +118,7 @@ export class SkadiApiClient implements ISkadiApiClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ campaignId, userId }),
+        body: JSON.stringify({ campaign_id: campaignId, user_id: userId }),
       });
     });
   }
@@ -135,7 +135,7 @@ export class SkadiApiClient implements ISkadiApiClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ limit, offset, userId }),
+        body: JSON.stringify({ limit, offset, user_id: userId }),
       });
     });
   }

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -142,7 +142,6 @@ const garmBoostService = new GarmrService({
   },
 });
 
-export const skadiBoostClient = new SkadiApiClient(
-  process.env.SKADI_API_ORIGIN,
-  { garmr: garmBoostService },
-);
+export const skadiApiClient = new SkadiApiClient(process.env.SKADI_API_ORIGIN, {
+  garmr: garmBoostService,
+});

--- a/src/integrations/skadi/api/index.ts
+++ b/src/integrations/skadi/api/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { SkadiApiClient } from './clients';

--- a/src/integrations/skadi/api/types.ts
+++ b/src/integrations/skadi/api/types.ts
@@ -46,7 +46,7 @@ export interface ISkadiApiClient {
   startPostCampaign(params: {
     postId: string;
     userId: string;
-    duration: number;
+    durationInDays: number;
     budget: number;
   }): Promise<{
     campaignId: string;
@@ -57,7 +57,7 @@ export interface ISkadiApiClient {
   estimatePostBoostReach(params: {
     postId: string;
     userId: string;
-    duration: number;
+    durationInDays: number;
     budget: number;
   }): Promise<PostEstimatedReach>;
   getCampaignById: (params: GetCampaignByIdProps) => Promise<PromotedPost>;

--- a/src/integrations/skadi/api/types.ts
+++ b/src/integrations/skadi/api/types.ts
@@ -1,0 +1,58 @@
+import type { User } from '../../../entity';
+
+export interface PostBoostReach {
+  estimatedReach: { min: number; max: number };
+}
+
+export interface PromotedPost {
+  campaignId: string;
+  postId: string;
+  status: string;
+  budget: number;
+  currentBudget: number;
+  startedAt: Date;
+  endedAt?: Date;
+  impressions: number;
+  clicks: number;
+}
+
+export interface PromotedPostList {
+  promotedPosts: PromotedPost[];
+  impressions: number;
+  clicks: number;
+  totalSpend: number;
+  postIds: string[];
+}
+
+export interface GetCampaignByIdProps {
+  campaignId: PromotedPost['campaignId'];
+  userId: User['id'];
+}
+
+export interface GetCampaignsProps {
+  userId: User['id'];
+  offset: number;
+  limit: number;
+}
+
+export interface ISkadiApiClient {
+  startPostCampaign(params: {
+    postId: string;
+    userId: string;
+    duration: number;
+    budget: number;
+  }): Promise<{
+    campaignId: string;
+  }>;
+  cancelPostCampaign(params: { postId: string; userId: string }): Promise<{
+    success: boolean;
+  }>;
+  estimatePostBoostReach(params: {
+    postId: string;
+    userId: string;
+    duration: number;
+    budget: number;
+  }): Promise<PostBoostReach>;
+  getCampaignById: (params: GetCampaignByIdProps) => Promise<PromotedPost>;
+  getCampaigns: (params: GetCampaignsProps) => Promise<PromotedPostList>;
+}

--- a/src/integrations/skadi/api/types.ts
+++ b/src/integrations/skadi/api/types.ts
@@ -1,7 +1,14 @@
 import type { User } from '../../../entity';
 
 export interface PostBoostReach {
-  estimatedReach: { min: number; max: number };
+  min: number;
+  max: number;
+}
+
+export interface PostEstimatedReach {
+  impressions: number;
+  clicks: number;
+  users: number;
 }
 
 export interface PromotedPost {
@@ -52,7 +59,7 @@ export interface ISkadiApiClient {
     userId: string;
     duration: number;
     budget: number;
-  }): Promise<PostBoostReach>;
+  }): Promise<PostEstimatedReach>;
   getCampaignById: (params: GetCampaignByIdProps) => Promise<PromotedPost>;
   getCampaigns: (params: GetCampaignsProps) => Promise<PromotedPostList>;
 }

--- a/src/integrations/skadi/clients.ts
+++ b/src/integrations/skadi/clients.ts
@@ -1,13 +1,5 @@
 import { RequestInit } from 'node-fetch';
-import {
-  ISkadiClient,
-  SkadiResponse,
-  type GetCampaignByIdProps,
-  type GetCampaignsProps,
-  type PostBoostReach,
-  type PromotedPost,
-  type PromotedPostList,
-} from './types';
+import { ISkadiClient, SkadiResponse } from './types';
 import { GarmrNoopService, IGarmrService, GarmrService } from '../garmr';
 import { fetchOptions as globalFetchOptions } from '../../http';
 import { fetchParse } from '../retry';
@@ -50,104 +42,6 @@ export class SkadiClient implements ISkadiClient {
           placement,
           metadata,
         }),
-      });
-    });
-  }
-
-  startPostCampaign({
-    postId,
-    userId,
-    duration,
-    budget,
-  }: {
-    postId: string;
-    userId: string;
-    duration: number;
-    budget: number;
-  }): Promise<{ campaignId: string }> {
-    return this.garmr.execute(() => {
-      return fetchParse(`${this.url}/promote/post/create`, {
-        ...this.fetchOptions,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ postId, userId, duration, budget }),
-      });
-    });
-  }
-
-  cancelPostCampaign({
-    postId,
-    userId,
-  }: {
-    postId: string;
-    userId: string;
-  }): Promise<{ success: boolean }> {
-    return this.garmr.execute(() => {
-      return fetchParse(`${this.url}/promote/post/cancel`, {
-        ...this.fetchOptions,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ postId, userId }),
-      });
-    });
-  }
-
-  estimatePostBoostReach({
-    postId,
-    userId,
-    duration,
-    budget,
-  }: {
-    postId: string;
-    userId: string;
-    duration: number;
-    budget: number;
-  }): Promise<PostBoostReach> {
-    return this.garmr.execute(() => {
-      return fetchParse(`${this.url}/promote/post/reach`, {
-        ...this.fetchOptions,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ postId, userId, duration, budget }),
-      });
-    });
-  }
-
-  getCampaignById({
-    campaignId,
-    userId,
-  }: GetCampaignByIdProps): Promise<PromotedPost> {
-    return this.garmr.execute(() => {
-      return fetchParse(`${this.url}/promote/post/get`, {
-        ...this.fetchOptions,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ campaignId, userId }),
-      });
-    });
-  }
-
-  getCampaigns({
-    limit,
-    offset,
-    userId,
-  }: GetCampaignsProps): Promise<PromotedPostList> {
-    return this.garmr.execute(() => {
-      return fetchParse(`${this.url}/promote/post/list`, {
-        ...this.fetchOptions,
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ limit, offset, userId }),
       });
     });
   }
@@ -198,19 +92,3 @@ export const skadiPersonalizedDigestClient = new SkadiClient(
     garmr: garmrSkadiPersonalizedDigestService,
   },
 );
-
-const garmBoostService = new GarmrService({
-  service: SkadiClient.name,
-  breakerOpts: {
-    halfOpenAfter: 5 * 1000,
-    threshold: 0.1,
-    duration: 10 * 1000,
-  },
-  retryOpts: {
-    maxAttempts: 1,
-  },
-});
-
-export const skadiBoostClient = new SkadiClient(process.env.SKADI_ORIGIN, {
-  garmr: garmBoostService,
-});

--- a/src/integrations/skadi/index.ts
+++ b/src/integrations/skadi/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export { SkadiClient, skadiPersonalizedDigestClient } from './clients';
+export * from './api';

--- a/src/integrations/skadi/types.ts
+++ b/src/integrations/skadi/types.ts
@@ -1,5 +1,3 @@
-import type { User } from '../../entity';
-
 // Keep the type flexible to allow for future changes
 export type SkadiAd = {
   title: string;
@@ -17,41 +15,6 @@ export type SkadiResponse = Partial<{
   pixels: string[];
 }>;
 
-export interface PostBoostReach {
-  estimatedReach: { min: number; max: number };
-}
-
-export interface PromotedPost {
-  campaignId: string;
-  postId: string;
-  status: string;
-  budget: number;
-  currentBudget: number;
-  startedAt: Date;
-  endedAt?: Date;
-  impressions: number;
-  clicks: number;
-}
-
-export interface PromotedPostList {
-  promotedPosts: PromotedPost[];
-  impressions: number;
-  clicks: number;
-  totalSpend: number;
-  postIds: string[];
-}
-
-export interface GetCampaignByIdProps {
-  campaignId: PromotedPost['campaignId'];
-  userId: User['id'];
-}
-
-export interface GetCampaignsProps {
-  userId: User['id'];
-  offset: number;
-  limit: number;
-}
-
 export interface ISkadiClient {
   getAd(
     placement: string,
@@ -59,23 +22,4 @@ export interface ISkadiClient {
       USERID: string;
     },
   ): Promise<SkadiResponse>;
-  startPostCampaign(params: {
-    postId: string;
-    userId: string;
-    duration: number;
-    budget: number;
-  }): Promise<{
-    campaignId: string;
-  }>;
-  cancelPostCampaign(params: { postId: string; userId: string }): Promise<{
-    success: boolean;
-  }>;
-  estimatePostBoostReach(params: {
-    postId: string;
-    userId: string;
-    duration: number;
-    budget: number;
-  }): Promise<PostBoostReach>;
-  getCampaignById: (params: GetCampaignByIdProps) => Promise<PromotedPost>;
-  getCampaigns: (params: GetCampaignsProps) => Promise<PromotedPostList>;
 }

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2084,7 +2084,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const { impressions } = await skadiApiClient.estimatePostBoostReach({
         postId,
         userId: ctx.userId,
-        duration,
+        durationInDays: duration,
         budget,
       });
 
@@ -2592,7 +2592,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const request = await ctx.con.transaction(async (entityManager) => {
         const { campaignId } = await skadiApiClient.startPostCampaign({
           postId,
-          duration,
+          durationInDays: duration,
           budget: coresToUsd(budget),
           userId,
         });

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -144,7 +144,7 @@ import {
   UserTransactionStatus,
   UserTransactionType,
 } from '../entity/user/UserTransaction';
-import { skadiBoostClient } from '../integrations/skadi/clients';
+import { skadiApiClient } from '../integrations/skadi/api/clients';
 import {
   validatePostBoostArgs,
   validatePostBoostPermissions,
@@ -2085,7 +2085,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const post = await validatePostBoostPermissions(ctx, postId);
       checkPostAlreadyBoosted(post);
 
-      const { estimatedReach } = await skadiBoostClient.estimatePostBoostReach({
+      const { estimatedReach } = await skadiApiClient.estimatePostBoostReach({
         postId,
         userId: ctx.userId,
         duration,
@@ -2099,7 +2099,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       { id }: { id: string },
       ctx: Context,
     ): Promise<GQLBoostedPost> => {
-      const campaign = await skadiBoostClient.getCampaignById({
+      const campaign = await skadiApiClient.getCampaignById({
         campaignId: id,
         userId: ctx.userId!,
       });
@@ -2137,7 +2137,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         (nodeSize) => nodeSize === first,
         (_, i) => offsetToCursor(offset + i + 1),
         async () => {
-          const campaigns = await skadiBoostClient.getCampaigns({
+          const campaigns = await skadiApiClient.getCampaigns({
             userId,
             offset,
             limit: first!,
@@ -2587,7 +2587,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const total = budget * duration;
 
       const request = await ctx.con.transaction(async (entityManager) => {
-        const { campaignId } = await skadiBoostClient.startPostCampaign({
+        const { campaignId } = await skadiApiClient.startPostCampaign({
           postId,
           duration,
           budget: coresToUsd(budget),
@@ -2681,7 +2681,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             { flags: updateFlagsStatement<Post>({ campaignId: null }) },
           );
 
-        await skadiBoostClient.cancelPostCampaign({
+        await skadiApiClient.cancelPostCampaign({
           postId,
           userId: ctx.userId,
         });

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -881,13 +881,9 @@ export const typeDefs = /* GraphQL */ `
     amount: Int!
   }
 
-  type Reach {
+  type PostBoostEstimate {
     min: Int!
     max: Int!
-  }
-
-  type PostBoostEstimate {
-    estimatedReach: Reach!
   }
 
   type CampaignPost {
@@ -2085,14 +2081,21 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const post = await validatePostBoostPermissions(ctx, postId);
       checkPostAlreadyBoosted(post);
 
-      const { estimatedReach } = await skadiApiClient.estimatePostBoostReach({
+      const { impressions } = await skadiApiClient.estimatePostBoostReach({
         postId,
         userId: ctx.userId,
         duration,
         budget,
       });
 
-      return { estimatedReach };
+      // We do plus-minus 8% of the generated value
+      const difference = impressions * 0.08;
+      const estimatedReach = {
+        min: Math.max(impressions - difference, 0),
+        max: impressions + difference,
+      };
+
+      return estimatedReach;
     },
     postCampaignById: async (
       _,

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ declare global {
       NJORD_ORIGIN: string;
       OPEN_EXCHANGE_RATES_APP_ID?: string;
       SKADI_ORIGIN: string;
+      SKADI_API_ORIGIN: string;
 
       APPLE_APP_APPLE_ID: string;
       APPLE_APP_BUNDLE_ID: string;


### PR DESCRIPTION
After setting up all the integrations, it was mentioned that the URL for the Post Boost feature is going to be different from our current Skadi integration client.

The changes here basically just copy-paste the existing functions and remove the newly unused ones from `SkadiClient` to `SkadiApiClient`.

### Jira ticket
MI-888