### PR TITLE
fix: exclude squads from sources best-of sitemap

### DIFF
--- a/__tests__/sitemaps.ts
+++ b/__tests__/sitemaps.ts
@@ -1150,6 +1150,25 @@ describe('GET /sitemaps/archive-index.xml', () => {
 
     expect(res.text).not.toContain('/sources/nonexistent-source/best-of');
   });
+
+  it('should exclude squad sources from archive index', async () => {
+    await con.getRepository(Archive).save([
+      {
+        ...archiveBase,
+        scopeType: ArchiveScopeType.Source,
+        scopeId: 'm',
+        periodType: ArchivePeriodType.Month,
+        periodStart: new Date('2025-01-01T00:00:00.000Z'),
+        createdAt: new Date(),
+      },
+    ]);
+
+    const res = await request(app.server)
+      .get('/sitemaps/archive-index.xml')
+      .expect(200);
+
+    expect(res.text).not.toContain('/sources/moderatedSquad/best-of');
+  });
 });
 
 describe('GET /sitemaps/archive-pages-:scopeType-:periodType-:page.xml', () => {
@@ -1302,6 +1321,25 @@ describe('GET /sitemaps/archive-pages-:scopeType-:periodType-:page.xml', () => {
       .expect(200);
 
     expect(res.text).not.toContain('/sources/nonexistent-source/best-of');
+  });
+
+  it('should exclude squad sources from archive pages', async () => {
+    await con.getRepository(Archive).save([
+      {
+        ...archiveBase,
+        scopeType: ArchiveScopeType.Source,
+        scopeId: 'm',
+        periodType: ArchivePeriodType.Month,
+        periodStart: new Date('2025-01-01T00:00:00.000Z'),
+        createdAt: new Date(),
+      },
+    ]);
+
+    const res = await request(app.server)
+      .get('/sitemaps/archive-pages-source-month-0.xml')
+      .expect(200);
+
+    expect(res.text).not.toContain('/sources/moderatedSquad/best-of');
   });
 });
 

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -455,7 +455,7 @@ const buildArchiveIndexSitemapQuery = (
       scopeTypes: [ArchiveScopeType.Tag, ArchiveScopeType.Source],
     })
     .andWhere(
-      `CASE WHEN a."scopeType" = '${ArchiveScopeType.Source}' THEN s.handle IS NOT NULL ELSE TRUE END`,
+      `CASE WHEN a."scopeType" = '${ArchiveScopeType.Source}' THEN s.handle IS NOT NULL AND s.type != '${SourceType.Squad}' ELSE TRUE END`,
     )
     .groupBy('a."scopeType"')
     .addGroupBy(
@@ -498,7 +498,11 @@ const buildArchivePagesPaginatedQuery = (
     .andWhere('a."periodType" = :periodType', { periodType });
 
   if (scopeType === ArchiveScopeType.Source) {
-    qb.innerJoin(Source, 's', 's.id = a."scopeId"');
+    qb.innerJoin(
+      Source,
+      's',
+      `s.id = a."scopeId" AND s.type != '${SourceType.Squad}'`,
+    );
     qb.orderBy('s.handle', 'ASC');
   } else {
     qb.orderBy('a."scopeId"', 'ASC');


### PR DESCRIPTION
## Summary
- Filter out squad-type sources from the archive-index and archive-pages sitemaps so only machine sources appear in best-of pages
- Adds squad exclusion to both `buildArchiveIndexSitemapQuery` and `buildArchivePagesPaginatedQuery`

## Test plan
- [x] Added test: squad sources excluded from archive index sitemap
- [x] Added test: squad sources excluded from archive pages sitemap
- [x] All 34 sitemap tests pass