### PR TITLE
feat: introduce pre-insert and pre-update hooks to posts

### DIFF
--- a/__tests__/common/vordr.ts
+++ b/__tests__/common/vordr.ts
@@ -2,7 +2,11 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { Comment, Post, Source, User } from '../../src/entity';
 import { badUsersFixture, sourcesFixture, usersFixture } from '../fixture';
-import { checkWithVordr, VordrFilterType } from '../../src/common/vordr';
+import {
+  checkWithVordr,
+  VordrFilterType,
+  validatePostTitle,
+} from '../../src/common/vordr';
 import { postsFixture } from '../fixture/post';
 import { saveFixtures } from '../helpers';
 
@@ -43,6 +47,34 @@ beforeEach(async () => {
 });
 
 describe('commmon/vordr', () => {
+  describe('validatePostTitle', () => {
+    it('should return false for normal titles without emoji', () => {
+      expect(validatePostTitle('This is a normal title')).toBeFalsy();
+      expect(validatePostTitle('Another regular title here')).toBeFalsy();
+      expect(validatePostTitle('123 Numbers in title')).toBeFalsy();
+    });
+
+    it('should return true for titles containing emoji', () => {
+      expect(validatePostTitle('Title with emoji 😀')).toBeTruthy();
+      expect(validatePostTitle('🚀 Starting with emoji')).toBeTruthy();
+      expect(validatePostTitle('Middle 🎉 emoji')).toBeTruthy();
+      expect(validatePostTitle('Ending with emoji 💯')).toBeTruthy();
+      expect(validatePostTitle('Multiple 😀 emojis 🚀')).toBeTruthy();
+    });
+
+    it('should return false for undefined or empty titles', () => {
+      expect(validatePostTitle(undefined)).toBeFalsy();
+      expect(validatePostTitle('')).toBeFalsy();
+    });
+
+    it('should return true for titles with vordr words when configured', () => {
+      expect(validatePostTitle('This title contains spam')).toBeTruthy();
+      expect(validatePostTitle('SPAM in uppercase')).toBeTruthy();
+      expect(validatePostTitle('This is banned content')).toBeTruthy();
+      expect(validatePostTitle('Clean title without bad words')).toBeFalsy();
+    });
+  });
+
   describe('checkWithVordr', () => {
     it('should return true if user has vordr flag set', async () => {
       const comment = await con
@@ -189,6 +221,66 @@ describe('commmon/vordr', () => {
       );
 
       expect(result).toBeFalsy();
+    });
+
+    it('should return true for posts with emoji in title', async () => {
+      const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+
+      const result = await checkWithVordr(
+        {
+          id: post.id,
+          type: VordrFilterType.Post,
+          content: 'Regular content',
+          title: 'Title with emoji 🚀',
+        },
+        {
+          req: { ip: '127.0.0.1' },
+          userId: '1',
+          con,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false for posts with clean title', async () => {
+      const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+
+      const result = await checkWithVordr(
+        {
+          id: post.id,
+          type: VordrFilterType.Post,
+          content: 'Regular content',
+          title: 'Clean title without issues',
+        },
+        {
+          req: { ip: '127.0.0.1' },
+          userId: '1',
+          con,
+        },
+      );
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should check title even when content is clean', async () => {
+      const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+
+      const result = await checkWithVordr(
+        {
+          id: post.id,
+          type: VordrFilterType.Post,
+          content: 'Perfectly clean content here',
+          title: 'Bad title with 😀 emoji',
+        },
+        {
+          req: { ip: '127.0.0.1' },
+          userId: '1',
+          con,
+        },
+      );
+
+      expect(result).toBeTruthy();
     });
   });
 });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3498,7 +3498,7 @@ describe('mutation submitExternalLink', () => {
           .getRepository(SharePost)
           .findOneByOrFail({ sourceId: 's1', authorId: loggedUser });
 
-        expect(post.flags.vordr).toEqual(false);
+        expect(post.flags.vordr).toBeFalsy();
       });
 
       it('should set the correct vordr flags on new post by a bad user', async () => {
@@ -3537,7 +3537,7 @@ describe('mutation submitExternalLink', () => {
           .getRepository(SharePost)
           .findOneByOrFail({ sourceId: 's1', authorId: loggedUser });
 
-        expect(post.flags.vordr).toEqual(false);
+        expect(post.flags.vordr).toBeFalsy();
       });
 
       it('should set the correct vordr flags on existing post by bad user', async () => {
@@ -4276,7 +4276,7 @@ describe('mutation createFreeformPost', () => {
         .getRepository(FreeformPost)
         .findOneByOrFail({ id: res.data.createFreeformPost.id });
 
-      expect(post.flags.vordr).toEqual(false);
+      expect(post.flags.vordr).toBeFalsy();
     });
 
     it('should set the correct vordr flags on a freeform post by good user if vordr filter catches it', async () => {

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -19,6 +19,7 @@ jest.mock('../src/remoteConfig', () => ({
   remoteConfig: {
     init: jest.fn(),
     vars: {
+      vordrWordsPostTitle: ['spam', 'banned', 'forbidden'],
       vordrWords: [
         'vordrwillcatchyou',
         'andvordrwillhavefun',

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "date-fns-tz": "^2.0.0",
     "deepmerge": "^4.3.1",
     "dotenv": "16.5.0",
+    "emoji-regex": "^10.5.0",
     "eventsource": "^2.0.2",
     "fast-json-stringify": "^6.0.1",
     "fastify": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       dotenv:
         specifier: 16.5.0
         version: 16.5.0
+      emoji-regex:
+        specifier: ^10.5.0
+        version: 10.5.0
       eventsource:
         specifier: ^2.0.2
         version: 2.0.2
@@ -2450,6 +2453,9 @@ packages:
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
+
+  emoji-regex@10.5.0:
+    resolution: {integrity: sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -7344,6 +7350,8 @@ snapshots:
   electron-to-chromium@1.5.79: {}
 
   emittery@0.13.1: {}
+
+  emoji-regex@10.5.0: {}
 
   emoji-regex@8.0.0: {}
 

--- a/src/common/vordr.ts
+++ b/src/common/vordr.ts
@@ -1,4 +1,5 @@
 import { isInSubnet, isIP } from 'is-in-subnet';
+import emojiRegex from 'emoji-regex';
 import { User } from '../entity';
 import { logger } from '../logger';
 import { counters } from '../telemetry';
@@ -21,6 +22,25 @@ export const validateVordrWords = (content?: string): boolean => {
   );
 };
 
+export const validatePostTitle = (title?: string): boolean => {
+  if (!title) {
+    return false;
+  }
+
+  // Check for vordr words in title
+  const vordrWordsTitle = remoteConfig.vars.vordrWordsPostTitle;
+  if (vordrWordsTitle && vordrWordsTitle.length > 0) {
+    const lowerCaseTitle = title.toLowerCase();
+    if (vordrWordsTitle.some((word) => lowerCaseTitle.includes(word))) {
+      return true;
+    }
+  }
+
+  // Check for emojis in title
+  const regex = emojiRegex();
+  return regex.test(title);
+};
+
 export enum VordrFilterType {
   Comment = 'comment',
   Post = 'post',
@@ -32,16 +52,17 @@ type CheckWithVordrInput = {
   id: string;
   type: VordrFilterType;
   content?: string;
+  title?: string;
 };
 
 type CheckWithVordrContext = {
-  userId: string;
+  userId?: string;
   con: DataSource | EntityManager;
   req?: Pick<FastifyRequest, 'ip'>;
 };
 
 export const checkWithVordr = async (
-  { id, type, content }: CheckWithVordrInput,
+  { id, type, content, title }: CheckWithVordrInput,
   { userId, con, req }: CheckWithVordrContext,
 ): Promise<boolean> => {
   if (req && validateVordrIPs(req.ip)) {
@@ -60,6 +81,20 @@ export const checkWithVordr = async (
     );
     counters?.api?.vordr?.add(1, { reason: 'vordr_word', type: type });
     return true;
+  }
+
+  // Check post title for vordr conditions
+  if (title && validatePostTitle(title)) {
+    logger.info(
+      { id, type, userId },
+      `Prevented ${type} because title contains banned content`,
+    );
+    counters?.api?.vordr?.add(1, { reason: 'vordr_title', type: type });
+    return true;
+  }
+
+  if (!userId) {
+    return false;
   }
 
   const user: Pick<User, 'flags' | 'reputation'> | null = await con

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -7,6 +7,8 @@ import type { PurchaseType } from './common/plus';
 export type RemoteConfigValue = {
   inc: number;
   vordrWords: string[];
+  vordrWordsPost: string[];
+  vordrWordsPostTitle: string[];
   vordrIps: string[];
   blockedCountries: string[];
   ignoredWorkEmailDomains: string[];

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -74,6 +74,7 @@ import {
   PostRelationType,
   type PostTranslation,
   PostType,
+  preparePostForUpdate,
   Settings,
   SharePost,
   SubmitExternalLinkArgs,
@@ -170,6 +171,7 @@ import {
   getBriefGenerationCost,
   requestBriefGeneration,
 } from '../common/brief';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 export interface GQLPost {
   id: string;
@@ -2782,7 +2784,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           );
         }
 
-        const updated: Partial<EditablePost> = {};
+        let updated: Partial<EditablePost> = {};
 
         if (title && title !== post.title) {
           updated.title = title;
@@ -2825,7 +2827,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         }
 
         if (Object.keys(updated).length) {
-          await repo.update({ id }, updated);
+          // Apply vordr checks before updating
+          updated = await preparePostForUpdate(updated, post, {
+            con: manager,
+            userId,
+            req: ctx.req,
+          });
+          // Type magic to avoid typescript issues
+          const updatedQuery: QueryDeepPartialEntity<Post> = updated;
+          if (updatedQuery.flags) {
+            updatedQuery.flags = updateFlagsStatement(updatedQuery.flags);
+          }
+          await repo.update({ id }, updatedQuery);
         }
       });
 

--- a/src/workers/postUpdated.ts
+++ b/src/workers/postUpdated.ts
@@ -17,6 +17,8 @@ import {
   PostOrigin,
   PostRelationType,
   PostType,
+  preparePostForInsert,
+  preparePostForUpdate,
   relatePosts,
   removeKeywords,
   SharePost,
@@ -129,7 +131,6 @@ type CreatePostProps = {
   logger: FastifyBaseLogger;
   entityManager: EntityManager;
   data: Partial<ArticlePost>;
-  submissionId?: string;
   mergedKeywords: string[];
   questions: string[];
   smartTitle?: string;
@@ -160,52 +161,6 @@ const handleCollectionRelations = async ({
       relationType: PostRelationType.Collection,
     });
   }
-};
-
-const assignScoutToPostAndVordrFlags = async ({
-  entityManager,
-  submissionId,
-  data,
-}: Pick<CreatePostProps, 'entityManager' | 'submissionId' | 'data'>): Promise<
-  Partial<Pick<Post, 'scoutId'> & { vordr: boolean }>
-> => {
-  const submission = await entityManager
-    .getRepository(Submission)
-    .findOneBy({ id: submissionId });
-
-  if (!submission) {
-    return {
-      scoutId: undefined,
-      vordr: undefined,
-    };
-  }
-
-  if (data.authorId === submission.userId) {
-    await entityManager.getRepository(Submission).update(
-      { id: submissionId },
-      {
-        status: SubmissionStatus.Rejected,
-        reason: SubmissionFailErrorKeys.ScoutIsAuthor,
-      },
-    );
-
-    return {
-      scoutId: undefined,
-      vordr: submission.flags?.vordr,
-    };
-  }
-
-  await entityManager.getRepository(Submission).update(
-    { id: submissionId },
-    {
-      status: SubmissionStatus.Accepted,
-    },
-  );
-
-  return {
-    scoutId: submission.userId,
-    vordr: submission.flags?.vordr,
-  };
 };
 
 type CheckExistingPostProps = {
@@ -259,7 +214,6 @@ const createPost = async ({
   logger,
   entityManager,
   data,
-  submissionId,
   mergedKeywords,
   questions,
   smartTitle,
@@ -275,30 +229,11 @@ const createPost = async ({
     return null;
   }
 
-  if (submissionId) {
-    const { scoutId, vordr } = await assignScoutToPostAndVordrFlags({
-      entityManager,
-      submissionId,
-      data,
-    });
-
-    data.scoutId = scoutId;
-    if (vordr === true) {
-      data.banned = true;
-      data.showOnFeed = false;
-
-      data.flags = {
-        ...data.flags,
-        banned: true,
-        showOnFeed: false,
-      };
-    }
-
-    data.flags = {
-      ...data.flags,
-      vordr: vordr,
-    };
-  }
+  // Apply vordr checks before creating the post
+  data = await preparePostForInsert(data, {
+    con: entityManager,
+    userId: data.authorId || undefined,
+  });
 
   const postId = await generateShortId();
   const postCreatedAt = new Date();
@@ -306,9 +241,7 @@ const createPost = async ({
   data.shortId = postId;
   data.createdAt = postCreatedAt;
   data.score = Math.floor(postCreatedAt.getTime() / (1000 * 60));
-  data.origin = data?.scoutId
-    ? PostOrigin.CommunityPicks
-    : (data.origin ?? PostOrigin.Crawler);
+  data.origin = data.origin ?? PostOrigin.Crawler;
   data.visible = getPostVisible({ post: data });
   data.visibleAt = data.visible ? postCreatedAt : null;
   data.flags = {
@@ -365,7 +298,6 @@ type UpdatePostProps = {
   mergedKeywords: string[];
   questions: string[];
   content_type: PostType;
-  submissionId?: string;
   smartTitle?: string;
 };
 const updatePost = async ({
@@ -376,7 +308,6 @@ const updatePost = async ({
   mergedKeywords,
   questions,
   content_type = PostType.Article,
-  submissionId,
   smartTitle,
 }: UpdatePostProps) => {
   const postType = contentTypeFromPostType[content_type];
@@ -429,35 +360,16 @@ const updatePost = async ({
     return null;
   }
 
-  if (submissionId && !databasePost.scoutId) {
-    const { scoutId, vordr } = await assignScoutToPostAndVordrFlags({
-      entityManager,
-      submissionId,
-      data,
-    });
-
-    data.scoutId = scoutId;
-    if (vordr === true) {
-      data.banned = true;
-      data.showOnFeed = false;
-
-      data.flags = {
-        ...data.flags,
-        banned: true,
-        showOnFeed: false,
-      };
-    }
-
-    data.flags = {
-      ...data.flags,
-      vordr: vordr,
-    };
-  }
-
   const title = data?.title || databasePost.title;
+  data.title = title;
+
+  // Apply vordr checks before updating the post
+  data = await preparePostForUpdate(data, databasePost, {
+    con: entityManager,
+    userId: data.authorId || undefined,
+  });
 
   data.id = databasePost.id;
-  data.title = title;
   data.sourceId = data.sourceId || databasePost.sourceId;
 
   let updateBecameVisible = false;
@@ -766,7 +678,6 @@ const worker: Worker = {
             logger,
             entityManager,
             data: fixedData,
-            submissionId: data?.submission_id,
             mergedKeywords,
             questions,
             smartTitle,
@@ -783,7 +694,6 @@ const worker: Worker = {
             mergedKeywords,
             questions,
             content_type,
-            submissionId: data?.submission_id,
             smartTitle,
           });
         }


### PR DESCRIPTION
Initially I started introducing a block by words in title feature, and it turned out to be a mess. So I decided to introduce hooks that will allow us to easily do that and also expand in the future. As part of the initial setup, I also do the vordr check there as well as added title check.

I also removed some old stuff of community picks when I encountered it