### PR TITLE
fix: allow empty freeform content

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3184,6 +3184,22 @@ describe('mutation createPostInMultipleSources', () => {
       );
     });
 
+    it('should handle empty content', async () => {
+      loggedUser = '1';
+      const singleParams = {
+        ...freeformParams,
+        content: null,
+        sourceIds: ['squad'],
+      };
+      const res = await client.mutate(MUTATION, { variables: singleParams });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.createPostInMultipleSources).toHaveLength(1);
+      const [post] = res.data.createPostInMultipleSources;
+      expect(post.sourceId).toBe('squad');
+      expect(post.type).toBe('post');
+    });
+
     it('should handle single squad posting', async () => {
       loggedUser = '1';
       const singleParams = { ...freeformParams, sourceIds: ['squad'] };

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -524,8 +524,8 @@ export interface CreateSourcePostModerationArgs
   duration?: number;
 }
 
-export interface EditPostArgs
-  extends Pick<GQLPost, 'id' | 'title' | 'content'> {
+export interface EditPostArgs extends Pick<GQLPost, 'id' | 'title'> {
+  content?: string | null;
   image: Promise<FileUpload>;
 }
 
@@ -561,7 +561,12 @@ const MAX_CONTENT_LENGTH = 10_000;
 export const postInMultipleSourcesArgsSchema = z
   .object({
     title: z.string().max(MAX_TITLE_LENGTH).optional(),
-    content: z.string().max(MAX_CONTENT_LENGTH).optional(),
+    content: z
+      .string()
+      .max(MAX_CONTENT_LENGTH)
+      .default('')
+      .nullable()
+      .optional(),
     commentary: z.string().max(MAX_TITLE_LENGTH).optional(),
     image: z.custom<Promise<FileUpload>>(),
     imageUrl: z.httpUrl().optional(),
@@ -1389,7 +1394,7 @@ export const createFreeformPost = async (
 
   await con.transaction(async (manager) => {
     const mentions = await getMentions(manager, content, userId, sourceId);
-    const contentHtml = markdown.render(content, { mentions });
+    const contentHtml = markdown.render(content || '', { mentions });
     const params: CreatePost = {
       id,
       title,

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -524,8 +524,8 @@ export interface CreateSourcePostModerationArgs
   duration?: number;
 }
 
-export interface EditPostArgs extends Pick<GQLPost, 'id' | 'title'> {
-  content?: string | null;
+export interface EditPostArgs
+  extends Pick<GQLPost, 'id' | 'title' | 'content'> {
   image: Promise<FileUpload>;
 }
 
@@ -564,9 +564,8 @@ export const postInMultipleSourcesArgsSchema = z
     content: z
       .string()
       .max(MAX_CONTENT_LENGTH)
-      .default('')
-      .nullable()
-      .optional(),
+      .nullish()
+      .transform((val) => val ?? ''),
     commentary: z.string().max(MAX_TITLE_LENGTH).optional(),
     image: z.custom<Promise<FileUpload>>(),
     imageUrl: z.httpUrl().optional(),
@@ -1394,7 +1393,7 @@ export const createFreeformPost = async (
 
   await con.transaction(async (manager) => {
     const mentions = await getMentions(manager, content, userId, sourceId);
-    const contentHtml = markdown.render(content || '', { mentions });
+    const contentHtml = markdown.render(content, { mentions });
     const params: CreatePost = {
       id,
       title,

--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -14,7 +14,7 @@ export class FreeformPost extends Post {
   image?: string;
 
   @Column({ type: 'text', nullable: true })
-  content: string | null;
+  content: string;
 
   @Column({ type: 'text', nullable: true })
   contentHtml: string;

--- a/src/entity/posts/FreeformPost.ts
+++ b/src/entity/posts/FreeformPost.ts
@@ -14,7 +14,7 @@ export class FreeformPost extends Post {
   image?: string;
 
   @Column({ type: 'text', nullable: true })
-  content: string;
+  content: string | null;
 
   @Column({ type: 'text', nullable: true })
   contentHtml: string;


### PR DESCRIPTION
Allows to create freeform posts without content
```json
{
  "data": null,
  "errors": [
    {
      "message": "Validation error",
      "locations": [
        {
          "line": 14,
          "column": 5
        }
      ],
      "path": [
        "createPostInMultipleSources"
      ],
      "extensions": {
        "code": "ZOD_VALIDATION_ERROR",
        "issues": [
          {
            "expected": "string",
            "code": "invalid_type",
            "path": [
              "content"
            ],
            "message": "Invalid input: expected string, received null"
          }
        ]
      }
    }
  ]
}
```