### PR TITLE
refactor: campaign by id fetched by regular users

### DIFF
--- a/__tests__/campaigns.ts
+++ b/__tests__/campaigns.ts
@@ -398,8 +398,8 @@ describe('query campaignById', () => {
     expect(res.data.campaignById).toEqual({
       id: CAMPAIGN_UUID_1,
       type: 'POST',
-      state: 'ACTIVE',
-      createdAt: new Date('2023-01-01').toISOString(),
+      state: null,
+      createdAt: null,
       endedAt: new Date('2023-12-31').toISOString(),
       flags: null, // No sensitive data for non-owners
       post: {
@@ -422,8 +422,8 @@ describe('query campaignById', () => {
     expect(res.data.campaignById).toEqual({
       id: CAMPAIGN_UUID_1,
       type: 'POST',
-      state: 'ACTIVE',
-      createdAt: new Date('2023-01-01').toISOString(),
+      state: null,
+      createdAt: null,
       endedAt: new Date('2023-12-31').toISOString(),
       flags: null, // No sensitive data for unauthenticated users
       post: {

--- a/__tests__/campaigns.ts
+++ b/__tests__/campaigns.ts
@@ -357,28 +357,94 @@ describe('query campaignById', () => {
     );
   });
 
-  it("should throw error when user tries to access another user's campaign", async () => {
-    loggedUser = '2'; // User 2 trying to access User 1's campaign
+  it('should allow any user to access any campaign', async () => {
+    loggedUser = '2'; // User 2 accessing User 1's campaign
 
-    return testQueryErrorCode(
-      client,
-      {
-        query: CAMPAIGN_BY_ID_QUERY,
-        variables: { id: CAMPAIGN_UUID_1 }, // This campaign belongs to user '1'
+    const res = await client.query(CAMPAIGN_BY_ID_QUERY, {
+      variables: { id: CAMPAIGN_UUID_1 }, // This campaign belongs to user '1'
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.campaignById).toEqual({
+      id: CAMPAIGN_UUID_1,
+      type: 'POST',
+      state: 'ACTIVE',
+      createdAt: new Date('2023-01-01').toISOString(),
+      endedAt: new Date('2023-12-31').toISOString(),
+      flags: {
+        budget: 1000,
+        spend: 250,
+        users: 50,
+        clicks: 100,
+        impressions: 5000,
       },
-      'NOT_FOUND',
-    );
+      post: {
+        id: 'p1',
+        title: 'P1',
+        url: 'http://p1.com',
+      },
+      source: null,
+    });
   });
 
-  it('should throw error when user is not authenticated', async () => {
+  it('should allow unauthenticated users to access post campaigns', async () => {
     loggedUser = null;
 
     const res = await client.query(CAMPAIGN_BY_ID_QUERY, {
       variables: { id: CAMPAIGN_UUID_1 },
     });
 
-    expect(res.errors).toBeTruthy();
-    expect(res.errors[0].extensions.code).toBe('UNAUTHENTICATED');
+    expect(res.errors).toBeFalsy();
+    expect(res.data.campaignById).toEqual({
+      id: CAMPAIGN_UUID_1,
+      type: 'POST',
+      state: 'ACTIVE',
+      createdAt: new Date('2023-01-01').toISOString(),
+      endedAt: new Date('2023-12-31').toISOString(),
+      flags: {
+        budget: 1000,
+        spend: 250,
+        users: 50,
+        clicks: 100,
+        impressions: 5000,
+      },
+      post: {
+        id: 'p1',
+        title: 'P1',
+        url: 'http://p1.com',
+      },
+      source: null,
+    });
+  });
+
+  it('should allow unauthenticated users to access source campaigns', async () => {
+    loggedUser = null;
+
+    const res = await client.query(CAMPAIGN_BY_ID_QUERY, {
+      variables: { id: CAMPAIGN_UUID_3 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.campaignById).toEqual({
+      id: CAMPAIGN_UUID_3,
+      type: 'SQUAD',
+      state: 'ACTIVE',
+      createdAt: new Date('2023-03-01').toISOString(),
+      endedAt: new Date('2023-12-31').toISOString(),
+      flags: {
+        budget: 2000,
+        spend: 750,
+        users: 100,
+        clicks: 200,
+        impressions: 10000,
+      },
+      post: null,
+      source: {
+        id: 'a',
+        name: 'A',
+        handle: 'a',
+      },
+    });
   });
 });
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1368,7 +1368,6 @@ const obj = new GraphORM({
         },
       },
       createdAt: {
-        rawSelect: true,
         transform: (value, ctx, parent) => {
           const campaign = parent as Campaign;
           return nullIfNotSameUser(value, ctx, { id: campaign.userId });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -19,6 +19,7 @@ import {
   type PostTranslation,
   PostType,
   type PostFlagsPublic,
+  type Campaign,
 } from '../entity';
 import {
   OrganizationMemberRole,
@@ -1354,10 +1355,17 @@ const obj = new GraphORM({
     },
   },
   Campaign: {
-    requiredColumns: ['id', 'createdAt'],
+    requiredColumns: ['id', 'userId', 'createdAt'],
     fields: {
       flags: {
         jsonType: true,
+        transform: (flag, ctx, parent) => {
+          if (ctx.userId === (parent as Campaign).userId) {
+            return flag;
+          }
+
+          return null;
+        },
       },
     },
   },

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1355,7 +1355,7 @@ const obj = new GraphORM({
     },
   },
   Campaign: {
-    requiredColumns: ['id', 'userId', 'createdAt'],
+    requiredColumns: ['id', 'userId'],
     fields: {
       flags: {
         jsonType: true,
@@ -1365,6 +1365,19 @@ const obj = new GraphORM({
           }
 
           return null;
+        },
+      },
+      createdAt: {
+        rawSelect: true,
+        transform: (value, ctx, parent) => {
+          const campaign = parent as Campaign;
+          return nullIfNotSameUser(value, ctx, { id: campaign.userId });
+        },
+      },
+      state: {
+        transform: (value: string, ctx: Context, parent) => {
+          const campaign = parent as Campaign;
+          return nullIfNotSameUser(value, ctx, { id: campaign.userId });
         },
       },
     },

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -58,8 +58,8 @@ export const typeDefs = /* GraphQL */ `
     id: String!
     referenceId: String!
     type: String!
-    state: String!
-    createdAt: DateTime!
+    state: String
+    createdAt: DateTime
     endedAt: DateTime!
     flags: CampaignFlags
     user: User

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -61,7 +61,7 @@ export const typeDefs = /* GraphQL */ `
     state: String!
     createdAt: DateTime!
     endedAt: DateTime!
-    flags: CampaignFlags!
+    flags: CampaignFlags
     user: User
     post: Post
     source: Source

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -91,7 +91,7 @@ export const typeDefs = /* GraphQL */ `
       ID of the campaign to fetch
       """
       id: ID!
-    ): Campaign! @auth
+    ): Campaign!
 
     campaignsList(
       """
@@ -172,7 +172,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       info,
     ): Promise<GQLCampaign> =>
       graphorm.queryOneOrFail(ctx, info, (builder) => {
-        builder.queryBuilder.where({ id }).andWhere({ userId: ctx.userId });
+        builder.queryBuilder.where({ id });
 
         return builder;
       }),


### PR DESCRIPTION
We use the `campaignById` query to fetch the information about who boosted the Squad and more details, such as when it is going to end. Also removed the `@auth` directive as anonymous users are able to view Squads directory that has this feature.

For other Squad mods/admins:

<img width="681" height="364" alt="Screenshot 2025-08-29 at 5 12 20 PM" src="https://github.com/user-attachments/assets/1dd8c6d4-a51d-4237-8365-e03c99663251" />


For anonymous user:

<img width="417" height="529" alt="Screenshot 2025-08-29 at 5 10 54 PM" src="https://github.com/user-attachments/assets/9b755938-26c3-4c2f-953d-094f2d2ea596" />

