### PR TITLE
fix: hide user source from source query

### DIFF
--- a/__tests__/search.ts
+++ b/__tests__/search.ts
@@ -18,6 +18,7 @@ import {
   Feed,
   Keyword,
   Source,
+  SourceUser,
   User,
   UserPost,
 } from '../src/entity';
@@ -703,6 +704,22 @@ describe('query searchSourceSuggestions', () => {
         contentPreference: null,
       },
     ]);
+  });
+
+  it('should not return user source', async () => {
+    loggedUser = '1';
+    await con.getRepository(User).save({ ...usersFixture[1] });
+    await con.getRepository(SourceUser).save({
+      id: loggedUser,
+      name: 'user-source',
+      handle: 'user-source',
+      userId: loggedUser,
+    });
+    const res = await client.query(QUERY('user-source', '2'));
+
+    expect(res.data.searchSourceSuggestions).toBeTruthy();
+    expect(res.data.searchSourceSuggestions.query).toBe('user-source');
+    expect(res.data.searchSourceSuggestions.hits).toHaveLength(0);
   });
 });
 

--- a/src/schema/search.ts
+++ b/src/schema/search.ts
@@ -487,6 +487,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         .createQueryBuilder()
         .select(`id, name as title, handle as subtitle, image`)
         .where(`private = false`)
+        .andWhere('type != :sourceType', {
+          sourceType: SourceType.User,
+        })
         .andWhere(
           `(type != '${SourceType.Squad}' OR (flags->>'publicThreshold')::boolean IS TRUE)`,
         )


### PR DESCRIPTION
We don't need to return the user source in the source query, as it already gets returned via the user query

### Jira ticket
AS-1160