### PR TITLE
fix: insert formatting for opportunity json fields

### DIFF
--- a/__tests__/schema/opportunity.ts
+++ b/__tests__/schema/opportunity.ts
@@ -2173,4 +2173,23 @@ describe('mutation editOpportunity', () => {
       'CONFLICT',
     );
   });
+
+  it('should avoid query quotes for column keywords', async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        id: opportunitiesFixture[0].id,
+        payload: {
+          content: {
+            requirements: {
+              content: 'Test state test',
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+  });
 });

--- a/__tests__/schema/opportunity.ts
+++ b/__tests__/schema/opportunity.ts
@@ -2183,6 +2183,7 @@ describe('mutation editOpportunity', () => {
         payload: {
           content: {
             requirements: {
+              // state is a column in opportunity table so typeorm usually adds quotes breaking the query
               content: 'Test state test',
             },
           },

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -696,16 +696,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
         const opportunityContent = new OpportunityContent(renderedContent);
 
-        await entityManager.getRepository(OpportunityJob).update(
-          { id },
-          {
+        await entityManager
+          .getRepository(OpportunityJob)
+          .createQueryBuilder()
+          .update({
             ...opportunityUpdate,
-            content: opportunityContent
-              ? () => `content || '${opportunityContent.toJsonString()}'`
-              : undefined,
-            meta: () => `meta || '${JSON.stringify(opportunity.meta || {})}'`,
-          },
-        );
+            content: () => `content || :contentJson`,
+            meta: () => `meta || :metaJson`,
+          })
+          .where({ id })
+          .setParameter('contentJson', opportunityContent.toJsonString())
+          .setParameter('metaJson', JSON.stringify(opportunity.meta || {}))
+          .execute();
 
         if (Array.isArray(keywords)) {
           await entityManager.getRepository(OpportunityKeyword).delete({


### PR DESCRIPTION
For example if in content there is a column name like `state`, typeorm will add quotes around `"state"` which then breaks insert. With params it does not add it so update goes through. 