### PR TITLE
feat: get campaigns per entity

### DIFF
--- a/__tests__/campaigns.ts
+++ b/__tests__/campaigns.ts
@@ -439,8 +439,8 @@ describe('query campaignById', () => {
 
 describe('query campaignsList', () => {
   const CAMPAIGNS_LIST_QUERY = /* GraphQL */ `
-    query CampaignsList($first: Int, $after: String) {
-      campaignsList(first: $first, after: $after) {
+    query CampaignsList($first: Int, $after: String, $entityId: ID) {
+      campaignsList(first: $first, after: $after, entityId: $entityId) {
         pageInfo {
           hasNextPage
           hasPreviousPage
@@ -483,7 +483,7 @@ describe('query campaignsList', () => {
     await con.getRepository(CampaignPost).save([
       {
         id: CAMPAIGN_UUID_1,
-        referenceId: 'ref1',
+        referenceId: 'p1',
         userId: '1',
         type: CampaignType.Post,
         state: CampaignState.Active,
@@ -500,7 +500,7 @@ describe('query campaignsList', () => {
       },
       {
         id: CAMPAIGN_UUID_2,
-        referenceId: 'ref2',
+        referenceId: 'p2',
         userId: '1',
         type: CampaignType.Post,
         state: CampaignState.Completed,
@@ -517,7 +517,7 @@ describe('query campaignsList', () => {
       },
       {
         id: CAMPAIGN_UUID_3,
-        referenceId: 'ref3',
+        referenceId: 'p3',
         userId: '1',
         type: CampaignType.Post,
         state: CampaignState.Active,
@@ -534,7 +534,7 @@ describe('query campaignsList', () => {
       },
       {
         id: CAMPAIGN_UUID_4,
-        referenceId: 'ref4',
+        referenceId: 'p4',
         userId: '2', // Different user
         type: CampaignType.Post,
         state: CampaignState.Active,
@@ -670,6 +670,30 @@ describe('query campaignsList', () => {
     expect(res.data.campaignsList.edges).toHaveLength(0);
     expect(res.data.campaignsList.pageInfo.hasNextPage).toBe(false);
     expect(res.data.campaignsList.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it('should return campaigns for entity', async () => {
+    loggedUser = '1';
+
+    const res = await client.query(CAMPAIGNS_LIST_QUERY, {
+      variables: { first: 10, entityId: 'p1' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.campaignsList.edges).toHaveLength(1);
+
+    expect(res.data.campaignsList.edges[0].node.id).toBe(CAMPAIGN_UUID_1);
+  });
+
+  it('should return campaigns for entity from other user', async () => {
+    loggedUser = '2';
+
+    const res = await client.query(CAMPAIGNS_LIST_QUERY, {
+      variables: { first: 10, entityId: 'p1' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.campaignsList.edges).toHaveLength(0);
   });
 });
 

--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -113,6 +113,11 @@ export const typeDefs = /* GraphQL */ `
       Paginate first
       """
       first: Int
+
+      """
+      ID of the entity to fetch campaigns for
+      """
+      entityId: ID
     ): CampaignConnection! @auth
 
     """
@@ -199,7 +204,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       }),
     campaignsList: async (
       _,
-      args: ConnectionArguments,
+      args: ConnectionArguments & {
+        entityId?: string;
+      },
       ctx: AuthContext,
       info,
     ): Promise<Connection<GQLCampaign>> => {
@@ -219,6 +226,15 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           builder.queryBuilder.andWhere(`"${alias}"."userId" = :userId`, {
             userId,
           });
+
+          if (args.entityId) {
+            builder.queryBuilder.andWhere(
+              `"${alias}"."referenceId" = :entityId`,
+              {
+                entityId: args.entityId,
+              },
+            );
+          }
 
           builder.queryBuilder.orderBy(
             `CASE WHEN "${alias}"."state" = '${CampaignState.Active}' THEN 0 ELSE 1 END`,


### PR DESCRIPTION
I need to query campaigns for post Id to show them on analytics graph, so I exposed `entityId` so we can fetch it in the future for squads and so on.