### PR TITLE
fix: clear all alerts for opportunity match when opportunity is no longer live

### DIFF
--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1272,6 +1272,20 @@ const onOpportunityChange = async (
       isUpdate,
     });
   }
+
+  if (
+    data.payload.op === 'u' &&
+    data.payload.after?.type === OpportunityType.JOB &&
+    data.payload.before?.state === OpportunityState.LIVE &&
+    data.payload.after?.state !== OpportunityState.LIVE
+  ) {
+    await con
+      .getRepository(Alerts)
+      .update(
+        { opportunityId: data.payload.after!.id },
+        { opportunityId: null },
+      );
+  }
 };
 
 const onOrganizationChange = async (


### PR DESCRIPTION
Automagically clear the opportunity alert when opportunity goes from live to something else.

### Jira ticket
AS-1206