### PR TITLE
fix: manager gets closed due to forEach not waiting for async callbacks

### DIFF
--- a/__tests__/cron/syncSubscriptionWithCIO.ts
+++ b/__tests__/cron/syncSubscriptionWithCIO.ts
@@ -37,9 +37,9 @@ describe('syncSubscriptionWithCIO cron', () => {
   });
 
   it('should sync subscriptions with customer.io', async () => {
-    usersFixture.forEach(async (user) => {
+    for (const user of usersFixture) {
       await pushToRedisList(redisKey, user.id as string);
-    });
+    }
     expect(await getRedisListLength(redisKey)).not.toEqual(0);
 
     await expectSuccessfulCron(cron);
@@ -55,10 +55,10 @@ describe('syncSubscriptionWithCIO cron', () => {
   });
 
   it('should remove duplicates before calling syncSubscription', async () => {
-    usersFixture.forEach(async (user) => {
+    for (const user of usersFixture) {
       await pushToRedisList(redisKey, user.id as string);
       await pushToRedisList(redisKey, user.id as string);
-    });
+    }
     expect(await getRedisListLength(redisKey)).not.toEqual(0);
 
     await expectSuccessfulCron(cron);


### PR DESCRIPTION
Looked at some other issue and then seen we have quite a lot of these:
> QueryRunnerAlreadyReleasedError: Query runner already released. Cannot run queries anymore

[Logs](https://console.cloud.google.com/logs/query;query=error_groups.id%3D%22CI_b6pmi6MK4Bw%22%0AlogName:%22stderr%22%0Aresource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22devkit-prod%22%0Aresource.labels.cluster_name%3D%22prod-vpc-native%22%0Aresource.labels.namespace_name%3D%22daily%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.container_name%3D%22app%22;cursorTimestamp=2025-09-25T09:05:27.187544806Z;duration=PT6H?authuser=2&project=devkit-prod)