### PR TITLE
perf: add PostgreSQL performance flags for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,12 @@ jobs:
         environment:
           POSTGRES_DB: api_test
           POSTGRES_PASSWORD: 12345
+        command: >
+          postgres
+          -c fsync=off
+          -c synchronous_commit=off
+          -c full_page_writes=off
+          -c max_connections=200
       - image: redis/redis-stack:7.2.0-v13
     parallelism: 6
     steps:


### PR DESCRIPTION
Add performance flags to the PostgreSQL container in CircleCI:
- fsync=off - Don't wait for writes to hit disk
- synchronous_commit=off - Don't wait for WAL flush
- full_page_writes=off - Skip extra safety writes
- max_connections=200 - Allow more connections

These are safe for tests since we don't need durability. Expected impact: 5-10% faster database writes.

Closes ENG-281