### PR TITLE
feat: make brief public

### DIFF
--- a/__tests__/workers/brief/userGenerateBrief.ts
+++ b/__tests__/workers/brief/userGenerateBrief.ts
@@ -183,6 +183,7 @@ describe('userGenerateBrief worker', () => {
     });
 
     expect(briefPost).toBeDefined();
+    expect(briefPost!.private).toBe(false);
     expect(briefPost!.visible).toBe(true);
     expect(briefPost!.content).toBe(`## Must know
 

--- a/src/workers/brief/userGenerateBrief.ts
+++ b/src/workers/brief/userGenerateBrief.ts
@@ -138,6 +138,7 @@ export const userGenerateBriefWorker: TypedWorker<'api.v1.brief-generate'> = {
         },
         collectionSources: brief.sourceIds || [],
         contentJSON: brief.sections.map((section) => section.toJson()),
+        private: false,
       });
       post.visible = getPostVisible({ post });
 


### PR DESCRIPTION
To make brief shareable we decided to make them public since there's no private/personal info there