### PR TITLE
feat: save entity reference on award

### DIFF
--- a/__tests__/njord.ts
+++ b/__tests__/njord.ts
@@ -31,6 +31,7 @@ import {
   UserTransaction,
   UserTransactionProcessor,
   UserTransactionStatus,
+  UserTransactionType,
 } from '../src/entity/user/UserTransaction';
 import { ghostUser } from '../src/common';
 import { UserComment } from '../src/entity/user/UserComment';
@@ -589,6 +590,9 @@ describe('award post mutation', () => {
     });
 
     expect(post.awards).toBe(1);
+
+    expect(transaction.referenceId).toEqual(post.id);
+    expect(transaction.referenceType).toEqual(UserTransactionType.Post);
   });
 
   it('should not award when user does not have access to cores', async () => {
@@ -1092,6 +1096,9 @@ describe('award comment mutation', () => {
     });
 
     expect(comment.awards).toBe(1);
+
+    expect(transaction.referenceId).toEqual(comment.id);
+    expect(transaction.referenceType).toEqual(UserTransactionType.Comment);
   });
 
   it('should award nested comment', async () => {

--- a/src/common/njord.ts
+++ b/src/common/njord.ts
@@ -22,6 +22,7 @@ import {
   UserTransactionFlags,
   UserTransactionProcessor,
   UserTransactionStatus,
+  UserTransactionType,
 } from '../entity/user/UserTransaction';
 import { isSpecialUser, parseBigInt, systemUser } from './utils';
 import { ForbiddenError } from 'apollo-server-errors';
@@ -120,6 +121,10 @@ export type TransactionProps = {
   receiverId: string;
   note?: string;
   flags?: Pick<UserTransactionFlags, 'sourceId'>;
+  entityReference?: {
+    id: string;
+    type: UserTransactionType;
+  };
 };
 
 export const createTransaction = createAuthProtectedFn(
@@ -131,6 +136,7 @@ export const createTransaction = createAuthProtectedFn(
     receiverId,
     note,
     flags,
+    entityReference,
   }: TransactionProps & {
     id?: string;
     entityManager: EntityManager;
@@ -158,6 +164,8 @@ export const createTransaction = createAuthProtectedFn(
           note,
           ...flags,
         },
+        referenceId: entityReference?.id,
+        referenceType: entityReference?.type,
       });
 
     const userTransactionResult = await entityManager
@@ -742,6 +750,10 @@ export const awardPost = async (
           productId: product.id,
           receiverId: post.authorId,
           note,
+          entityReference: {
+            id: post.id,
+            type: UserTransactionType.Post,
+          },
         });
 
         if (!transaction.productId) {
@@ -898,6 +910,10 @@ export const awardComment = async (
           productId: product.id,
           receiverId: comment.userId,
           note,
+          entityReference: {
+            id: comment.id,
+            type: UserTransactionType.Comment,
+          },
         });
 
         if (!transaction.productId) {

--- a/src/entity/user/UserTransaction.ts
+++ b/src/entity/user/UserTransaction.ts
@@ -49,6 +49,8 @@ export enum UserTransactionProcessor {
 export enum UserTransactionType {
   PostBoost = 'post_boost',
   SquadBoost = 'squad_boost',
+  Post = 'post',
+  Comment = 'comment',
 }
 
 @Entity()


### PR DESCRIPTION
So that cores can be more easily attributed back to entity from transaction.