### PR TITLE
fix: return both moderators and admin on moderator query

### DIFF
--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -2052,10 +2052,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             if (role === SourceMemberRoles.Moderator) {
               // We should include both Moderator and Admin now
               queryBuilder = queryBuilder.andWhere(
-                `(${alias}."role" = :role OR ${alias}."role" = :role2)`,
+                `${alias}."role" IN (:...roles)`,
                 {
-                  role: SourceMemberRoles.Moderator,
-                  role2: SourceMemberRoles.Admin,
+                  roles: [SourceMemberRoles.Moderator, SourceMemberRoles.Admin],
                 },
               );
             } else {


### PR DESCRIPTION
When querying for moderators we should also include admins.
https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1755589022101189