### PR TITLE
fix: organization founded column type

### DIFF
--- a/src/entity/Organization.ts
+++ b/src/entity/Organization.ts
@@ -56,7 +56,7 @@ export class Organization {
   @Column({ type: 'text', array: true, default: null })
   perks: Array<string>;
 
-  @Column({ type: 'numeric', default: null })
+  @Column({ type: 'int', default: null })
   founded: number;
 
   @Column({ type: 'text', default: null })

--- a/src/migration/1757494437588-OrganizationFoundedType.ts
+++ b/src/migration/1757494437588-OrganizationFoundedType.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class OrganizationFoundedType1757494437588 implements MigrationInterface {
+  name = 'OrganizationFoundedType1757494437588'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */`
+      ALTER TABLE "organization" DROP COLUMN "founded"
+    `);
+    await queryRunner.query(/* sql */`
+      ALTER TABLE "organization" ADD "founded" integer
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */`
+      ALTER TABLE "organization" DROP COLUMN "founded"
+    `);
+    await queryRunner.query(/* sql */`
+      ALTER TABLE "organization" ADD "founded" numeric
+    `);
+  }
+}


### PR DESCRIPTION
TIL `numeric` returns value as string