### PR TITLE
fix: prevent briefs notifications

### DIFF
--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -31,6 +31,8 @@ interface Data {
   post: ChangeObject<Post>;
 }
 
+const blockedTypes = Object.freeze([PostType.Welcome, PostType.Brief]);
+
 const worker: NotificationWorker = {
   subscription: 'api.post-added-notification-v2',
   handler: async (message, con) => {
@@ -41,7 +43,7 @@ const worker: NotificationWorker = {
     }
     const { post, source } = baseCtx;
 
-    if (post.type === PostType.Welcome) {
+    if (blockedTypes.includes(post.type)) {
       return;
     }
 


### PR DESCRIPTION
Now that briefs are public users receive notifications with new briefs from users they follow, the user itself gets a notification that their article is listed, etc. This is now prevented