### PR TITLE
fix: send recruiter to match accepted

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -172,7 +172,10 @@ import {
 } from '../../../src/entity/contentPreference/types';
 import { OpportunityMatch } from '../../../src/entity/OpportunityMatch';
 import { UserCandidatePreference } from '../../../src/entity/user/UserCandidatePreference';
-import { OpportunityMatchStatus } from '../../../src/entity/opportunities/types';
+import {
+  OpportunityMatchStatus,
+  OpportunityUserType,
+} from '../../../src/entity/opportunities/types';
 import { OpportunityJob } from '../../../src/entity/opportunities/OpportunityJob';
 import {
   opportunitiesFixture,
@@ -185,6 +188,7 @@ import {
   ContentPreferenceOrganization,
   ContentPreferenceOrganizationStatus,
 } from '../../../src/entity/contentPreference/ContentPreferenceOrganization';
+import { OpportunityUser } from '../../../src/entity/opportunities/user';
 
 jest.mock('../../../src/common', () => ({
   ...(jest.requireActual('../../../src/common') as Record<string, unknown>),
@@ -5643,6 +5647,13 @@ describe('opportunity match', () => {
 
   beforeEach(async () => {
     await saveFixtures(con, User, usersFixture);
+    await con.getRepository(User).update(
+      { id: usersFixture[0].id },
+      {
+        title: 'CTO',
+        bio: 'Here to break things',
+      },
+    );
     await saveFixtures(con, Organization, organizationsFixture);
     await saveFixtures(con, Opportunity, opportunitiesFixture);
     await con.getRepository(UserCandidatePreference).save({
@@ -5658,6 +5669,11 @@ describe('opportunity match', () => {
       description: {},
       screening: [],
       applicationRank: {},
+    });
+    await con.getRepository(OpportunityUser).save({
+      userId: usersFixture[0].id,
+      opportunityId: opportunitiesFixture[0].id,
+      type: OpportunityUserType.Recruiter,
     });
   });
 
@@ -5800,6 +5816,11 @@ describe('opportunity match', () => {
         expect.objectContaining({
           opportunityId: opportunitiesFixture[0].id,
           userId: '1',
+          recruiter: {
+            name: 'Ido',
+            role: 'CTO',
+            bio: 'Here to break things',
+          },
         }),
       );
     });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@connectrpc/connect-fastify": "^1.6.1",
     "@connectrpc/connect-node": "^1.6.1",
     "@dailydotdev/graphql-redis-subscriptions": "^2.4.3",
-    "@dailydotdev/schema": "0.2.40",
+    "@dailydotdev/schema": "0.2.46",
     "@dailydotdev/ts-ioredis-pool": "^1.0.2",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3(graphql-subscriptions@3.0.0(graphql@16.11.0))
       '@dailydotdev/schema':
-        specifier: 0.2.40
-        version: 0.2.40(@bufbuild/protobuf@1.10.0)
+        specifier: 0.2.46
+        version: 0.2.46(@bufbuild/protobuf@1.10.0)
       '@dailydotdev/ts-ioredis-pool':
         specifier: ^1.0.2
         version: 1.0.2
@@ -699,8 +699,8 @@ packages:
     peerDependencies:
       graphql-subscriptions: ^1.0.0 || ^2.0.0
 
-  '@dailydotdev/schema@0.2.40':
-    resolution: {integrity: sha512-xC4iRGavRGJI1KOY97ZuGmeL33ibn5KJyjfBqwQiGO56yzOKwrsEYnRmngM5147Sq1wozdpKiqfzlOlHrp9vFQ==}
+  '@dailydotdev/schema@0.2.46':
+    resolution: {integrity: sha512-XfirE4+WchWMLiSN7XfqIKUSnsp9BAPo7UvfV1P66cmVavjvPp2cFnqLIcLKI2DHhs5aF/0KYxmxRLXCt1HgXw==}
     peerDependencies:
       '@bufbuild/protobuf': 1.x
 
@@ -5173,7 +5173,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dailydotdev/schema@0.2.40(@bufbuild/protobuf@1.10.0)':
+  '@dailydotdev/schema@0.2.46(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 


### PR DESCRIPTION
Added recruited needed data so Gondul can generate warm intro.
For now it's semi hardcoded to just pick 1st recruiter.
Task is there to optimize the recruiter who matched you. (We need to store this)

But this will unblock Denis for now.