### PR TITLE
feat: async user deletion via background worker

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -510,6 +510,13 @@ export const workers: Worker[] = [
     topic: 'api.v1.generate-channel-highlight',
     subscription: 'api.generate-channel-highlight',
   },
+  {
+    topic: 'api.v1.user-deletion-requested',
+    subscription: 'api.user-deletion-cleanup',
+    args: {
+      ackDeadlineSeconds: 600,
+    },
+  },
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/__tests__/cron/cleanZombieUsers.ts
+++ b/__tests__/cron/cleanZombieUsers.ts
@@ -18,7 +18,6 @@ beforeEach(async () => {
     User,
     usersFixture.map((u) => ({ ...u, emailConfirmed: true, flags: {} })),
   );
-  // Reset inDeletion flag for all users to ensure test isolation
   await con.query(`UPDATE "user" SET flags = '{}'`);
 });
 
@@ -32,13 +31,15 @@ describe('cleanZombieUsers', () => {
       .update({ id: '2' }, { createdAt: new Date() });
 
     await expectSuccessfulCron(cron);
-    const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(6);
 
-    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
-    expect(markedUsers.length).toEqual(4);
-    expect(markedUsers.map((u) => u.id)).not.toContain('1');
-    expect(markedUsers.map((u) => u.id)).not.toContain('2');
+    const markedUsers = await con.getRepository(User).find({
+      where: usersFixture.map((u) => ({ id: u.id as string })),
+      order: { id: 'ASC' },
+    });
+    const marked = markedUsers.filter(
+      (u) => (u.flags as UserFlags)?.inDeletion,
+    );
+    expect(marked.map((u) => u.id)).toEqual(['3', '4']);
   });
 
   it('should mark users with email confirmed false that are older than one hour for deletion', async () => {
@@ -50,28 +51,31 @@ describe('cleanZombieUsers', () => {
       .update({ id: '2' }, { createdAt: new Date() });
 
     await expectSuccessfulCron(cron);
-    const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(6);
 
-    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
-    expect(markedUsers.length).toEqual(4);
-    expect(markedUsers.map((u) => u.id)).not.toContain('1');
-    expect(markedUsers.map((u) => u.id)).not.toContain('2');
+    const markedUsers = await con.getRepository(User).find({
+      where: usersFixture.map((u) => ({ id: u.id as string })),
+      order: { id: 'ASC' },
+    });
+    const marked = markedUsers.filter(
+      (u) => (u.flags as UserFlags)?.inDeletion,
+    );
+    expect(marked.map((u) => u.id)).toEqual(['3', '4']);
   });
 
   it('should not mark users with info confirmed true and email confirmed true', async () => {
     await con
       .getRepository(User)
       .update({ id: Not('1') }, { infoConfirmed: true, emailConfirmed: true });
-    await con
-      .getRepository(User)
-      .update({ id: '2' }, { createdAt: new Date() });
 
     await expectSuccessfulCron(cron);
-    const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(6);
 
-    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
-    expect(markedUsers.length).toEqual(0);
+    const markedUsers = await con.getRepository(User).find({
+      where: usersFixture.map((u) => ({ id: u.id as string })),
+      order: { id: 'ASC' },
+    });
+    const marked = markedUsers.filter(
+      (u) => (u.flags as UserFlags)?.inDeletion,
+    );
+    expect(marked.length).toEqual(0);
   });
 });

--- a/__tests__/cron/cleanZombieUsers.ts
+++ b/__tests__/cron/cleanZombieUsers.ts
@@ -4,7 +4,7 @@ import { User } from '../../src/entity';
 import { usersFixture } from '../fixture/user';
 import { DataSource, Not } from 'typeorm';
 import createOrGetConnection from '../../src/db';
-import { DeletedUser } from '../../src/entity/user/DeletedUser';
+import type { UserFlags } from '../../src/entity/user/User';
 
 let con: DataSource;
 
@@ -16,12 +16,14 @@ beforeEach(async () => {
   await saveFixtures(
     con,
     User,
-    usersFixture.map((u) => ({ ...u, emailConfirmed: true })),
+    usersFixture.map((u) => ({ ...u, emailConfirmed: true, flags: {} })),
   );
+  // Reset inDeletion flag for all users to ensure test isolation
+  await con.query(`UPDATE "user" SET flags = '{}'`);
 });
 
 describe('cleanZombieUsers', () => {
-  it('should delete users with info confirmed false that are older than one hour', async () => {
+  it('should mark users with info confirmed false that are older than one hour for deletion', async () => {
     await con
       .getRepository(User)
       .update({ id: Not('1') }, { infoConfirmed: false });
@@ -31,12 +33,15 @@ describe('cleanZombieUsers', () => {
 
     await expectSuccessfulCron(cron);
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(4);
-    expect(users[0].id).toEqual('1');
-    expect(users[1].id).toEqual('2');
+    expect(users.length).toEqual(6);
+
+    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
+    expect(markedUsers.length).toEqual(4);
+    expect(markedUsers.map((u) => u.id)).not.toContain('1');
+    expect(markedUsers.map((u) => u.id)).not.toContain('2');
   });
 
-  it('should delete users with email confirmed false that are older than one hour', async () => {
+  it('should mark users with email confirmed false that are older than one hour for deletion', async () => {
     await con
       .getRepository(User)
       .update({ id: Not('1') }, { infoConfirmed: true, emailConfirmed: false });
@@ -46,12 +51,15 @@ describe('cleanZombieUsers', () => {
 
     await expectSuccessfulCron(cron);
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(4);
-    expect(users[0].id).toEqual('1');
-    expect(users[1].id).toEqual('2');
+    expect(users.length).toEqual(6);
+
+    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
+    expect(markedUsers.length).toEqual(4);
+    expect(markedUsers.map((u) => u.id)).not.toContain('1');
+    expect(markedUsers.map((u) => u.id)).not.toContain('2');
   });
 
-  it('should not delete users with info confirmed true and email confirmed true', async () => {
+  it('should not mark users with info confirmed true and email confirmed true', async () => {
     await con
       .getRepository(User)
       .update({ id: Not('1') }, { infoConfirmed: true, emailConfirmed: true });
@@ -62,26 +70,8 @@ describe('cleanZombieUsers', () => {
     await expectSuccessfulCron(cron);
     const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
     expect(users.length).toEqual(6);
-    expect(users[0].id).toEqual('1');
-    expect(users[1].id).toEqual('2');
-  });
 
-  it('should create deleted user records', async () => {
-    await con
-      .getRepository(User)
-      .update({ id: Not('1') }, { infoConfirmed: false });
-    await con
-      .getRepository(User)
-      .update({ id: '2' }, { createdAt: new Date() });
-
-    await expectSuccessfulCron(cron);
-    const users = await con.getRepository(User).find({ order: { id: 'ASC' } });
-    expect(users.length).toEqual(4);
-
-    const deletedUsers = await con.getRepository(DeletedUser).find();
-    expect(deletedUsers.length).toEqual(2);
-    expect(deletedUsers.map((item) => item.id)).toEqual(
-      expect.arrayContaining(['3', '4']),
-    );
+    const markedUsers = users.filter((u) => (u.flags as UserFlags)?.inDeletion);
+    expect(markedUsers.length).toEqual(0);
   });
 });

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -4736,68 +4736,6 @@ describe('mutation deleteUser', () => {
     expect(markedUser?.flags).toMatchObject({ inDeletion: true });
   });
 
-  describe('deleting user resume', () => {
-    it('should delete user resume if it exists', async () => {
-      loggedUser = '1';
-
-      await client.mutate(MUTATION);
-
-      // Verify we requested delete action for every extension supported
-      expect(deleteFileFromBucket).toHaveBeenCalledWith(
-        expect.any(Bucket),
-        loggedUser,
-      );
-    });
-
-    it('should handle case when user has no resume', async () => {
-      loggedUser = '1';
-
-      // Mock that the resume file doesn't exist
-
-      await client.mutate(MUTATION);
-
-      // Verify the function was called but no error was thrown
-      expect(deleteFileFromBucket).toHaveBeenCalledWith(
-        expect.any(Bucket),
-        loggedUser,
-      );
-
-      // User should still be marked for deletion
-      const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-      expect(userOne?.flags).toMatchObject({ inDeletion: true });
-    });
-  });
-
-  describe('deleting user employment agreement', () => {
-    it('should delete user employment agreement if it exists', async () => {
-      loggedUser = '1';
-
-      await client.mutate(MUTATION);
-
-      // Verify we requested delete action for every extension supported
-      expect(deleteFileFromBucket).toHaveBeenCalledWith(
-        expect.any(Bucket),
-        'employment-agreement/1',
-      );
-    });
-
-    it('should handle case when user has no employment agreement', async () => {
-      loggedUser = '1';
-
-      await client.mutate(MUTATION);
-
-      // Verify the function was called but no error was thrown
-      expect(deleteFileFromBucket).toHaveBeenCalledWith(
-        expect.any(Bucket),
-        'employment-agreement/1',
-      );
-
-      // User should still be marked for deletion
-      const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-      expect(userOne?.flags).toMatchObject({ inDeletion: true });
-    });
-  });
-
   describe('opportunity and organization cleanup', () => {
     const testUserId = 'opp-cleanup-user';
     const testUserId2 = 'opp-cleanup-user-2';

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -135,12 +135,7 @@ import type { GQLUser } from '../src/schema/users';
 import { cancelSubscription } from '../src/common/paddle';
 import { isPlusMember, SubscriptionCycles } from '../src/paddle';
 import { CoresRole, StreakRestoreCoresPrice } from '../src/types';
-import {
-  UserTransaction,
-  UserTransactionProcessor,
-  UserTransactionStatus,
-} from '../src/entity/user/UserTransaction';
-import { DeletedUser } from '../src/entity/user/DeletedUser';
+import { UserTransaction } from '../src/entity/user/UserTransaction';
 import { randomUUID } from 'crypto';
 import {
   ClaimableItem,
@@ -4591,59 +4586,8 @@ describe('mutation deleteUser', () => {
 
     await client.mutate(MUTATION);
 
-    const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(4);
-
     const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-    expect(userOne).toEqual(null);
-  });
-
-  it('should delete author ID from post', async () => {
-    loggedUser = '1';
-
-    await client.mutate(MUTATION);
-
-    const post = await con.getRepository(Post).findOneBy({ id: 'p1' });
-    expect(post.authorId).toEqual(null);
-  });
-
-  it('should delete digest posts on user deletion', async () => {
-    loggedUser = '1';
-
-    await con.getRepository(Source).save({
-      id: '1',
-      name: 'User Source',
-      image: 'https://daily.dev/1.jpg',
-      handle: 'user1',
-      active: true,
-      private: false,
-    });
-
-    await con.getRepository(Post).save({
-      id: 'pdigest1',
-      shortId: 'spdigest1',
-      title: 'Digest Post',
-      sourceId: '1',
-      authorId: '1',
-      type: PostType.Digest,
-      createdAt: new Date(),
-    });
-
-    await client.mutate(MUTATION);
-
-    const deletedDigest = await con
-      .getRepository(Post)
-      .findOneBy({ id: 'pdigest1' });
-    expect(deletedDigest).toBeNull();
-  });
-
-  it('should delete scout ID from post', async () => {
-    loggedUser = '1';
-
-    await client.mutate(MUTATION);
-
-    const post = await con.getRepository(Post).findOneBy({ id: 'p6' });
-    expect(post.authorId).toEqual(null);
+    expect(userOne?.flags).toMatchObject({ inDeletion: true });
   });
 
   it('should cancel paddle subscription for user', async () => {
@@ -4663,7 +4607,7 @@ describe('mutation deleteUser', () => {
 
     expect(cancelSubscription).toHaveBeenCalledWith({ subscriptionId: '123' });
     const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-    expect(userOne).toEqual(null);
+    expect(userOne?.flags).toMatchObject({ inDeletion: true });
   });
 
   it('should not call cancel subscription for gifted subscription', async () => {
@@ -4684,7 +4628,7 @@ describe('mutation deleteUser', () => {
 
     expect(cancelSubscription).not.toHaveBeenCalled();
     const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-    expect(userOne).toEqual(null);
+    expect(userOne?.flags).toMatchObject({ inDeletion: true });
   });
 
   describe('when user has a storekit subscription', () => {
@@ -4753,10 +4697,10 @@ describe('mutation deleteUser', () => {
       const userOne = await con
         .getRepository(User)
         .findOneBy({ id: 'sk-del-user-0' });
-      expect(userOne).toEqual(null);
+      expect(userOne?.flags).toMatchObject({ inDeletion: true });
     });
 
-    it('should delete user if storekit subscription is expired', async () => {
+    it('should mark user for deletion if storekit subscription is expired', async () => {
       loggedUser = 'sk-del-user-0';
 
       await con.getRepository(User).update(
@@ -4776,68 +4720,20 @@ describe('mutation deleteUser', () => {
       const userOne = await con
         .getRepository(User)
         .findOneBy({ id: 'sk-del-user-0' });
-      expect(userOne).toEqual(null);
+      expect(userOne?.flags).toMatchObject({ inDeletion: true });
     });
   });
 
-  it('should set user transactions to ghost', async () => {
-    loggedUser = '1';
-
-    const userTransactions = await con.getRepository(UserTransaction).save([
-      {
-        id: '962c880f-7523-426c-b02f-e5695e94d77f',
-        processor: UserTransactionProcessor.Njord,
-        receiverId: '1',
-        status: UserTransactionStatus.Success,
-        productId: null,
-        senderId: '2',
-        fee: 0,
-        value: 100,
-        valueIncFees: 100,
-      },
-      {
-        id: '4f2e8ff9-4489-466b-9296-87630839fdac',
-        processor: UserTransactionProcessor.Njord,
-        receiverId: '2',
-        status: UserTransactionStatus.Success,
-        productId: null,
-        senderId: '1',
-        fee: 0,
-        value: 100,
-        valueIncFees: 100,
-      },
-    ]);
-
-    await client.mutate(MUTATION);
-
-    const transactions = await con.getRepository(UserTransaction).findBy({
-      id: In(userTransactions.map((t) => t.id)),
-    });
-
-    expect(transactions.length).toEqual(2);
-    expect(
-      transactions.find((t) => t.id === '962c880f-7523-426c-b02f-e5695e94d77f')!
-        .receiverId,
-    ).toEqual(ghostUser.id);
-    expect(
-      transactions.find((t) => t.id === '4f2e8ff9-4489-466b-9296-87630839fdac')!
-        .senderId,
-    ).toEqual(ghostUser.id);
-  });
-
-  it('should soft delete user', async () => {
+  it('should mark user for deletion', async () => {
     loggedUser = '1';
 
     const user = await con.getRepository(User).findOneBy({ id: '1' });
-
     expect(user).not.toBeNull();
 
     await client.mutate(MUTATION);
 
-    const deletedUser = await con
-      .getRepository(DeletedUser)
-      .findOneBy({ id: '1' });
-    expect(deletedUser).not.toBeNull();
+    const markedUser = await con.getRepository(User).findOneBy({ id: '1' });
+    expect(markedUser?.flags).toMatchObject({ inDeletion: true });
   });
 
   describe('deleting user resume', () => {
@@ -4866,9 +4762,9 @@ describe('mutation deleteUser', () => {
         loggedUser,
       );
 
-      // User should still be deleted
+      // User should still be marked for deletion
       const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-      expect(userOne).toEqual(null);
+      expect(userOne?.flags).toMatchObject({ inDeletion: true });
     });
   });
 
@@ -4896,9 +4792,9 @@ describe('mutation deleteUser', () => {
         'employment-agreement/1',
       );
 
-      // User should still be deleted
+      // User should still be marked for deletion
       const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-      expect(userOne).toEqual(null);
+      expect(userOne?.flags).toMatchObject({ inDeletion: true });
     });
   });
 
@@ -4997,11 +4893,8 @@ describe('DELETE /v1/users/me', () => {
   it('should delete user from database', async () => {
     await authorizeRequest(request(app.server).delete(BASE_PATH)).expect(204);
 
-    const users = await con.getRepository(User).find();
-    expect(users.length).toEqual(4);
-
     const userOne = await con.getRepository(User).findOneBy({ id: '1' });
-    expect(userOne).toEqual(null);
+    expect(userOne?.flags).toMatchObject({ inDeletion: true });
   });
 
   it('should clear cookies', async () => {
@@ -5020,31 +4913,6 @@ describe('DELETE /v1/users/me', () => {
     expect(cookies.dast.value).toBeFalsy();
     expect(cookies.ory_kratos_session.value).toBeFalsy();
     expect(cookies.ory_kratos_continuity.value).toBeFalsy();
-  });
-
-  it('clears invitedBy from associated features', async () => {
-    await con.getRepository(Feature).insert({
-      feature: FeatureType.Search,
-      userId: '2',
-      value: FeatureValue.Allow,
-      invitedById: '1',
-    });
-
-    await authorizeRequest(request(app.server).delete(BASE_PATH)).expect(204);
-
-    const feature = await con.getRepository(Feature).findOneBy({ userId: '2' });
-    expect(feature.invitedById).toBeNull();
-  });
-
-  it('removes associated invite records', async () => {
-    await con.getRepository(Invite).insert({
-      userId: '1',
-      campaign: InviteCampaignType.Search,
-    });
-
-    await authorizeRequest(request(app.server).delete(BASE_PATH)).expect(204);
-
-    expect(await con.getRepository(Invite).count()).toEqual(0);
   });
 });
 

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -108,6 +108,9 @@ export type PubSubSchema = {
     id: string;
     email: string;
   };
+  'api.v1.user-deletion-requested': {
+    userId: string;
+  };
   'api.v1.user-created': {
     user: ChangeObject<User>;
   };

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -1,38 +1,20 @@
 import { DataSource } from 'typeorm';
-import {
-  Alerts,
-  ArticlePost,
-  Bookmark,
-  BookmarkList,
-  Comment,
-  DevCard,
-  Feed,
-  Organization,
-  Post,
-  PostReport,
-  Settings,
-  SourceDisplay,
-  SourceRequest,
-  User,
-  View,
-} from '../entity';
+import { Organization, User } from '../entity';
 import { OpportunityJob } from '../entity/opportunities/OpportunityJob';
 import { OpportunityUser } from '../entity/opportunities/user';
-import { ghostUser } from './index';
+import { updateFlagsStatement } from './utils';
 import { cancelSubscription } from './paddle';
 import type { AuthContext, Context } from '../Context';
 import { ForbiddenError } from 'apollo-server-errors';
 import { logger } from '../logger';
 import { CoresRole } from '../types';
 import { remoteConfig } from '../remoteConfig';
-import { UserTransaction } from '../entity/user/UserTransaction';
 import { SubscriptionProvider, SubscriptionStatus } from './plus';
 import {
   deleteEmploymentAgreementByUserId,
   deleteResumeByUserId,
 } from './googleCloud';
 import { ConflictError } from '../errors';
-import { DigestPost } from '../entity/posts/DigestPost';
 
 export const deleteUser = async (
   con: DataSource,
@@ -76,110 +58,60 @@ export const deleteUser = async (
       }
     }
 
+    // Check organization recruiter subscription conflicts before marking for deletion
+    const opportunityOrganization = await con
+      .getRepository(OpportunityUser)
+      .createQueryBuilder('ou')
+      .select('ou."opportunityId"', 'opportunityId')
+      .addSelect('oj."organizationId"', 'organizationId')
+      .innerJoin(OpportunityJob, 'oj', 'oj.id = ou."opportunityId"')
+      .where('ou."userId" = :userId', { userId })
+      .getRawMany<{
+        opportunityId: string;
+        organizationId: string;
+      }>();
+
+    if (opportunityOrganization.length > 0) {
+      const orgsWithActiveSubscription = await con
+        .getRepository(Organization)
+        .createQueryBuilder('org')
+        .where('org.id IN (:...ids)', {
+          ids: opportunityOrganization.map((item) => item.organizationId),
+        })
+        .andWhere(`org."recruiterSubscriptionFlags"->>'status' = :status`, {
+          status: SubscriptionStatus.Active,
+        })
+        .getCount();
+
+      if (orgsWithActiveSubscription > 0) {
+        throw new ConflictError(
+          'Cannot delete your account because one of your organizations has an active recruiter subscription. Please cancel the subscription first.',
+        );
+      }
+    }
+
     // Delete user's resume if exists
     await deleteResumeByUserId(userId);
     await deleteEmploymentAgreementByUserId({ userId, logger });
 
-    await con.transaction(async (entityManager): Promise<void> => {
-      await entityManager.getRepository(View).delete({ userId });
-      await entityManager.getRepository(Alerts).delete({ userId });
-      await entityManager.getRepository(BookmarkList).delete({ userId });
-      await entityManager.getRepository(Bookmark).delete({ userId });
-      await entityManager.getRepository(Comment).update(
-        { userId },
-        {
-          userId: ghostUser.id,
-        },
-      );
-      await entityManager.getRepository(Comment).delete({ userId });
-      await entityManager.getRepository(DevCard).delete({ userId });
-      await entityManager.getRepository(Feed).delete({ userId });
-      await entityManager.getRepository(PostReport).delete({ userId });
-      await entityManager.getRepository(Settings).delete({ userId });
-      await entityManager.getRepository(SourceDisplay).delete({ userId });
-      await entityManager.getRepository(SourceRequest).delete({ userId });
-      await entityManager
-        .getRepository(ArticlePost)
-        .update({ authorId: userId }, { authorId: null });
-      // Delete digest posts authored by the user
-      await entityManager
-        .getRepository(DigestPost)
-        .delete({ authorId: userId });
-      // Manually set user source posts to ghost user
-      await entityManager
-        .getRepository(Post)
-        .update(
-          { authorId: userId, sourceId: userId },
-          { authorId: ghostUser.id, sourceId: ghostUser.id },
-        );
-      // Manually set shared post to 404 dummy user
-      await entityManager
-        .getRepository(Post)
-        .update({ authorId: userId }, { authorId: ghostUser.id });
-      await entityManager
-        .getRepository(Post)
-        .update({ scoutId: userId }, { scoutId: null });
-      await entityManager.getRepository(UserTransaction).update(
-        {
-          senderId: userId,
-        },
-        {
-          senderId: ghostUser.id,
-        },
-      );
-      await entityManager.getRepository(UserTransaction).update(
-        {
-          receiverId: userId,
-        },
-        {
-          receiverId: ghostUser.id,
-        },
-      );
-
-      const opportunityOrganization = await entityManager
-        .getRepository(OpportunityUser)
-        .createQueryBuilder('ou')
-        .select('ou."opportunityId"', 'opportunityId')
-        .addSelect('oj."organizationId"', 'organizationId')
-        .innerJoin(OpportunityJob, 'oj', 'oj.id = ou."opportunityId"')
-        .where('ou."userId" = :userId', { userId })
-        .getRawMany<{
-          opportunityId: string;
-          organizationId: string;
-        }>();
-
-      if (opportunityOrganization.length > 0) {
-        const orgsWithActiveSubscription = await entityManager
-          .getRepository(Organization)
-          .createQueryBuilder('org')
-          .where('org.id IN (:...ids)', {
-            ids: opportunityOrganization.map((item) => item.organizationId),
-          })
-          .andWhere(`org."recruiterSubscriptionFlags"->>'status' = :status`, {
-            status: SubscriptionStatus.Active,
-          })
-          .getCount();
-
-        if (orgsWithActiveSubscription > 0) {
-          throw new ConflictError(
-            'Cannot delete your account because one of your organizations has an active recruiter subscription. Please cancel the subscription first.',
-          );
-        }
-      }
-
-      await entityManager.query(
-        'DELETE FROM ba_verification WHERE identifier IN ($1, $2)',
-        [`change-email:${userId}`, `signup-verify:${userId}`],
-      );
-
-      await entityManager.getRepository(User).delete(userId);
+    // Mark user for async deletion — CDC will trigger the cleanup worker
+    await con.getRepository(User).update(userId, {
+      flags: updateFlagsStatement<User>({ inDeletion: true }),
     });
+
+    // Immediately invalidate all sessions
+    await con.query('DELETE FROM ba_session WHERE "userId" = $1', [userId]);
+    await con.query(
+      'DELETE FROM ba_verification WHERE identifier IN ($1, $2)',
+      [`change-email:${userId}`, `signup-verify:${userId}`],
+    );
+
     logger.info(
       {
         userId,
         messageId,
       },
-      'deleted user',
+      'user marked for deletion',
     );
   } catch (err) {
     logger.error(

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -10,10 +10,7 @@ import { logger } from '../logger';
 import { CoresRole } from '../types';
 import { remoteConfig } from '../remoteConfig';
 import { SubscriptionProvider, SubscriptionStatus } from './plus';
-import {
-  deleteEmploymentAgreementByUserId,
-  deleteResumeByUserId,
-} from './googleCloud';
+
 import { ConflictError } from '../errors';
 
 export const deleteUser = async (
@@ -89,10 +86,6 @@ export const deleteUser = async (
         );
       }
     }
-
-    // Delete user's resume if exists
-    await deleteResumeByUserId(userId);
-    await deleteEmploymentAgreementByUserId({ userId, logger });
 
     // Mark user for async deletion — CDC will trigger the cleanup worker
     await con.getRepository(User).update(userId, {

--- a/src/cron/cleanZombieUsers.ts
+++ b/src/cron/cleanZombieUsers.ts
@@ -1,9 +1,7 @@
 import { Cron } from './cron';
 import { User } from '../entity';
-import { LessThan, In } from 'typeorm';
 import { subHours } from 'date-fns';
-
-const BATCH_SIZE = 50;
+import { updateFlagsStatement } from '../common/utils';
 
 const cron: Cron = {
   name: 'clean-zombie-users',
@@ -12,24 +10,25 @@ const cron: Cron = {
     const timeThreshold = subHours(new Date(), 1);
     const userRepo = con.getRepository(User);
 
-    const zombieUsers = await userRepo.find({
-      select: ['id'],
-      where: [
-        { infoConfirmed: false, createdAt: LessThan(timeThreshold) },
-        { emailConfirmed: false, createdAt: LessThan(timeThreshold) },
-      ],
-    });
+    const zombieUsers = await userRepo
+      .createQueryBuilder('user')
+      .select(['user.id'])
+      .where('("infoConfirmed" = false OR "emailConfirmed" = false)')
+      .andWhere('"createdAt" < :timeThreshold', { timeThreshold })
+      .andWhere(
+        `(flags->>'inDeletion' IS NULL OR flags->>'inDeletion' = 'false')`,
+      )
+      .getMany();
 
-    const ids = zombieUsers.map((u) => u.id);
-    let totalDeleted = 0;
-
-    for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-      const batch = ids.slice(i, i + BATCH_SIZE);
-      const { affected } = await userRepo.delete({ id: In(batch) });
-      totalDeleted += affected ?? 0;
+    let totalMarked = 0;
+    for (const zombie of zombieUsers) {
+      await userRepo.update(zombie.id, {
+        flags: updateFlagsStatement<User>({ inDeletion: true }),
+      });
+      totalMarked++;
     }
 
-    logger.info({ count: totalDeleted }, 'zombies users cleaned! 🧟');
+    logger.info({ count: totalMarked }, 'zombie users marked for deletion 🧟');
   },
 };
 

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -49,6 +49,7 @@ export type UserFlags = Partial<{
   subdivision: string | null;
   lastCVParseAt: Date | null;
   lastExtensionUse: Date | null;
+  inDeletion: boolean;
 }>;
 
 export type UserFlagsPublic = Pick<UserFlags, 'showPlusGift'>;

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -693,7 +693,7 @@ const loggedInBoot = async ({
 
     const profileCompletion = calculateProfileCompletion(user, experienceFlags);
 
-    if (!user) {
+    if (!user || user.flags?.inDeletion) {
       return handleNonExistentUser(con, req, res, middleware);
     }
 

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -52,6 +52,7 @@ import {
 } from '../../entity';
 import { BookmarkList } from '../../entity/BookmarkList';
 import { HotTake } from '../../entity/user/HotTake';
+import type { UserFlags } from '../../entity/user/User';
 import { UserStack } from '../../entity/user/UserStack';
 import { SharePost } from '../../entity/posts/SharePost';
 import { PostAnalytics } from '../../entity/posts/PostAnalytics';
@@ -927,6 +928,18 @@ const onUserChange = async (
     }
 
     await checkProfileCompletionAchievement(con, logger, data.payload.after!);
+
+    const beforeUserFlags = JSON.parse(
+      (data.payload.before!.flags as unknown as string) || '{}',
+    ) as UserFlags;
+    const afterUserFlags = JSON.parse(
+      (data.payload.after!.flags as unknown as string) || '{}',
+    ) as UserFlags;
+    if (!beforeUserFlags.inDeletion && afterUserFlags.inDeletion) {
+      await triggerTypedEvent(logger, 'api.v1.user-deletion-requested', {
+        userId: data.payload.after!.id,
+      });
+    }
   }
   if (data.payload.op === 'd') {
     await triggerTypedEvent(logger, 'user-deleted', {

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -929,11 +929,17 @@ const onUserChange = async (
 
     await checkProfileCompletionAchievement(con, logger, data.payload.after!);
 
-    const beforeUserFlags = JSON.parse(
-      (data.payload.before!.flags as unknown as string) || '{}',
+    const rawBeforeFlags = data.payload.before!.flags;
+    const rawAfterFlags = data.payload.after!.flags;
+    const beforeUserFlags = (
+      typeof rawBeforeFlags === 'string'
+        ? JSON.parse(rawBeforeFlags || '{}')
+        : rawBeforeFlags || {}
     ) as UserFlags;
-    const afterUserFlags = JSON.parse(
-      (data.payload.after!.flags as unknown as string) || '{}',
+    const afterUserFlags = (
+      typeof rawAfterFlags === 'string'
+        ? JSON.parse(rawAfterFlags || '{}')
+        : rawAfterFlags || {}
     ) as UserFlags;
     if (!beforeUserFlags.inDeletion && afterUserFlags.inDeletion) {
       await triggerTypedEvent(logger, 'api.v1.user-deletion-requested', {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -86,6 +86,7 @@ import generateChannelDigest from './generateChannelDigest';
 import generateChannelHighlight from './generateChannelHighlight';
 import { jobExecuteWorker } from './job/jobExecute';
 import workerJobDeadLetterLog from './workerJobDeadLetterLog';
+import userDeletionCleanup from './userDeletionCleanup';
 
 export { Worker } from './worker';
 
@@ -173,6 +174,7 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   agenticDigestTweet,
   generateChannelDigest,
   generateChannelHighlight,
+  userDeletionCleanup,
 ];
 
 export const personalizedDigestWorkers: Worker[] = [

--- a/src/workers/userDeletionCleanup.ts
+++ b/src/workers/userDeletionCleanup.ts
@@ -96,7 +96,7 @@ const batchDelete = async ({
     }
   }
   if (totalDeleted > 0) {
-    log.info({ table, totalDeleted, userId }, 'batch deleted rows');
+    log.debug({ table, totalDeleted, userId }, 'batch deleted rows');
   }
 };
 

--- a/src/workers/userDeletionCleanup.ts
+++ b/src/workers/userDeletionCleanup.ts
@@ -236,7 +236,8 @@ const worker: TypedWorker<'api.v1.user-deletion-requested'> = {
     await con.getRepository(SourceRequest).delete({ userId });
     // Legacy table without TypeORM entity
     await con.query('DELETE FROM comment_upvote WHERE "userId" = $1', [userId]);
-    // Auth tables
+    // Auth tables (ba_session may already be deleted by deleteUser, safe to re-run)
+    await con.query('DELETE FROM ba_session WHERE "userId" = $1', [userId]);
     await con.query('DELETE FROM ba_account WHERE "userId" = $1', [userId]);
 
     // Step 3: Hard delete the user — triggers CDC user-deleted event

--- a/src/workers/userDeletionCleanup.ts
+++ b/src/workers/userDeletionCleanup.ts
@@ -1,0 +1,247 @@
+import type { DataSource } from 'typeorm';
+import type { FastifyBaseLogger } from 'fastify';
+import { TypedWorker } from './worker';
+import {
+  Alerts,
+  Bookmark,
+  BookmarkList,
+  Comment,
+  CommentMention,
+  DevCard,
+  Feed,
+  Feature,
+  Invite,
+  Post,
+  PostReport,
+  ReputationEvent,
+  Settings,
+  SourceDisplay,
+  SourceMember,
+  SourceRequest,
+  SourceUser,
+  View,
+} from '../entity';
+import { ArticlePost } from '../entity/posts/ArticlePost';
+import { DigestPost } from '../entity/posts/DigestPost';
+import { PostMention } from '../entity/posts/PostMention';
+import { SourcePostModeration } from '../entity/SourcePostModeration';
+import { UserAction } from '../entity/user/UserAction';
+import { UserAchievement } from '../entity/user/UserAchievement';
+import { UserComment } from '../entity/user/UserComment';
+import { UserCompany } from '../entity/UserCompany';
+import { UserExperience } from '../entity/user/experiences/UserExperience';
+import { UserGear } from '../entity/user/UserGear';
+import { HotTake } from '../entity/user/HotTake';
+import { UserHotTake } from '../entity/user/UserHotTake';
+import { UserIntegration } from '../entity/UserIntegration';
+import { UserMarketingCta } from '../entity/user/UserMarketingCta';
+import { UserPersonalizedDigest } from '../entity/user/UserPersonalizedDigest';
+import { UserPost } from '../entity/user/UserPost';
+import { UserStack } from '../entity/user/UserStack';
+import { UserStreak } from '../entity/user/UserStreak';
+import { UserStreakAction } from '../entity/user/UserStreakAction';
+import { UserTopReader } from '../entity/user/UserTopReader';
+import { UserTransaction } from '../entity/user/UserTransaction';
+import { UserWorkspacePhoto } from '../entity/user/UserWorkspacePhoto';
+import { NotificationPreference } from '../entity/notifications/NotificationPreference';
+import { ContentPreferenceUser } from '../entity/contentPreference/ContentPreferenceUser';
+import { OpportunityMatch } from '../entity/OpportunityMatch';
+import { OpportunityUser } from '../entity/opportunities/user';
+import { Campaign } from '../entity/campaign/Campaign';
+import { Feedback } from '../entity/Feedback';
+import { ClaimableItem } from '../entity/ClaimableItem';
+import { PersonalAccessToken } from '../entity/PersonalAccessToken';
+import { Submission } from '../entity/Submission';
+import { SquadPublicRequest } from '../entity/SquadPublicRequest';
+import { SourceStack } from '../entity/sources/SourceStack';
+import { CommentReport } from '../entity/CommentReport';
+import { SourceReport } from '../entity/sources/SourceReport';
+import { UserReport } from '../entity/UserReport';
+import { UserQuest } from '../entity/user/UserQuest';
+import { UserQuestProfile } from '../entity/user/UserQuestProfile';
+import { UserCandidatePreference } from '../entity/user/UserCandidatePreference';
+import { UserCandidateKeyword } from '../entity/user/UserCandidateKeyword';
+import { UserCandidateAnswer } from '../entity/user/UserCandidateAnswer';
+import { User } from '../entity/user/User';
+import { ghostUser } from '../common/utils';
+
+const BATCH_SIZE = 1000;
+
+const batchDelete = async ({
+  con,
+  table,
+  column,
+  userId,
+  log,
+}: {
+  con: DataSource;
+  table: string;
+  column: string;
+  userId: string;
+  log: FastifyBaseLogger;
+}) => {
+  let totalDeleted = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await con.query(
+      `DELETE FROM "${table}" WHERE ctid IN (
+        SELECT ctid FROM "${table}" WHERE "${column}" = $1 LIMIT ${BATCH_SIZE}
+      )`,
+      [userId],
+    );
+    const affected = result?.[1] ?? 0;
+    totalDeleted += affected;
+    if (affected < BATCH_SIZE) {
+      break;
+    }
+  }
+  if (totalDeleted > 0) {
+    log.info({ table, totalDeleted, userId }, 'batch deleted rows');
+  }
+};
+
+const worker: TypedWorker<'api.v1.user-deletion-requested'> = {
+  subscription: 'api.user-deletion-cleanup',
+  handler: async (message, con, log) => {
+    const { userId } = message.data;
+
+    const user = await con.getRepository(User).findOneBy({ id: userId });
+    if (!user) {
+      log.info({ userId }, 'user already deleted, skipping cleanup');
+      return;
+    }
+
+    log.info({ userId }, 'starting user deletion cleanup');
+
+    // Step 1: Ghost user reassignment
+    await con
+      .getRepository(Comment)
+      .update({ userId }, { userId: ghostUser.id });
+    await con
+      .getRepository(SourceUser)
+      .update({ userId }, { userId: ghostUser.id });
+    await con
+      .getRepository(SourcePostModeration)
+      .update({ createdById: userId }, { createdById: ghostUser.id });
+    await con
+      .getRepository(PostMention)
+      .update(
+        { mentionedByUserId: userId },
+        { mentionedByUserId: ghostUser.id },
+      );
+    await con
+      .getRepository(PostMention)
+      .update({ mentionedUserId: userId }, { mentionedUserId: ghostUser.id });
+    await con
+      .getRepository(CommentMention)
+      .update({ commentByUserId: userId }, { commentByUserId: ghostUser.id });
+    await con
+      .getRepository(CommentMention)
+      .update({ mentionedUserId: userId }, { mentionedUserId: ghostUser.id });
+    await con
+      .getRepository(ReputationEvent)
+      .update({ grantToId: userId }, { grantToId: ghostUser.id });
+    await con
+      .getRepository(UserTransaction)
+      .update({ senderId: userId }, { senderId: ghostUser.id });
+    await con
+      .getRepository(UserTransaction)
+      .update({ receiverId: userId }, { receiverId: ghostUser.id });
+    await con
+      .getRepository(ArticlePost)
+      .update({ authorId: userId }, { authorId: null });
+    await con.getRepository(DigestPost).delete({ authorId: userId });
+    await con
+      .getRepository(Post)
+      .update(
+        { authorId: userId, sourceId: userId },
+        { authorId: ghostUser.id, sourceId: ghostUser.id },
+      );
+    await con
+      .getRepository(Post)
+      .update({ authorId: userId }, { authorId: ghostUser.id });
+    await con
+      .getRepository(Post)
+      .update({ scoutId: userId }, { scoutId: null });
+
+    // Step 2: Delete child tables — large tables batched
+    await batchDelete({
+      con,
+      table: 'user_notification',
+      column: 'userId',
+      userId,
+      log,
+    });
+    await batchDelete({
+      con,
+      table: 'content_preference',
+      column: 'userId',
+      userId,
+      log,
+    });
+    await con
+      .getRepository(ContentPreferenceUser)
+      .delete({ referenceUserId: userId });
+    await con.getRepository(BookmarkList).delete({ userId });
+    await con.getRepository(Bookmark).delete({ userId });
+
+    // Step 2b: Delete child tables — medium tables
+    await con.getRepository(UserPost).delete({ userId });
+    await con.getRepository(UserAction).delete({ userId });
+    await con.getRepository(UserComment).delete({ userId });
+    await con.getRepository(Feed).delete({ userId });
+    await con.getRepository(UserStreak).delete({ userId });
+    await con.getRepository(Alerts).delete({ userId });
+    await con.getRepository(Settings).delete({ userId });
+    await con.getRepository(UserPersonalizedDigest).delete({ userId });
+    await con.getRepository(UserMarketingCta).delete({ userId });
+    await con.getRepository(SourceMember).delete({ userId });
+    await con.getRepository(UserAchievement).delete({ userId });
+    await con.getRepository(UserExperience).delete({ userId });
+    await con.getRepository(DevCard).delete({ userId });
+    await con.getRepository(UserQuest).delete({ userId });
+    await con.getRepository(UserQuestProfile).delete({ userId });
+    await con.getRepository(NotificationPreference).delete({ userId });
+    await con.getRepository(Feature).delete({ userId });
+    await con.getRepository(UserTopReader).delete({ userId });
+    await con.getRepository(UserStreakAction).delete({ userId });
+    await con.getRepository(UserCandidatePreference).delete({ userId });
+    await con.getRepository(UserCandidateKeyword).delete({ userId });
+    await con.getRepository(UserCandidateAnswer).delete({ userId });
+    await con.getRepository(OpportunityMatch).delete({ userId });
+    await con.getRepository(OpportunityUser).delete({ userId });
+    await con.getRepository(Invite).delete({ userId });
+    await con.getRepository(UserStack).delete({ userId });
+    await con.getRepository(UserHotTake).delete({ userId });
+    await con.getRepository(UserCompany).delete({ userId });
+    await con.getRepository(PostReport).delete({ userId });
+    await con.getRepository(CommentReport).delete({ userId });
+    await con.getRepository(SourceReport).delete({ userId });
+    await con.getRepository(UserReport).delete({ userId });
+    await con.getRepository(PersonalAccessToken).delete({ userId });
+    await con.getRepository(UserIntegration).delete({ userId });
+    await con.getRepository(UserGear).delete({ userId });
+    await con.getRepository(Campaign).delete({ userId });
+    await con.getRepository(Feedback).delete({ userId });
+    await con.getRepository(ClaimableItem).delete({ claimedById: userId });
+    await con.getRepository(UserWorkspacePhoto).delete({ userId });
+    await con.getRepository(HotTake).delete({ userId });
+    await con.getRepository(SquadPublicRequest).delete({ requestorId: userId });
+    await con.getRepository(SourceStack).delete({ createdById: userId });
+    await con.getRepository(Submission).delete({ userId });
+    await con.getRepository(View).delete({ userId });
+    await con.getRepository(SourceDisplay).delete({ userId });
+    await con.getRepository(SourceRequest).delete({ userId });
+    // Legacy table without TypeORM entity
+    await con.query('DELETE FROM comment_upvote WHERE "userId" = $1', [userId]);
+    // Auth tables
+    await con.query('DELETE FROM ba_account WHERE "userId" = $1', [userId]);
+
+    // Step 3: Hard delete the user — triggers CDC user-deleted event
+    await con.getRepository(User).delete(userId);
+
+    log.info({ userId }, 'user deletion cleanup completed');
+  },
+};
+
+export default worker;

--- a/src/workers/userDeletionCleanup.ts
+++ b/src/workers/userDeletionCleanup.ts
@@ -21,7 +21,6 @@ import {
   SourceUser,
   View,
 } from '../entity';
-import { ArticlePost } from '../entity/posts/ArticlePost';
 import { DigestPost } from '../entity/posts/DigestPost';
 import { PostMention } from '../entity/posts/PostMention';
 import { SourcePostModeration } from '../entity/SourcePostModeration';
@@ -64,6 +63,11 @@ import { UserCandidateKeyword } from '../entity/user/UserCandidateKeyword';
 import { UserCandidateAnswer } from '../entity/user/UserCandidateAnswer';
 import { User } from '../entity/user/User';
 import { ghostUser } from '../common/utils';
+import {
+  deleteEmploymentAgreementByUserId,
+  deleteResumeByUserId,
+} from '../common/googleCloud';
+import { logger } from '../logger';
 
 const BATCH_SIZE = 1000;
 
@@ -113,6 +117,10 @@ const worker: TypedWorker<'api.v1.user-deletion-requested'> = {
 
     log.info({ userId }, 'starting user deletion cleanup');
 
+    // Step 0: Clean up external resources
+    await deleteResumeByUserId(userId);
+    await deleteEmploymentAgreementByUserId({ userId, logger });
+
     // Step 1: Ghost user reassignment
     await con
       .getRepository(Comment)
@@ -142,21 +150,15 @@ const worker: TypedWorker<'api.v1.user-deletion-requested'> = {
       .getRepository(ReputationEvent)
       .update({ grantToId: userId }, { grantToId: ghostUser.id });
     await con
+      .getRepository(ReputationEvent)
+      .update({ grantById: userId }, { grantById: ghostUser.id });
+    await con
       .getRepository(UserTransaction)
       .update({ senderId: userId }, { senderId: ghostUser.id });
     await con
       .getRepository(UserTransaction)
       .update({ receiverId: userId }, { receiverId: ghostUser.id });
-    await con
-      .getRepository(ArticlePost)
-      .update({ authorId: userId }, { authorId: null });
     await con.getRepository(DigestPost).delete({ authorId: userId });
-    await con
-      .getRepository(Post)
-      .update(
-        { authorId: userId, sourceId: userId },
-        { authorId: ghostUser.id, sourceId: ghostUser.id },
-      );
     await con
       .getRepository(Post)
       .update({ authorId: userId }, { authorId: ghostUser.id });


### PR DESCRIPTION
## Summary
- Replace synchronous user deletion (CASCADE-locked 60 FK tables for 10-20min, blocking logins) with an async flow
- `deleteUser()` now sets `flags.inDeletion=true`, invalidates sessions, and returns immediately
- New `userDeletionCleanup` worker handles child table cleanup one table at a time
- Boot endpoint blocks login for users marked `inDeletion`
- Zombie cron marks users for deletion instead of deleting directly

## Test plan
- [x] Build passes
- [x] Lint passes (0 warnings)
- [x] `__tests__/users.ts` delete tests pass (19/19)
- [x] `__tests__/cron/cleanZombieUsers.ts` passes (3/3)
- [ ] Companion PR: dailydotdev/streams#93 (topic must be deployed first)
- [ ] Follow-up: migration to remove CASCADE from user FK constraints