### PR TITLE
fix: get campaign by id

### DIFF
--- a/src/common/post/boost.ts
+++ b/src/common/post/boost.ts
@@ -145,8 +145,9 @@ export const getBoostedPost = async (
   id: string,
 ): Promise<GetBoostedPost> => {
   const builder = getBoostedPostBuilder(con);
-  const bookmarks = getBookmarksCountBuilder(builder).where({ postId: id });
-  const result = await getBoostedPostBuilder(con)
+  const bookmarks =
+    getBookmarksCountBuilder(builder).where(`b."postId" = p1.id`);
+  const result = await builder
     .addSelect(`(${bookmarks.getQuery()})::int`, 'bookmarks')
     .where({ id })
     .getRawOne();

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -151,7 +151,7 @@ export class SkadiApiClient implements ISkadiApiClient {
     userId,
   }: GetCampaignByIdProps): Promise<ObjectSnakeToCamelCase<PromotedPost>> {
     return this.garmr.execute(async () => {
-      const response = await fetchParse<PromotedPost>(
+      const response = await fetchParse<{ promoted_post: PromotedPost }>(
         `${this.url}/promote/post/get`,
         {
           ...this.fetchOptions,
@@ -163,7 +163,7 @@ export class SkadiApiClient implements ISkadiApiClient {
         },
       );
 
-      return mapCampaign(response);
+      return mapCampaign(response.promoted_post);
     });
   }
 


### PR DESCRIPTION
Fixed two things:
- The generated query is malformed due to using shorthand where clause on both sub and main queries.
- The response when fetching the campaign by id is wrapped in an object.