### PR TITLE
fix: only decrease on banned

### DIFF
--- a/__tests__/workers/postBannedRep.ts
+++ b/__tests__/workers/postBannedRep.ts
@@ -55,7 +55,10 @@ beforeEach(async () => {
 it('should create a reputation event that increases reputation', async () => {
   const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
   await expectSuccessfulBackground(worker, {
-    post,
+    post: {
+      ...post,
+      banned: true,
+    },
   });
   const events = await con
     .getRepository(ReputationEvent)
@@ -149,7 +152,7 @@ it('should create a reputation decrease event for the author of the freeform pos
 it('should create a reputation event that decreases reputation', async () => {
   await con
     .getRepository(Post)
-    .update({ id: 'p1' }, { authorId: '1', scoutId: '2' });
+    .update({ id: 'p1' }, { authorId: '1', scoutId: '2', banned: true });
   const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
   await expectSuccessfulBackground(worker, {
     post,

--- a/src/workers/postBannedRep.ts
+++ b/src/workers/postBannedRep.ts
@@ -17,14 +17,21 @@ const worker: Worker = {
   subscription: 'post-banned-rep',
   handler: async (message, con, logger): Promise<void> => {
     const data: Data = messageToJson(message);
-    const { id, authorId, scoutId, flags } = data.post;
+    const { id, authorId, scoutId, flags, banned } = data.post;
     const parsedFlags =
       typeof flags === 'string' ? JSON.parse(flags as string) : flags;
     const { deletedBy } = parsedFlags;
 
+    /**
+     * We don't deduct reputation on hard deletion, only bans
+     */
+    if (!banned) {
+      return;
+    }
     if (deletedBy === DELETED_BY_WORKER) {
       return;
     }
+    console.log('data', data.post);
 
     try {
       await con.transaction(async (transaction) => {


### PR DESCRIPTION
We should only decrease reputation on deletion of banned posts.
(We hardly hard-delete,. only on squad deletion)

The only edge-case is welcome posts as they are always banned, but since it's 99% the squad admin should be acceptable for now.

Solves:
https://github.com/dailydotdev/daily/issues/1938#issuecomment-3228353239