### PR TITLE
feat: opportunity preview details

### DIFF
--- a/src/common/schema/opportunities.ts
+++ b/src/common/schema/opportunities.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import { organizationLinksSchema } from './organizations';
 import { fileUploadSchema, urlParseSchema } from './common';
 import { parseBigInt } from '../utils';
+import { OpportunityMatchStatus } from '../../entity/opportunities/types';
 
 export const opportunityMatchDescriptionSchema = z.object({
   reasoning: z.string(),
@@ -254,4 +255,17 @@ export const createSharedSlackChannelSchema = z.object({
       /^[a-z0-9-_]+$/,
       'Channel name can only contain lowercase letters, numbers, hyphens, and underscores',
     ),
+});
+
+export const opportunityMatchesQuerySchema = z.object({
+  opportunityId: z.string(),
+  status: z
+    .enum([
+      OpportunityMatchStatus.CandidateAccepted,
+      OpportunityMatchStatus.RecruiterAccepted,
+      OpportunityMatchStatus.RecruiterRejected,
+    ])
+    .optional(),
+  after: z.string().optional(),
+  first: z.number().optional(),
 });

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1601,6 +1601,7 @@ const obj = new GraphORM({
     },
   },
   OpportunityMatch: {
+    requiredColumns: ['updatedAt'],
     ignoredColumns: ['engagementProfile'],
     fields: {
       createdAt: {


### PR DESCRIPTION
Decided to switch to singular endpoint:

```
{
    opportunityPreview {
        edges {
            node {
                topTags
                company {
                    name
                    favicon
                }
                activeSquads
            }
        }
        pageInfo {
            hasNextPage
        }
        result {
            tags
            companies {
                name
                favicon
            }
            squads
            totalCount
        }
        opportunity {
            title
            tldr
            keywords {
                keyword
            }
        }
    }
}
```

Results:
```
{
    "data": {
        "opportunityPreview": {
            "edges": [
                {
                    "node": {
                        "topTags": [
                            "google",
                            "startup"
                        ],
                        "company": {
                            "name": "daily.dev",
                            "favicon": null
                        },
                        "activeSquads": [
                            "publicsquad"
                        ]
                    }
                },
                {
                    "node": {
                        "topTags": [],
                        "company": null,
                        "activeSquads": [
                            "publicsquad"
                        ]
                    }
                },
                {
                    "node": {
                        "topTags": [],
                        "company": null,
                        "activeSquads": []
                    }
                }
            ],
            "pageInfo": {
                "hasNextPage": false
            },
            "result": {
                "tags": [
                    "google",
                    "startup"
                ],
                "companies": [
                    {
                        "name": "Infosys",
                        "favicon": "https://www.infosys.com/"
                    },
                    {
                        "name": "GitHub",
                        "favicon": "https://github.com/"
                    },
                    {
                        "name": "Sentry",
                        "favicon": "https://sentry.io/"
                    },
                    {
                        "name": "Ubisoft",
                        "favicon": "https://www.ubisoft.com/"
                    },
                    {
                        "name": "JPMorgan Chase & Co",
                        "favicon": "https://www.jpmorganchase.com/"
                    },
                    {
                        "name": "PwC",
                        "favicon": "https://www.pwc.com/"
                    }
                ],
                "squads": [
                    "publicsquad"
                ],
                "totalCount": 3
            },
            "opportunity": {
                "title": "Senior Frontend Developer",
                "tldr": "Senior frontend role at Linear (issue tracking startup). React/TS stack, $140k-$180k, remote- first, Series B stage. Build dev tools used by top companies. Strong culture, great benefits, perfect match for your skills and preferences.",
                "keywords": [
                    {
                        "keyword": "GraphQL"
                    },
                    {
                        "keyword": "Next.js"
                    },
                    {
                        "keyword": "Node.js"
                    },
                    {
                        "keyword": "React"
                    },
                    {
                        "keyword": "Tailwind CSS"
                    },
                    {
                        "keyword": "TypeScript"
                    }
                ]
            }
        }
    }
}
```