### PR TITLE
fix: opportunity slack channel to validate from opp id

### DIFF
--- a/src/common/opportunity/accessControl.ts
+++ b/src/common/opportunity/accessControl.ts
@@ -10,6 +10,7 @@ export enum OpportunityPermissions {
   Edit = 'opportunity_edit',
   UpdateState = 'opportunity_update_state',
   ViewDraft = 'opportunity_view_draft',
+  CreateSlackChannel = 'opportunity_create_slack_channel',
 }
 
 export const ensureOpportunityPermissions = async ({
@@ -43,6 +44,7 @@ export const ensureOpportunityPermissions = async ({
       OpportunityPermissions.Edit,
       OpportunityPermissions.UpdateState,
       OpportunityPermissions.ViewDraft,
+      OpportunityPermissions.CreateSlackChannel,
     ].includes(permission)
   ) {
     const opportunityUserQb = con

--- a/src/common/schema/opportunities.ts
+++ b/src/common/schema/opportunities.ts
@@ -322,7 +322,7 @@ export const reimportOpportunitySchema = z
   );
 
 export const createSharedSlackChannelSchema = z.object({
-  organizationId: z.string().uuid('Organization ID must be a valid UUID'),
+  opportunityId: z.uuid('Opportunity ID must be a valid UUID'),
   email: z.string().email('Email must be a valid email address'),
   channelName: z
     .string()

--- a/src/schema/opportunity.ts
+++ b/src/schema/opportunity.ts
@@ -70,7 +70,6 @@ import { QuestionScreening } from '../entity/questions/QuestionScreening';
 import { In, Not, JsonContains, EntityManager } from 'typeorm';
 import { Organization } from '../entity/Organization';
 import { Source, SourceType } from '../entity/Source';
-import { ContentPreferenceOrganization } from '../entity/contentPreference/ContentPreferenceOrganization';
 import {
   OrganizationLinkType,
   SocialMediaType,
@@ -904,9 +903,9 @@ export const typeDefs = /* GraphQL */ `
     """
     createSharedSlackChannel(
       """
-      Organization ID
+      Opportunity ID
       """
-      organizationId: ID!
+      opportunityId: ID!
 
       """
       Email address of the user to invite
@@ -2493,47 +2492,26 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
       payload: z.infer<typeof createSharedSlackChannelSchema>,
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
-      const { organizationId, channelName, email } =
+      const { opportunityId, channelName, email } =
         createSharedSlackChannelSchema.parse(payload);
 
-      // Check if the user is a recruiter
-      const isRecruiter = await ctx.con
-        .getRepository(OpportunityUserRecruiter)
-        .findOne({
-          where: {
-            userId: ctx.userId,
-            type: OpportunityUserType.Recruiter,
-          },
+      await ensureOpportunityPermissions({
+        con: ctx.con.manager,
+        userId: ctx.userId,
+        opportunityId,
+        permission: OpportunityPermissions.CreateSlackChannel,
+        isTeamMember: ctx.isTeamMember,
+      });
+
+      const opportunity = await ctx.con
+        .getRepository(OpportunityJob)
+        .findOneOrFail({
+          where: { id: opportunityId },
+          relations: { organization: true },
         });
-
-      if (!isRecruiter) {
-        throw new ForbiddenError(
-          'Access denied! Only recruiters can create Slack channels',
-        );
-      }
-
-      // Verify user is a member of the organization
-      const organizationMembership = await ctx.con
-        .getRepository(ContentPreferenceOrganization)
-        .findOne({
-          where: {
-            userId: ctx.userId,
-            organizationId,
-          },
-        });
-
-      if (!organizationMembership) {
-        throw new ForbiddenError(
-          'Access denied! You are not a member of this organization',
-        );
-      }
 
       // Get the organization and check subscription status
-      const organization = await ctx.con
-        .getRepository(Organization)
-        .findOneOrFail({
-          where: { id: organizationId },
-        });
+      const organization = await opportunity.organization;
 
       // Check if organization has an active subscription
       if (
@@ -2570,7 +2548,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = traceResolvers<
 
         // Mark organization as having a Slack connection and store channel name
         await ctx.con.getRepository(Organization).update(
-          { id: organizationId },
+          { id: organization.id },
           {
             recruiterSubscriptionFlags:
               updateRecruiterSubscriptionFlags<Organization>({


### PR DESCRIPTION
- org membership is not really assigned through content preference on opportunities and orgs, its all based on opportunity_user, so slack creation never worked for our new customers
- refactored to just check opportunity_user
- moved to opportunityId (vs organizationId), it still checks per org but org is resolved from opportunityId
- moved permission checks to new permission and standard helper