### PR TITLE
feat: expose impressions analytics under post query

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1340,6 +1340,38 @@ describe('query post', () => {
       expect(res.data.post.clickbaitTitleDetected).toEqual(false);
     });
   });
+
+  describe('analytics field', () => {
+    const LOCAL_QUERY = /* GraphQL */ `
+      query Post($id: ID!) {
+        post(id: $id) {
+          id
+          analytics {
+            impressions
+          }
+        }
+      }
+    `;
+
+    it('should return public analytics', async () => {
+      await con.getRepository(PostAnalytics).save({
+        id: 'p1',
+        impressions: 110,
+        impressionsAds: 310,
+      });
+
+      const res = await client.query(LOCAL_QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+
+      expect(res.data.post).toEqual({
+        id: 'p1',
+        analytics: { impressions: 420 },
+      });
+    });
+  });
 });
 
 describe('query postByUrl', () => {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1427,7 +1427,6 @@ const obj = new GraphORM({
       },
     },
   },
-
   PostAnalytics: {
     requiredColumns: ['id', 'updatedAt'],
     fields: {
@@ -1487,6 +1486,19 @@ const obj = new GraphORM({
       updatedAt: {
         transform: transformDate,
       },
+      impressions: {
+        rawSelect: true,
+        select: (_, alias) => {
+          return `
+            GREATEST(${alias}.impressions + ${alias}."impressionsAds", 0)
+          `;
+        },
+      },
+    },
+  },
+  PostAnalyticsPublic: {
+    from: 'PostAnalytics',
+    fields: {
       impressions: {
         rawSelect: true,
         select: (_, alias) => {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -817,6 +817,11 @@ export const typeDefs = /* GraphQL */ `
     Total number of votes in the poll
     """
     numPollVotes: Int
+
+    """
+    Post analytics
+    """
+    analytics: PostAnalyticsPublic
   }
 
   type PostConnection {
@@ -1038,6 +1043,11 @@ export const typeDefs = /* GraphQL */ `
     shares: Int!
     reachAds: Int!
     impressionsAds: Int!
+  }
+
+  type PostAnalyticsPublic {
+    id: ID!
+    impressions: Int!
   }
 
   type PostAnalyticsHistory {


### PR DESCRIPTION
We will show them instead of views

<img width="737" height="150" alt="image" src="https://github.com/user-attachments/assets/2b012465-38f0-4f40-a571-dd8fe0b30201" />
