### PR TITLE
Add explicit ordering for highlight channels

### DIFF
--- a/__tests__/highlights.ts
+++ b/__tests__/highlights.ts
@@ -171,16 +171,19 @@ describe('query channelConfigurations', () => {
         channel: 'career',
         displayName: 'Career Growth',
         mode: 'shadow',
+        order: 1,
       },
       {
         channel: 'backend',
         displayName: 'Backend Engineering',
         mode: 'publish',
+        order: 2,
       },
       {
         channel: 'disabled',
         displayName: 'Disabled',
         mode: 'disabled',
+        order: 0,
       },
     ]);
 
@@ -200,6 +203,11 @@ describe('query channelConfigurations', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data.channelConfigurations).toEqual([
       {
+        channel: 'career',
+        displayName: 'Career Growth',
+        digest: null,
+      },
+      {
         channel: 'backend',
         displayName: 'Backend Engineering',
         digest: {
@@ -210,11 +218,6 @@ describe('query channelConfigurations', () => {
             handle: 'backend_digest',
           },
         },
-      },
-      {
-        channel: 'career',
-        displayName: 'Career Growth',
-        digest: null,
       },
     ]);
   });

--- a/src/common/channelHighlight/definitions.ts
+++ b/src/common/channelHighlight/definitions.ts
@@ -12,6 +12,7 @@ export const getChannelHighlightDefinitions = async ({
       mode: Not('disabled'),
     },
     order: {
+      order: 'ASC',
       channel: 'ASC',
     },
   });

--- a/src/entity/ChannelHighlightDefinition.ts
+++ b/src/entity/ChannelHighlightDefinition.ts
@@ -15,6 +15,9 @@ export class ChannelHighlightDefinition {
   @Column({ type: 'text', default: '' })
   displayName: string;
 
+  @Column({ type: 'smallint', default: 0 })
+  order: number;
+
   @Column({ type: 'text', default: 'disabled' })
   mode: ChannelHighlightMode;
 

--- a/src/migration/1776108702577-ChannelHighlightDefinitionOrder.ts
+++ b/src/migration/1776108702577-ChannelHighlightDefinitionOrder.ts
@@ -1,0 +1,34 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChannelHighlightDefinitionOrder1776108702577
+  implements MigrationInterface
+{
+  name = 'ChannelHighlightDefinitionOrder1776108702577';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "channel_highlight_definition"
+        ADD COLUMN "order" smallint NOT NULL DEFAULT 0
+    `);
+
+    await queryRunner.query(/* sql */ `
+      WITH ordered_definitions AS (
+        SELECT
+          "channel",
+          ROW_NUMBER() OVER (ORDER BY "channel" ASC) - 1 AS "order"
+        FROM "channel_highlight_definition"
+      )
+      UPDATE "channel_highlight_definition" AS definition
+      SET "order" = ordered_definitions."order"
+      FROM ordered_definitions
+      WHERE ordered_definitions."channel" = definition."channel"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "channel_highlight_definition"
+        DROP COLUMN "order"
+    `);
+  }
+}

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -124,7 +124,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             .where(`"${builder.alias}"."mode" != :disabledMode`, {
               disabledMode: 'disabled',
             })
-            .orderBy(`"${builder.alias}"."channel"`, 'ASC');
+            .orderBy(`"${builder.alias}"."order"`, 'ASC')
+            .addOrderBy(`"${builder.alias}"."channel"`, 'ASC');
           return builder;
         },
         true,


### PR DESCRIPTION
## Summary
- add an `order` column to `channel_highlight_definition` and backfill it from the current alphabetical channel order
- order highlight-backed channel configuration reads by `order ASC, channel ASC`
- update the highlights integration test to verify explicit ordering instead of alphabetical ordering

## Testing
- NODE_ENV=test pnpm run db:migrate:latest
- NODE_ENV=test npx jest __tests__/highlights.ts --testEnvironment=node --runInBand
- pnpm run build
- pnpm run lint