### PR TITLE
feat: allow estimating reach for boosted posts

### DIFF
--- a/__tests__/schema/posts/boost.ts
+++ b/__tests__/schema/posts/boost.ts
@@ -3138,7 +3138,7 @@ describe('query boostEstimatedReachDaily', () => {
     );
   });
 
-  it('should return an error if post is already boosted', async () => {
+  it('should not return an error if post is already boosted', async () => {
     loggedUser = '1';
     // Set the post as already boosted
     await con.getRepository(Post).update(
@@ -3148,11 +3148,21 @@ describe('query boostEstimatedReachDaily', () => {
       },
     );
 
-    return testQueryErrorCode(
-      client,
-      { query: QUERY, variables: { ...params, budget: 5000, duration: 7 } },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
+    const mockFetchParse = fetchParse as jest.Mock;
+
+    mockFetchParse.mockResolvedValue({
+      impressions: 100,
+      clicks: 5,
+      users: 50,
+      min_impressions: 45,
+      max_impressions: 55,
+    });
+
+    const res = await client.query(QUERY, {
+      variables: { ...params, budget: 5000, duration: 7 },
+    });
+
+    expect(res.errors).toBeFalsy();
   });
 
   describe('budget validation', () => {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2294,8 +2294,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       ctx: AuthContext,
     ): Promise<CampaignReach> => {
       const { postId, budget, duration } = args;
-      const post = await validatePostBoostPermissions(ctx, postId);
-      checkPostAlreadyBoosted(post);
+      await validatePostBoostPermissions(ctx, postId);
       validateCampaignArgs({ budget, duration });
 
       const { minImpressions, maxImpressions } =


### PR DESCRIPTION
- we want to show estimate reach on analytics page while boost is active