### PR TITLE
feat: streamline content to match type to avoid juggling string/object

### DIFF
--- a/__tests__/schema/opportunity.ts
+++ b/__tests__/schema/opportunity.ts
@@ -1918,7 +1918,9 @@ describe('mutation editOpportunity', () => {
         id: opportunitiesFixture[0].id,
         payload: {
           content: {
-            requirements: 'Updated requirements *italic*',
+            requirements: {
+              content: 'Updated requirements *italic*',
+            },
           },
         },
       },

--- a/src/common/schema/opportunities.ts
+++ b/src/common/schema/opportunities.ts
@@ -6,7 +6,17 @@ export const opportunityMatchDescriptionSchema = z.object({
   matchScore: z.number(),
 });
 
-export const opportunityContentSchema = z.string().max(1440);
+export const createOpportunityEditContentSchema = ({
+  optional = false,
+}: {
+  optional?: boolean;
+} = {}) => {
+  const contentSchema = z.string().max(1440);
+
+  return z.object({
+    content: optional ? contentSchema.optional() : contentSchema.nonempty(),
+  });
+};
 
 export const opportunityEditSchema = z
   .object({
@@ -41,11 +51,13 @@ export const opportunityEditSchema = z
     }),
     content: z
       .object({
-        overview: opportunityContentSchema,
-        responsibilities: opportunityContentSchema,
-        requirements: opportunityContentSchema,
-        whatYoullDo: opportunityContentSchema,
-        interviewProcess: opportunityContentSchema,
+        overview: createOpportunityEditContentSchema(),
+        responsibilities: createOpportunityEditContentSchema(),
+        requirements: createOpportunityEditContentSchema(),
+        whatYoullDo: createOpportunityEditContentSchema({ optional: true }),
+        interviewProcess: createOpportunityEditContentSchema({
+          optional: true,
+        }),
       })
       .partial(),
     questions: z

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -226,12 +226,16 @@ export const typeDefs = /* GraphQL */ `
     keyword: String!
   }
 
+  input OpportunityContentBlockInput {
+    content: String
+  }
+
   input OpportunityContentInput {
-    overview: String
-    responsibilities: String
-    requirements: String
-    whatYoullDo: String
-    interviewProcess: String
+    overview: OpportunityContentBlockInput
+    responsibilities: OpportunityContentBlockInput
+    requirements: OpportunityContentBlockInput
+    whatYoullDo: OpportunityContentBlockInput
+    interviewProcess: OpportunityContentBlockInput
   }
 
   input OpportunityScreeningQuestionInput {
@@ -680,9 +684,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
         > = {};
 
         Object.entries(content || {}).forEach(([key, value]) => {
+          if (typeof value.content !== 'string') {
+            return;
+          }
+
           renderedContent[key] = {
-            content: value.replace(/'/g, "''"),
-            html: markdown.render(value).replace(/'/g, "''"),
+            content: value.content.replace(/'/g, "''"),
+            html: markdown.render(value.content).replace(/'/g, "''"),
           };
         });
 


### PR DESCRIPTION
Just moved so input also accepts object `{ content }` easier because then zod schema is also the same and previously had to juggle string and `{ content }`.