### PR TITLE
feat: reference id on newly created transaction and comments permalink

### DIFF
--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -1661,6 +1661,7 @@ describe('mutation startPostBoost', () => {
     mutation StartPostBoost($postId: ID!, $duration: Int!, $budget: Int!) {
       startPostBoost(postId: $postId, duration: $duration, budget: $budget) {
         transactionId
+        referenceId
         balance {
           amount
         }
@@ -2036,6 +2037,7 @@ describe('mutation startPostBoost', () => {
 
     expect(res.errors).toBeFalsy();
     expect(res.data.startPostBoost.transactionId).toBeDefined();
+    expect(res.data.startPostBoost.referenceId).toBe('mock-campaign-id');
     expect(res.data.startPostBoost.balance.amount).toBe(10000);
 
     // Verify the boosted flag is now set

--- a/src/common/njord.ts
+++ b/src/common/njord.ts
@@ -512,6 +512,7 @@ export type AwardInput = Pick<
 export type TransactionCreated = {
   transactionId: string;
   balance: GetBalanceResult;
+  referenceId?: string;
 };
 
 const canAward = async ({

--- a/src/common/post/boost.ts
+++ b/src/common/post/boost.ts
@@ -99,7 +99,7 @@ interface CampaignBoostedPost
   image: string;
   permalink: string;
   engagements: number;
-  commentsPermalink: string;
+  commentsPermalink?: string;
 }
 
 export interface GQLBoostedPost {
@@ -183,7 +183,7 @@ export const getFormattedBoostedPost = (
     title,
     image: mapCloudinaryUrl(image) ?? pickImageUrl({ createdAt: new Date() }),
     permalink: getPostPermalink({ shortId }),
-    commentsPermalink: getDiscussionLink(post.slug),
+    commentsPermalink: post.slug ? getDiscussionLink(post.slug) : undefined,
     engagements:
       post.bookmarks +
       post.comments +

--- a/src/schema/njord.ts
+++ b/src/schema/njord.ts
@@ -80,6 +80,11 @@ export const typeDefs = /* GraphQL */ `
     Balance of the user
     """
     balance: UserBalance!
+
+    """
+    Reference id of the relevant entity
+    """
+    referenceId: ID
   }
 
   type ProductFlagsPublic {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2739,6 +2739,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           return {
             transfer,
             transaction: {
+              referenceId: campaignId,
               transactionId: userTransaction.id,
               balance: {
                 amount: parseBigInt(transfer.senderBalance!.newBalance),

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2724,6 +2724,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           if (isProd || ctx.isTeamMember) {
             return {
               transaction: {
+                referenceId: campaignId,
                 transactionId: userTransaction.id,
                 balance: { amount: (await getBalance({ userId })).amount },
               },


### PR DESCRIPTION
Two things:
- Returning `referenceId`: to run some optimistic updates on applicable cases.
- Discussion link: We want to utilize the post's discussion link in certain cases, so it must be returned.

### Jira ticket
MI-888