### PR TITLE
chore: stop noisy logs

### DIFF
--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -2182,7 +2182,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       const timeForRecoveryPassed = !!streak && streak.currentStreak > 1;
 
       if (!streak || !oldStreakLength || timeForRecoveryPassed) {
-        logger.info(
+        logger.debug(
           { streak, today: new Date(), oldStreakLength },
           `streak restore not possible`,
         );


### PR DESCRIPTION
Reduces `api` logs with ~900k lines per month

<img width="421" height="296" alt="image" src="https://github.com/user-attachments/assets/820e933a-522f-447c-89ea-64a57608b37d" />
