### PR TITLE
fix: do not send brief notifications from followed users

### DIFF
--- a/src/workers/notifications/postAddedUserNotification.ts
+++ b/src/workers/notifications/postAddedUserNotification.ts
@@ -16,17 +16,23 @@ import {
 import { counters } from '../../telemetry/metrics';
 import { processStream } from '../../common/streaming';
 import { buildPostContext } from './utils';
-import { Post } from '../../entity/posts/Post';
+import { Post, PostType } from '../../entity/posts/Post';
 import { NotificationPreferenceUser } from '../../entity';
 import { Brackets } from 'typeorm';
 
 const sendQueueConcurrency = 10;
+
+const skippedTypes = Object.freeze([PostType.Brief]);
 
 export const postAddedUserNotification =
   generateTypedNotificationWorker<'api.v1.post-visible'>({
     subscription: 'api.post-added-user-notification',
     handler: async (data, con) => {
       if (data.post.private) {
+        return;
+      }
+
+      if (skippedTypes.includes(data.post.type)) {
         return;
       }
 


### PR DESCRIPTION
I am still getting notifications for briefs of other users even after https://github.com/dailydotdev/daily-api/pull/2967