### PR TITLE
feat: allow estimating reach for boosted posts v2

### DIFF
--- a/src/schema/campaigns.ts
+++ b/src/schema/campaigns.ts
@@ -14,7 +14,6 @@ import type { GQLSource } from './sources';
 import { getLimit, toGQLEnum } from '../common';
 import { type TransactionCreated } from '../common/njord';
 import {
-  checkPostAlreadyBoosted,
   getAdjustedReach,
   startCampaignPost,
   stopCampaignPost,
@@ -261,9 +260,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
       switch (type) {
         case CampaignType.Post:
-          checkPostAlreadyBoosted(
-            await validatePostBoostPermissions(ctx, value),
-          );
+          await validatePostBoostPermissions(ctx, value);
           break;
         case CampaignType.Squad:
           await validateSquadBoostPermissions(ctx, value);


### PR DESCRIPTION
- reverted https://github.com/dailydotdev/daily-api/pull/3080 since code I modified was for v1
- now updated code for skadi v2 which frontend actually uses