### PR TITLE
refactor: ignore campaigns that are not found

### DIFF
--- a/src/workers/campaignUpdatedAction.ts
+++ b/src/workers/campaignUpdatedAction.ts
@@ -17,7 +17,6 @@ import {
   type CampaignUpdateEventArgs,
 } from '../common/campaign/common';
 import { usdToCores } from '../common/number';
-import { logger } from '../logger';
 import type { TypeORMQueryFailedError } from '../errors';
 
 interface HandlerEventArgs {
@@ -68,9 +67,6 @@ const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
       const err = originalError as TypeORMQueryFailedError;
 
       if (err?.name === 'EntityNotFoundError') {
-        // some campaigns do not exist on API so just warn in case we need to check later
-        logger.warn({ err, params }, 'could not find campaign');
-
         return;
       }
 

--- a/src/workers/campaignUpdatedSlack.ts
+++ b/src/workers/campaignUpdatedSlack.ts
@@ -41,10 +41,7 @@ const worker: TypedWorker<'skadi.v2.campaign-updated'> = {
     } catch (originalError) {
       const err = originalError as TypeORMQueryFailedError;
 
-      if (err?.name === 'EntityNotFoundError') {
-        // some campaigns do not exist on API so just warn in case we need to check later
-        logger.warn({ err, params }, 'could not find campaign');
-
+      if (err?.name !== 'EntityNotFoundError') {
         return;
       }
 

--- a/src/workers/notifications/campaignUpdatedAction.ts
+++ b/src/workers/notifications/campaignUpdatedAction.ts
@@ -14,7 +14,6 @@ import {
 } from '../../common/campaign/common';
 import { CampaignType } from '../../entity/campaign/Campaign';
 import { type DataSource } from 'typeorm';
-import { logger } from '../../logger';
 import type { TypeORMQueryFailedError } from '../../errors';
 
 const worker: TypedNotificationWorker<'skadi.v2.campaign-updated'> = {
@@ -44,9 +43,6 @@ const worker: TypedNotificationWorker<'skadi.v2.campaign-updated'> = {
       const err = originalError as TypeORMQueryFailedError;
 
       if (err?.name === 'EntityNotFoundError') {
-        // some campaigns do not exist on API so just warn in case we need to check later
-        logger.warn({ err, params }, 'could not find campaign');
-
         return;
       }
 


### PR DESCRIPTION
I think we can just ignore these campaigns that are not found. We really have no reference as what kind they are anyway.