### PR TITLE
chore: require parseMessage on typed notification workers

### DIFF
--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -77,7 +77,10 @@ export type TypedNotificationWorker<T extends keyof PubSubSchema> =
     T,
     PubSubSchema[T],
     NotificationWorkerHandler<PubSubSchema[T]>
-  >;
+    // TODO require parseMessage as BC until all notification workers are TypedWorkers
+  > & {
+    parseMessage: (message: Message) => PubSubSchema[T];
+  };
 
 export interface ExperimentWorker extends Worker {
   subscription: string;


### PR DESCRIPTION
To avoid forgetting it by mistake until we move