### PR TITLE
feat: add highlights sitemap

### DIFF
--- a/__tests__/sitemaps.ts
+++ b/__tests__/sitemaps.ts
@@ -33,6 +33,7 @@ import { updateFlagsStatement } from '../src/common/utils';
 import { sourcesFixture } from './fixture/source';
 import { keywordsFixture } from './fixture/keywords';
 import { ONE_DAY_IN_SECONDS } from '../src/common/constants';
+import { ChannelHighlightDefinition } from '../src/entity/ChannelHighlightDefinition';
 let app: FastifyInstance;
 let con: DataSource;
 const previousSitemapLimit = process.env.SITEMAP_LIMIT;
@@ -150,6 +151,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   nock.cleanAll();
+  await con.getRepository(ChannelHighlightDefinition).clear();
   await saveFixtures(con, SentimentGroup, sentimentGroupsFixture);
   await saveFixtures(con, SentimentEntity, sentimentEntitiesFixture);
   await saveFixtures(con, Keyword, keywordsFixture);
@@ -525,6 +527,9 @@ describe('GET /sitemaps/index.xml', () => {
       '<loc>http://localhost:5002/api/sitemaps/collections.xml</loc>',
     );
     expect(res.text).toContain(
+      '<loc>http://localhost:5002/api/sitemaps/highlights.xml</loc>',
+    );
+    expect(res.text).toContain(
       '<loc>http://localhost:5002/api/sitemaps/agents.xml</loc>',
     );
     expect(res.text).toContain(
@@ -541,6 +546,56 @@ describe('GET /sitemaps/index.xml', () => {
     );
     expect(res.text).toContain(
       '<loc>http://localhost:5002/api/sitemaps/tags.xml</loc>',
+    );
+  });
+});
+
+describe('GET /sitemaps/highlights.xml', () => {
+  it('should return the highlights sitemap with enabled channels only', async () => {
+    await con.getRepository(ChannelHighlightDefinition).save([
+      {
+        channel: 'career',
+        displayName: 'Career',
+        mode: 'shadow',
+        order: 1,
+      },
+      {
+        channel: 'backend',
+        displayName: 'Backend',
+        mode: 'publish',
+        order: 2,
+      },
+      {
+        channel: 'disabled',
+        displayName: 'Disabled',
+        mode: 'disabled',
+        order: 0,
+      },
+    ]);
+
+    const res = await request(app.server)
+      .get('/sitemaps/highlights.xml')
+      .expect(200);
+
+    expect(res.header['content-type']).toContain('application/xml');
+    expect(res.header['cache-control']).toBeTruthy();
+    expect(res.text).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(res.text).toContain('<loc>http://localhost:5002/highlights</loc>');
+    expect(res.text).toContain(
+      '<loc>http://localhost:5002/highlights/career</loc>',
+    );
+    expect(res.text).toContain(
+      '<loc>http://localhost:5002/highlights/backend</loc>',
+    );
+    expect(res.text).not.toContain('/highlights/disabled');
+
+    expect(res.text.indexOf('/highlights</loc>')).toBeLessThan(
+      res.text.indexOf('/highlights/career</loc>'),
+    );
+    expect(res.text.indexOf('/highlights/career</loc>')).toBeLessThan(
+      res.text.indexOf('/highlights/backend</loc>'),
     );
   });
 });

--- a/__tests__/sitemaps.ts
+++ b/__tests__/sitemaps.ts
@@ -34,6 +34,7 @@ import { sourcesFixture } from './fixture/source';
 import { keywordsFixture } from './fixture/keywords';
 import { ONE_DAY_IN_SECONDS } from '../src/common/constants';
 import { ChannelHighlightDefinition } from '../src/entity/ChannelHighlightDefinition';
+import { PostHighlight } from '../src/entity/PostHighlight';
 let app: FastifyInstance;
 let con: DataSource;
 const previousSitemapLimit = process.env.SITEMAP_LIMIT;
@@ -551,7 +552,7 @@ describe('GET /sitemaps/index.xml', () => {
 });
 
 describe('GET /sitemaps/highlights.xml', () => {
-  it('should return the highlights sitemap with enabled channels only', async () => {
+  it('should return the highlights sitemap with latest live highlight lastmod per channel', async () => {
     await con.getRepository(ChannelHighlightDefinition).save([
       {
         channel: 'career',
@@ -572,6 +573,33 @@ describe('GET /sitemaps/highlights.xml', () => {
         order: 0,
       },
     ]);
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'p1',
+        channel: 'career',
+        highlightedAt: new Date('2026-04-10T10:00:00.000Z'),
+        headline: 'Career early',
+      },
+      {
+        postId: 'p4',
+        channel: 'career',
+        highlightedAt: new Date('2026-04-12T09:00:00.000Z'),
+        headline: 'Career latest',
+      },
+      {
+        postId: 'p1',
+        channel: 'backend',
+        highlightedAt: new Date('2026-04-09T08:00:00.000Z'),
+        headline: 'Backend live',
+      },
+      {
+        postId: 'p4',
+        channel: 'backend',
+        highlightedAt: new Date('2026-04-13T08:00:00.000Z'),
+        headline: 'Backend retired',
+        retiredAt: new Date('2026-04-13T08:30:00.000Z'),
+      },
+    ]);
 
     const res = await request(app.server)
       .get('/sitemaps/highlights.xml')
@@ -582,14 +610,17 @@ describe('GET /sitemaps/highlights.xml', () => {
     expect(res.text).toContain(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     );
-    expect(res.text).toContain('<loc>http://localhost:5002/highlights</loc>');
     expect(res.text).toContain(
-      '<loc>http://localhost:5002/highlights/career</loc>',
+      '<loc>http://localhost:5002/highlights</loc><lastmod>2026-04-12T09:00:00.000Z</lastmod>',
     );
     expect(res.text).toContain(
-      '<loc>http://localhost:5002/highlights/backend</loc>',
+      '<loc>http://localhost:5002/highlights/career</loc><lastmod>2026-04-12T09:00:00.000Z</lastmod>',
+    );
+    expect(res.text).toContain(
+      '<loc>http://localhost:5002/highlights/backend</loc><lastmod>2026-04-09T08:00:00.000Z</lastmod>',
     );
     expect(res.text).not.toContain('/highlights/disabled');
+    expect(res.text).not.toContain('2026-04-13T08:00:00.000Z');
 
     expect(res.text.indexOf('/highlights</loc>')).toBeLessThan(
       res.text.indexOf('/highlights/career</loc>'),

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -11,6 +11,7 @@ import {
   User,
 } from '../entity';
 import { AGENTS_DIGEST_SOURCE } from '../entity/Source';
+import { ChannelHighlightDefinition } from '../entity/ChannelHighlightDefinition';
 import { ArchivePeriodType, ArchiveScopeType } from '../common/archive';
 import { getUserProfileUrl } from '../common/users';
 import createOrGetConnection from '../db';
@@ -97,6 +98,29 @@ const getSourceSitemapUrl = (prefix: string, handle: string): string =>
 
 const getSquadSitemapUrl = (prefix: string, handle: string): string =>
   `${prefix}/squads/${encodeURIComponent(handle)}`;
+
+const getHighlightsSitemapUrl = (prefix: string, channel?: string): string =>
+  channel
+    ? `${prefix}/highlights/${encodeURIComponent(channel)}`
+    : `${prefix}/highlights`;
+
+type SitemapUrlEntry = {
+  url: string;
+  lastmod?: string;
+};
+
+const getSitemapUrlSetXml = (
+  entries: SitemapUrlEntry[],
+): string => `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries
+  .map(({ url, lastmod }) =>
+    lastmod
+      ? `  <url><loc>${escapeXml(url)}</loc><lastmod>${escapeXml(lastmod)}</lastmod></url>`
+      : `  <url><loc>${escapeXml(url)}</loc></url>`,
+  )
+  .join('\n')}
+</urlset>`;
 
 const streamReplicaQuery = async <T extends ObjectLiteral>(
   con: DataSource,
@@ -298,6 +322,19 @@ const buildCollectionsSitemapQuery = (
       )
       .limit(DEFAULT_SITEMAP_LIMIT),
   );
+
+const buildHighlightsSitemapQuery = (
+  source: DataSource | EntityManager,
+): SelectQueryBuilder<ChannelHighlightDefinition> =>
+  source
+    .createQueryBuilder()
+    .select('chd.channel', 'channel')
+    .addSelect('chd."updatedAt"', 'lastmod')
+    .from(ChannelHighlightDefinition, 'chd')
+    .where('chd.mode != :disabledMode', { disabledMode: 'disabled' })
+    .orderBy('chd."order"', 'ASC')
+    .addOrderBy('chd.channel', 'ASC')
+    .limit(DEFAULT_SITEMAP_LIMIT);
 
 const buildTagsSitemapQuery = (
   source: DataSource | EntityManager,
@@ -617,6 +654,27 @@ const buildArchivePagesIndexEntries = (
     })
     .join('\n');
 
+const buildHighlightsSitemapXml = async (con: DataSource): Promise<string> => {
+  const prefix = getSitemapUrlPrefix();
+  const queryRunner = con.createQueryRunner('slave');
+
+  try {
+    const rows = await buildHighlightsSitemapQuery(
+      queryRunner.manager,
+    ).getRawMany<{ channel: string; lastmod?: string | Date | null }>();
+
+    return getSitemapUrlSetXml([
+      { url: getHighlightsSitemapUrl(prefix) },
+      ...rows.map((row) => ({
+        url: getHighlightsSitemapUrl(prefix, row.channel),
+        lastmod: getSitemapRowLastmod(row),
+      })),
+    ]);
+  } finally {
+    await queryRunner.release();
+  }
+};
+
 const getSitemapIndexXml = (
   postsSitemapCount: number,
   evergreenSitemapCount: number,
@@ -644,6 +702,9 @@ ${postsSitemaps}
 ${evergreenSitemaps}
   <sitemap>
     <loc>${escapeXml(`${prefix}/api/sitemaps/collections.xml`)}</loc>
+  </sitemap>
+  <sitemap>
+    <loc>${escapeXml(`${prefix}/api/sitemaps/highlights.xml`)}</loc>
   </sitemap>
   <sitemap>
     <loc>${escapeXml(`${prefix}/api/sitemaps/tags.xml`)}</loc>
@@ -783,6 +844,15 @@ export default async function (fastify: FastifyInstance): Promise<void> {
           getPostSitemapUrl(prefix, row.slug),
         ),
       );
+  });
+
+  fastify.get('/highlights.xml', async (_, res) => {
+    const con = await createOrGetConnection();
+
+    return res
+      .type('application/xml')
+      .header('cache-control', SITEMAP_CACHE_CONTROL)
+      .send(await buildHighlightsSitemapXml(con));
   });
 
   fastify.get('/tags.txt', async (_, res) => {

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -12,6 +12,7 @@ import {
 } from '../entity';
 import { AGENTS_DIGEST_SOURCE } from '../entity/Source';
 import { ChannelHighlightDefinition } from '../entity/ChannelHighlightDefinition';
+import { PostHighlight } from '../entity/PostHighlight';
 import { ArchivePeriodType, ArchiveScopeType } from '../common/archive';
 import { getUserProfileUrl } from '../common/users';
 import createOrGetConnection from '../db';
@@ -329,9 +330,16 @@ const buildHighlightsSitemapQuery = (
   source
     .createQueryBuilder()
     .select('chd.channel', 'channel')
-    .addSelect('chd."updatedAt"', 'lastmod')
+    .addSelect('MAX(ph."highlightedAt")', 'lastmod')
     .from(ChannelHighlightDefinition, 'chd')
+    .leftJoin(
+      PostHighlight,
+      'ph',
+      'ph.channel = chd.channel AND ph."retiredAt" IS NULL',
+    )
     .where('chd.mode != :disabledMode', { disabledMode: 'disabled' })
+    .groupBy('chd.channel')
+    .addGroupBy('chd."order"')
     .orderBy('chd."order"', 'ASC')
     .addOrderBy('chd.channel', 'ASC')
     .limit(DEFAULT_SITEMAP_LIMIT);
@@ -663,12 +671,27 @@ const buildHighlightsSitemapXml = async (con: DataSource): Promise<string> => {
       queryRunner.manager,
     ).getRawMany<{ channel: string; lastmod?: string | Date | null }>();
 
+    const channelEntries = rows.map((row) => ({
+      url: getHighlightsSitemapUrl(prefix, row.channel),
+      lastmod: getSitemapRowLastmod(row),
+    }));
+    const rootLastmod = channelEntries.reduce<string | undefined>(
+      (latest, entry) => {
+        if (!entry.lastmod) {
+          return latest;
+        }
+
+        return !latest || entry.lastmod > latest ? entry.lastmod : latest;
+      },
+      undefined,
+    );
+
     return getSitemapUrlSetXml([
-      { url: getHighlightsSitemapUrl(prefix) },
-      ...rows.map((row) => ({
-        url: getHighlightsSitemapUrl(prefix, row.channel),
-        lastmod: getSitemapRowLastmod(row),
-      })),
+      {
+        url: getHighlightsSitemapUrl(prefix),
+        lastmod: rootLastmod,
+      },
+      ...channelEntries,
     ]);
   } finally {
     await queryRunner.release();


### PR DESCRIPTION
## Summary
- add a dedicated `highlights.xml` sitemap for `/highlights` and enabled `/highlights/[channel]` pages
- include the new highlights sitemap in `/sitemaps/index.xml`
- cover the new sitemap and index entry in the sitemap integration tests

## Verification
- `pnpm exec eslint src/routes/sitemaps.ts __tests__/sitemaps.ts`
- `NODE_ENV=test pnpm exec jest __tests__/sitemaps.ts --testEnvironment=node --runInBand --modulePathIgnorePatterns='<rootDir>/build/'`
