### PR TITLE
fix: hide user source from publicSourceMemberships

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -2126,7 +2126,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           return queryBuilder
             .addOrderBy(`${alias}."createdAt"`, 'DESC')
             .innerJoin(Source, 's', `${alias}."sourceId" = s.id`)
-            .andWhere('s.private = false');
+            .andWhere('s.private = false')
+            .andWhere('s.type != :type', {
+              type: SourceType.User,
+            });
         },
         args,
         ctx,


### PR DESCRIPTION
Filter out the user source from publicSourceMemberships query 

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b372b52d-bd6f-4460-aeb5-92043a2cb6b2">
    <td><img src="https://github.com/user-attachments/assets/20127656-5624-4175-917a-a3b303d8ac50">
  </tr>
</table>