### PR TITLE
feat: query campaign stats as a separate query

### DIFF
--- a/__tests__/campaigns.ts
+++ b/__tests__/campaigns.ts
@@ -1766,10 +1766,10 @@ describe('mutation stopCampaign', () => {
   });
 });
 
-describe('query userCampaignData', () => {
+describe('query userCampaignStats', () => {
   const USER_CAMPAIGN_STATS_QUERY = /* GraphQL */ `
-    query UserCampaignData {
-      userCampaignData {
+    query UserCampaignStats {
+      userCampaignStats {
         impressions
         clicks
         users
@@ -1858,7 +1858,7 @@ describe('query userCampaignData', () => {
     const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
 
     expect(res.errors).toBeFalsy();
-    expect(res.data.userCampaignData).toEqual({
+    expect(res.data.userCampaignStats).toEqual({
       clicks: 235, // 100 + 75 + 60
       impressions: 10500, // 5000 + 2500 + 3000
       users: 105, // 50 + 25 + 30
@@ -1872,7 +1872,7 @@ describe('query userCampaignData', () => {
     const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
 
     expect(res.errors).toBeFalsy();
-    expect(res.data.userCampaignData).toEqual({
+    expect(res.data.userCampaignStats).toEqual({
       clicks: 0,
       impressions: 0,
       users: 0,
@@ -1886,7 +1886,7 @@ describe('query userCampaignData', () => {
     const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
 
     expect(res.errors).toBeFalsy();
-    expect(res.data.userCampaignData).toEqual({
+    expect(res.data.userCampaignStats).toEqual({
       clicks: 150,
       impressions: 7500,
       users: 75,
@@ -1901,7 +1901,7 @@ describe('query userCampaignData', () => {
 
     expect(res.errors).toBeFalsy();
     // Should include Active, Completed, and Cancelled campaigns
-    expect(res.data.userCampaignData.clicks).toBe(235); // All campaigns counted
+    expect(res.data.userCampaignStats.clicks).toBe(235); // All campaigns counted
   });
 
   it('should handle null flags gracefully', async () => {
@@ -1924,7 +1924,7 @@ describe('query userCampaignData', () => {
 
     expect(res.errors).toBeFalsy();
     // Should still return the aggregated stats, treating null flags as 0
-    expect(res.data.userCampaignData).toEqual({
+    expect(res.data.userCampaignStats).toEqual({
       clicks: 235, // Same as before, null flags contribute 0
       impressions: 10500,
       users: 105,
@@ -1956,7 +1956,7 @@ describe('query userCampaignData', () => {
 
     expect(res.errors).toBeFalsy();
     // Should handle missing fields gracefully
-    expect(res.data.userCampaignData).toEqual({
+    expect(res.data.userCampaignStats).toEqual({
       clicks: 235, // Same as before, missing fields contribute 0
       impressions: 10500,
       users: 105,

--- a/__tests__/campaigns.ts
+++ b/__tests__/campaigns.ts
@@ -1766,6 +1766,214 @@ describe('mutation stopCampaign', () => {
   });
 });
 
+describe('query userCampaignData', () => {
+  const USER_CAMPAIGN_STATS_QUERY = /* GraphQL */ `
+    query UserCampaignData {
+      userCampaignData {
+        impressions
+        clicks
+        users
+        spend
+      }
+    }
+  `;
+
+  beforeEach(async () => {
+    // Create multiple campaigns with different stats for user 1
+    await con.getRepository(CampaignPost).save([
+      {
+        id: CAMPAIGN_UUID_1,
+        referenceId: 'ref1',
+        userId: '1',
+        type: CampaignType.Post,
+        state: CampaignState.Active,
+        createdAt: new Date('2023-01-01'),
+        endedAt: new Date('2023-12-31'),
+        flags: {
+          budget: 1000,
+          spend: 250,
+          users: 50,
+          clicks: 100,
+          impressions: 5000,
+        },
+        postId: 'p1',
+      },
+      {
+        id: CAMPAIGN_UUID_2,
+        referenceId: 'ref2',
+        userId: '1',
+        type: CampaignType.Post,
+        state: CampaignState.Completed,
+        createdAt: new Date('2023-02-01'),
+        endedAt: new Date('2023-11-30'),
+        flags: {
+          budget: 500,
+          spend: 500,
+          users: 25,
+          clicks: 75,
+          impressions: 2500,
+        },
+        postId: 'p2',
+      },
+      {
+        id: CAMPAIGN_UUID_3,
+        referenceId: 'ref3',
+        userId: '1',
+        type: CampaignType.Post,
+        state: CampaignState.Cancelled,
+        createdAt: new Date('2023-03-01'),
+        endedAt: new Date('2023-12-31'),
+        flags: {
+          budget: 2000,
+          spend: 150,
+          users: 30,
+          clicks: 60,
+          impressions: 3000,
+        },
+        postId: 'p3',
+      },
+      {
+        id: CAMPAIGN_UUID_4,
+        referenceId: 'ref4',
+        userId: '2', // Different user
+        type: CampaignType.Post,
+        state: CampaignState.Active,
+        createdAt: new Date('2023-04-01'),
+        endedAt: new Date('2023-12-31'),
+        flags: {
+          budget: 1500,
+          spend: 300,
+          users: 75,
+          clicks: 150,
+          impressions: 7500,
+        },
+        postId: 'p4',
+      },
+    ]);
+  });
+
+  it('should return aggregated campaign statistics for authenticated user', async () => {
+    loggedUser = '1';
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userCampaignData).toEqual({
+      clicks: 235, // 100 + 75 + 60
+      impressions: 10500, // 5000 + 2500 + 3000
+      users: 105, // 50 + 25 + 30
+      spend: 900, // 250 + 500 + 150
+    });
+  });
+
+  it('should return zero stats when user has no campaigns', async () => {
+    loggedUser = '3'; // User with no campaigns
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userCampaignData).toEqual({
+      clicks: 0,
+      impressions: 0,
+      users: 0,
+      spend: 0,
+    });
+  });
+
+  it('should only return stats for the authenticated user', async () => {
+    loggedUser = '2'; // User 2 has only one campaign
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userCampaignData).toEqual({
+      clicks: 150,
+      impressions: 7500,
+      users: 75,
+      spend: 300,
+    });
+  });
+
+  it('should include campaigns in all states', async () => {
+    loggedUser = '1';
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    // Should include Active, Completed, and Cancelled campaigns
+    expect(res.data.userCampaignData.clicks).toBe(235); // All campaigns counted
+  });
+
+  it('should handle null flags gracefully', async () => {
+    loggedUser = '1';
+
+    // Add a campaign with null flags
+    await con.getRepository(CampaignPost).save({
+      id: CAMPAIGN_UUID_5,
+      referenceId: 'ref5',
+      userId: '1',
+      type: CampaignType.Post,
+      state: CampaignState.Active,
+      createdAt: new Date('2023-05-01'),
+      endedAt: new Date('2023-12-31'),
+      flags: undefined, // Undefined flags
+      postId: 'p1',
+    });
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    // Should still return the aggregated stats, treating null flags as 0
+    expect(res.data.userCampaignData).toEqual({
+      clicks: 235, // Same as before, null flags contribute 0
+      impressions: 10500,
+      users: 105,
+      spend: 900,
+    });
+  });
+
+  it('should handle missing flag fields gracefully', async () => {
+    loggedUser = '1';
+
+    // Add a campaign with incomplete flags
+    await con.getRepository(CampaignPost).save({
+      id: CAMPAIGN_UUID_5,
+      referenceId: 'ref5',
+      userId: '1',
+      type: CampaignType.Post,
+      state: CampaignState.Active,
+      createdAt: new Date('2023-05-01'),
+      endedAt: new Date('2023-12-31'),
+      flags: {
+        budget: 1000,
+        spend: 100,
+        // Missing clicks, impressions, users
+      },
+      postId: 'p1',
+    });
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    // Should handle missing fields gracefully
+    expect(res.data.userCampaignData).toEqual({
+      clicks: 235, // Same as before, missing fields contribute 0
+      impressions: 10500,
+      users: 105,
+      spend: 1000, // 900 + 100
+    });
+  });
+
+  it('should throw error when user is not authenticated', async () => {
+    loggedUser = null;
+
+    const res = await client.query(USER_CAMPAIGN_STATS_QUERY);
+
+    expect(res.errors).toBeTruthy();
+    expect(res.errors?.[0].extensions.code).toBe('UNAUTHENTICATED');
+  });
+});
+
 describe('query dailyCampaignReachEstimate', () => {
   const QUERY = `
     query DailyCampaignReachEstimate(

--- a/src/common/campaign/common.ts
+++ b/src/common/campaign/common.ts
@@ -138,16 +138,16 @@ export const getReferenceTags = (
   }
 };
 
-export interface UserCampaignData {
+export interface UserCampaignStats {
   impressions: number;
   clicks: number;
   spend: number;
   users: number;
 }
 
-export const getUserCampaignData = async (
+export const getUserCampaignStats = async (
   ctx: AuthContext,
-): Promise<UserCampaignData> => {
+): Promise<UserCampaignStats> => {
   const result = await queryReadReplica(ctx.con, ({ queryRunner }) =>
     queryRunner.manager
       .getRepository(CampaignPost)

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -22,8 +22,10 @@ import {
 } from '../common/campaign/post';
 import {
   getReferenceTags,
+  getUserCampaignData,
   StartCampaignArgs,
   validateCampaignArgs,
+  type UserCampaignData,
 } from '../common/campaign/common';
 import { ValidationError } from 'apollo-server-errors';
 import {
@@ -85,6 +87,13 @@ export const typeDefs = /* GraphQL */ `
     max: Int!
   }
 
+  type UserCampaignData {
+    impressions: Int!
+    clicks: Int!
+    users: Int!
+    spend: Int!
+  }
+
   extend type Query {
     campaignById(
       """
@@ -103,6 +112,11 @@ export const typeDefs = /* GraphQL */ `
       """
       first: Int
     ): CampaignConnection! @auth
+
+    """
+    Get aggregated campaign statistics for the authenticated user
+    """
+    userCampaignData: UserCampaignData! @auth
 
     dailyCampaignReachEstimate(
       """
@@ -165,6 +179,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   BaseContext
 >({
   Query: {
+    userCampaignData: async (
+      _,
+      __,
+      ctx: AuthContext,
+    ): Promise<UserCampaignData> => getUserCampaignData(ctx),
     campaignById: async (
       _,
       { id }: { id: string },

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -22,10 +22,10 @@ import {
 } from '../common/campaign/post';
 import {
   getReferenceTags,
-  getUserCampaignData,
+  getUserCampaignStats,
   StartCampaignArgs,
   validateCampaignArgs,
-  type UserCampaignData,
+  type UserCampaignStats,
 } from '../common/campaign/common';
 import { ValidationError } from 'apollo-server-errors';
 import {
@@ -87,7 +87,7 @@ export const typeDefs = /* GraphQL */ `
     max: Int!
   }
 
-  type UserCampaignData {
+  type UserCampaignStats {
     impressions: Int!
     clicks: Int!
     users: Int!
@@ -116,7 +116,7 @@ export const typeDefs = /* GraphQL */ `
     """
     Get aggregated campaign statistics for the authenticated user
     """
-    userCampaignData: UserCampaignData! @auth
+    userCampaignStats: UserCampaignStats! @auth
 
     dailyCampaignReachEstimate(
       """
@@ -179,11 +179,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
   BaseContext
 >({
   Query: {
-    userCampaignData: async (
+    userCampaignStats: async (
       _,
       __,
       ctx: AuthContext,
-    ): Promise<UserCampaignData> => getUserCampaignData(ctx),
+    ): Promise<UserCampaignStats> => getUserCampaignStats(ctx),
     campaignById: async (
       _,
       { id }: { id: string },


### PR DESCRIPTION
We've separated the stats call from the list to avoid coupling things together.