### PR TITLE
feat: squad_member_joined should now have source.id as reference

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -959,8 +959,8 @@ describe('generateNotification', () => {
     expect(actual.notification.type).toEqual(type);
     expect(actual.userIds).toEqual([userId]);
     expect(actual.notification.public).toEqual(true);
-    expect(actual.notification.referenceId).toEqual(post.id);
-    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.notification.referenceId).toEqual(source.id);
+    expect(actual.notification.referenceType).toEqual('source');
     expect(actual.notification.uniqueKey).toEqual('2');
     expect(actual.notification.targetUrl).toEqual(
       'http://localhost:5002/posts/welcome1?comment=%40tsahidaily+welcome+to+A%21',

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -342,7 +342,7 @@ export const generateNotificationMap: Record<
   ) =>
     builder
       .icon(NotificationIcon.Bell)
-      .referencePost(ctx.post)
+      .referenceSource(ctx.source)
       .targetPost(ctx.post)
       .avatarSource(ctx.source)
       .avatarManyUsers([ctx.doneBy])

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -481,7 +481,7 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
       con.getRepository(User).findOneBy({ id: notification.uniqueKey }),
       con
         .getRepository(WelcomePost)
-        .findOneByOrFail({ id: notification.referenceId }),
+        .findOneByOrFail({ sourceId: notification.referenceId }),
     ]);
     const source = await post.source;
     if (!joinedUser || !source) {


### PR DESCRIPTION
Changing to use `referenceSource` instead of `referencePost` on `squad_member_joined` so that the `referenceId` is the source id. This is so we can mute this notification preference per squad on the notifications page on the frontend.

I address what happens to old notifications that still have the post id as reference in the frontend [PR](https://github.com/dailydotdev/apps/pull/4809)


### Jira ticket
MI-1003