### PR TITLE
feat: show team members on boosts

### DIFF
--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -36,11 +36,13 @@ interface NotifyBoostedProps {
     Campaign,
     'createdAt' | 'endedAt' | 'type' | 'flags' | 'id' | 'userId'
   >;
+  isTeamMember: boolean;
 }
 
 export const notifyNewPostBoostedSlack = async ({
   mdLink,
   campaign,
+  isTeamMember = false,
 }: NotifyBoostedProps): Promise<void> => {
   const { createdAt, endedAt, userId, flags, type, id } = campaign;
   const difference = getAbsoluteDifferenceInDays(endedAt, createdAt);
@@ -70,6 +72,7 @@ export const notifyNewPostBoostedSlack = async ({
             text: concatTextToNewline(
               '*Boosted by:*',
               `<https://app.daily.dev/${userId}|${userId}>`,
+              `${isTeamMember ? ' (team)' : ''}`,
             ),
           },
         ],

--- a/src/workers/campaignUpdatedSlack.ts
+++ b/src/workers/campaignUpdatedSlack.ts
@@ -86,6 +86,7 @@ const handleCampaignStarted = async ({
     where: {
       userId: campaign.userId,
       feature: FeatureType.Team,
+      value: 1,
     },
   });
 

--- a/src/workers/campaignUpdatedSlack.ts
+++ b/src/workers/campaignUpdatedSlack.ts
@@ -4,6 +4,8 @@ import {
   CampaignType,
   Source,
   type ConnectionManager,
+  Feature,
+  FeatureType,
 } from '../entity';
 import { type DataSource } from 'typeorm';
 import {
@@ -80,8 +82,16 @@ const handleCampaignStarted = async ({
     return;
   }
 
+  const isTeamMember = await con.getRepository(Feature).exists({
+    where: {
+      userId: campaign.userId,
+      feature: FeatureType.Team,
+    },
+  });
+
   await notifyNewPostBoostedSlack({
     mdLink,
     campaign,
+    isTeamMember,
   });
 };

--- a/src/workers/postBoostActionSlack.ts
+++ b/src/workers/postBoostActionSlack.ts
@@ -1,5 +1,5 @@
 import { TypedWorker } from './worker';
-import { CampaignType, Post } from '../entity';
+import { CampaignType, Feature, FeatureType, Post } from '../entity';
 import type { DataSource } from 'typeorm';
 import {
   debeziumTimeToDate,
@@ -47,6 +47,13 @@ const handlePostBoostStarted = async (
     return;
   }
 
+  const isTeamMember = await con.getRepository(Feature).exists({
+    where: {
+      userId,
+      feature: FeatureType.Team,
+    },
+  });
+
   await notifyNewPostBoostedSlack({
     campaign: {
       id: campaign.campaignId,
@@ -57,5 +64,6 @@ const handlePostBoostStarted = async (
       userId,
     },
     mdLink: `<${getDiscussionLink(post.id)}|${post.id}>`,
+    isTeamMember,
   });
 };

--- a/src/workers/postBoostActionSlack.ts
+++ b/src/workers/postBoostActionSlack.ts
@@ -51,6 +51,7 @@ const handlePostBoostStarted = async (
     where: {
       userId,
       feature: FeatureType.Team,
+      value: 1,
     },
   });
 


### PR DESCRIPTION
Small addition to show team members on boosts.
Contemplated doing it inside the slack worker, but seemed more streamlined like this, with query client outside.