### PR TITLE
fix: temporary write error to markdown if extraction fails

### DIFF
--- a/__tests__/workers/extractCVMarkdown.ts
+++ b/__tests__/workers/extractCVMarkdown.ts
@@ -194,7 +194,7 @@ describe('extractCVMarkdown worker', () => {
     ).toMatchObject({
       userId: userId,
       cv: {},
-      cvParsedMarkdown: null,
+      cvParsedMarkdown: '@@ConnectError',
     });
     expect(spyLogger).toHaveBeenCalledWith(
       { err: expect.any(ConnectError) },

--- a/src/workers/extractCVMarkdown.ts
+++ b/src/workers/extractCVMarkdown.ts
@@ -29,6 +29,9 @@ export const extractCVMarkdown: TypedWorker<'api.v1.candidate-preference-updated
             { userId, blobName, bucketName },
             'No markdown content extracted from CV',
           );
+          await con
+            .getRepository(UserCandidatePreference)
+            .update({ userId }, { cvParsedMarkdown: '@@NoMarkdownContent' });
           return;
         }
 
@@ -38,6 +41,9 @@ export const extractCVMarkdown: TypedWorker<'api.v1.candidate-preference-updated
       } catch (err) {
         if (err instanceof ConnectError) {
           logger.error({ err }, 'ConnectError when extracting CV markdown');
+          await con
+            .getRepository(UserCandidatePreference)
+            .update({ userId }, { cvParsedMarkdown: '@@ConnectError' });
           return;
         }
 


### PR DESCRIPTION
Temporary sets known data in the markdown field so I don't keep on retrying them 🙈 