### PR TITLE
feat: clickhouse migrations support

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -486,16 +486,22 @@ const [apps] = deployApplicationSuite(
     imageTag,
     serviceAccount,
     secrets: envVars,
-    migration: {
-      args: isAdhocEnv
-        ? ['npm', 'run', 'db:migrate:latest']
-        : [
-            'node',
-            './node_modules/typeorm/cli.js',
-            'migration:run',
-            '-d',
-            'src/data-source.js',
-          ],
+    migrations: {
+      db: {
+        args: isAdhocEnv
+          ? ['npm', 'run', 'db:migrate:latest']
+          : [
+              'node',
+              './node_modules/typeorm/cli.js',
+              'migration:run',
+              '-d',
+              'src/data-source.js',
+            ],
+      },
+      clickhouse: {
+        args: ['node', './bin/runClickhouseMigrations.js'],
+        toleratesSpot: false // due to clickhosue not having transactions support
+      },
     },
     debezium: {
       version: '3.0.5.Final',

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -25,7 +25,7 @@ import {
   Stream,
   ClickHouseSync,
   ClickHouseSyncConfig,
-  MigrationArgs,
+  ApplicationSuiteArgs,
 } from '@dailydotdev/pulumi-common';
 
 const isAdhocEnv = detectIsAdhocEnv();
@@ -482,10 +482,7 @@ if (isAdhocEnv) {
 const vpcNativeProvider = isAdhocEnv ? undefined : getVpcNativeCluster();
 const cert = config.requireObject<Record<string, string>>('cert');
 
-const migrations: {
-  db: MigrationArgs;
-  clickhouse?: MigrationArgs;
-} = {
+const migrations: ApplicationSuiteArgs['migrations'] = {
   db: {
     args: isAdhocEnv
       ? ['npm', 'run', 'db:migrate:latest']

--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -25,7 +25,7 @@ import {
   Stream,
   ClickHouseSync,
   ClickHouseSyncConfig,
-  type MigrationArgs,
+  MigrationArgs,
 } from '@dailydotdev/pulumi-common';
 
 const isAdhocEnv = detectIsAdhocEnv();

--- a/bin/createClickhouseMigration.ts
+++ b/bin/createClickhouseMigration.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { clickhouseMigrationsDir } from '../src/types';
+import { logger } from '../src/logger';
 
 const main = async () => {
   try {
@@ -32,7 +33,7 @@ const main = async () => {
 
     const migrationName = `${Date.now()}_${dataResult.data.name}`;
 
-    console.log(`Created migration ${migrationName} files 🎉`);
+    logger.info(`Created migration ${migrationName} files 🎉`);
 
     await Promise.all([
       fs.writeFile(
@@ -49,7 +50,7 @@ const main = async () => {
   } catch (originalError) {
     const error = originalError as Error;
 
-    console.error(error.message);
+    logger.error(error.message);
   }
 };
 

--- a/bin/createClickhouseMigration.ts
+++ b/bin/createClickhouseMigration.ts
@@ -1,0 +1,56 @@
+import { parseArgs } from 'node:util';
+import z from 'zod';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { clickhouseMigrationsDir } from '../src/types';
+
+const main = async () => {
+  try {
+    const { values } = parseArgs({
+      options: {
+        name: {
+          type: 'string',
+          short: 'n',
+        },
+      },
+    });
+
+    const paramsSchema = z.object({
+      name: z
+        .string()
+        .lowercase()
+        .regex(/^[a-z_]+$/),
+    });
+
+    const dataResult = paramsSchema.safeParse(values);
+
+    if (dataResult.error) {
+      throw new Error(
+        `Error '${dataResult.error.issues[0].path}': ${dataResult.error.issues[0].message}`,
+      );
+    }
+
+    const migrationName = `${Date.now()}_${dataResult.data.name}`;
+
+    console.log(`Created migration ${migrationName} files 🎉`);
+
+    await Promise.all([
+      fs.writeFile(
+        path.join(clickhouseMigrationsDir, `${migrationName}.up.sql`),
+        '-- up\n\n',
+        'utf-8',
+      ),
+      fs.writeFile(
+        path.join(clickhouseMigrationsDir, `${migrationName}.down.sql`),
+        '-- down\n\n',
+        'utf-8',
+      ),
+    ]);
+  } catch (originalError) {
+    const error = originalError as Error;
+
+    console.error(error.message);
+  }
+};
+
+main();

--- a/bin/runClickhouseMigrations.ts
+++ b/bin/runClickhouseMigrations.ts
@@ -1,0 +1,284 @@
+//
+// Runs ClickHouse migrations from clickhouse/migrations.
+// - Discovers migrations named: {id}_{snake_case_name}_{up|down}.sql
+// - Creates api.migrations table if missing
+// - Executes pending *_up.sql in ascending id order
+// - If any up fails: run its down (if present), then run down for all
+//   migrations applied earlier in THIS run (reverse order) and
+//   remove their records from api.migrations.
+// - Records each applied up into api.migrations (id, name, timestamp)
+//
+
+import '../src/config';
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+import { getClickHouseClient } from '../src/common/clickhouse';
+import z from 'zod';
+import { logger } from '../src/logger';
+
+type Migration = {
+  id: number;
+  name: string;
+  upPath: string;
+  downPath: string;
+};
+
+type MigrationPair = Pick<Migration, 'id' | 'name'> &
+  Partial<Pick<Migration, 'upPath' | 'downPath'>>;
+
+const migrationRowSchema = z.object({
+  id: z.coerce.number(),
+  name: z.string(),
+  timestamp: z.string(),
+});
+
+const migrationsDir = path.resolve(process.cwd(), 'clickhouse', 'migrations');
+const filenameMatch = /^(\d+)_([a-z_]+)\.(up|down)\.sql$/i;
+
+const main = async () => {
+  const client = getClickHouseClient();
+
+  try {
+    await ensureMigrationsTable(client);
+
+    const applied = await getAppliedMigrations(client);
+    const appliedIds = new Set(applied.map((m) => m.id.toString()));
+
+    const migrations = discoverMigrations(migrationsDir).sort(
+      (a, b) => a.id - b.id,
+    );
+
+    const pendingMigrations = migrations.filter(
+      (m) => !appliedIds.has(m.id.toString()),
+    );
+
+    if (pendingMigrations.length === 0) {
+      throw new Error('No pending migrations');
+    }
+
+    logger.info(`Found ${pendingMigrations.length} pending migration(s).`);
+
+    // Track what we successfully apply in THIS run
+    const appliedThisRun: Array<Migration> = [];
+
+    for (const migration of pendingMigrations) {
+      logger.info(`Applying migration ${migration.id}_${migration.name}`);
+
+      try {
+        await runMigrationFile(client, migration.upPath);
+        await recordAppliedMigration(client, migration.id, migration.name); // record AFTER success
+
+        appliedThisRun.push(migration);
+      } catch (originalError) {
+        const error = originalError as Error;
+
+        logger.error(
+          `Failed migration ${migration.id}_${migration.name}: ${error.message} ❌`,
+        );
+
+        try {
+          logger.info(
+            `Rolling back failed migration ${migration.id}_${migration.name}`,
+          );
+
+          await runMigrationFile(client, migration.downPath);
+        } catch (originalError) {
+          const rbErr = originalError as Error;
+
+          logger.error(
+            `Rollback (failed migration) error for ${migration.id}_${migration.name}: ${rbErr.message} ❌`,
+          );
+        }
+
+        // 2) Roll back everything that succeeded earlier in this run (reverse order)
+        if (appliedThisRun.length > 0) {
+          logger.info(
+            `Reverting ${appliedThisRun.length} previously applied migration(s) from this run`,
+          );
+
+          for (const done of [...appliedThisRun].reverse()) {
+            try {
+              logger.info(`Rolling back ${done.id}_${done.name}`);
+
+              await runMigrationFile(client, done.downPath);
+            } catch (originalError) {
+              const rbErr = originalError as Error;
+
+              logger.error(
+                `Rollback error for ${done.id}_${done.name}: ${rbErr.message} ❌`,
+              );
+            }
+
+            // 3) Clear its record from api.migrations
+            try {
+              await deleteMigrationRecord(client, done.id);
+            } catch (originalError) {
+              const delErr = originalError as Error;
+
+              logger.error(
+                `Failed to clear record for ${done.id}_${done.name}: ${delErr.message} ❌`,
+              );
+            }
+          }
+        }
+
+        throw new Error('Some migrations failed ❌');
+      }
+    }
+
+    logger.info('All pending migrations applied successfully. 🎉');
+  } catch (originalError) {
+    const error = originalError as Error;
+
+    if (error.message === 'No pending migrations') {
+      logger.info(`No pending migrations found. ✅`);
+    } else {
+      logger.error(`Fatal error: ${error.message || error.name}`);
+    }
+  } finally {
+    await client.close();
+
+    process.exit(1);
+  }
+};
+
+const validateMigrations = (
+  migrations: MigrationPair[],
+): migrations is Migration[] => {
+  return migrations.every((item) => item.upPath || item.downPath);
+};
+
+const discoverMigrations = (dir: string): Migration[] => {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Migrations directory not found: ${dir}`);
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const map = new Map<string, MigrationPair>();
+
+  for (const item of entries) {
+    if (!item.isFile()) continue;
+    const fileMatch = item.name.match(filenameMatch);
+
+    if (!fileMatch) {
+      continue;
+    }
+
+    const [, idStr, name, kind] = fileMatch;
+    const id = +idStr;
+    const key = `${id}_${name}`;
+    const full = path.join(dir, item.name);
+    const prev = map.get(key) || { id, name };
+
+    if (kind.toLowerCase() === 'up') {
+      prev.upPath = full;
+    }
+
+    if (kind.toLowerCase() === 'down') {
+      prev.downPath = full;
+    }
+
+    map.set(key, prev);
+  }
+
+  const migrations = Array.from(map.values());
+
+  if (!validateMigrations(migrations)) {
+    throw new Error('Some migrations are missing up or down files');
+  }
+
+  return migrations;
+};
+
+const ensureMigrationsTable = async (
+  client: ReturnType<typeof getClickHouseClient>,
+) => {
+  await client.command({
+    query: /* sql */ `
+      CREATE DATABASE IF NOT EXISTS api
+    `,
+  });
+  await client.command({
+    query: /* sql */ `
+      CREATE TABLE IF NOT EXISTS api.migrations
+      (
+        id UInt64,
+        name String,
+        timestamp DateTime64(3) DEFAULT now()
+      )
+      ENGINE = MergeTree
+      ORDER BY id
+    `,
+  });
+};
+
+const getAppliedMigrations = async (
+  client: ReturnType<typeof getClickHouseClient>,
+): Promise<z.infer<typeof migrationRowSchema>[]> => {
+  const response = await client.query({
+    query: /* sql */ `
+      SELECT id, name, timestamp
+      FROM api.migrations
+      ORDER BY id ASC
+    `,
+    format: 'JSONEachRow',
+  });
+
+  const result = z.array(migrationRowSchema).safeParse(await response.json());
+
+  if (!result.success) {
+    throw new Error(result.error.issues[0].message);
+  }
+
+  return result.data;
+};
+
+const recordAppliedMigration = async (
+  client: ReturnType<typeof getClickHouseClient>,
+  id: number,
+  name: string,
+) => {
+  await client.command({
+    query: /* sql */ `
+      INSERT INTO api.migrations (id, name) VALUES ({id:String}, {name:String})
+    `,
+    query_params: { id: id.toString(), name },
+  });
+};
+
+const deleteMigrationRecord = async (
+  client: ReturnType<typeof getClickHouseClient>,
+  id: number,
+) => {
+  await client.command({
+    query: /* sql */ `
+      ALTER TABLE api.migrations DELETE WHERE id = {id:String} SYNC
+    `,
+    query_params: {
+      id: id.toString(),
+    },
+  });
+};
+
+const runMigrationFile = async (
+  client: ReturnType<typeof getClickHouseClient>,
+  fullPath: string,
+) => {
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Migration file not found: ${fullPath}`);
+  }
+
+  const content = fs.readFileSync(fullPath, 'utf-8');
+
+  const statements = content
+    .split(';')
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    await client.command({ query: statement });
+  }
+};
+
+main();

--- a/bin/runClickhouseMigrations.ts
+++ b/bin/runClickhouseMigrations.ts
@@ -1,8 +1,8 @@
 //
 // Runs ClickHouse migrations from clickhouse/migrations.
-// - Discovers migrations named: {id}_{snake_case_name}_{up|down}.sql
+// - Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
 // - Creates api.migrations table if missing
-// - Executes pending *_up.sql in ascending id order
+// - Executes pending *.up.sql in ascending id order
 // - If any up fails: run its down (if present), then run down for all
 //   migrations applied earlier in THIS run (reverse order) and
 //   remove their records from api.migrations.

--- a/bin/runClickhouseMigrations.ts
+++ b/bin/runClickhouseMigrations.ts
@@ -1,12 +1,12 @@
 //
 // Runs ClickHouse migrations from clickhouse/migrations.
 // - Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
-// - Creates ch_migration table if missing
+// - Creates migrations_ch table if missing
 // - Executes pending *.up.sql in ascending id order
 // - If any up fails: run its down (if present), then run down for all
 //   migrations applied earlier in THIS run (reverse order) and
-//   remove their records from ch_migration.
-// - Records each applied up into ch_migration (id, name, timestamp)
+//   remove their records from migrations_ch.
+// - Records each applied up into migrations_ch (id, name, timestamp)
 //
 
 import '../src/config';
@@ -48,7 +48,7 @@ const main = async () => {
 
     if (hasDirtyMigrations) {
       throw new Error(
-        'Some migrations are marked as dirty. Please resolve manually and update their state in ch_migration table',
+        'Some migrations are marked as dirty. Please resolve manually and update their state in migrations_ch table',
       );
     }
 

--- a/bin/runClickhouseMigrations.ts
+++ b/bin/runClickhouseMigrations.ts
@@ -1,13 +1,13 @@
-//
-// Runs ClickHouse migrations from clickhouse/migrations.
-// - Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
-// - Creates migrations_ch table if missing
-// - Executes pending *.up.sql in ascending id order
-// - If any up fails: run its down (if present), then run down for all
-//   migrations applied earlier in THIS run (reverse order) and
-//   remove their records from migrations_ch.
-// - Records each applied up into migrations_ch (id, name, timestamp)
-//
+/*
+
+Runs ClickHouse migrations from clickhouse/migrations.
+- Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
+- Records migration as dirty in the migrations_ch table on API
+- Executes pending *.up.sql in ascending id order
+- If any up fails blocks further execution
+- Records each applied up into migrations_ch table (id, name, timestamp, dirty)
+
+*/
 
 import '../src/config';
 import fs from 'node:fs';

--- a/bin/runClickhouseMigrations.ts
+++ b/bin/runClickhouseMigrations.ts
@@ -1,24 +1,26 @@
 //
 // Runs ClickHouse migrations from clickhouse/migrations.
 // - Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
-// - Creates api.migrations table if missing
+// - Creates ch_migration table if missing
 // - Executes pending *.up.sql in ascending id order
 // - If any up fails: run its down (if present), then run down for all
 //   migrations applied earlier in THIS run (reverse order) and
-//   remove their records from api.migrations.
-// - Records each applied up into api.migrations (id, name, timestamp)
+//   remove their records from ch_migration.
+// - Records each applied up into ch_migration (id, name, timestamp)
 //
 
 import '../src/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import { getClickHouseClient } from '../src/common/clickhouse';
-import z from 'zod';
 import { logger } from '../src/logger';
 import {
   clickhouseMigrationFilenameMatch,
   clickhouseMigrationsDir,
 } from '../src/types';
+import createOrGetConnection from '../src/db';
+import type { DataSource } from 'typeorm';
+import { ChMigration } from '../src/entity/ChMigration';
 
 type Migration = {
   id: number;
@@ -30,24 +32,25 @@ type Migration = {
 type MigrationPair = Pick<Migration, 'id' | 'name'> &
   Partial<Pick<Migration, 'upPath' | 'downPath'>>;
 
-const migrationRowSchema = z.object({
-  id: z.coerce.number(),
-  name: z.string(),
-  timestamp: z.string(),
-});
-
 const main = async () => {
   const client = getClickHouseClient();
+  const con = await createOrGetConnection();
 
   try {
-    await ensureMigrationsTable(client);
-
-    const applied = await getAppliedMigrations(client);
+    const applied = await getAppliedMigrations(con);
     const appliedIds = new Set(applied.map((m) => m.id.toString()));
 
     const migrations = discoverMigrations(clickhouseMigrationsDir).sort(
       (a, b) => a.id - b.id,
     );
+
+    const hasDirtyMigrations = applied.some((m) => m.dirty);
+
+    if (hasDirtyMigrations) {
+      throw new Error(
+        'Some migrations are marked as dirty. Please resolve manually and update their state in ch_migration table',
+      );
+    }
 
     const pendingMigrations = migrations.filter(
       (m) => !appliedIds.has(m.id.toString()),
@@ -59,69 +62,21 @@ const main = async () => {
 
     logger.info(`Found ${pendingMigrations.length} pending migration(s).`);
 
-    // Track what we successfully apply in THIS run
-    const appliedThisRun: Array<Migration> = [];
-
     for (const migration of pendingMigrations) {
       logger.info(`Applying migration ${migration.id}_${migration.name}`);
 
       try {
-        await runMigrationFile(client, migration.upPath);
-        await recordAppliedMigration(client, migration.id, migration.name); // record AFTER success
+        await recordMigration(con, migration.id, migration.name, true); // record migration as dirty
 
-        appliedThisRun.push(migration);
+        await runMigrationFile(client, migration.upPath);
+
+        await recordMigration(con, migration.id, migration.name, false); // record after success
       } catch (originalError) {
         const error = originalError as Error;
 
         logger.error(
           `Failed migration ${migration.id}_${migration.name}: ${error.message} ❌`,
         );
-
-        try {
-          logger.info(
-            `Rolling back failed migration ${migration.id}_${migration.name}`,
-          );
-
-          await runMigrationFile(client, migration.downPath);
-        } catch (originalError) {
-          const rbErr = originalError as Error;
-
-          logger.error(
-            `Rollback (failed migration) error for ${migration.id}_${migration.name}: ${rbErr.message} ❌`,
-          );
-        }
-
-        // 2) Roll back everything that succeeded earlier in this run (reverse order)
-        if (appliedThisRun.length > 0) {
-          logger.info(
-            `Reverting ${appliedThisRun.length} previously applied migration(s) from this run`,
-          );
-
-          for (const done of [...appliedThisRun].reverse()) {
-            try {
-              logger.info(`Rolling back ${done.id}_${done.name}`);
-
-              await runMigrationFile(client, done.downPath);
-            } catch (originalError) {
-              const rbErr = originalError as Error;
-
-              logger.error(
-                `Rollback error for ${done.id}_${done.name}: ${rbErr.message} ❌`,
-              );
-            }
-
-            // 3) Clear its record from api.migrations
-            try {
-              await deleteMigrationRecord(client, done.id);
-            } catch (originalError) {
-              const delErr = originalError as Error;
-
-              logger.error(
-                `Failed to clear record for ${done.id}_${done.name}: ${delErr.message} ❌`,
-              );
-            }
-          }
-        }
 
         throw new Error('Some migrations failed ❌');
       }
@@ -134,7 +89,7 @@ const main = async () => {
     if (error.message === 'No pending migrations') {
       logger.info(`No pending migrations found. ✅`);
     } else {
-      logger.error(`Fatal error: ${error.message || error.name}`);
+      logger.error(`Migration error: ${error.message || error.name}`);
     }
   } finally {
     await client.close();
@@ -191,73 +146,22 @@ const discoverMigrations = (dir: string): Migration[] => {
   return migrations;
 };
 
-const ensureMigrationsTable = async (
-  client: ReturnType<typeof getClickHouseClient>,
-) => {
-  await client.command({
-    query: /* sql */ `
-      CREATE DATABASE IF NOT EXISTS api
-    `,
-  });
-  await client.command({
-    query: /* sql */ `
-      CREATE TABLE IF NOT EXISTS api.migrations
-      (
-        id UInt64,
-        name String,
-        timestamp DateTime64(3) DEFAULT now()
-      )
-      ENGINE = MergeTree
-      ORDER BY id
-    `,
-  });
-};
-
 const getAppliedMigrations = async (
-  client: ReturnType<typeof getClickHouseClient>,
-): Promise<z.infer<typeof migrationRowSchema>[]> => {
-  const response = await client.query({
-    query: /* sql */ `
-      SELECT id, name, timestamp
-      FROM api.migrations
-      ORDER BY id ASC
-    `,
-    format: 'JSONEachRow',
-  });
-
-  const result = z.array(migrationRowSchema).safeParse(await response.json());
-
-  if (!result.success) {
-    throw new Error(result.error.issues[0].message);
-  }
-
-  return result.data;
+  con: DataSource,
+): Promise<ChMigration[]> => {
+  return await con.getRepository(ChMigration).find();
 };
 
-const recordAppliedMigration = async (
-  client: ReturnType<typeof getClickHouseClient>,
+const recordMigration = async (
+  con: DataSource,
   id: number,
   name: string,
+  dirty: boolean,
 ) => {
-  await client.command({
-    query: /* sql */ `
-      INSERT INTO api.migrations (id, name) VALUES ({id:String}, {name:String})
-    `,
-    query_params: { id: id.toString(), name },
-  });
-};
-
-const deleteMigrationRecord = async (
-  client: ReturnType<typeof getClickHouseClient>,
-  id: number,
-) => {
-  await client.command({
-    query: /* sql */ `
-      ALTER TABLE api.migrations DELETE WHERE id = {id:String} SYNC
-    `,
-    query_params: {
-      id: id.toString(),
-    },
+  await con.getRepository(ChMigration).save({
+    id: id.toString(),
+    name,
+    dirty,
   });
 };
 

--- a/clickhouse/migrations/1756316678212_post_analytics.down.sql
+++ b/clickhouse/migrations/1756316678212_post_analytics.down.sql
@@ -1,0 +1,11 @@
+-- down
+
+drop table if exists api.post_analytics_history_events_daily_mv;
+
+drop table if exists api.post_analytics_history;
+
+drop table if exists api.post_analytics_events_referrer_mv;
+
+drop table if exists api.post_analytics_events_mv;
+
+drop table if exists api.post_analytics;

--- a/clickhouse/migrations/1756316678212_post_analytics.up.sql
+++ b/clickhouse/migrations/1756316678212_post_analytics.up.sql
@@ -1,0 +1,81 @@
+-- up
+
+CREATE TABLE IF NOT EXISTS api.post_analytics
+(
+    post_id String,
+    created_at SimpleAggregateFunction(max, DateTime64(3)),
+    impressions SimpleAggregateFunction(sum, UInt64),
+    reach AggregateFunction(uniq, String),
+    profile_views AggregateFunction(uniq, String),
+    followers AggregateFunction(uniq, String),
+    squad_joins AggregateFunction(uniq, String),
+    bookmarks AggregateFunction(uniq, String),
+    shares_internal SimpleAggregateFunction(sum, UInt64),
+    shares_external SimpleAggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(created_at)
+ORDER BY post_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS api.post_analytics_events_mv
+TO api.post_analytics
+AS
+SELECT
+    target_id AS post_id,
+    sumIf(toUInt64(1), event_name = 'share post') AS shares_external,
+    sumIf(toUInt64(1), event_name = 'share to squad') AS shares_internal,
+    uniqStateIf(user_id, event_name = 'bookmark post') AS bookmarks,
+    sumIf(toUInt64(1), event_name = 'impression' and target_type = 'post') AS impressions,
+    uniqStateIf(user_id, event_name = 'impression' AND target_type = 'post') AS reach,
+    max(server_timestamp) AS created_at
+FROM events.raw_events
+WHERE event_name IN ('share post', 'bookmark post', 'impression', 'share to squad')
+AND target_id is not null
+AND server_timestamp > '2025-08-25 18:45:00'
+GROUP BY target_id
+SETTINGS materialized_views_ignore_errors = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS api.post_analytics_events_referrer_mv
+TO api.post_analytics
+AS
+SELECT
+    JSON_VALUE(extra, '$.referrer_target_id') AS post_id,
+    uniqStateIf(user_id, event_name = 'profile view') AS profile_views,
+    uniqStateIf(user_id, event_name = 'follow') AS followers,
+    uniqStateIf(user_id, event_name = 'complete joining squad') AS squad_joins,
+    max(server_timestamp) AS created_at
+FROM events.raw_events
+WHERE event_name IN ('profile view', 'follow', 'complete joining squad')
+AND JSON_VALUE(extra, '$.referrer_target_id') is not null
+AND JSON_VALUE(extra, '$.referrer_target_type') = 'post'
+AND JSON_VALUE(extra, '$.author') = '1'
+AND server_timestamp > '2025-08-25 18:45:00'
+GROUP BY JSON_VALUE(extra, '$.referrer_target_id')
+SETTINGS materialized_views_ignore_errors = 1;
+
+CREATE TABLE IF NOT EXISTS api.post_analytics_history
+(
+    post_id String,
+    created_at SimpleAggregateFunction(max, DateTime64(3)),
+    date Date, -- YYYY-MM-DD
+    impressions SimpleAggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree
+PARTITION BY toYYYYMM(created_at)
+ORDER BY (date, post_id);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS api.post_analytics_history_events_daily_mv
+TO api.post_analytics_history
+AS
+SELECT
+    target_id                                          AS post_id,
+    toDate(server_timestamp)                           AS date,
+    sumIf(toUInt64(1), event_name = 'impression'
+              AND target_type = 'post')                AS impressions,
+    max(server_timestamp)                              AS created_at
+FROM events.raw_events
+WHERE event_name IN ('impression')
+AND target_id is not null
+AND "server_timestamp" > '2025-08-25 20:08:00'
+GROUP BY date, post_id
+SETTINGS materialized_views_ignore_errors = 1;

--- a/src/entity/ChMigration.ts
+++ b/src/entity/ChMigration.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class ChMigration {
+  @PrimaryColumn({ type: 'bigint' })
+  id: string;
+
+  @Column()
+  name: string;
+
+  @UpdateDateColumn()
+  timestamp: Date;
+
+  @Column()
+  dirty: boolean;
+}

--- a/src/entity/ChMigration.ts
+++ b/src/entity/ChMigration.ts
@@ -1,6 +1,6 @@
 import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
 
-@Entity()
+@Entity({ name: 'migrations_ch' })
 export class ChMigration {
   @PrimaryColumn({ type: 'bigint' })
   id: string;

--- a/src/migration/1756375302904-ChMigration.ts
+++ b/src/migration/1756375302904-ChMigration.ts
@@ -5,11 +5,11 @@ export class ChMigration1756375302904 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "migrations_ch" ("id" bigint NOT NULL, "name" character varying NOT NULL, "timestamp" TIMESTAMP NOT NULL DEFAULT now(), "dirty" boolean NOT NULL, CONSTRAINT "PK_b0fa9708b4cd4f2ade3bf4d3e56" PRIMARY KEY ("id"))`,
+      `CREATE TABLE IF NOT EXISTS "migrations_ch" ("id" bigint NOT NULL, "name" character varying NOT NULL, "timestamp" TIMESTAMP NOT NULL DEFAULT now(), "dirty" boolean NOT NULL, CONSTRAINT "PK_b0fa9708b4cd4f2ade3bf4d3e56" PRIMARY KEY ("id"))`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP TABLE "migrations_ch"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "migrations_ch"`);
   }
 }

--- a/src/migration/1756375302904-ChMigration.ts
+++ b/src/migration/1756375302904-ChMigration.ts
@@ -5,11 +5,11 @@ export class ChMigration1756375302904 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "ch_migration" ("id" bigint NOT NULL, "name" character varying NOT NULL, "timestamp" TIMESTAMP NOT NULL DEFAULT now(), "dirty" boolean NOT NULL, CONSTRAINT "PK_b0fa9708b4cd4f2ade3bf4d3e56" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "migrations_ch" ("id" bigint NOT NULL, "name" character varying NOT NULL, "timestamp" TIMESTAMP NOT NULL DEFAULT now(), "dirty" boolean NOT NULL, CONSTRAINT "PK_b0fa9708b4cd4f2ade3bf4d3e56" PRIMARY KEY ("id"))`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP TABLE "ch_migration"`);
+    await queryRunner.query(`DROP TABLE "migrations_ch"`);
   }
 }

--- a/src/migration/1756375302904-ChMigration.ts
+++ b/src/migration/1756375302904-ChMigration.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChMigration1756375302904 implements MigrationInterface {
+  name = 'ChMigration1756375302904';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "ch_migration" ("id" bigint NOT NULL, "name" character varying NOT NULL, "timestamp" TIMESTAMP NOT NULL DEFAULT now(), "dirty" boolean NOT NULL, CONSTRAINT "PK_b0fa9708b4cd4f2ade3bf4d3e56" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "ch_migration"`);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Roles } from './roles';
 import type { AccessToken } from './auth';
 import type { opentelemetry } from './telemetry';
+import path from 'node:path';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -265,3 +266,12 @@ export const acceptedResumeExtensions = [
   'pdf',
   'docx',
 ] as const satisfies Array<(typeof acceptedResumeFileTypes)[number]['ext']>;
+
+export const clickhouseMigrationsDir = path.resolve(
+  process.cwd(),
+  'clickhouse',
+  'migrations',
+);
+
+export const clickhouseMigrationFilenameMatch =
+  /^(\d+)_([a-zA-Z_]+)\.(up|down)\.sql$/i;


### PR DESCRIPTION
Added a small script to run clickhouse migrations. Based it on lib I found, but opted to just copy small portion of functionality vs using the whole lib. Copied naming/structure of migrations from go projects.

Logic is:
- Discovers migrations named: {id}_{snake_case_name}.{up|down}.sql
- Records migration as dirty in the migrations_ch table on API
- Executes pending *.up.sql in ascending id order
- If any up fails blocks further execution
- Records each applied up into migrations_ch table (id, name, timestamp, dirty = true)