### PR TITLE
fix: truncate X notification attachment titles to 140 characters

### DIFF
--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1490,6 +1490,61 @@ describe('storeNotificationBundle', () => {
     ]);
   });
 
+  it('should truncate attachment title for SocialTwitter posts exceeding 140 characters', () => {
+    const type = NotificationType.SourcePostAdded;
+    const longTitle = 'a'.repeat(200);
+    const post = {
+      ...postsFixture[0],
+      title: longTitle,
+      type: PostType.SocialTwitter,
+    } as Reference<Post>;
+    const ctx: NotificationSourceContext & NotificationPostContext = {
+      userIds: [userId],
+      source: sourcesFixture[0] as Reference<Source>,
+      post,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.attachments![0].title).toEqual(`${'a'.repeat(137)}...`);
+    expect(actual.attachments![0].title!.length).toEqual(140);
+  });
+
+  it('should not truncate attachment title for SocialTwitter posts within 140 characters', () => {
+    const type = NotificationType.SourcePostAdded;
+    const shortTitle = 'a'.repeat(140);
+    const post = {
+      ...postsFixture[0],
+      title: shortTitle,
+      type: PostType.SocialTwitter,
+    } as Reference<Post>;
+    const ctx: NotificationSourceContext & NotificationPostContext = {
+      userIds: [userId],
+      source: sourcesFixture[0] as Reference<Source>,
+      post,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.attachments![0].title).toEqual(shortTitle);
+  });
+
+  it('should not truncate attachment title for non-SocialTwitter posts', () => {
+    const type = NotificationType.SourcePostAdded;
+    const longTitle = 'a'.repeat(200);
+    const post = {
+      ...postsFixture[0],
+      title: longTitle,
+      type: PostType.Article,
+    } as Reference<Post>;
+    const ctx: NotificationSourceContext & NotificationPostContext = {
+      userIds: [userId],
+      source: sourcesFixture[0] as Reference<Source>,
+      post,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.attachments![0].title).toEqual(longTitle);
+  });
+
   it('should generate user_post_added notification', () => {
     const type = NotificationType.UserPostAdded;
     const ctx: NotificationUserContext & NotificationPostContext = {

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -311,10 +311,18 @@ export class NotificationBuilder {
         post.type as keyof typeof postTypeToAttachmentType
       ] ?? NotificationAttachmentType.Post;
 
+    const MAX_TWITTER_TITLE_LENGTH = 140;
+    const title = post.title ?? '';
+    const truncatedTitle =
+      post.type === PostType.SocialTwitter &&
+      title.length > MAX_TWITTER_TITLE_LENGTH
+        ? `${title.substring(0, MAX_TWITTER_TITLE_LENGTH - 3)}...`
+        : title;
+
     this.attachments.push({
       type,
       image: (post as ArticlePost)?.image || pickImageUrl(post),
-      title: post.title ?? '',
+      title: truncatedTitle,
       referenceId: post.id,
     });
     return this;


### PR DESCRIPTION
## Summary
- Truncate `SocialTwitter` post attachment titles to 140 characters (137 + `...`) in `NotificationBuilder.attachmentPost()`
- Only applies to `SocialTwitter` post type — article and other post titles are unaffected
- Follows existing truncation patterns (`simplifyComment`, `truncateToTweet`)

## Test plan
- [x] Added test: SocialTwitter titles >140 chars are truncated to exactly 140
- [x] Added test: SocialTwitter titles ≤140 chars are preserved as-is
- [x] Added test: Non-SocialTwitter (Article) titles are never truncated
- [x] All 65 notification tests pass
- [x] Lint and build clean

Closes ENG-1256

---
Created by Huginn 🐦‍⬛