### PR TITLE
feat: demo mode for recruiter

### DIFF
--- a/__tests__/fixture/opportunity.ts
+++ b/__tests__/fixture/opportunity.ts
@@ -17,6 +17,7 @@ import {
   SocialMediaType,
 } from '../../src/common/schema/organizations';
 import type { QuestionScreening } from '../../src/entity/questions/QuestionScreening';
+import { demoCompany } from '../../src/common';
 
 export const organizationsFixture: DeepPartial<Organization>[] = [
   {
@@ -56,6 +57,15 @@ export const organizationsFixture: DeepPartial<Organization>[] = [
     website: 'https://yearly.dev',
     description: 'A platform for others',
     location: 'Skatval',
+    links: [],
+  },
+  {
+    id: demoCompany.id,
+    name: 'Demo Dev Inc',
+    image: 'https://example.com/logo.png',
+    website: 'https://monthly.dev',
+    description: 'Another platform for developers',
+    location: 'Oslo',
     links: [],
   },
 ];
@@ -194,6 +204,40 @@ export const opportunitiesFixture: DeepPartial<OpportunityJob>[] = [
       {
         type: LocationType.HYBRID,
         country: 'USA',
+      },
+    ],
+  },
+  {
+    id: '550e8400-e29b-41d4-a716-446655440005',
+    type: OpportunityType.JOB,
+    state: OpportunityState.LIVE,
+    title: 'Senior Full Stack Developer',
+    tldr: 'Join our team as a Senior Full Stack Developer',
+    content: {
+      overview: {
+        content: 'We are looking for a Senior Full Stack Developer...',
+        html: '<p>We are looking for a Senior Full Stack Developer...</p>',
+      },
+    },
+    meta: {
+      roleType: 0.0,
+      teamSize: 10,
+      seniorityLevel: SeniorityLevel.SENIOR,
+      employmentType: EmploymentType.FULL_TIME,
+      salary: {
+        min: 60000,
+        max: 120000,
+        currency: 'USD',
+        period: SalaryPeriod.ANNUAL,
+      },
+    },
+    createdAt: new Date('2023-01-01'),
+    updatedAt: new Date('2023-01-01'),
+    organizationId: demoCompany.id,
+    location: [
+      {
+        type: LocationType.REMOTE,
+        country: 'Norway',
       },
     ],
   },

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -68,6 +68,7 @@ import {
 import {
   DayOfWeek,
   debeziumTimeToDate,
+  demoCompany,
   notifyBannerCreated,
   notifyBannerRemoved,
   notifyCommentCommented,
@@ -177,6 +178,10 @@ import {
 import { Opportunity } from '../../../src/entity/opportunities/Opportunity';
 import type z from 'zod';
 import type { entityReminderSchema } from '../../../src/common/schema/reminders';
+import {
+  ContentPreferenceOrganization,
+  ContentPreferenceOrganizationStatus,
+} from '../../../src/entity/contentPreference/ContentPreferenceOrganization';
 
 jest.mock('../../../src/common', () => ({
   ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
@@ -5666,6 +5671,62 @@ describe('opportunity', () => {
     );
   });
 
+  it('should trigger opportunity job for demo company', async () => {
+    await con.getRepository(Feed).save([
+      { id: '1', userId: '1' },
+      { id: '2', userId: '2' },
+    ]);
+    await con.getRepository(ContentPreferenceOrganization).save([
+      {
+        feedId: '1',
+        userId: '1',
+        referenceId: demoCompany.id,
+        organizationId: demoCompany.id,
+        type: ContentPreferenceType.Organization,
+        status: ContentPreferenceOrganizationStatus.Free,
+        createdAt: new Date(),
+      },
+      {
+        feedId: '2',
+        userId: '2',
+        referenceId: demoCompany.id,
+        organizationId: demoCompany.id,
+        type: ContentPreferenceType.Organization,
+        status: ContentPreferenceOrganizationStatus.Plus,
+        createdAt: new Date(),
+      },
+    ]);
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<OpportunityJob>({
+        after: {
+          id: '550e8400-e29b-41d4-a716-446655440005',
+          createdAt: new Date().getTime(),
+          updatedAt: new Date().getTime(),
+          type: OpportunityType.JOB,
+          title: 'Senior Backend Engineer',
+          tldr: 'We are looking for a Senior Backend Engineer...',
+          content: [],
+          meta: {},
+          state: OpportunityState.LIVE,
+          organizationId: demoCompany.id,
+        },
+        op: 'c',
+        table: 'opportunity',
+      }),
+    );
+
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0][1]).toEqual(
+      'gondul.v1.candidate-opportunity-match',
+    );
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0][2].userId).toEqual('1');
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1][1]).toEqual(
+      'gondul.v1.candidate-opportunity-match',
+    );
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1][2].userId).toEqual('2');
+  });
+
   it('should not trigger on new opportunity when state is not live', async () => {
     await expectSuccessfulBackground(
       worker,
@@ -5736,9 +5797,7 @@ describe('opportunity', () => {
     );
 
     expect(triggerTypedEvent).toHaveBeenCalledTimes(1);
-    expect(jest.mocked(triggerTypedEvent).mock.calls[0][1]).toEqual(
-      'api.v1.opportunity-updated',
-    );
+    expect(jest.mocked(triggerTypedEvent).mock.calls[0][1]).toEqual('');
   });
 
   it('should not trigger on updated opportunity when state is not live', async () => {

--- a/src/common/opportunity/pubsub.ts
+++ b/src/common/opportunity/pubsub.ts
@@ -3,11 +3,12 @@ import { FastifyBaseLogger } from 'fastify';
 import {
   CandidateAcceptedOpportunityMessage,
   CandidatePreferenceUpdated,
+  MatchedCandidate,
   OpportunityMessage,
   Salary,
   UserCV,
 } from '@dailydotdev/schema';
-import { triggerTypedEvent } from '../../common';
+import { demoCompany, triggerTypedEvent } from '../../common';
 import { getSecondsTimestamp } from '../date';
 import { UserCandidatePreference } from '../../entity/user/UserCandidatePreference';
 import { ChangeObject } from '../../types';
@@ -20,6 +21,7 @@ import {
   ContentPreferenceStatus,
   ContentPreferenceType,
 } from '../../entity/contentPreference/types';
+import { ContentPreferenceOrganization } from '../../entity/contentPreference/ContentPreferenceOrganization';
 
 const fetchCandidateKeywords = async (
   manager: EntityManager,
@@ -196,6 +198,34 @@ export const notifyJobOpportunity = async ({
       },
       'opportunity has no organization, skipping',
     );
+    return;
+  }
+
+  /**
+   * Demo logic: if the company is the demo company we can omit using Gondul and simply return the users from that company as matched candidates
+   */
+  if (organization.id === demoCompany.id) {
+    const members = await con
+      .getRepository(ContentPreferenceOrganization)
+      .find({
+        select: ['userId'],
+        where: { organizationId: organization.id },
+      });
+    for (const { userId } of members) {
+      await triggerTypedEvent(
+        logger,
+        'gondul.v1.candidate-opportunity-match',
+        new MatchedCandidate({
+          opportunityId,
+          userId,
+          matchScore: 0.87,
+          reasoning:
+            "We have noticed that you've been digging into React performance optimization and exploring payment systems lately. Your skills in TypeScript and Node.js line up directly with the core technologies this team uses. You also follow several Atlassian engineers and have shown consistent interest in project management software, which makes this role a natural fit for your trajectory.",
+          reasoningShort:
+            'Your skills in TypeScript and Node.js line up directly with the core technologies this team uses.',
+        }),
+      );
+    }
     return;
   }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -30,6 +30,10 @@ export const systemUser = {
   name: 'System',
 };
 
+export const demoCompany = {
+  id: 'e8c7a930-ca69-4cba-b26c-b6c810d6ab7d',
+};
+
 interface GetTimezonedIsoWeekProps {
   date: Date;
   timezone: string;


### PR DESCRIPTION
We are adding a demo mode for recruiter.
If we use the demo company, it should bypass gondul but by mock example publish all that companies users as a match.

Purely for demo purposes :) 