### PR TITLE
refactor: validate both country and iso2 fields in location filtering

### DIFF
--- a/src/common/opportunity/parse.ts
+++ b/src/common/opportunity/parse.ts
@@ -226,8 +226,14 @@ export async function parseOpportunityWithBrokkr(
               return loc;
             })
             .filter((loc) => {
-              // Only keep locations with valid country
-              return loc?.country && loc.country.trim().length > 0;
+              // Only keep locations with valid country and iso2
+              // Both are required for downstream processing in gondul
+              return (
+                loc?.country &&
+                loc.country.trim().length > 0 &&
+                loc?.iso2 &&
+                loc.iso2.trim().length > 0
+              );
             })
         : [],
     };


### PR DESCRIPTION
This PR fixes the location filtering logic in the parseOpportunity function to validate both country and iso2 fields.

## Changes
- Updated location filtering to check both `country` and `iso2` fields
- Ensures both fields are present and have non-empty trimmed values
- Prevents invalid location data from reaching gondul which requires valid ISO codes

Follows up on PR #3387 based on review feedback from @capJavert about iso2 validation being important for downstream processing.