### PR TITLE
fix: return all opportunity keywords

### DIFF
--- a/__tests__/fixture/opportunity.ts
+++ b/__tests__/fixture/opportunity.ts
@@ -208,6 +208,10 @@ export const opportunityKeywordsFixture: DeepPartial<OpportunityKeyword>[] = [
     keyword: 'fullstack',
   },
   {
+    opportunityId: '550e8400-e29b-41d4-a716-446655440001',
+    keyword: 'Fortune 500',
+  },
+  {
     opportunityId: '550e8400-e29b-41d4-a716-446655440002',
     keyword: 'webdev',
   },

--- a/__tests__/schema/opportunity.ts
+++ b/__tests__/schema/opportunity.ts
@@ -122,7 +122,7 @@ describe('opportunity queries', () => {
             id
           }
           keywords {
-            value
+            keyword
           }
         }
       }
@@ -210,8 +210,9 @@ describe('opportunity queries', () => {
         },
         recruiters: [{ id: '1' }],
         keywords: expect.arrayContaining([
-          { value: 'webdev' },
-          { value: 'fullstack' },
+          { keyword: 'webdev' },
+          { keyword: 'fullstack' },
+          { keyword: 'Fortune 500' },
         ]),
       });
     });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -66,7 +66,6 @@ import {
 } from '../entity/user/UserJobPreferences';
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
-import { OpportunityKeyword } from '../entity/OpportunityKeyword';
 import { OrganizationLinkType } from '../common/schema/organizations';
 
 const existsByUserAndPost =
@@ -1523,14 +1522,8 @@ const obj = new GraphORM({
       keywords: {
         relation: {
           isMany: true,
-          customRelation: (_, parentAlias, childAlias, qb): QueryBuilder =>
-            qb
-              .innerJoin(
-                OpportunityKeyword,
-                'ok',
-                `"${childAlias}"."value" = ok."keyword"`,
-              )
-              .where(`ok."opportunityId" = "${parentAlias}".id`),
+          parentColumn: 'id',
+          childColumn: 'opportunityId',
         },
       },
     },

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -58,6 +58,10 @@ export const typeDefs = /* GraphQL */ `
     roleType: Float
   }
 
+  type OpportunityKeyword {
+    keyword: String!
+  }
+
   type Opportunity {
     id: ID!
     type: ProtoEnumValue!
@@ -68,7 +72,7 @@ export const typeDefs = /* GraphQL */ `
     location: [Location]!
     organization: Organization!
     recruiters: [User!]!
-    keywords: [Keyword!]!
+    keywords: [OpportunityKeyword]!
   }
 
   type OpportunityMatchDescription {


### PR DESCRIPTION
We don't want GraphORM to join the opportunity keyword to keyword table, so we need custom type for it, since we want to display any keyword they have