### PR TITLE
feat: set location when it's not known in flags

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -153,6 +153,7 @@ const LOGGED_IN_BODY = {
     subscriptionFlags: {},
     coresRole: CoresRole.None,
     clickbaitTries: null,
+    hasLocationSet: false,
   },
   marketingCta: null,
   feeds: [],
@@ -390,6 +391,22 @@ describe('logged in boot', () => {
           LOGGED_IN_BODY.user.reputation >= submitArticleThreshold,
       },
     });
+  });
+
+  it('should set hasLocationSet to true when user has country flag', async () => {
+    await con.getRepository(User).save({
+      ...usersFixture[0],
+      flags: {
+        country: 'US',
+      },
+    });
+    mockLoggedIn();
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('Cookie', 'ory_kratos_session=value;')
+      .expect(200);
+    expect(res.body.user.hasLocationSet).toBe(true);
   });
 
   it('should set kratos cookie expiration', async () => {
@@ -1668,6 +1685,7 @@ describe('funnel boot', () => {
         'roles',
         'subscriptionFlags',
         'clickbaitTries',
+        'hasLocationSet',
       ]),
     });
   });

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -393,11 +393,14 @@ describe('logged in boot', () => {
     });
   });
 
-  it('should set hasLocationSet to true when user has country flag', async () => {
+  it('should set hasLocationSet to true when user has location date flag', async () => {
     await con.getRepository(User).save({
       ...usersFixture[0],
       flags: {
         country: 'US',
+        location: {
+          lastStored: new Date(),
+        },
       },
     });
     mockLoggedIn();

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -6594,13 +6594,16 @@ describe('query checkLocation', () => {
     jest.clearAllMocks();
   });
 
-  it('should return false when user already has country flag set', async () => {
+  it('should return false when user already has lastStored location flag set', async () => {
     loggedUser = '1';
 
     // Set up user with existing country flag
     await con
       .getRepository(User)
-      .update({ id: '1' }, { flags: { country: 'US' } });
+      .update(
+        { id: '1' },
+        { flags: { country: 'US', location: { lastStored: new Date() } } },
+      );
 
     const res = await client.query(QUERY);
 
@@ -6686,6 +6689,7 @@ describe('query checkLocation', () => {
       continent: 'North America',
       subdivision: 'NY',
       location: {
+        lastStored: expect.any(Date),
         accuracyRadius: 50,
         lat: 40.7128,
         lng: -74.006,
@@ -6722,6 +6726,7 @@ describe('query checkLocation', () => {
       continent: undefined,
       subdivision: undefined,
       location: {
+        lastStored: expect.any(Date),
         accuracyRadius: undefined,
         lat: undefined,
         lng: undefined,

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -6689,7 +6689,7 @@ describe('query checkLocation', () => {
       continent: 'North America',
       subdivision: 'NY',
       location: {
-        lastStored: expect.any(Date),
+        lastStored: expect.any(String),
         accuracyRadius: 50,
         lat: 40.7128,
         lng: -74.006,
@@ -6726,7 +6726,7 @@ describe('query checkLocation', () => {
       continent: undefined,
       subdivision: undefined,
       location: {
-        lastStored: expect.any(Date),
+        lastStored: expect.any(String),
         accuracyRadius: undefined,
         lat: undefined,
         lng: undefined,

--- a/src/common/geo.ts
+++ b/src/common/geo.ts
@@ -320,7 +320,7 @@ export const getGeo = ({ ip }: { ip: string }): GeoRecord => {
       country: geo.country?.isoCode,
       continent: geo.continent?.code,
       city: geo.city?.names?.en,
-      location: geo.location
+      location: geo.location,
       subdivision: geo.subdivisions?.[0]?.isoCode,
     };
   } catch (error) {

--- a/src/common/geo.ts
+++ b/src/common/geo.ts
@@ -281,7 +281,7 @@ const initGeoReader = async (): Promise<ReaderModel | undefined> => {
     }
 
     const reader = await Reader.open(
-      join(process.env.GEOIP_PATH, 'GeoIP2-Country.mmdb'),
+      join(process.env.GEOIP_PATH, 'GeoIP2-City.mmdb'),
       {
         cache: {
           max: 10_000,
@@ -314,11 +314,18 @@ export const getGeo = ({ ip }: { ip: string }): GeoRecord => {
   }
 
   try {
-    const geo = geoReader.country(ip);
+    const geo = geoReader.city(ip);
 
     return {
       country: geo.country?.isoCode,
       continent: geo.continent?.code,
+      city: geo.city?.names?.en,
+      location: {
+        accuracyRadius: geo.location?.accuracyRadius,
+        lat: geo.location?.latitude,
+        lng: geo.location?.longitude,
+      },
+      subdivision: geo.subdivisions?.[0]?.isoCode,
     };
   } catch (error) {
     logger.warn({ err: error, ip }, 'Error fetching geo data');

--- a/src/common/geo.ts
+++ b/src/common/geo.ts
@@ -320,11 +320,7 @@ export const getGeo = ({ ip }: { ip: string }): GeoRecord => {
       country: geo.country?.isoCode,
       continent: geo.continent?.code,
       city: geo.city?.names?.en,
-      location: {
-        accuracyRadius: geo.location?.accuracyRadius,
-        lat: geo.location?.latitude,
-        lng: geo.location?.longitude,
-      },
+      location: geo.location
       subdivision: geo.subdivisions?.[0]?.isoCode,
     };
   } catch (error) {

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -35,6 +35,7 @@ export type UserFlags = Partial<{
   city: string | null;
   continent: string | null;
   location: {
+    lastStored: Date | null;
     accuracyRadius: number | null | undefined;
     lat: number | null | undefined;
     lng: number | null | undefined;

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -33,6 +33,13 @@ export type UserFlags = Partial<{
   showPlusGift: boolean;
   country: string | null;
   city: string | null;
+  continent: string | null;
+  location: {
+    accuracyRadius: number | null | undefined;
+    lat: number | null | undefined;
+    lng: number | null | undefined;
+  };
+  subdivision: string | null;
 }>;
 
 export type UserFlagsPublic = Pick<UserFlags, 'showPlusGift'>;

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -560,7 +560,7 @@ const loggedInBoot = async ({
     if (!user) {
       return handleNonExistentUser(con, req, res, middleware);
     }
-    const hasLocationSet = !!user.flags?.country;
+    const hasLocationSet = !!user.flags?.location?.lastStored;
     const isTeamMember = exp?.a?.team === 1;
     const isPlus = isPlusMember(user.subscriptionFlags?.cycle);
 

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -560,6 +560,7 @@ const loggedInBoot = async ({
     if (!user) {
       return handleNonExistentUser(con, req, res, middleware);
     }
+    const hasLocationSet = !!user.flags?.country;
     const isTeamMember = exp?.a?.team === 1;
     const isPlus = isPlusMember(user.subscriptionFlags?.cycle);
 
@@ -605,6 +606,7 @@ const loggedInBoot = async ({
           status: user.subscriptionFlags?.status,
         },
         clickbaitTries,
+        hasLocationSet,
       },
       visit,
       alerts: {

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -2180,7 +2180,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         where: { id: ctx.userId },
       });
 
-      if (!user || !!user.flags?.country) {
+      if (!user || !!user.flags?.location?.lastStored) {
         return { _: false };
       }
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -2199,6 +2199,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
             continent: geo?.continent,
             subdivision: geo?.subdivision,
             location: {
+              lastStored: new Date(),
               accuracyRadius: geo?.location?.accuracyRadius,
               lat: geo?.location?.lat,
               lng: geo?.location?.lng,

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,13 @@ export const serviceClientId = 'api';
 export type GeoRecord = Partial<{
   country: string;
   continent: string;
+  city: string;
+  location: Partial<{
+    lat: number;
+    lng: number;
+    accuracyRadius: number;
+  }>;
+  subdivision?: string;
 }>;
 
 export enum StreakRestoreCoresPrice {


### PR DESCRIPTION
Adds location flags from our geo IP db, when user doesn't have them set in flags.
It's a one time call from the frontend so not too heavy load.

Preparation for the matching service to use, we'd like to start collecting it asap.
Ante noted we probably need to up memory on API pod.