### PR TITLE
chore: remove popular feed client

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,6 @@ ENABLE_SETTINGS_EXPERIMENT=
 INTERNAL_FEED=http://localhost:6000/feed.json
 SNOTRA_ORIGIN=http://localhost:6001
 PERSONALIZED_DIGEST_FEED=http://localhost:6000/feed.json
-POPULAR_FEED=http://localhost:6000/popular
 LOFN_ORIGIN=http://localhost:6002
 BRIEFING_FEED=http://api
 

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -95,7 +95,6 @@ config:
     personalizedDigestFeed: http://feed-digest-server.feed/api/personalised
     personalizedDigestSecret:
       secure: AAABAN1TYaqznVMVbKDZtYEnLGB0VIzXDrpcmB6rBsImneobrDOS12T4XwbVvnexdZt1NBCnZRBwH4AL7OgpZkj/2UgT8Lzj0o7TdVSBeIeVDzKa/V6jlvJ4AskEC9rg
-    popularFeed: http://feed.feed.svc.cluster.local/api/popular
     postScraperOrigin: http://post-scraper-one-ai-server.content.svc.cluster.local
     roasterUrl:
       secure: AAABAG345FgrKQUdnHkiyTstCqLN33wENnz6dIoBkxqaUAbJPS2h+kPwSH/W0i8+TWHmE4npH37runeN8qm/fyoZxz425ATWQsyrTVJU4KMAApeHwGUI4pgtAvDB11x96eWDX5SBLW2t4UemyaHXw1kYagdwWkd9LP4e3j8E7oKXJE7YwHRaIT4LI09JoTQWTuMLwYfZY1vWzAy5BOHqouf1v1+hGWWSF+NTdFHHkw==

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -74,9 +74,6 @@ export const feedClient = new FeedClient(process.env.INTERNAL_FEED, {
 export const lofnClient = new LofnClient(process.env.LOFN_ORIGIN, {
   garmr: garmLofnService,
 });
-export const popularFeedClient = new FeedClient(process.env.POPULAR_FEED, {
-  garmr: garmFeedService,
-});
 
 const opts: Options = {
   includeBlockedTags: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,6 @@ declare global {
       NODE_ENV: 'development' | 'production' | 'test';
       SNOTRA_ORIGIN: string;
       LOFN_ORIGIN: string;
-      POPULAR_FEED: string;
       INTERNAL_FEED: string;
       ROASTER_URL: string;
       MAGNI_ORIGIN: string;


### PR DESCRIPTION
Unused feed client, its all config based now, also removed from feed side in https://github.com/dailydotdev/daily-feed/pull/696