### PR TITLE
refactor: remove gql enums of protobf enums

### DIFF
--- a/__tests__/schema/opportunity.ts
+++ b/__tests__/schema/opportunity.ts
@@ -116,7 +116,7 @@ describe('opportunity queries', () => {
       expect(res.errors).toBeFalsy();
       expect(res.data.opportunityById).toEqual({
         id: '550e8400-e29b-41d4-a716-446655440001',
-        type: 'JOB',
+        type: 1,
         title: 'Senior Full Stack Developer',
         tldr: 'Join our team as a Senior Full Stack Developer',
         content: {
@@ -128,8 +128,8 @@ describe('opportunity queries', () => {
         meta: {
           roleType: 0.0,
           teamSize: 10,
-          seniorityLevel: 'SENIOR',
-          employmentType: 'FULL_TIME',
+          seniorityLevel: 4,
+          employmentType: 1,
         },
         organization: {
           id: '550e8400-e29b-41d4-a716-446655440000',

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -66,14 +66,6 @@ import {
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
 import { OpportunityKeyword } from '../entity/OpportunityKeyword';
-import {
-  CompanySize,
-  CompanyStage,
-  EmploymentType,
-  OpportunityType,
-  SeniorityLevel,
-  type OpportunityMeta,
-} from '@dailydotdev/schema';
 
 const existsByUserAndPost =
   (entity: string, build?: (queryBuilder: QueryBuilder) => QueryBuilder) =>
@@ -1300,12 +1292,6 @@ const obj = new GraphORM({
         rawSelect: true,
         select: (_, alias) => `${alias}."subscriptionFlags"->>'status'`,
       },
-      size: {
-        transform: (value) => CompanySize[value as keyof typeof CompanySize],
-      },
-      stage: {
-        transform: (value) => CompanyStage[value as keyof typeof CompanyStage],
-      },
       activeSeats: {
         rawSelect: true,
         select: (_, alias, qb) =>
@@ -1457,10 +1443,6 @@ const obj = new GraphORM({
   },
   Opportunity: {
     fields: {
-      type: {
-        transform: (value) =>
-          OpportunityType[value as keyof typeof OpportunityType],
-      },
       createdAt: {
         transform: transformDate,
       },
@@ -1479,17 +1461,6 @@ const obj = new GraphORM({
       },
       meta: {
         jsonType: true,
-        transform: (value: OpportunityMeta) => ({
-          ...value,
-          seniorityLevel:
-            SeniorityLevel[
-              value.seniorityLevel as unknown as keyof typeof SeniorityLevel
-            ],
-          employmentType:
-            EmploymentType[
-              value.employmentType as unknown as keyof typeof EmploymentType
-            ],
-        }),
       },
       recruiters: {
         relation: {

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -1,3 +1,4 @@
+import z from 'zod';
 import { IFieldResolver, IResolvers } from '@graphql-tools/utils';
 import {
   Connection,
@@ -104,15 +105,12 @@ export const typeDefs = /* GraphQL */ `
 `;
 
 function toPositiveInt(value: unknown): number {
-  const n = Number(value);
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+  const res = z.coerce.number().int().nonnegative().safeParse(value);
+  if (!res.success) {
     throw new TypeError('ProtoEnumValue must be a positive integer (>= 0)');
   }
 
-  if (!Number.isSafeInteger(n)) {
-    throw new TypeError('ProtoEnumValue must be a safe integer');
-  }
-  return n;
+  return res.data;
 }
 
 const ProtoEnumValue = new GraphQLScalarType({

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -123,7 +123,7 @@ const ProtoEnumValue = new GraphQLScalarType({
     if (ast.kind !== Kind.INT) {
       throw new TypeError('ProtoEnumValue must be provided as an int literal');
     }
-    return toPositiveInt(Number(ast.value));
+    return toPositiveInt(ast.value);
   },
 });
 

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -36,16 +36,16 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type OpportunityMeta {
-    employmentType: Int
+    employmentType: ProtoEnumValue
     teamSize: Int
     # salary: Salary # TODO: implement Salary type
-    seniorityLevel: Int
+    seniorityLevel: ProtoEnumValue
     roleType: Float
   }
 
   type Opportunity {
     id: ID!
-    type: Int!
+    type: ProtoEnumValue!
     title: String!
     tldr: String
     content: OpportunityContent!

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -2,14 +2,9 @@ import { IResolvers } from '@graphql-tools/utils';
 import { traceResolvers } from './trace';
 import { AuthContext, BaseContext } from '../Context';
 import graphorm from '../graphorm';
-import {
-  EmploymentType,
-  Opportunity,
-  OpportunityType,
-  SeniorityLevel,
-} from '@dailydotdev/schema';
+import { Opportunity } from '@dailydotdev/schema';
 import { OpportunityMatch } from '../entity/OpportunityMatch';
-import { protoToGQLEnum, toGQLEnum } from '../common';
+import { toGQLEnum } from '../common';
 import { OpportunityMatchStatus } from '../entity/opportunities/types';
 
 export interface GQLOpportunity
@@ -25,10 +20,6 @@ export interface GQLOpportunityMatch
   extends Pick<OpportunityMatch, 'status' | 'description'> {}
 
 export const typeDefs = /* GraphQL */ `
-  ${protoToGQLEnum<typeof OpportunityType>(OpportunityType, 'OpportunityType')}
-  ${protoToGQLEnum<typeof SeniorityLevel>(SeniorityLevel, 'SeniorityLevel')}
-  ${protoToGQLEnum<typeof EmploymentType>(EmploymentType, 'EmploymentType')}
-
   ${toGQLEnum(OpportunityMatchStatus, 'OpportunityMatchStatus')}
 
   type OpportunityContentBlock {
@@ -45,16 +36,16 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type OpportunityMeta {
-    employmentType: EmploymentType
+    employmentType: Int
     teamSize: Int
     # salary: Salary # TODO: implement Salary type
-    seniorityLevel: SeniorityLevel
+    seniorityLevel: Int
     roleType: Float
   }
 
   type Opportunity {
     id: ID!
-    type: OpportunityType!
+    type: Int!
     title: String!
     tldr: String
     content: OpportunityContent!

--- a/src/schema/organizations.ts
+++ b/src/schema/organizations.ts
@@ -15,7 +15,6 @@ import {
   notifyOrganizationUserJoined,
   notifyOrganizationUserLeft,
   notifyOrganizationUserRemoved,
-  protoToGQLEnum,
   toGQLEnum,
   updateFlagsStatement,
   updateSubscriptionFlags,
@@ -48,7 +47,6 @@ import {
 import { parsePaddlePriceInCents } from '../common/paddle';
 import { SubscriptionStatus } from '../common/plus';
 import { organizationSubscriptionFlagsSchema } from '../common/schema/organizations';
-import { CompanySize, CompanyStage } from '@dailydotdev/schema';
 
 export type GQLOrganizationMember = {
   role: OrganizationMemberRole;
@@ -79,9 +77,6 @@ export const typeDefs = /* GraphQL */ `
     ContentPreferenceOrganizationStatus,
     'OrganizationMemberSeatType',
   )}
-
-  ${protoToGQLEnum<typeof CompanyStage>(CompanyStage, 'CompanyStage')}
-  ${protoToGQLEnum<typeof CompanySize>(CompanySize, 'CompanySize')}
 
   type OrganizationMember {
     """
@@ -179,12 +174,12 @@ export const typeDefs = /* GraphQL */ `
     """
     The size of the organization
     """
-    size: CompanySize
+    size: Int
 
     """
     The stage of the organization
     """
-    stage: CompanyStage
+    stage: Int
   }
 
   type ProratedPricePreview {

--- a/src/schema/organizations.ts
+++ b/src/schema/organizations.ts
@@ -174,12 +174,12 @@ export const typeDefs = /* GraphQL */ `
     """
     The size of the organization
     """
-    size: Int
+    size: ProtoEnumValue
 
     """
     The stage of the organization
     """
-    stage: Int
+    stage: ProtoEnumValue
   }
 
   type ProratedPricePreview {


### PR DESCRIPTION
Remove GQL enums from Protobuf enums, use Int instead via custom scalar ProtoEnumValue, that way we can differentiate between actual Int and when we intend for proto enums.

The scalar ProtoEnumValue just accepts whole ints above and 0