### PR TITLE
fix: estimated boost reach - reduced params and returning pure int

### DIFF
--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -2278,15 +2278,15 @@ describe('mutation cancelPostBoost', () => {
 
 describe('query boostEstimatedReach', () => {
   const QUERY = `
-    query BoostEstimatedReach($postId: ID!, $duration: Int!, $budget: Int!) {
-      boostEstimatedReach(postId: $postId, duration: $duration, budget: $budget) {
+    query BoostEstimatedReach($postId: ID!) {
+      boostEstimatedReach(postId: $postId) {
         min
         max
       }
     }
   `;
 
-  const params = { postId: 'p1', duration: 7, budget: 5000 };
+  const params = { postId: 'p1' };
 
   beforeEach(async () => {
     isTeamMember = true; // TODO: remove when we are about to run production
@@ -2299,56 +2299,6 @@ describe('query boostEstimatedReach', () => {
       { query: QUERY, variables: params },
       'UNAUTHENTICATED',
     ));
-
-  it('should return an error if duration is less than 1', async () => {
-    loggedUser = '1';
-
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, duration: 0 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
-
-  it('should return an error if duration is greater than 30', async () => {
-    loggedUser = '1';
-
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, duration: 31 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
-
-  it('should return an error if budget is less than 1000', async () => {
-    loggedUser = '1';
-
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, budget: 999 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
-
-  it('should return an error if budget is greater than 100000', async () => {
-    loggedUser = '1';
-
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, budget: 100001 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
-
-  it('should return an error if budget is not divisible by 1000', async () => {
-    loggedUser = '1';
-
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, budget: 1500 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
-  });
 
   it('should return an error if post does not exist', async () => {
     loggedUser = '1';
@@ -2387,7 +2337,7 @@ describe('query boostEstimatedReach', () => {
     );
   });
 
-  it('should the response returned by skadi client', async () => {
+  it('should return the response returned by skadi client', async () => {
     loggedUser = '1';
 
     // Mock the skadi client to return impressions
@@ -2398,21 +2348,19 @@ describe('query boostEstimatedReach', () => {
     });
 
     const res = await client.query(QUERY, {
-      variables: { ...params, duration: 1, budget: 1000 },
+      variables: params,
     });
 
     expect(res.errors).toBeFalsy();
     expect(res.data.boostEstimatedReach).toEqual({
-      max: 108, // 100 + (100 * 0.08) = 108
-      min: 92, // 100 - (100 * 0.08) = 92
+      max: 108, // 100 + Math.floor(100 * 0.08) = 100 + 8 = 108
+      min: 92, // 100 - Math.floor(100 * 0.08) = 100 - 8 = 92
     });
 
     // Verify the skadi client was called with correct parameters
     expect(skadiApiClient.estimatePostBoostReach).toHaveBeenCalledWith({
       postId: 'p1',
       userId: '1',
-      durationInDays: 1,
-      budget: 1000,
     });
   });
 });

--- a/src/integrations/skadi/api/clients.ts
+++ b/src/integrations/skadi/api/clients.ts
@@ -112,13 +112,9 @@ export class SkadiApiClient implements ISkadiApiClient {
   estimatePostBoostReach({
     postId,
     userId,
-    durationInDays,
-    budget,
   }: {
     postId: string;
     userId: string;
-    durationInDays: number;
-    budget: number;
   }): Promise<ObjectSnakeToCamelCase<PostEstimatedReach>> {
     return this.garmr.execute(async () => {
       const response = await fetchParse<PostEstimatedReach>(
@@ -132,8 +128,6 @@ export class SkadiApiClient implements ISkadiApiClient {
           body: JSON.stringify({
             post_id: postId,
             user_id: userId,
-            duration: durationInDays * ONE_DAY_IN_SECONDS,
-            budget,
           }),
         },
       );

--- a/src/integrations/skadi/api/types.ts
+++ b/src/integrations/skadi/api/types.ts
@@ -72,8 +72,6 @@ export interface ISkadiApiClient {
   estimatePostBoostReach(params: {
     postId: string;
     userId: string;
-    durationInDays: number;
-    budget: number;
   }): Promise<ObjectSnakeToCamelCase<PostEstimatedReach>>;
   getCampaignById: (
     params: GetCampaignByIdProps,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1124,7 +1124,6 @@ export const typeDefs = /* GraphQL */ `
       ID of the post to boost
       """
       postId: ID!
-      """
     ): PostBoostEstimate! @auth
 
     postCampaignById(

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1125,13 +1125,6 @@ export const typeDefs = /* GraphQL */ `
       """
       postId: ID!
       """
-      Duration of the boost in days (1-30)
-      """
-      duration: Int!
-      """
-      Budget for the boost in cores (1000-100000, must be divisible by 1000)
-      """
-      budget: Int!
     ): PostBoostEstimate! @auth
 
     postCampaignById(
@@ -2138,33 +2131,26 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
     },
     boostEstimatedReach: async (
       _,
-      args: Omit<StartPostBoostArgs, 'userId'>,
+      args: { postId: string },
       ctx: AuthContext,
     ): Promise<PostBoostReach> => {
-      const { postId, duration, budget } = args;
-      validatePostBoostArgs(args);
+      const { postId } = args;
       const post = await validatePostBoostPermissions(ctx, postId);
       checkPostAlreadyBoosted(post);
 
       const { impressions } = await skadiApiClient.estimatePostBoostReach({
         postId,
         userId: ctx.userId,
-        durationInDays: duration,
-        budget,
       });
 
-      try {
-        // We do plus-minus 8% of the generated value
-        const difference = impressions * 0.08;
-        const estimatedReach = {
-          min: Math.max(impressions - difference, 0),
-          max: impressions + difference,
-        };
+      // We do plus-minus 8% of the generated value
+      const difference = Math.floor(impressions * 0.08);
+      const estimatedReach = {
+        min: Math.max(impressions - difference, 0),
+        max: impressions + difference,
+      };
 
-        return estimatedReach;
-      } catch (err) {
-        throw new ValidationError('Unable to generate reach: ' + err);
-      }
+      return estimatedReach;
     },
     postCampaignById: async (
       _,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2153,14 +2153,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         budget,
       });
 
-      // // We do plus-minus 8% of the generated value
-      // const difference = impressions * 0.08;
-      // const estimatedReach = {
-      //   min: Math.max(impressions - difference, 0),
-      //   max: impressions + difference,
-      // };
+      try {
+        // We do plus-minus 8% of the generated value
+        const difference = impressions * 0.08;
+        const estimatedReach = {
+          min: Math.max(impressions - difference, 0),
+          max: impressions + difference,
+        };
 
-      return { min: impressions, max: impressions };
+        return estimatedReach;
+      } catch (err) {
+        throw new ValidationError('Unable to generate reach: ' + err);
+      }
     },
     postCampaignById: async (
       _,


### PR DESCRIPTION
This was the source of the issue. However, we want to know more about it by wrapping it in a try-catch instead.

Only thing I can think of where this can break was if the `impressions` is actually a string. We'll find out.