### PR TITLE
fix: add missing break in cdc worker

### DIFF
--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1499,6 +1499,7 @@ const worker: Worker = {
           break;
         case getTableName(con, OpportunityMatch):
           await onOpportunityMatchChange(con, logger, data);
+          break;
         case getTableName(con, Opportunity):
           await onOpportunityChange(con, logger, data);
           break;


### PR DESCRIPTION
shouldn't really cause any issues not having it, but to be on the safe side I added it