### PR TITLE
feat: fetch poll options for moderation

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -4455,6 +4455,10 @@ describe('query sourcePostModeration', () => {
         id
         title
         type
+        pollOptions {
+          text
+          order
+        }
       }
     }
   }
@@ -4547,6 +4551,42 @@ describe('query sourcePostModeration', () => {
     });
     expect(res.errors).toBeUndefined();
     expect(res.data.sourcePostModerations.edges.length).toEqual(3);
+  });
+
+  it('should return pollOptions when querying poll moderation items', async () => {
+    loggedUser = '4';
+
+    const pollOptions = [
+      { text: 'Option A', order: 0 },
+      { text: 'Option B', order: 1 },
+    ];
+
+    const pollModeration = await con.getRepository(SourcePostModeration).save({
+      sourceId: 'm',
+      title: 'Test Poll',
+      type: PostType.Poll,
+      pollOptions: pollOptions,
+      status: SourcePostModerationStatus.Pending,
+      createdById: '4',
+    });
+
+    const queryRes = await client.query(queryAllForSource, {
+      variables: { sourceId: 'm' },
+    });
+
+    expect(queryRes.errors).toBeUndefined();
+
+    const pollModerationItem = queryRes.data.sourcePostModerations.edges.find(
+      (edge) => edge.node.id === pollModeration.id,
+    );
+
+    expect(pollModerationItem).toBeTruthy();
+    expect(pollModerationItem.node.pollOptions).toBeDefined();
+    expect(pollModerationItem.node.pollOptions).toHaveLength(2);
+    expect(pollModerationItem.node.pollOptions).toEqual([
+      { text: 'Option A', order: 0 },
+      { text: 'Option B', order: 1 },
+    ]);
   });
 
   it('should not have access because user is not member of source', async () => {

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -80,6 +80,7 @@ export interface GQLSourcePostModeration {
   source: Source;
   post?: Post;
   postId?: string;
+  pollOptions?: CreatePollOption[];
 }
 
 const POST_MODERATION_PAGE_SIZE = 15;

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -329,6 +329,11 @@ const obj = new GraphORM({
   },
   SourcePostModeration: {
     requiredColumns: ['id'],
+    fields: {
+      pollOptions: {
+        jsonType: true,
+      },
+    },
   },
   UserStreak: {
     requiredColumns: ['lastViewAt'],

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -436,6 +436,10 @@ export const typeDefs = /* GraphQL */ `
     Moderator of the post
     """
     moderatedBy: User
+    """
+    Poll options for poll posts
+    """
+    pollOptions: [CreatePollOption!]
   }
 
   type TocItem {
@@ -927,6 +931,11 @@ export const typeDefs = /* GraphQL */ `
   }
 
   input PollOptionInput {
+    text: String!
+    order: Int!
+  }
+
+  type CreatePollOption {
     text: String!
     order: Int!
   }


### PR DESCRIPTION
Poll options weren't added to the post moderation when we [updated](https://github.com/dailydotdev/daily-api/pull/3156) it.