### PR TITLE
feat: handle consumption request of iap cores purchase

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -30,6 +30,12 @@ config:
     apiConfigFeatureKey: api-config
     appleAppAppleId: 6740634400
     appleAppBundleId: dev.daily.app
+    appleIssuerId:
+      secure: AAABAK7J9W93y2dJnNDSiDfzwj2+bSPdo3uOswwQE/vX4RrWSVtPndgGY4EStNzK5dAyV34Osd5Ktekn9wHyEeptNN4=
+    appleAppStoreServerClientKey:
+      secure: AAABAPaOTw3J1adzb3RaGgZYE7eywB9UHAw85tagbYBXaIzM6MxQI7vgSFUP5bbvMwuZVaZ2F2aB5WXn0V6ZcoqV/OCGJk/XygbjovFqMlqCEjO4ovRu0Cjck+82nJYk6hPuLqsTUw6C0aJUBour4a1o2Jl04X5XRcUUTTanguOyFlWxSUxVDZ6As9DGuFYsNV3jIhhiAtgC1IHZH/luyURuUkprm7iHKvdlVqMO9ctne+PQ2bMVWCSGvJeXt/oQDWRQT9UHxnbD7LSgWDmMAbd4aaXD/YE/gN220FSzeV7EsiXUb4+NyPtP6dSc4GSKVfa7keGn57KZK+U+duFZjhEqch8uenb0RO28zvyYYcbbcpsd7TvggwbBgqc2cTJXUA==
+    appleAppStoreServerClientKeyId:
+      secure: AAABAOxbRgC+Npj/q0uRCmHXjAnMs8W507CAyKb50ndVgQkx1YKyYPZb
     validLanguagesFeatureKey: valid_languages
     cdcWorkerMaxMessages: 1
     cioApiKey:

--- a/src/common/apple/types.ts
+++ b/src/common/apple/types.ts
@@ -28,6 +28,11 @@ export const bundleId = isTest ? 'dev.fylla' : env.APPLE_APP_BUNDLE_ID;
 export const appAppleId = parseInt(env.APPLE_APP_APPLE_ID);
 export const appleEnableOnlineChecks = true;
 export const appleEnvironment = getVerifierEnvironment();
+export const appleIssuerId = env.APPLE_ISSUER_ID;
+export const appleAppStoreServerClientKey =
+  env.APPLE_APP_STORE_SERVER_CLIENT_KEY;
+export const appleAppStoreServerClientKeyId =
+  env.APPLE_APP_STORE_SERVER_CLIENT_KEY_ID;
 
 export const allowedIPs = [
   '127.0.0.1/24',

--- a/src/common/apple/utils.ts
+++ b/src/common/apple/utils.ts
@@ -1,4 +1,5 @@
 import {
+  AccountTenure,
   NotificationTypeV2,
   Subtype,
   type Environment,
@@ -24,6 +25,7 @@ import { readFile } from 'fs/promises';
 import { isTest } from '../utils';
 import { isCorePurchaseApple } from './purchase';
 import { SubscriptionProvider } from '../plus';
+import { differenceInDays } from 'date-fns';
 
 export const verifyAndDecodeAppleSignedData = async ({
   notification,
@@ -154,4 +156,22 @@ export const getAppleTransactionType = ({
     default:
       return null;
   }
+};
+
+export const getAccountTenure = (user: Pick<User, 'createdAt'>): number => {
+  if (!user.createdAt) {
+    return 0;
+  }
+
+  const difference = differenceInDays(new Date(), user.createdAt);
+
+  if (difference < 3) return AccountTenure.ZERO_TO_THREE_DAYS;
+  if (difference < 10) return AccountTenure.THREE_DAYS_TO_TEN_DAYS;
+  if (difference < 30) return AccountTenure.TEN_DAYS_TO_THIRTY_DAYS;
+  if (difference < 90) return AccountTenure.THIRTY_DAYS_TO_NINETY_DAYS;
+  if (difference < 180)
+    return AccountTenure.NINETY_DAYS_TO_ONE_HUNDRED_EIGHTY_DAYS;
+  if (difference < 365)
+    return AccountTenure.ONE_HUNDRED_EIGHTY_DAYS_TO_THREE_HUNDRED_SIXTY_FIVE_DAYS;
+  return AccountTenure.GREATER_THAN_THREE_HUNDRED_SIXTY_FIVE_DAYS;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,9 @@ declare global {
 
       APPLE_APP_APPLE_ID: string;
       APPLE_APP_BUNDLE_ID: string;
+      APPLE_ISSUER_ID: string;
+      APPLE_APP_STORE_SERVER_CLIENT_KEY: string;
+      APPLE_APP_STORE_SERVER_CLIENT_KEY_ID: string;
 
       GEOIP_PATH?: string;
       RESUME_BUCKET_NAME: string;


### PR DESCRIPTION
When we receive a consumption request for an IAP cores purchase, we must send consumption information to Apple. 

https://dailydotdev.slack.com/archives/C07LHS7RXA4/p1762863856813219