### PR TITLE
fix: default for organization id

### DIFF
--- a/src/common/schema/opportunities.ts
+++ b/src/common/schema/opportunities.ts
@@ -89,12 +89,34 @@ export const opportunityEditSchema = z
       .min(1)
       .max(100),
     location: z.array(
-      z.object({
-        country: z.string().nonempty().max(240),
-        city: z.string().nonempty().max(240).optional(),
-        subdivision: z.string().nonempty().max(240).optional(),
-        type: z.coerce.number().min(1),
-      }),
+      z
+        .object({
+          country: z.string().max(240),
+          city: z.string().max(240).optional(),
+          subdivision: z.string().max(240).optional(),
+          continent: z
+            .union([z.literal('Europe'), z.literal(''), z.undefined()])
+            .optional(),
+          type: z.coerce.number().min(1),
+        })
+        .superRefine((val, ctx) => {
+          const present = [
+            val.country && val.country.trim() !== '',
+            val.city && val.city.trim() !== '',
+            val.subdivision && val.subdivision.trim() !== '',
+            // continent counts only if it is "Europe" (empty string should not count)
+            val.continent === 'Europe',
+          ].some(Boolean);
+
+          if (!present) {
+            ctx.addIssue({
+              code: 'custom',
+              message:
+                'At least one of country, city, subdivision, or continent must be provided.',
+              path: [''], // form-level error
+            });
+          }
+        }),
     ),
     meta: z.object({
       employmentType: z.coerce.number().min(1),

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -215,6 +215,7 @@ export const typeDefs = /* GraphQL */ `
     city: String
     country: String
     subdivision: String
+    continent: String
     type: ProtoEnumValue
   }
 


### PR DESCRIPTION
Fix default to propose uuidv4
ideally it should set type to uuid, but we reference it too much in other tables now.