### PR TITLE
fix: filter out unread posts for same author

### DIFF
--- a/src/workers/postAddedSquadUnreadPosts.ts
+++ b/src/workers/postAddedSquadUnreadPosts.ts
@@ -35,7 +35,8 @@ export const postAddedSquadUnreadPostsWorker: TypedWorker<'api.v1.post-visible'>
           .where('sm.sourceId = :sourceId', { sourceId: source.id })
           .andWhere(
             `COALESCE((sm.flags->>'hasUnreadPosts')::boolean, false) != true`,
-          );
+          )
+          .andWhere(`sm.userId != :authorId`, { authorId: data.post.authorId });
 
         const stream = await query.stream();
 


### PR DESCRIPTION
When there is a new unread post in a squad, we can filter out the author of the post.