### PR TITLE
fix: preview testers backwards support for campaigns dashboard list

### DIFF
--- a/src/integrations/skadi/api/v1/clients.ts
+++ b/src/integrations/skadi/api/v1/clients.ts
@@ -199,7 +199,7 @@ export class SkadiApiClientV1 implements ISkadiApiClientV1 {
 
       return {
         promotedPosts: posts?.map(mapCampaign) ?? [],
-        postIds: response.post_ids ?? [],
+        postIds: response.post_ids?.filter(Boolean) ?? [],
         totalSpend: response.total_spend,
         impressions: response.impressions,
         clicks: response.clicks,

--- a/src/integrations/skadi/api/v1/clients.ts
+++ b/src/integrations/skadi/api/v1/clients.ts
@@ -193,8 +193,12 @@ export class SkadiApiClientV1 implements ISkadiApiClientV1 {
         },
       );
 
+      const posts = response.promoted_posts?.filter(
+        ({ post_id }) => !!post_id?.length,
+      );
+
       return {
-        promotedPosts: response.promoted_posts?.map(mapCampaign) ?? [],
+        promotedPosts: posts?.map(mapCampaign) ?? [],
         postIds: response.post_ids ?? [],
         totalSpend: response.total_spend,
         impressions: response.impressions,


### PR DESCRIPTION
Being a preview tester, you will be able to test both flows (v1 and v2) through preview deployment and the current production env. To avoid breaking your dashboard until rollout, we will filter posts only on the legacy API. Note, the concern here (creating campaigns on both flows) will not break the regular user's flow, just for everyone within the team to have a better experience.