### PR TITLE
feat: brief notification settings

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -4653,9 +4653,7 @@ describe('query personalizedDigest', () => {
       personalizedDigest {
         type
         flags {
-          email
           sendType
-          slack
         }
       }
   }`;
@@ -4675,8 +4673,6 @@ describe('query personalizedDigest', () => {
         type: UserPersonalizedDigestType.Digest,
         flags: {
           sendType: UserPersonalizedDigestSendType.workdays,
-          email: true,
-          slack: true,
         },
       });
 
@@ -4686,8 +4682,6 @@ describe('query personalizedDigest', () => {
       expect(res.data.personalizedDigest.length).toEqual(1);
       expect(res.data.personalizedDigest[0].flags).toEqual({
         sendType: UserPersonalizedDigestSendType.workdays,
-        email: true,
-        slack: true,
       });
     });
 
@@ -4698,8 +4692,6 @@ describe('query personalizedDigest', () => {
       expect(res.data.personalizedDigest.length).toEqual(1);
       expect(res.data.personalizedDigest[0].flags).toEqual({
         sendType: UserPersonalizedDigestSendType.weekly,
-        email: null,
-        slack: null,
       });
     });
   });

--- a/__tests__/workers/newNotificationV2Mail.ts
+++ b/__tests__/workers/newNotificationV2Mail.ts
@@ -8,7 +8,6 @@ import {
   formatMailDate,
   notificationsLink,
   sendEmail,
-  updateFlagsStatement,
 } from '../../src/common';
 import worker, {
   notificationToTemplateId,
@@ -1375,21 +1374,46 @@ it('should not invoke squad_blocked email', async () => {
 it('should not send brief email notification if the user prefers not to receive them', async () => {
   const userId = '1';
 
+  const briefPost = await con.getRepository(BriefPost).save({
+    id: 'bnp-1-send',
+    shortId: 'bnp-1-send',
+    sourceId: BRIEFING_SOURCE,
+    visible: true,
+    private: true,
+    authorId: '1',
+    title: 'Presidential briefing',
+    content: '',
+    readTime: 4,
+    contentJSON: [],
+  });
+
   const ctx: NotificationPostContext = {
     userIds: ['1'],
     source: sourcesFixture.find(
       (item) => item.id === 'unknown',
     ) as Reference<Source>,
-    post: postsFixture[0] as Reference<Post>,
+    post: briefPost as Reference<Post>,
   };
 
   await con.getRepository(UserPersonalizedDigest).save({
     userId: '1',
     type: UserPersonalizedDigestType.Brief,
-    flags: {
-      email: false,
-    },
   } as UserPersonalizedDigest);
+
+  await con.getRepository(User).update(
+    { id: '1' },
+    {
+      notificationFlags: () =>
+        `jsonb_set(
+          jsonb_set("notificationFlags", '{briefing_ready}', coalesce("notificationFlags"->'briefing_ready', '{}'::jsonb), true),
+          '{briefing_ready,email}',
+          '"muted"',
+          true
+        )`,
+    },
+  );
+
+  console.log(await con.getRepository(User).findOneBy({ id: '1' }));
 
   const notificationId = await saveNotificationV2Fixture(
     con,
@@ -2712,18 +2736,11 @@ describe('briefing_ready notification', () => {
     expect(args.transactional_message_id).toEqual('81');
   });
 
-  it('should not send email if digest flag is not true', async () => {
-    await con.getRepository(UserPersonalizedDigest).update(
-      {
-        userId: 'u-bnp-1',
-        type: UserPersonalizedDigestType.Brief,
-      },
-      {
-        flags: updateFlagsStatement<UserPersonalizedDigest>({
-          email: false,
-        }),
-      },
-    );
+  it('should not send email if digest subscription is missing', async () => {
+    await con.getRepository(UserPersonalizedDigest).delete({
+      userId: 'u-bnp-1',
+      type: UserPersonalizedDigestType.Brief,
+    });
 
     const postContext = await buildPostContext(con, 'bnp-1');
 

--- a/__tests__/workers/postAddedSlackChannelSendBrief.ts
+++ b/__tests__/workers/postAddedSlackChannelSendBrief.ts
@@ -133,7 +133,6 @@ describe('postAddedSlackChannelSendBrief worker', () => {
       type: UserPersonalizedDigestType.Brief,
       flags: {
         sendType: UserPersonalizedDigestSendType.daily,
-        slack: true,
       },
     });
   });
@@ -329,36 +328,6 @@ describe('postAddedSlackChannelSendBrief worker', () => {
       userId: '1',
       type: UserPersonalizedDigestType.Brief,
     });
-
-    const post = await con.getRepository(BriefPost).findOneByOrFail({
-      id: 'bsp-p1',
-    });
-
-    await expectSuccessfulTypedBackground(worker, {
-      payload: new UserBriefingRequest({
-        userId: '1',
-        frequency: 'daily',
-        modelName: BriefingModel.Default,
-      }),
-      postId: post.id,
-    });
-
-    expect(conversationsJoin).toHaveBeenCalledTimes(0);
-    expect(chatPostMessage).toHaveBeenCalledTimes(0);
-  });
-
-  it('should ignore if digest slack flag is not true', async () => {
-    await con.getRepository(UserPersonalizedDigest).update(
-      {
-        userId: '1',
-        type: UserPersonalizedDigestType.Brief,
-      },
-      {
-        flags: updateFlagsStatement<UserPersonalizedDigest>({
-          slack: false,
-        }),
-      },
-    );
 
     const post = await con.getRepository(BriefPost).findOneByOrFail({
       id: 'bsp-p1',

--- a/src/entity/user/UserPersonalizedDigest.ts
+++ b/src/entity/user/UserPersonalizedDigest.ts
@@ -17,14 +17,11 @@ export enum UserPersonalizedDigestType {
 
 export type UserPersonalizedDigestFlags = Partial<{
   sendType: UserPersonalizedDigestSendType;
-  email: boolean;
-  inApp: boolean;
-  slack: boolean;
 }>;
 
 export type UserPersonalizedDigestFlagsPublic = Pick<
   UserPersonalizedDigestFlags,
-  'sendType' | 'email' | 'inApp' | 'slack'
+  'sendType'
 >;
 
 @Entity()

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1078,8 +1078,6 @@ const obj = new GraphORM({
         ): UserPersonalizedDigestFlagsPublic => {
           return {
             sendType: value?.sendType ?? UserPersonalizedDigestSendType.weekly,
-            email: value?.email,
-            slack: value?.slack,
           };
         },
       },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -773,8 +773,6 @@ export const typeDefs = /* GraphQL */ `
   """
   type PersonalizedDigestFlagsPublic {
     sendType: UserPersonalizedDigestSendType
-    email: Boolean
-    slack: Boolean
   }
 
   type UserPersonalizedDigest {
@@ -1128,16 +1126,6 @@ export const typeDefs = /* GraphQL */ `
       Send type of the digest
       """
       sendType: UserPersonalizedDigestSendType
-
-      """
-      Send digest over email
-      """
-      email: Boolean
-
-      """
-      Send digest over slack
-      """
-      slack: Boolean
     ): UserPersonalizedDigest @auth
 
     """
@@ -2334,8 +2322,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         day?: number;
         type?: UserPersonalizedDigestType;
         sendType?: UserPersonalizedDigestSendType;
-        email?: boolean;
-        slack?: boolean;
       },
       ctx: AuthContext,
     ): Promise<GQLUserPersonalizedDigest> => {
@@ -2344,8 +2330,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         day,
         type = UserPersonalizedDigestType.Digest,
         sendType = UserPersonalizedDigestSendType.workdays,
-        email,
-        slack,
       } = args;
 
       if (type === UserPersonalizedDigestType.Brief && !ctx.isPlus) {
@@ -2367,14 +2351,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const flags: UserPersonalizedDigestFlags = {};
       if (sendType) {
         flags.sendType = sendType;
-      }
-
-      if (!isNullOrUndefined(email)) {
-        flags.email = email;
-      }
-
-      if (!isNullOrUndefined(slack)) {
-        flags.slack = slack;
       }
 
       const personalizedDigest = await repo.save({

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -979,7 +979,7 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       },
     });
 
-    if (!personalizedDigest?.flags?.email) {
+    if (!personalizedDigest) {
       return null;
     }
 

--- a/src/workers/postAddedSlackChannelSendBrief.ts
+++ b/src/workers/postAddedSlackChannelSendBrief.ts
@@ -68,7 +68,7 @@ export const postAddedSlackChannelSendBriefWorker: TypedWorker<'api.v1.brief-rea
           }),
         ]);
 
-        if (!personalizedDigest?.flags?.slack) {
+        if (!personalizedDigest) {
           return;
         }
 


### PR DESCRIPTION
- remove flags.email and flags.slack from user_personalized_digest
- email setting is now managed through `notificationFlags->briefing_ready->email` and https://github.com/dailydotdev/daily-api/pull/2990 will sync it for existing users
- slack setting is now exclusively managed by user_integration, and will send if integration exists for brief source (no more checkbox on frontend)
- remove flags from subscribePersonalizedDigest mutation 
- frontend will handle changes to manage digest settings through notificationFlags mutation instead of subscribePersonalizedDigest mutation