### PR TITLE
fix: allow connecting multiple briefing sources on same org

### DIFF
--- a/src/schema/integrations.ts
+++ b/src/schema/integrations.ts
@@ -31,7 +31,7 @@ import {
   GQLSource,
   SourcePermissions,
 } from './sources';
-import { SourceMember, SourceType } from '../entity';
+import { BRIEFING_SOURCE, SourceMember, SourceType } from '../entity';
 import { Connection, ConnectionArguments } from 'graphql-relay';
 import {
   GQLDatePageGeneratorConfig,
@@ -367,13 +367,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         ? await existingSourceIntegration.userIntegration
         : undefined;
 
-      if (
-        existingSourceIntegration &&
-        existingSourceIntegration.userIntegrationId !== slackIntegration.id &&
-        existingUserIntegration &&
-        existingUserIntegration.userId !== slackIntegration.userId
-      ) {
-        throw new ConflictError('source already connected to a channel');
+      // we allow connecting multiple times only for briefing source for now
+      if (args.sourceId !== BRIEFING_SOURCE) {
+        if (
+          existingSourceIntegration &&
+          existingSourceIntegration.userIntegrationId !== slackIntegration.id &&
+          existingUserIntegration &&
+          existingUserIntegration.userId !== slackIntegration.userId
+        ) {
+          throw new ConflictError('source already connected to a channel');
+        }
       }
 
       const client = await getSlackClient({


### PR DESCRIPTION
If users from same organization try to connect briefing it will fail due to existing restriction of one integration per source (that we apply for squads). For now I just ignore this for briefing source, if we add more sources for slack we can move this to more reusable logic.