### PR TITLE
fix: missing data from workers

### DIFF
--- a/__tests__/workers/campaignUpdatedSlack.ts
+++ b/__tests__/workers/campaignUpdatedSlack.ts
@@ -8,7 +8,7 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import {
   CampaignUpdateEvent,
-  type CampaignStatsUpdateEvent,
+  type CampaignUpdateEventArgs,
 } from '../../src/common/campaign/common';
 import { webhooks } from '../../src/common/slack';
 import {
@@ -37,11 +37,11 @@ beforeEach(async () => {
 
 describe('campaignUpdatedSlack worker', () => {
   it('should send a slack notification when a post campaign starts', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       event: CampaignUpdateEvent.Started,
       unique_users: 100,
-      data: { budget: '10.00', spend: '1.00' },
+      data: { budget: '10.00' },
       d_update: Date.now(),
     };
 
@@ -101,11 +101,11 @@ describe('campaignUpdatedSlack worker', () => {
   });
 
   it('should send a slack notification when a squad campaign starts', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d481',
       event: CampaignUpdateEvent.Started,
       unique_users: 50,
-      data: { budget: '5.00', spend: '0.00' },
+      data: { budget: '5.00' },
       d_update: Date.now(),
     };
 
@@ -165,7 +165,7 @@ describe('campaignUpdatedSlack worker', () => {
   });
 
   it('should not send notification for non-started events', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       event: CampaignUpdateEvent.Completed,
       unique_users: 200,
@@ -179,7 +179,7 @@ describe('campaignUpdatedSlack worker', () => {
   });
 
   it('should not send notification for stats updated events', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       event: CampaignUpdateEvent.StatsUpdated,
       unique_users: 150,
@@ -193,11 +193,11 @@ describe('campaignUpdatedSlack worker', () => {
   });
 
   it('should not send notification for state updated events', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-      event: CampaignUpdateEvent.StateUpdated,
+      event: CampaignUpdateEvent.BudgetUpdated,
       unique_users: 100,
-      data: { budget: '15.00', spend: '5.00' },
+      data: { budget: '15.00' },
       d_update: Date.now(),
     };
 
@@ -206,23 +206,22 @@ describe('campaignUpdatedSlack worker', () => {
     expect(mockAdsSend).not.toHaveBeenCalled();
   });
 
-  it('should handle when campaign is not found', async () => {
-    const eventData: CampaignStatsUpdateEvent = {
+  it('should ignore when campaign is not found', async () => {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d999',
       event: CampaignUpdateEvent.Started,
       unique_users: 100,
-      data: { budget: '10.00', spend: '0.00' },
+      data: { budget: '10.00' },
       d_update: Date.now(),
     };
 
-    await expect(
-      expectSuccessfulTypedBackground(worker, eventData),
-    ).rejects.toThrow();
+    // Worker should complete successfully and just ignore non-existent campaign
+    await expectSuccessfulTypedBackground(worker, eventData);
 
     expect(mockAdsSend).not.toHaveBeenCalled();
   });
 
-  it('should handle when source is not found for squad campaign', async () => {
+  it('should ignore when source is not found for squad campaign', async () => {
     // Create a campaign with non-existent source
     const campaignWithInvalidSource = {
       id: 'f47ac10b-58cc-4372-a567-0e02b2c3d485',
@@ -239,17 +238,16 @@ describe('campaignUpdatedSlack worker', () => {
 
     await saveFixtures(con, Campaign, [campaignWithInvalidSource]);
 
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d485',
       event: CampaignUpdateEvent.Started,
       unique_users: 100,
-      data: { budget: '10.00', spend: '0.00' },
+      data: { budget: '10.00' },
       d_update: Date.now(),
     };
 
-    await expect(
-      expectSuccessfulTypedBackground(worker, eventData),
-    ).rejects.toThrow();
+    // Worker should complete successfully and just ignore when source is not found
+    await expectSuccessfulTypedBackground(worker, eventData);
 
     expect(mockAdsSend).not.toHaveBeenCalled();
   });
@@ -258,11 +256,11 @@ describe('campaignUpdatedSlack worker', () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
 
-    const eventData: CampaignStatsUpdateEvent = {
+    const eventData: CampaignUpdateEventArgs = {
       campaignId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
       event: CampaignUpdateEvent.Started,
       unique_users: 100,
-      data: { budget: '10.00', spend: '0.00' },
+      data: { budget: '10.00' },
       d_update: Date.now(),
     };
 

--- a/__tests__/workers/campaignUpdatedSlack.ts
+++ b/__tests__/workers/campaignUpdatedSlack.ts
@@ -221,7 +221,7 @@ describe('campaignUpdatedSlack worker', () => {
     expect(mockAdsSend).not.toHaveBeenCalled();
   });
 
-  it('should ignore when source is not found for squad campaign', async () => {
+  it('should handle when source is not found for squad campaign', async () => {
     // Create a campaign with non-existent source
     const campaignWithInvalidSource = {
       id: 'f47ac10b-58cc-4372-a567-0e02b2c3d485',
@@ -247,7 +247,9 @@ describe('campaignUpdatedSlack worker', () => {
     };
 
     // Worker should complete successfully and just ignore when source is not found
-    await expectSuccessfulTypedBackground(worker, eventData);
+    await expect(
+      expectSuccessfulTypedBackground(worker, eventData),
+    ).rejects.toThrow();
 
     expect(mockAdsSend).not.toHaveBeenCalled();
   });

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -1007,6 +1007,22 @@ describe('post boost action', () => {
     const updatedPost = await con.getRepository(Post).findOneBy({ id: 'p1' });
     expect(updatedPost?.flags?.campaignId).toEqual('tmp-campaign');
   });
+
+  it('should ignore when userId is missing', async () => {
+    const worker = await import(
+      '../../src/workers/notifications/postBoostAction'
+    );
+
+    const actual = await invokeNotificationWorker(worker.default, {
+      userId: undefined, // Missing userId
+      postId: 'p1',
+      campaignId: 'tmp-campaign',
+      action: 'first_milestone',
+    });
+
+    // Should not return any notifications when userId is missing
+    expect(actual).toBeFalsy();
+  });
 });
 
 describe('post bookmark reminder', () => {

--- a/src/workers/campaignUpdatedAction.ts
+++ b/src/workers/campaignUpdatedAction.ts
@@ -24,7 +24,6 @@ const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
     try {
       const campaign = await con.getRepository(Campaign).findOneOrFail({
         where: { id: params.data.campaignId },
-        relations: ['user'],
       });
 
       await con.transaction(async (manager) => {

--- a/src/workers/campaignUpdatedAction.ts
+++ b/src/workers/campaignUpdatedAction.ts
@@ -24,7 +24,7 @@ const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
       .findOneBy({ id: message.data.campaignId });
 
     if (!campaign) {
-      throw new Error(`Campaign not found! ${message.data.campaignId}`);
+      return;
     }
 
     await con.transaction(async (manager) => {

--- a/src/workers/campaignUpdatedSlack.ts
+++ b/src/workers/campaignUpdatedSlack.ts
@@ -57,6 +57,10 @@ const handleCampaignStarted = async (
     .getRepository(Campaign)
     .findOneByOrFail({ id: data.campaignId });
 
+  if (!campaign) {
+    return;
+  }
+
   const mdLink = await getMdLink(con, campaign);
 
   if (!mdLink) {

--- a/src/workers/campaignUpdatedSlack.ts
+++ b/src/workers/campaignUpdatedSlack.ts
@@ -24,9 +24,17 @@ const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
       return;
     }
 
+    const campaign = await con
+      .getRepository(Campaign)
+      .findOneByOrFail({ id: message.data.campaignId });
+
+    if (!campaign) {
+      return;
+    }
+
     switch (message.data.event) {
       case CampaignUpdateEvent.Started:
-        return handleCampaignStarted(con, message.data);
+        return handleCampaignStarted(con, message.data, campaign);
       default:
         return;
     }
@@ -52,15 +60,8 @@ const getMdLink = async (con: ConnectionManager, campaign: Campaign) => {
 const handleCampaignStarted = async (
   con: DataSource,
   data: CampaignUpdateEventArgs,
+  campaign: Campaign,
 ) => {
-  const campaign = await con
-    .getRepository(Campaign)
-    .findOneByOrFail({ id: data.campaignId });
-
-  if (!campaign) {
-    return;
-  }
-
   const mdLink = await getMdLink(con, campaign);
 
   if (!mdLink) {

--- a/src/workers/notifications/campaignUpdatedAction.ts
+++ b/src/workers/notifications/campaignUpdatedAction.ts
@@ -35,6 +35,11 @@ const handleCampaignCompleted = async (
       .getRepository(Campaign)
       .findOneOrFail({ where: { id: campaignId }, relations: ['user'] }),
   );
+
+  if (!campaign) {
+    return;
+  }
+
   const user = await campaign.user;
 
   const ctx: NotificationCampaignContext = {

--- a/src/workers/notifications/postBoostAction.ts
+++ b/src/workers/notifications/postBoostAction.ts
@@ -4,7 +4,6 @@ import { generateTypedNotificationWorker } from './worker';
 import { type NotificationBoostContext } from '../../notifications';
 import { queryReadReplica } from '../../common/queryReadReplica';
 import { updateFlagsStatement } from '../../common';
-import { logger } from '../../logger';
 
 const worker = generateTypedNotificationWorker<'skadi.v1.campaign-updated'>({
   subscription: 'api.campaign-updated-notification',
@@ -12,7 +11,6 @@ const worker = generateTypedNotificationWorker<'skadi.v1.campaign-updated'>({
     const { userId, postId, campaignId, action } = params;
 
     if (!userId) {
-      logger.error({ data: params }, `skadi v1 worker: user id is empty!`);
       return;
     }
 

--- a/src/workers/notifications/postBoostAction.ts
+++ b/src/workers/notifications/postBoostAction.ts
@@ -4,11 +4,17 @@ import { generateTypedNotificationWorker } from './worker';
 import { type NotificationBoostContext } from '../../notifications';
 import { queryReadReplica } from '../../common/queryReadReplica';
 import { updateFlagsStatement } from '../../common';
+import { logger } from '../../logger';
 
 const worker = generateTypedNotificationWorker<'skadi.v1.campaign-updated'>({
   subscription: 'api.campaign-updated-notification',
   handler: async (params, con) => {
     const { userId, postId, campaignId, action } = params;
+
+    if (!userId) {
+      logger.error({ data: params }, `skadi v1 worker: user id is empty!`);
+      return;
+    }
 
     const user = await queryReadReplica(con, ({ queryRunner }) => {
       return queryRunner.manager


### PR DESCRIPTION
Campaign v2 workers: if campaign does not exist, ignore it as [Viktor have said](https://dailydotdev.slack.com/archives/C07LHS7RXA4/p1756719562719959?thread_ts=1756718292.452039&cid=C07LHS7RXA4).

Campaign v1 workers: when a user is not found, log an error instead of throwing it.