### PR TITLE
feat: return existing post id when brief is generating

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -8340,4 +8340,31 @@ describe('mutation generateBriefing', () => {
       'CONFLICT',
     );
   });
+
+  it('should throw existing post data if briefing is already generating', async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, {
+      variables,
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+
+    const resError = await client.mutate(MUTATION, {
+      variables,
+    });
+
+    expect(resError.errors).toBeTruthy();
+
+    expect(resError.errors?.[0].extensions?.postId).toEqual(
+      res.data.generateBriefing.postId,
+    );
+    expect(resError.errors?.[0].extensions?.createdAt).toEqual(
+      expect.any(String),
+    );
+
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -58,6 +58,7 @@ import {
   notifyView,
   pickImageUrl,
   postScraperOrigin,
+  triggerTypedEvent,
   updateFlagsStatement,
   WATERCOOLER_ID,
 } from '../src/common';
@@ -8366,5 +8367,27 @@ describe('mutation generateBriefing', () => {
     );
 
     expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should start briefing generation if other user brief is generating', async () => {
+    loggedUser = '2';
+
+    const res = await client.mutate(MUTATION, {
+      variables,
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
+
+    loggedUser = '1';
+
+    const res2 = await client.mutate(MUTATION, {
+      variables,
+    });
+
+    expect(res2.errors).toBeFalsy();
+
+    expect(res2.errors).toBeFalsy();
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -132,8 +132,8 @@ export enum SourcePermissionErrorKeys {
 
 // Return 409 HTTP status code
 export class ConflictError extends ApolloError {
-  constructor(message: string) {
-    super(message, 'CONFLICT');
+  constructor(message: string, extensions: Record<string, unknown> = {}) {
+    super(message, 'CONFLICT', extensions);
 
     Object.defineProperty(this, 'name', { value: 'ConflictError' });
   }

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -3182,7 +3182,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         async ({ queryRunner }) => {
           return queryRunner.manager.getRepository(BriefPost).findOne({
             select: ['id', 'createdAt'],
-            where: { visible: false },
+            where: { visible: false, authorId: ctx.userId },
           });
         },
       );

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -3181,14 +3181,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         ctx.con,
         async ({ queryRunner }) => {
           return queryRunner.manager.getRepository(BriefPost).findOne({
-            select: ['id'],
+            select: ['id', 'createdAt'],
             where: { visible: false },
           });
         },
       );
 
       if (pendingBrief) {
-        throw new ConflictError('There is already a briefing being generated');
+        throw new ConflictError('There is already a briefing being generated', {
+          postId: pendingBrief.id,
+          createdAt: pendingBrief.createdAt,
+        });
       }
 
       const postId = await generateShortId();


### PR DESCRIPTION
So we can restart process and show loader again in case of an issue on client.