### PR TITLE
fix: 404 empty paginated sitemap pages

### DIFF
--- a/__tests__/sitemaps.ts
+++ b/__tests__/sitemaps.ts
@@ -255,6 +255,10 @@ describe('GET /sitemaps/posts-:page.xml', () => {
       '<loc>http://localhost:5002/posts/p6-p6</loc>',
     );
   });
+
+  it('should return 404 for paginated pages with no rows', async () => {
+    await request(app.server).get('/sitemaps/posts-3.xml').expect(404);
+  });
 });
 
 describe('GET /sitemaps/posts.xml (type filtering)', () => {
@@ -1124,6 +1128,10 @@ describe('GET /sitemaps/evergreen.xml', () => {
     expect(res.header['content-type']).toContain('application/xml');
     expect(res.text).toContain('/posts/evergreen-no-author-evergreen-norep');
     expect(res.text).not.toContain('/posts/evergreen-low-rep-evergreen-lowrep');
+  });
+
+  it('should return 404 for paginated pages with no rows', async () => {
+    await request(app.server).get('/sitemaps/evergreen-2.xml').expect(404);
   });
 });
 

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -753,9 +753,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
     const con = await createOrGetConnection();
 
-    if (
-      !(await hasPaginatedSitemapPage(con, buildPostsSitemapQuery, page))
-    ) {
+    if (!(await hasPaginatedSitemapPage(con, buildPostsSitemapQuery, page))) {
       return res.code(404).send();
     }
 

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -205,7 +205,7 @@ const buildSitemapXmlStream = async <T extends ObjectLiteral>(
 };
 
 const getSitemapPageCount = (totalPosts: number): number =>
-  Math.max(1, Math.ceil(totalPosts / getPaginatedSitemapLimit()));
+  Math.ceil(totalPosts / getPaginatedSitemapLimit());
 
 const getReplicaQueryCount = async (
   con: DataSource,
@@ -215,6 +215,20 @@ const getReplicaQueryCount = async (
 
   try {
     return await buildQuery(queryRunner.manager).getCount();
+  } finally {
+    await queryRunner.release();
+  }
+};
+
+const hasPaginatedSitemapPage = async (
+  con: DataSource,
+  buildQuery: (source: EntityManager, page: number) => SelectQueryBuilder<Post>,
+  page: number,
+): Promise<boolean> => {
+  const queryRunner = con.createQueryRunner('slave');
+
+  try {
+    return !!(await buildQuery(queryRunner.manager, page).limit(1).getRawOne());
   } finally {
     await queryRunner.release();
   }
@@ -739,6 +753,12 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
     const con = await createOrGetConnection();
 
+    if (
+      !(await hasPaginatedSitemapPage(con, buildPostsSitemapQuery, page))
+    ) {
+      return res.code(404).send();
+    }
+
     return res
       .type('application/xml')
       .header('cache-control', SITEMAP_CACHE_CONTROL)
@@ -764,6 +784,12 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     }
 
     const con = await createOrGetConnection();
+
+    if (
+      !(await hasPaginatedSitemapPage(con, buildEvergreenSitemapQuery, page))
+    ) {
+      return res.code(404).send();
+    }
 
     return res
       .type('application/xml')


### PR DESCRIPTION
## Summary
- return 404 for paginated posts and evergreen sitemap pages when the requested page has no rows
- stop generating sitemap index entries for empty paginated sitemap families
- add coverage for empty paginated sitemap requests

## Testing
- pnpm -s jest __tests__/sitemaps.ts --testEnvironment=node --runInBand -t "posts-:page|evergreen.xml|index.xml"