### PR TITLE
fix: add resolver for endsAt

### DIFF
--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -3638,6 +3638,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       }
       return undefined;
     },
+    endsAt: (post: GQLPost): Date | null => {
+      if (!post.endsAt) return null;
+      return new Date(post.endsAt);
+    },
   },
   LinkPreview: {
     image: (preview: ExternalLinkPreview) =>


### PR DESCRIPTION
Missing resolver made the history page explode

<img width="790" height="762" alt="Screenshot 2025-09-24 at 16 19 40" src="https://github.com/user-attachments/assets/9df0696f-b1fa-4ce9-ada1-262b2aff0256" />


### Jira ticket
MI-1047