### PR TITLE
fix: allow keyword autocomplete to have empty query

### DIFF
--- a/src/common/schema/autocompletes.ts
+++ b/src/common/schema/autocompletes.ts
@@ -1,6 +1,7 @@
 import z from 'zod';
 import { AutocompleteType } from '../../entity/Autocomplete';
 import { CompanyType } from '../../entity/Company';
+import { normalizeContentForDeduplication } from '../../entity/posts/hooks';
 
 export const autocompleteBaseSchema = z.object({
   query: z.string().trim().toLowerCase().normalize().min(1).max(100).nonempty(),
@@ -13,4 +14,9 @@ export const autocompleteSchema = autocompleteBaseSchema.extend({
 
 export const autocompleteCompanySchema = autocompleteBaseSchema.extend({
   type: z.enum(CompanyType).optional(),
+});
+
+export const autocompleteKeywordsSchema = z.object({
+  query: z.string().transform(normalizeContentForDeduplication),
+  limit: z.number().min(1).max(50).default(20),
 });

--- a/src/schema/autocompletes.ts
+++ b/src/schema/autocompletes.ts
@@ -8,6 +8,7 @@ import { queryReadReplica } from '../common/queryReadReplica';
 import {
   autocompleteBaseSchema,
   autocompleteCompanySchema,
+  autocompleteKeywordsSchema,
   autocompleteSchema,
 } from '../common/schema/autocompletes';
 import type z from 'zod';
@@ -166,10 +167,10 @@ export const resolvers = traceResolvers<unknown, BaseContext>({
     },
     autocompleteKeywords: async (
       _,
-      payload: z.infer<typeof autocompleteBaseSchema>,
+      payload: z.infer<typeof autocompleteKeywordsSchema>,
       ctx: AuthContext,
     ): Promise<GQLKeywordAutocomplete[]> => {
-      const data = autocompleteBaseSchema.parse(payload);
+      const data = autocompleteKeywordsSchema.parse(payload);
 
       const status = !!ctx.userId
         ? [KeywordStatus.Allow, KeywordStatus.Synonym]


### PR DESCRIPTION
This is to allow to fetch initial keywords in autocomplete.

Noticed it was broken when trying to edit an opportunity, it didn't show me the initial set of keywords.