### PR TITLE
fix: workers receiving completed event

### DIFF
--- a/__tests__/workers/campaignUpdatedAction.ts
+++ b/__tests__/workers/campaignUpdatedAction.ts
@@ -342,11 +342,6 @@ describe('campaignUpdatedAction worker', () => {
       .findOneByOrFail({ id: cancelledCampaignId });
 
     expect(campaign.state).toBe(CampaignState.Cancelled);
-
-    // Verify post campaignId was not cleared since campaign wasn't actually completed
-    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
-
-    expect(post.flags?.campaignId).toBe(cancelledCampaignId);
   });
 
   it('should not update cancelled Squad campaigns when completion event is received', async () => {
@@ -379,13 +374,6 @@ describe('campaignUpdatedAction worker', () => {
       .findOneByOrFail({ id: cancelledCampaignId });
 
     expect(campaign.state).toBe(CampaignState.Cancelled);
-
-    // Verify source campaignId was not cleared since campaign wasn't actually completed
-    const source = await con
-      .getRepository(Source)
-      .findOneByOrFail({ id: 'squad' });
-
-    expect(source.flags?.campaignId).toBe(cancelledCampaignId);
   });
 
   it('should update multiple campaign stats correctly', async () => {

--- a/__tests__/workers/campaignUpdatedAction.ts
+++ b/__tests__/workers/campaignUpdatedAction.ts
@@ -312,6 +312,82 @@ describe('campaignUpdatedAction worker', () => {
     );
   });
 
+  it('should not update cancelled Post campaigns when completion event is received', async () => {
+    // Set up a campaign in cancelled state
+    const cancelledCampaignId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    await con
+      .getRepository(Campaign)
+      .update({ id: cancelledCampaignId }, { state: CampaignState.Cancelled });
+
+    // Set a campaignId on a post to verify it's not cleared for cancelled campaigns
+    await con
+      .getRepository(Post)
+      .update({ id: 'p1' }, { flags: { campaignId: cancelledCampaignId } });
+
+    const eventData: CampaignUpdateEventArgs = {
+      campaignId: cancelledCampaignId,
+      event: CampaignUpdateEvent.Completed,
+      unique_users: 100,
+      data: {
+        budget: '10.00',
+      },
+      d_update: Date.now() * 1000,
+    };
+
+    await expectSuccessfulTypedBackground(worker, eventData);
+
+    // Verify campaign remains in cancelled state (not updated to completed)
+    const campaign = await con
+      .getRepository(Campaign)
+      .findOneByOrFail({ id: cancelledCampaignId });
+
+    expect(campaign.state).toBe(CampaignState.Cancelled);
+
+    // Verify post campaignId was not cleared since campaign wasn't actually completed
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+
+    expect(post.flags?.campaignId).toBe(cancelledCampaignId);
+  });
+
+  it('should not update cancelled Squad campaigns when completion event is received', async () => {
+    // Set up a Squad campaign in cancelled state
+    const cancelledCampaignId = 'f47ac10b-58cc-4372-a567-0e02b2c3d481';
+    await con
+      .getRepository(Campaign)
+      .update({ id: cancelledCampaignId }, { state: CampaignState.Cancelled });
+
+    // Set a campaignId on a source to verify it's not cleared for cancelled campaigns
+    await con
+      .getRepository(Source)
+      .update({ id: 'squad' }, { flags: { campaignId: cancelledCampaignId } });
+
+    const eventData: CampaignUpdateEventArgs = {
+      campaignId: cancelledCampaignId,
+      event: CampaignUpdateEvent.Completed,
+      unique_users: 100,
+      data: {
+        budget: '5.00',
+      },
+      d_update: Date.now() * 1000,
+    };
+
+    await expectSuccessfulTypedBackground(worker, eventData);
+
+    // Verify campaign remains in cancelled state (not updated to completed)
+    const campaign = await con
+      .getRepository(Campaign)
+      .findOneByOrFail({ id: cancelledCampaignId });
+
+    expect(campaign.state).toBe(CampaignState.Cancelled);
+
+    // Verify source campaignId was not cleared since campaign wasn't actually completed
+    const source = await con
+      .getRepository(Source)
+      .findOneByOrFail({ id: 'squad' });
+
+    expect(source.flags?.campaignId).toBe(cancelledCampaignId);
+  });
+
   it('should update multiple campaign stats correctly', async () => {
     // First stats update
     const firstUpdate: CampaignUpdateEventArgs = {

--- a/src/workers/campaignUpdatedAction.ts
+++ b/src/workers/campaignUpdatedAction.ts
@@ -18,6 +18,12 @@ import { usdToCores } from '../common/number';
 import { logger } from '../logger';
 import type { TypeORMQueryFailedError } from '../errors';
 
+interface HandlerEventArgs {
+  con: ConnectionManager;
+  params: CampaignUpdateEventArgs;
+  campaign: Campaign;
+}
+
 const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
   subscription: 'api.campaign-updated-v2-action',
   handler: async (params, con): Promise<void> => {
@@ -69,11 +75,7 @@ export default worker;
 const handleCampaignBudgetUpdate = async ({
   con,
   params: { data, campaignId },
-}: {
-  con: ConnectionManager;
-  params: CampaignUpdateEventArgs;
-  campaign: Campaign;
-}) => {
+}: HandlerEventArgs) => {
   const { budget: usedBudget } = data as CampaignStateUpdate;
 
   await con.getRepository(Campaign).update(
@@ -89,11 +91,7 @@ const handleCampaignBudgetUpdate = async ({
 const handleCampaignStatsUpdate = async ({
   con,
   params: { data, campaignId },
-}: {
-  con: ConnectionManager;
-  params: CampaignUpdateEventArgs;
-  campaign: Campaign;
-}) => {
+}: HandlerEventArgs) => {
   const { impressions, clicks, unique_users } = data as CampaignStatsUpdate;
 
   await con.getRepository(Campaign).update(
@@ -112,11 +110,7 @@ const handleCampaignCompleted = async ({
   con,
   params,
   campaign,
-}: {
-  con: ConnectionManager;
-  params: CampaignUpdateEventArgs;
-  campaign: Campaign;
-}) => {
+}: HandlerEventArgs) => {
   const { campaignId } = params;
 
   await con.getRepository(Campaign).update(

--- a/src/workers/campaignUpdatedAction.ts
+++ b/src/workers/campaignUpdatedAction.ts
@@ -119,9 +119,10 @@ const handleCampaignCompleted = async ({
 }) => {
   const { campaignId } = params;
 
-  await con
-    .getRepository(Campaign)
-    .update({ id: campaignId }, { state: CampaignState.Completed });
+  await con.getRepository(Campaign).update(
+    { id: campaignId, state: CampaignState.Active }, // only update if still active - for example if cancelled, do not update
+    { state: CampaignState.Completed },
+  );
 
   switch (campaign.type) {
     case CampaignType.Post:


### PR DESCRIPTION
Skadi will send a `completed` event regardless of whether it was due to budget consumption or cancellation. As long as the state in Skadi turns from active to inactive, an event is sent.

When we cancel a campaign, on our side, we immediately set its state to Cancelled, so when Skadi triggers completed event, we don't have to overwrite it.