### PR TITLE
fix: only publish one topic for now

### DIFF
--- a/src/common/opportunity/pubsub.ts
+++ b/src/common/opportunity/pubsub.ts
@@ -264,7 +264,6 @@ export const notifyCandidateOpportunityMatchRejected = async ({
 export const notifyJobOpportunity = async ({
   con,
   logger,
-  isUpdate,
   opportunityId,
 }: {
   con: DataSource;
@@ -272,10 +271,6 @@ export const notifyJobOpportunity = async ({
   isUpdate: boolean;
   opportunityId: string;
 }) => {
-  const topicName = isUpdate
-    ? 'api.v1.opportunity-updated'
-    : 'api.v1.opportunity-added';
-
   const [opportunity, organization, keywords] = await queryReadReplica(
     con,
     async ({ queryRunner }) => {
@@ -352,7 +347,7 @@ export const notifyJobOpportunity = async ({
   });
 
   try {
-    await triggerTypedEvent(logger, topicName, message);
+    await triggerTypedEvent(logger, 'api.v1.opportunity-added', message);
   } catch (_err) {
     const err = _err as Error;
     logger.error({ err, message }, 'failed to send opportunity event');


### PR DESCRIPTION
For now we should only use the new topic.
We'll keep the isUpdate call, eventually we might want to use it.