### PR TITLE
feat: add worker to handle extracting markdown from uploaded CVs

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,7 @@ SKADI_API_ORIGIN=http://skadi-post-boost-api.local.svc.cluster.local
 SKADI_API_ORIGIN_V2=http://skadi-api-server.local.svc.cluster.local
 MIMIR_ORIGIN=http://localhost:7600
 GONDUL_ORIGIN=http://host.docker.internal:9021
+BROKKR_ORIGIN=http://brokkr-grpc:50051
 
 MEILI_INDEX=dev
 MEILI_TOKEN=dev

--- a/.infra/Pulumi.adhoc.yaml
+++ b/.infra/Pulumi.adhoc.yaml
@@ -95,6 +95,7 @@ config:
     validLanguagesFeatureKey: valid_languages
     resumeBucketName: adhoc-daily-api
     employmentAgreementBucketName: adhoc-daily-api
+    brokkrOrigin: http://brokkr-grpc:50051
   api:k8s:
     namespace: local
   api:temporal:

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -172,6 +172,8 @@ config:
       secure: AAABALYmrJB/AIJh7SXF/2vStsA+vCbPUZ3GVJH/JgIxRg9azoA5A/BZkpSUYHwbVGMLP4yNZpc9Js3/2ISG
     gondulOrigin:
       secure: AAABANvfb9iJDOmbRPpMpkPzBLpeKTHsLCsFkNfU38yn53ZKUmeP0PA34uVGPZp+y4luHmEFXRE/jy/4rFwr9ZoVtufE59aa7J5AtVJcYY1VlumIY6P5olg=
+    brokkrOrigin:
+      secure: AAABABvk5Zi2sL2p8Gjl4vwVS+Ge+P2S3Jo8yDBOTNMZ6FZ1WquX+DqQkvE1YBTCvSMy9kmd+TCsRzeV3LrTC0Xbnlh7PxLog7fseJS37GUJ
   api:k8s:
     host: subs.daily.dev
     namespace: daily

--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -425,6 +425,10 @@ export const workers: Worker[] = [
     topic: 'gondul.v1.warm-intro-generated',
     subscription: 'api.recruiter-warm-intro-notification',
   },
+  {
+    topic: 'api.v1.candidate-preference-updated',
+    subscription: 'api.extract-cv-markdown'
+  }
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/__tests__/workers/extractCVMarkdown.ts
+++ b/__tests__/workers/extractCVMarkdown.ts
@@ -1,0 +1,202 @@
+import type { DataSource } from 'typeorm';
+import { BrokkrService, CandidatePreferenceUpdated } from '@dailydotdev/schema';
+import createOrGetConnection from '../../src/db';
+import {
+  createMockBrokkrTransport,
+  expectSuccessfulTypedBackground,
+  saveFixtures,
+} from '../helpers';
+import { User } from '../../src/entity';
+import { usersFixture } from '../fixture/user';
+import { extractCVMarkdown as worker } from '../../src/workers/extractCVMarkdown';
+import * as brokkrCommon from '../../src/common/brokkr';
+import { ConnectError, createClient } from '@connectrpc/connect';
+import { UserCandidatePreference } from '../../src/entity/user/UserCandidatePreference';
+import { logger } from '../../src/logger';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await saveFixtures(con, User, usersFixture);
+
+  const mockTransport = createMockBrokkrTransport();
+  jest
+    .spyOn(brokkrCommon, 'getBrokkrClient')
+    .mockImplementation(() => createClient(BrokkrService, mockTransport));
+});
+
+describe('extractCVMarkdown worker', () => {
+  const spyLogger = jest.fn();
+  beforeEach(async () => {
+    await saveFixtures(con, UserCandidatePreference, [
+      { userId: '1', cv: { blob: '1.pdf', bucket: '1' }, role: 'Goose farmer' },
+      {
+        userId: '2',
+        cv: { blob: '2.pdf', bucket: '2' },
+        cvParsedMarkdown: 'Already parsed',
+      },
+      { userId: '3' },
+    ]);
+  });
+
+  it('should extract markdown from CV and update user candidate preference', async () => {
+    const userId = '1';
+    jest.spyOn(logger, 'info').mockImplementation(spyLogger);
+    const payload = new CandidatePreferenceUpdated({
+      payload: {
+        userId: userId,
+        cv: { blob: '1.pdf', bucket: userId },
+      },
+    });
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      role: 'Goose farmer',
+      cvParsedMarkdown: null,
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.candidate-preference-updated'>(
+      worker,
+      payload,
+    );
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      role: 'Goose farmer',
+      cvParsedMarkdown: '# Extracted content for 1.pdf in 1',
+    });
+
+    expect(spyLogger).toHaveBeenCalledWith(
+      { userId: userId },
+      'Extracted markdown',
+    );
+  });
+
+  it('should return early when markdown is already extracted', async () => {
+    const userId = '2';
+    jest.spyOn(logger, 'info').mockImplementation(spyLogger);
+    const payload = new CandidatePreferenceUpdated({
+      payload: {
+        userId: userId,
+        cv: { blob: '2.pdf', bucket: userId },
+        cvParsedMarkdown: 'Already parsed',
+      },
+    });
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      cvParsedMarkdown: 'Already parsed',
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.candidate-preference-updated'>(
+      worker,
+      payload,
+    );
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      cvParsedMarkdown: 'Already parsed',
+    });
+
+    expect(spyLogger).toHaveBeenCalledWith(
+      'CV markdown already extracted, skipping',
+    );
+  });
+
+  it('should return early when no CV is found', async () => {
+    const userId = '3';
+    jest.spyOn(logger, 'warn').mockImplementation(spyLogger);
+    const payload = new CandidatePreferenceUpdated({
+      payload: {
+        userId: userId,
+      },
+    });
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      cv: {},
+      cvParsedMarkdown: null,
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.candidate-preference-updated'>(
+      worker,
+      payload,
+    );
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      cv: {},
+      cvParsedMarkdown: null,
+    });
+
+    expect(spyLogger).toHaveBeenCalledWith(
+      { blobName: undefined, bucketName: undefined, userId: userId },
+      'No CV found, skipping',
+    );
+  });
+
+  it('should handle when Brokkr is unable to extract markdown', async () => {
+    const userId = '3';
+    jest.spyOn(logger, 'error').mockImplementation(spyLogger);
+    const payload = new CandidatePreferenceUpdated({
+      payload: {
+        userId: userId,
+        cv: { blob: 'error.pdf', bucket: userId },
+      },
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.candidate-preference-updated'>(
+      worker,
+      payload,
+    );
+
+    expect(
+      await con
+        .getRepository(UserCandidatePreference)
+        .findOneBy({ userId: userId }),
+    ).toMatchObject({
+      userId: userId,
+      cv: {},
+      cvParsedMarkdown: null,
+    });
+
+    expect(spyLogger).toHaveBeenCalledWith(
+      {
+        blobName: 'error.pdf',
+        bucketName: userId,
+        userId: userId,
+        err: expect.any(ConnectError),
+      },
+      'Failed to extract markdown from CV',
+    );
+  });
+});

--- a/src/common/brokkr.ts
+++ b/src/common/brokkr.ts
@@ -1,0 +1,17 @@
+import { env } from 'node:process';
+import { createClient } from '@connectrpc/connect';
+import { createGrpcTransport } from '@connectrpc/connect-node';
+import { BrokkrService } from '@dailydotdev/schema';
+
+const transport = createGrpcTransport({
+  baseUrl: env.BROKKR_ORIGIN,
+  httpVersion: '2',
+});
+
+export const getBrokkrClient = (clientTransport = transport) =>
+  createClient<typeof BrokkrService>(BrokkrService, clientTransport);
+
+export const extractMarkdownFromCV = async (
+  blobName: string,
+  bucketName: string,
+) => getBrokkrClient().extractMarkdown({ blobName, bucketName });

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ declare global {
       RESUME_BUCKET_NAME: string;
       EMPLOYMENT_AGREEMENT_BUCKET_NAME: string;
       GONDUL_ORIGIN: string;
+      BROKKR_ORIGIN: string;
     }
   }
 }

--- a/src/workers/extractCVMarkdown.ts
+++ b/src/workers/extractCVMarkdown.ts
@@ -1,0 +1,47 @@
+import { CandidatePreferenceUpdated } from '@dailydotdev/schema';
+import type { TypedWorker } from './worker';
+import { UserCandidatePreference } from '../entity/user/UserCandidatePreference';
+import { extractMarkdownFromCV } from '../common/brokkr';
+
+export const extractCVMarkdown: TypedWorker<'api.v1.candidate-preference-updated'> =
+  {
+    subscription: 'api.extract-cv-markdown',
+    parseMessage: ({ data }) => CandidatePreferenceUpdated.fromBinary(data),
+    handler: async ({ data }, con, logger) => {
+      const { userId, cv, cvParsedMarkdown } = data.payload || {};
+      const blobName = cv?.blob;
+      const bucketName = cv?.bucket;
+      if (!!cvParsedMarkdown) {
+        logger.info('CV markdown already extracted, skipping');
+        return;
+      }
+
+      if (!blobName || !bucketName) {
+        logger.warn({ userId, blobName, bucketName }, 'No CV found, skipping');
+        return;
+      }
+
+      try {
+        const markdown = await extractMarkdownFromCV(blobName, bucketName);
+        if (!markdown?.content) {
+          logger.warn(
+            { userId, blobName, bucketName },
+            'No markdown content extracted from CV',
+          );
+          return;
+        }
+
+        await con
+          .getRepository(UserCandidatePreference)
+          .update({ userId }, { cvParsedMarkdown: markdown.content });
+
+        logger.info({ userId }, 'Extracted markdown');
+      } catch (_err) {
+        const err = _err as Error;
+        logger.error(
+          { userId, blobName, bucketName, err },
+          'Failed to extract markdown from CV',
+        );
+      }
+    },
+  };

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -70,6 +70,7 @@ import { postAuthorReputationEvent } from './postAnalytics/postAuthorReputationE
 import { postAuthorCoresEarned } from './postAnalytics/postAuthorCoresEarned';
 import { storeCandidateOpportunityMatch } from './opportunity/storeCandidateOpportunityMatch';
 import { storeCandidateApplicationScore } from './opportunity/storeCandidateApplicationScore';
+import { extractCVMarkdown } from './extractCVMarkdown';
 
 export { Worker } from './worker';
 
@@ -143,6 +144,7 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   campaignUpdatedSlack,
   storeCandidateOpportunityMatch,
   storeCandidateApplicationScore,
+  extractCVMarkdown,
 ];
 
 export const personalizedDigestWorkers: Worker[] = [


### PR DESCRIPTION
Adds a new worker that listens to the `api.v1.candidate-preference-updated` topic, and calls Brokkr to extract markdown from the CV if it has not already been extracted.