### PR TITLE
fix: `bio` -> `title`, `readme` -> `bio` on recruiter seed

### DIFF
--- a/seeds/User.json
+++ b/seeds/User.json
@@ -241,8 +241,8 @@
     "acceptedMarketing": true,
     "username": "recruiter0",
     "timezone": "Europe/London",
-    "bio": "Lead Talent Acquisition",
-    "readme": "Senior Organizational consultant & HR manager with a broad understanding of corporate & executive levels needs. Led various change management processes and post merge integrations. Excellent communication skills, multi-tasking, business oriented advisor. Always willing to listen and share knowledge."
+    "title": "Lead Talent Acquisition",
+    "bio": "Senior Organizational consultant & HR manager with a broad understanding of corporate & executive levels needs. Led various change management processes and post merge integrations. Excellent communication skills, multi-tasking, business oriented advisor. Always willing to listen and share knowledge."
   },
   {
     "id": "recruiter1",
@@ -252,7 +252,7 @@
     "acceptedMarketing": true,
     "username": "recruiter1",
     "timezone": "Europe/London",
-    "bio": "HR Manager",
-    "readme": "Senior Organizational consultant & HR manager with a broad understanding of corporate & executive levels needs. Led various change management processes and post merge integrations. Excellent communication skills, multi-tasking, business oriented advisor. Always willing to listen and share knowledge."
+    "title": "HR Manager",
+    "bio": "Senior Organizational consultant & HR manager with a broad understanding of corporate & executive levels needs. Led various change management processes and post merge integrations. Excellent communication skills, multi-tasking, business oriented advisor. Always willing to listen and share knowledge."
   }
 ]


### PR DESCRIPTION
I forgot we had `title` on users 🙈 Much better than using bio as title and readme as bio and mess with markdown