### PR TITLE
fix: syncSubscriptions should no longer malform notificationFlags on user

### DIFF
--- a/__tests__/common/mailing.ts
+++ b/__tests__/common/mailing.ts
@@ -11,6 +11,14 @@ import {
 import { usersFixture } from '../fixture/user';
 import { syncSubscription, updateFlagsStatement } from '../../src/common';
 import { CioUnsubscribeTopic } from '../../src/cio';
+import * as cio from '../../src/cio';
+import {
+  NotificationType,
+  DEFAULT_NOTIFICATION_SETTINGS,
+  NotificationPreferenceStatus,
+} from '../../src/notifications/common';
+import type { UserNotificationFlags } from '../../src/entity/user/User';
+import { logger } from '../../src/logger';
 
 let con: DataSource;
 
@@ -182,6 +190,263 @@ describe('mailing', () => {
         expect(user.followingEmail).toBe(false);
         expect(user.awardEmail).toBe(false);
       });
+    });
+
+    it('should preserve user-customized notification flags during CIO sync', async () => {
+      const customNotificationFlags: UserNotificationFlags = {
+        ...DEFAULT_NOTIFICATION_SETTINGS,
+        [NotificationType.ArticleNewComment]: {
+          email: NotificationPreferenceStatus.Subscribed,
+          inApp: NotificationPreferenceStatus.Muted,
+        },
+        [NotificationType.CommentReply]: {
+          email: NotificationPreferenceStatus.Muted,
+          inApp: NotificationPreferenceStatus.Subscribed,
+        },
+        [NotificationType.UserReceivedAward]: {
+          email: NotificationPreferenceStatus.Subscribed,
+          inApp: NotificationPreferenceStatus.Muted,
+        },
+        [NotificationType.DevCardUnlocked]: {
+          email: NotificationPreferenceStatus.Muted,
+          inApp: NotificationPreferenceStatus.Muted,
+        },
+      };
+
+      const testUserIds = usersFixture.map((user) => `mss-${user.id}`);
+      await con
+        .getRepository(User)
+        .update(
+          { id: In(testUserIds) },
+          { notificationFlags: customNotificationFlags },
+        );
+
+      let users = await con.getRepository(User).find({
+        where: { id: In(testUserIds) },
+        select: ['id', 'notificationFlags'],
+      });
+
+      nock(`https://api.customer.io`)
+        .post('/v1/customers/attributes', {
+          ids: testUserIds,
+        })
+        .reply(200, {
+          customers: users.map((user) => ({
+            id: user.id,
+            attributes: {
+              cio_subscription_preferences: JSON.stringify({
+                topics: {
+                  [`topic_${CioUnsubscribeTopic.CommentsOnPost}`]: false, // article_new_comment email -> muted
+                  [`topic_${CioUnsubscribeTopic.CommentReply}`]: true, // comment_reply email -> subscribed
+                  [`topic_${CioUnsubscribeTopic.UserReceivedAward}`]: false, // user_received_award email -> muted
+                  [`topic_${CioUnsubscribeTopic.Marketing}`]: true,
+                  [`topic_${CioUnsubscribeTopic.Digest}`]: true,
+                  [`topic_${CioUnsubscribeTopic.Notifications}`]: true,
+                  [`topic_${CioUnsubscribeTopic.Follow}`]: true,
+                  [`topic_${CioUnsubscribeTopic.Award}`]: true,
+                },
+              }),
+            },
+            unsubscribed: false,
+          })),
+        });
+
+      await syncSubscription(testUserIds, con);
+
+      users = await con.getRepository(User).find({
+        where: { id: In(testUserIds) },
+        select: ['id', 'notificationFlags'],
+        order: { id: 'ASC' },
+      });
+
+      users.forEach((user) => {
+        const flags = user.notificationFlags;
+
+        expect(flags[NotificationType.ArticleNewComment].email).toBe(
+          NotificationPreferenceStatus.Muted,
+        );
+        expect(flags[NotificationType.CommentReply].email).toBe(
+          NotificationPreferenceStatus.Subscribed,
+        );
+        expect(flags[NotificationType.UserReceivedAward].email).toBe(
+          NotificationPreferenceStatus.Muted,
+        );
+
+        expect(flags[NotificationType.ArticleNewComment].inApp).toBe(
+          NotificationPreferenceStatus.Muted,
+        );
+        expect(flags[NotificationType.CommentReply].inApp).toBe(
+          NotificationPreferenceStatus.Subscribed,
+        );
+        expect(flags[NotificationType.UserReceivedAward].inApp).toBe(
+          NotificationPreferenceStatus.Muted,
+        );
+
+        expect(flags[NotificationType.DevCardUnlocked]).toEqual({
+          email: NotificationPreferenceStatus.Muted,
+          inApp: NotificationPreferenceStatus.Muted,
+        });
+
+        // All notification types should have both email and inApp properties.
+        Object.entries(flags).forEach(([, preferences]) => {
+          expect(preferences).toHaveProperty('email');
+          expect(preferences).toHaveProperty('inApp');
+          expect([
+            NotificationPreferenceStatus.Muted,
+            NotificationPreferenceStatus.Subscribed,
+          ]).toContain(preferences.email);
+          expect([
+            NotificationPreferenceStatus.Muted,
+            NotificationPreferenceStatus.Subscribed,
+          ]).toContain(preferences.inApp);
+        });
+      });
+    });
+
+    it('should handle validation failures gracefully during CIO sync', async () => {
+      const testUserId = `mss-${usersFixture[0].id}`;
+      await con.getRepository(User).update(
+        { id: testUserId },
+        {
+          notificationFlags: DEFAULT_NOTIFICATION_SETTINGS,
+          acceptedMarketing: false,
+          notificationEmail: false,
+        },
+      );
+
+      const loggerSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      const mockGetCioTopicsToNotificationFlags = jest
+        .spyOn(cio, 'getCioTopicsToNotificationFlags')
+        .mockReturnValue({
+          // Return invalid data that will fail Zod validation
+          [NotificationType.ArticleNewComment]: {
+            email: 'muted',
+            // Missing inApp field
+          },
+          // Missing other required notification types
+        });
+
+      nock(`https://api.customer.io`)
+        .post('/v1/customers/attributes', {
+          ids: [testUserId],
+        })
+        .reply(200, {
+          customers: [
+            {
+              id: testUserId,
+              attributes: {
+                cio_subscription_preferences: JSON.stringify({
+                  topics: {
+                    [`topic_${CioUnsubscribeTopic.CommentsOnPost}`]: false,
+                  },
+                }),
+              },
+              unsubscribed: false,
+            },
+          ],
+        });
+
+      await syncSubscription([testUserId], con);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: testUserId,
+          errors: expect.any(Array),
+          flags: expect.any(Object),
+        }),
+        'Failed to validate merged notification flags from CIO sync, skipping notification flags update',
+      );
+
+      const user = await con.getRepository(User).findOne({
+        where: { id: testUserId },
+        select: ['notificationFlags', 'acceptedMarketing', 'notificationEmail'],
+      });
+
+      // notificationFlags should remain unchanged due to validation failure
+      expect(user.notificationFlags).toEqual(DEFAULT_NOTIFICATION_SETTINGS);
+
+      expect(user.acceptedMarketing).toBe(true); // Updated from CIO
+      expect(user.notificationEmail).toBe(true); // Updated from CIO
+
+      mockGetCioTopicsToNotificationFlags.mockRestore();
+      loggerSpy.mockRestore();
+    });
+
+    it('should handle users with incomplete notification flags during CIO sync', async () => {
+      const incompleteFlags: Partial<UserNotificationFlags> = {
+        [NotificationType.ArticleNewComment]: {
+          email: NotificationPreferenceStatus.Subscribed,
+          inApp: NotificationPreferenceStatus.Subscribed,
+        },
+        [NotificationType.CommentReply]: {
+          email: NotificationPreferenceStatus.Muted,
+          inApp: NotificationPreferenceStatus.Subscribed,
+        },
+        // Missing many other notification types that exist in DEFAULT_NOTIFICATION_SETTINGS
+      };
+
+      const testUserId = `mss-${usersFixture[0].id}`;
+      await con
+        .getRepository(User)
+        .update(
+          { id: testUserId },
+          { notificationFlags: incompleteFlags as UserNotificationFlags },
+        );
+
+      nock(`https://api.customer.io`)
+        .post('/v1/customers/attributes', {
+          ids: [testUserId],
+        })
+        .reply(200, {
+          customers: [
+            {
+              id: testUserId,
+              attributes: {
+                cio_subscription_preferences: JSON.stringify({
+                  topics: {
+                    [`topic_${CioUnsubscribeTopic.CommentsOnPost}`]: false,
+                    [`topic_${CioUnsubscribeTopic.CommentReply}`]: true,
+                    [`topic_${CioUnsubscribeTopic.UserReceivedAward}`]: false,
+                  },
+                }),
+              },
+              unsubscribed: false,
+            },
+          ],
+        });
+
+      await syncSubscription([testUserId], con);
+
+      const user = await con.getRepository(User).findOne({
+        where: { id: testUserId },
+        select: ['notificationFlags'],
+      });
+
+      const flags = user.notificationFlags;
+
+      expect(flags[NotificationType.ArticleNewComment].email).toBe(
+        NotificationPreferenceStatus.Muted,
+      );
+      expect(flags[NotificationType.ArticleNewComment].inApp).toBe(
+        NotificationPreferenceStatus.Subscribed,
+      );
+      expect(flags[NotificationType.CommentReply].email).toBe(
+        NotificationPreferenceStatus.Subscribed,
+      );
+      expect(flags[NotificationType.CommentReply].inApp).toBe(
+        NotificationPreferenceStatus.Subscribed,
+      );
+
+      expect(flags[NotificationType.UserReceivedAward]).toEqual({
+        email: NotificationPreferenceStatus.Muted,
+        inApp: NotificationPreferenceStatus.Subscribed,
+      });
+
+      expect(Object.keys(flags).length).toBeGreaterThan(2);
+      expect(flags).toHaveProperty(NotificationType.ArticleNewComment);
+      expect(flags).toHaveProperty(NotificationType.CommentReply);
+      expect(flags).toHaveProperty(NotificationType.UserReceivedAward);
     });
   });
 });

--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -18,6 +18,7 @@ import createOrGetConnection from '../src/db';
 import { DisallowHandle } from '../src/entity/DisallowHandle';
 import { DayOfWeek } from '../src/common';
 import { ContentLanguage, CoresRole } from '../src/types';
+import { DEFAULT_NOTIFICATION_SETTINGS } from '../src/notifications/common';
 import { postsFixture } from './fixture/post';
 import { DeletedUser } from '../src/entity/user/DeletedUser';
 import { getGeo } from '../src/common/geo';
@@ -293,6 +294,7 @@ describe('POST /p/newUser', () => {
     expect(users[0].email).toEqual(usersFixture[0].email);
     expect(users[0].infoConfirmed).toBeTruthy();
     expect(users[0].createdAt).not.toBeNull();
+    expect(users[0].notificationFlags).toEqual(DEFAULT_NOTIFICATION_SETTINGS);
   });
 
   it('should allow underscore in username', async () => {

--- a/src/cio.ts
+++ b/src/cio.ts
@@ -182,10 +182,15 @@ export const getNotificationFlagsCioTopics = (
   return result;
 };
 
-export const getCioTopicsToNotificationFlags = (subscriptionPreferences: {
-  topics?: Record<string, boolean>;
-}): User['notificationFlags'] => {
-  const notificationFlags: User['notificationFlags'] = {};
+export const getCioTopicsToNotificationFlags = (
+  subscriptionPreferences: {
+    topics?: Record<string, boolean>;
+  },
+  existingNotificationFlags: User['notificationFlags'] = {},
+): User['notificationFlags'] => {
+  const mergedNotificationFlags: User['notificationFlags'] = {
+    ...existingNotificationFlags,
+  };
 
   const isSubscribed = (topicId: string): NotificationPreferenceStatus =>
     subscriptionPreferences?.topics?.[`topic_${topicId}`] === false
@@ -194,13 +199,15 @@ export const getCioTopicsToNotificationFlags = (subscriptionPreferences: {
 
   Object.entries(CIO_TOPIC_TO_NOTIFICATION_MAP).forEach(
     ([topicId, notificationType]) => {
-      notificationFlags[notificationType] = {
+      mergedNotificationFlags[notificationType] = {
+        ...mergedNotificationFlags[notificationType],
+        // CIO is only email, so we don't touch inApp
         email: isSubscribed(topicId),
       };
     },
   );
 
-  return notificationFlags;
+  return mergedNotificationFlags;
 };
 
 export const getIdentifyAttributes = async (

--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -1,5 +1,6 @@
 import z from 'zod';
 import { NotificationType } from '../../notifications/common';
+import { UserPersonalizedDigestType } from '../../entity/user/UserPersonalizedDigest';
 
 const notificationPreferenceSchema = z.object({
   email: z.enum(['muted', 'subscribed']),
@@ -16,7 +17,7 @@ export const notificationFlagsSchema = z
     [NotificationType.CommentMention]: notificationPreferenceSchema,
     [NotificationType.ArticleReportApproved]: notificationPreferenceSchema,
     [NotificationType.StreakResetRestore]: notificationPreferenceSchema,
-    ['streak_reminder']: notificationPreferenceSchema,
+    [UserPersonalizedDigestType.StreakReminder]: notificationPreferenceSchema,
     [NotificationType.UserTopReaderBadge]: notificationPreferenceSchema,
     [NotificationType.DevCardUnlocked]: notificationPreferenceSchema,
     [NotificationType.SourcePostAdded]: notificationPreferenceSchema,

--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -1,5 +1,4 @@
 import z from 'zod';
-import { UserPersonalizedDigestType } from '../../entity';
 import { NotificationType } from '../../notifications/common';
 
 const notificationPreferenceSchema = z.object({
@@ -17,7 +16,7 @@ export const notificationFlagsSchema = z
     [NotificationType.CommentMention]: notificationPreferenceSchema,
     [NotificationType.ArticleReportApproved]: notificationPreferenceSchema,
     [NotificationType.StreakResetRestore]: notificationPreferenceSchema,
-    [UserPersonalizedDigestType.StreakReminder]: notificationPreferenceSchema,
+    ['streak_reminder']: notificationPreferenceSchema,
     [NotificationType.UserTopReaderBadge]: notificationPreferenceSchema,
     [NotificationType.DevCardUnlocked]: notificationPreferenceSchema,
     [NotificationType.SourcePostAdded]: notificationPreferenceSchema,

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -50,6 +50,7 @@ import {
   TargetType,
 } from '../../integrations/analytics';
 import { paddleInstance } from '../../common/paddle';
+import { DEFAULT_NOTIFICATION_SETTINGS } from '../../notifications/common';
 
 export type AddUserData = Pick<
   User,
@@ -360,6 +361,7 @@ export const addNewUser = async (
       twitter: data.twitter,
       experienceLevel: data.experienceLevel,
       language: data.language,
+      notificationFlags: DEFAULT_NOTIFICATION_SETTINGS,
       flags: {
         trustScore: 1,
         vordr: false,


### PR DESCRIPTION
* updated syncSubscriptions to preserve existing flags
* If we add new flags, syncSubscription should still pass because we spread them
* while not strictly necessary, added the default flags on user creation
* added some tests to ensure desired behavior when syncing