### PR TITLE
feat: add support for building social links from legacy fields and reverse dual-write

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,7 @@
       "Bash(docker-compose:*)",
       "WebFetch(domain:*.daily.dev)",
       "mcp__github__*",
+      "mcp__plugin_linear_linear__*",
       "Read",
       "Glob",
       "Grep",


### PR DESCRIPTION
- Implemented functions to generate `socialLinks` array from legacy individual fields.
- Added validation to detect updates in legacy social fields.
- Enhanced update logic to handle dual-write scenarios, ensuring synchronization between legacy fields and `socialLinks`.
- Updated tests to validate reverse dual-write functionality.