### PR TITLE
perf: replace DELETE loop with TRUNCATE CASCADE in test cleanup

### DIFF
--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -61,20 +61,16 @@ const cleanDatabase = async (): Promise<void> => {
   await remoteConfig.init();
 
   const con = await createOrGetConnection();
-  for (const entity of con.entityMetadatas) {
-    const repository = con.getRepository(entity.name);
-    if (repository.metadata.tableType === 'view') continue;
-    await repository.query(`DELETE
-                            FROM "${entity.tableName}";`);
 
-    for (const column of entity.primaryColumns) {
-      if (column.generationStrategy === 'increment') {
-        await repository.query(
-          `ALTER SEQUENCE ${entity.tableName}_${column.databaseName}_seq RESTART WITH 1`,
-        );
-      }
-    }
-  }
+  // Get all table names, excluding views
+  const tableNames = con.entityMetadatas
+    .filter((entity) => entity.tableType !== 'view')
+    .map((entity) => `"${entity.tableName}"`)
+    .join(', ');
+
+  // Single TRUNCATE with CASCADE and RESTART IDENTITY
+  // Much faster than individual DELETE statements per table
+  await con.query(`TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE`);
 };
 
 export const fileTypeFromBuffer = jest.fn();


### PR DESCRIPTION
## Summary
- Replace individual DELETE statements (~131 tables × 2 queries each) with a single `TRUNCATE TABLE ... RESTART IDENTITY CASCADE` query in test cleanup
- TRUNCATE is faster than DELETE (no row-by-row WAL logging)
- CASCADE handles foreign key constraints automatically
- RESTART IDENTITY resets sequences in the same statement

**Expected impact:** 60-70% reduction in per-test cleanup time

## Test plan
- [ ] CI tests pass
- [ ] Compare test runtime before/after in CircleCI Insights

Closes ENG-280