### PR TITLE
fix: empty promoted_posts property

### DIFF
--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -186,7 +186,7 @@ export class SkadiApiClient implements ISkadiApiClient {
       );
 
       return {
-        promotedPosts: response.promoted_posts.map(mapCampaign),
+        promotedPosts: response.promoted_posts?.map(mapCampaign),
         postIds: response.post_ids,
         totalSpend: response.total_spend,
         impressions: response.impressions,

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -186,8 +186,8 @@ export class SkadiApiClient implements ISkadiApiClient {
       );
 
       return {
-        promotedPosts: response.promoted_posts?.map(mapCampaign),
-        postIds: response.post_ids,
+        promotedPosts: response.promoted_posts?.map(mapCampaign) ?? [],
+        postIds: response.post_ids ?? [],
         totalSpend: response.total_spend,
         impressions: response.impressions,
         clicks: response.clicks,


### PR DESCRIPTION
When there are no promoted posts, the value can be null.

### Jira ticket
MI-888