### PR TITLE
feat: customLocation for user experience

### DIFF
--- a/__tests__/common/profile/import.ts
+++ b/__tests__/common/profile/import.ts
@@ -60,6 +60,10 @@ describe('UserExperienceType work import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {
+        city: 'New York',
+        country: 'USA',
+      },
     });
     const skills = await con
       .getRepository(UserExperienceSkill)
@@ -98,6 +102,10 @@ describe('UserExperienceType work import', () => {
       userId: 'user-work-2',
       verified: false,
       flags: {},
+      customLocation: {
+        city: 'Wahkkauppp',
+        country: 'Mars',
+      },
     });
   });
 });
@@ -134,6 +142,9 @@ describe('UserExperienceType education import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {
+        country: 'Colombia',
+      },
     });
   });
 
@@ -167,6 +178,9 @@ describe('UserExperienceType education import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {
+        country: 'NowhereLand',
+      },
     });
   });
 });
@@ -205,6 +219,7 @@ describe('UserExperienceType certification import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {},
     });
   });
 
@@ -241,6 +256,7 @@ describe('UserExperienceType certification import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {},
     });
   });
 });
@@ -280,6 +296,7 @@ describe('UserExperienceType project import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {},
     });
     expect(skills.map((s) => s.value).sort()).toEqual(
       ['GraphQL', 'Node.js'].sort(),
@@ -316,6 +333,7 @@ describe('UserExperienceType project import', () => {
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),
       flags: {},
+      customLocation: {},
     });
   });
 });

--- a/src/common/profile/import.ts
+++ b/src/common/profile/import.ts
@@ -66,7 +66,7 @@ const resolveUserLocationPart = async ({
   } | null;
   con: EntityManager;
   threshold?: number;
-}): Promise<Partial<Pick<UserExperience, 'locationId'>>> => {
+}): Promise<Partial<Pick<UserExperience, 'locationId' | 'customLocation'>>> => {
   if (!location) {
     return {};
   }
@@ -125,7 +125,9 @@ const resolveUserLocationPart = async ({
     };
   }
 
-  return {};
+  return {
+    customLocation: location,
+  };
 };
 
 export const importUserExperienceWork = async ({

--- a/src/entity/user/experiences/UserExperience.ts
+++ b/src/entity/user/experiences/UserExperience.ts
@@ -69,6 +69,13 @@ export class UserExperience {
   @Column({ type: 'text', default: null })
   locationId: string | null;
 
+  @Column({ type: 'jsonb', default: {} })
+  customLocation: Partial<{
+    city: string | null;
+    subdivision: string | null;
+    country: string | null;
+  }>;
+
   @ManyToOne('DatasetLocation', { lazy: true, onDelete: 'SET NULL' })
   @JoinColumn({
     name: 'locationId',

--- a/src/migration/1764076115716-UserExperienceCustomLocation.ts
+++ b/src/migration/1764076115716-UserExperienceCustomLocation.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserExperienceCustomLocation1764076115716
+  implements MigrationInterface
+{
+  name = 'UserExperienceCustomLocation1764076115716';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_experience" ADD "customLocation" jsonb NOT NULL DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_experience" DROP COLUMN "customLocation"`,
+    );
+  }
+}


### PR DESCRIPTION
We currently don't have data in dataset_location, so saving unmatched locations to `customLocation` column so we can do enrichment later. 