### PR TITLE
fix: skip tracking cookie on sitemap routes

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -34,6 +34,11 @@ const plugin = async (fastify: FastifyInstance): Promise<void> => {
 
   fastify.addHook('preHandler', async (req, res) => {
     req.isBot = isBotRequest(req);
+
+    if (req.url.startsWith('/sitemaps')) {
+      return;
+    }
+
     req.sessionId = req.cookies[cookies.session.key];
 
     const trackingCookie = req.cookies[cookies.tracking.key];


### PR DESCRIPTION
## Summary
- Skip tracking middleware for `/sitemaps` routes so responses don't include `Set-Cookie: da2=...`
- This allows Vercel CDN to cache sitemap responses (`s-maxage=7200`)
- Every sitemap request was hitting the origin with `x-vercel-cache: MISS` because `Set-Cookie` prevents caching

## Context
All sitemaps show "Couldn't fetch" in Google Search Console. Investigation found the tracking cookie is set on every sitemap response, preventing CDN caching and forcing Google to always hit the origin.

## Test plan
- [ ] Verify sitemap responses no longer include `Set-Cookie` header
- [ ] Verify `x-vercel-cache: HIT` on subsequent sitemap requests