### PR TITLE
feat: check brief updated time before generation

### DIFF
--- a/__tests__/cron/personalizedDigest.ts
+++ b/__tests__/cron/personalizedDigest.ts
@@ -6,6 +6,7 @@ import {
   User,
   UserPersonalizedDigest,
   UserPersonalizedDigestSendType,
+  UserPersonalizedDigestType,
 } from '../../src/entity';
 import { usersFixture } from '../fixture/user';
 import {
@@ -17,6 +18,7 @@ import { format, setHours, startOfHour } from 'date-fns';
 import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import { crons } from '../../src/cron/index';
 import { logger } from '../../src/logger';
+import { briefFeedClient } from '../../src/common/brief';
 
 let con: DataSource;
 
@@ -398,5 +400,112 @@ describe('personalizedDigest cron', () => {
         );
       },
     );
+  });
+
+  it('should not schedule generation for brief if brief feed is not updated', async () => {
+    const { fakePreferredDay, fakePreferredHour } = fakeSendDate(
+      new Date('2024-09-11T10:32:42.680Z'),
+      9,
+    );
+
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay: fakePreferredDay,
+        preferredHour: fakePreferredHour,
+        type: UserPersonalizedDigestType.Brief,
+        flags: {
+          sendType,
+        },
+        lastSendDate: new Date('2024-09-10T10:32:42.680Z'),
+      })),
+    );
+
+    jest.spyOn(briefFeedClient, 'getBriefLastUpdate').mockResolvedValue({
+      updatedAt: new Date('2024-09-10T06:00:42.680Z'),
+    });
+
+    const errorSpy = jest.spyOn(logger, 'error');
+
+    await expectSuccessfulCron(cron);
+
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(0);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      {
+        briefingUptime: { updatedAt: new Date('2024-09-10T06:00:42.680Z') },
+        personalizedDigest: expect.objectContaining({
+          userId: expect.any(String),
+          type: UserPersonalizedDigestType.Brief,
+          lastSendDate: new Date('2024-09-10T10:32:42.680Z'),
+        }),
+        emailSendTimestamp: expect.any(Number),
+        previousSendTimestamp: expect.any(Number),
+        emailBatchId: expect.any(String),
+      },
+      'Brief generation skipped, outdated',
+    );
+  });
+
+  it('should schedule generation for brief if brief feed is updated', async () => {
+    const { fakePreferredDay, fakePreferredHour } = fakeSendDate(
+      new Date('2024-09-11T10:32:42.680Z'),
+      9,
+    );
+
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay: fakePreferredDay,
+        preferredHour: fakePreferredHour,
+        type: UserPersonalizedDigestType.Brief,
+        flags: {
+          sendType,
+        },
+        lastSendDate: new Date('2024-09-10T10:32:42.680Z'),
+      })),
+    );
+
+    jest.spyOn(briefFeedClient, 'getBriefLastUpdate').mockResolvedValue({
+      updatedAt: new Date('2024-09-11T06:00:42.680Z'),
+    });
+
+    await expectSuccessfulCron(cron);
+
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(4);
+  });
+
+  it('should schedule generation for other digest if brief feed is not updated', async () => {
+    const { fakePreferredDay, fakePreferredHour } = fakeSendDate(
+      new Date('2024-09-11T10:32:42.680Z'),
+      9,
+    );
+
+    const usersToSchedule = usersFixture;
+
+    await con.getRepository(UserPersonalizedDigest).save(
+      usersToSchedule.map((item) => ({
+        userId: item.id,
+        preferredDay: fakePreferredDay,
+        preferredHour: fakePreferredHour,
+        type: UserPersonalizedDigestType.Digest,
+        flags: {
+          sendType,
+        },
+        lastSendDate: new Date('2024-09-10T10:32:42.680Z'),
+      })),
+    );
+
+    jest.spyOn(briefFeedClient, 'getBriefLastUpdate').mockResolvedValue({
+      updatedAt: new Date('2024-09-10T06:00:42.680Z'),
+    });
+
+    await expectSuccessfulCron(cron);
+
+    expect(notifyGeneratePersonalizedDigest).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/common/brief.ts
+++ b/src/common/brief.ts
@@ -1,0 +1,21 @@
+import { FeedClient } from '../integrations/feed/clients';
+import { GarmrService } from '../integrations/garmr';
+
+export const briefFeedClient = new FeedClient(process.env.BRIEFING_FEED, {
+  garmr: new GarmrService({
+    service: 'feed-client-generate-brief',
+    breakerOpts: {
+      halfOpenAfter: 5 * 1000,
+      threshold: 0.1,
+      duration: 10 * 1000,
+      minimumRps: 1,
+    },
+    limits: {
+      maxRequests: 150,
+      queuedRequests: 100,
+    },
+    retryOpts: {
+      maxAttempts: 0,
+    },
+  }),
+});

--- a/src/cron/personalizedDigest.ts
+++ b/src/cron/personalizedDigest.ts
@@ -15,6 +15,7 @@ import {
 } from '../entity';
 import { Cron } from './cron';
 import { Brackets } from 'typeorm';
+import { briefFeedClient } from '../common/brief';
 
 const sendType = UserPersonalizedDigestSendType.weekly;
 const digestTypes = [
@@ -61,6 +62,8 @@ const cron: Cron = {
     // Make sure digest is sent at the beginning of the hour
     const timestamp = startOfHour(new Date());
 
+    const briefingUptime = await briefFeedClient.getBriefLastUpdate();
+
     await schedulePersonalizedDigestSubscriptions({
       queryBuilder: personalizedDigestQuery,
       logger,
@@ -80,6 +83,24 @@ const cron: Cron = {
           generationTimestamp: timestamp.getTime(),
           timezone: timezone,
         }).getTime();
+
+        if (
+          personalizedDigest.type === UserPersonalizedDigestType.Brief &&
+          briefingUptime.updatedAt < personalizedDigest.lastSendDate
+        ) {
+          logger.error(
+            {
+              briefingUptime,
+              personalizedDigest,
+              emailSendTimestamp,
+              previousSendTimestamp,
+              emailBatchId,
+            },
+            'Brief generation skipped, outdated',
+          );
+
+          return;
+        }
 
         await notifyGeneratePersonalizedDigest({
           log: logger,

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -95,4 +95,26 @@ export class FeedClient implements IFeedClient, IGarmrClient {
 
     return Briefing.fromJson(result);
   }
+
+  async getBriefLastUpdate(): Promise<{ updatedAt: Date }> {
+    const result = await this.garmr.execute(() => {
+      return fetchParse<{ last_update_time: string }>(
+        `${this.url}/api/briefing/last-update-time`,
+        {
+          ...this.fetchOptions,
+          method: 'GET',
+        },
+      );
+    });
+
+    const updatedAt = new Date(result.last_update_time);
+
+    if (Number.isNaN(updatedAt.getTime())) {
+      throw new Error('Invalid last update time');
+    }
+
+    return {
+      updatedAt,
+    };
+  }
 }


### PR DESCRIPTION
- fetch brief generation time before scheduling briefs
- check with each brief (digest) `lastUpdatedAt`
- log error which we can use for alerting