### PR TITLE
chore: safe in query

### DIFF
--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -1378,7 +1378,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
           (_, i) => offsetToCursor(offset + i + 1),
           (builder) => {
             builder.queryBuilder.where(`${builder.alias}.id IN (:...userIds)`, {
-              userIds: userIds,
+              userIds: userIds.length ? userIds : ['nosuchid'],
             });
             return builder;
           },


### PR DESCRIPTION
In case of userIds being empty array the IN would fail, we do this same for feed