### PR TITLE
fix: ensure user source is created in the sharePost mutation

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2987,6 +2987,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
       info,
     ): Promise<GQLPost> => {
+      if (sourceId === ctx.userId) {
+        await ensureUserSourceExists(ctx.userId, ctx.con);
+      }
+
       const [post] = await Promise.all([
         ctx.con
           .createQueryBuilder()


### PR DESCRIPTION
Missed doing the "polyfill" in the `sharePost` mutation.

https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1754424084071199