### PR TITLE
fix: replace auth with long ttl of autocompleteKeywords query

### DIFF
--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -448,16 +448,18 @@ describe('query autocompleteKeywords', () => {
     await saveFixtures(con, Keyword, keywordsFixture);
   });
 
-  it('should require authentication', async () => {
-    await testQueryErrorCode(
-      client,
-      {
-        query: QUERY,
-        variables: {
-          query: 'next',
-        },
+  it('should return autocomplete allowed keywords when not logged in', async () => {
+    const res = await client.query(QUERY, {
+      variables: {
+        query: 'dev',
       },
-      'UNAUTHENTICATED',
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.autocompleteKeywords).toEqual(
+      expect.arrayContaining([
+        { keyword: 'webdev', title: 'Web Development' },
+        { keyword: 'development', title: null },
+      ]),
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,6 +320,9 @@ export default async function app(
           searchTags: true,
           userReadingRankHistory: true,
           userReadHistory: true,
+          autocompleteKeywords: {
+            ttl: 3600,
+          },
         },
       },
     });

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -237,6 +237,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         throw error;
       }
 
+      const status = !!ctx.userId
+        ? [KeywordStatus.Allow, KeywordStatus.Synonym]
+        : [KeywordStatus.Allow];
+
       return queryReadReplica(ctx.con, async ({ queryRunner }) =>
         queryRunner.manager
           .createQueryBuilder()
@@ -244,7 +248,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           .addSelect(`COALESCE(k.flags->>'title', NULL)`, 'title')
           .from(Keyword, 'k')
           .where('k.status IN (:...status)', {
-            status: [KeywordStatus.Allow, KeywordStatus.Synonym],
+            status: status,
           })
           .andWhere('k.value ILIKE :query', { query: `%${data.query}%` })
           .orderBy(`(k.status <> '${KeywordStatus.Allow}')`, 'ASC')

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -128,7 +128,7 @@ export const typeDefs = /* GraphQL */ `
     autocompleteKeywords(
       query: String!
       limit: Int = 20
-    ): [KeywordAutocomplete!]! @auth
+    ): [KeywordAutocomplete!]! @cacheControl(maxAge: 3600)
     """
     Get a keyword
     """


### PR DESCRIPTION
Replace auth in favour of 1 hour long TTL. Keywords has a low chance of actually changing that often, so we can safely add a 1 hour long TTL of the query.

### Jira ticket
AS-1210