### PR TITLE
fix: add content type metadata to blob

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -6849,6 +6849,7 @@ describe('mutation uploadResume', () => {
     expect(uploadResumeFromBuffer).toHaveBeenCalledWith(
       loggedUser,
       expect.any(Object),
+      { contentType: 'application/pdf' },
     );
   });
 
@@ -6890,6 +6891,10 @@ describe('mutation uploadResume', () => {
     expect(uploadResumeFromBuffer).toHaveBeenCalledWith(
       loggedUser,
       expect.any(Object),
+      {
+        contentType:
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      },
     );
   });
 

--- a/src/common/googleCloud.ts
+++ b/src/common/googleCloud.ts
@@ -1,4 +1,9 @@
-import { Bucket, DownloadOptions, Storage } from '@google-cloud/storage';
+import {
+  Bucket,
+  DownloadOptions,
+  Storage,
+  type SaveOptions,
+} from '@google-cloud/storage';
 import { acceptedResumeExtensions, PropsParameters } from '../types';
 import path from 'path';
 import { BigQuery } from '@google-cloud/bigquery';
@@ -40,27 +45,31 @@ interface UploadFileFromStreamParams {
   bucketName: string;
   fileName: string;
   file: Buffer;
+  options?: SaveOptions;
 }
 
 export const uploadFileFromBuffer = async ({
   bucketName,
   fileName,
   file,
+  options,
 }: UploadFileFromStreamParams): Promise<string> => {
   const storage = new Storage();
-  await storage.bucket(bucketName).file(fileName).save(file);
+  await storage.bucket(bucketName).file(fileName).save(file, options);
   return `https://storage.cloud.google.com/${bucketName}/${fileName}`;
 };
 
 export const uploadResumeFromBuffer = async (
   fileName: string,
   file: Buffer,
+  options?: SaveOptions,
   bucketName = RESUMES_BUCKET_NAME,
 ): Promise<string> => {
   return uploadFileFromBuffer({
     bucketName,
     fileName,
     file,
+    options,
   });
 };
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -2529,7 +2529,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       // Actual upload using buffer as a stream
       const filename = ctx.userId;
-      await uploadResumeFromBuffer(filename, buffer);
+      await uploadResumeFromBuffer(filename, buffer, {
+        contentType: fileType?.mime,
+      });
 
       return { _: true };
     },


### PR DESCRIPTION
I assumed that GCS automagically detected the content type on uploaded blobs, but it does not. so added the content type to blob metadata during upload.

### Jira ticket
AS-1177