### PR TITLE
fix(auth): set up new user defaults in betterAuth hook

### DIFF
--- a/__tests__/routes/betterAuth.ts
+++ b/__tests__/routes/betterAuth.ts
@@ -175,13 +175,23 @@ describe('betterAuth routes', () => {
         overrides: {
           body?: Record<string, unknown>;
           cookie?: string;
+          ip?: string;
         } = {},
-      ) => ({
-        request: new Request('http://localhost/auth/sign-up/email', {
-          headers: overrides.cookie ? { cookie: overrides.cookie } : undefined,
-        }),
-        body: overrides.body,
-      });
+      ) => {
+        const headers: Record<string, string> = {};
+        if (overrides.cookie) {
+          headers.cookie = overrides.cookie;
+        }
+        if (overrides.ip) {
+          headers['x-forwarded-for'] = overrides.ip;
+        }
+        return {
+          request: new Request('http://localhost/auth/sign-up/email', {
+            headers: Object.keys(headers).length ? headers : undefined,
+          }),
+          body: overrides.body,
+        };
+      };
 
       const createBaseUser = async () => {
         const id = await generateShortId();
@@ -224,11 +234,11 @@ describe('betterAuth routes', () => {
         expect(digestPost!.private).toBeTruthy();
       });
 
-      it('should set UserAction for cores role', async () => {
+      it('should set UserAction for cores role when ip is present', async () => {
         const after = await getAfterHook();
         const user = await createBaseUser();
 
-        await after(user, makeContext());
+        await after(user, makeContext({ ip: '1.2.3.4' }));
 
         const userAction = await con.getRepository(UserAction).findOneBy({
           userId: user.id,

--- a/__tests__/routes/betterAuth.ts
+++ b/__tests__/routes/betterAuth.ts
@@ -1,12 +1,56 @@
 import request from 'supertest';
 import { FastifyInstance } from 'fastify';
 import { DataSource } from 'typeorm';
+import type { Pool } from 'pg';
 import createOrGetConnection from '../../src/db';
 import { saveFixtures } from '../helpers';
 import { User } from '../../src/entity/user/User';
+import { DeletedUser } from '../../src/entity/user/DeletedUser';
+import { Source } from '../../src/entity/Source';
+import { sourcesFixture } from '../fixture/source';
+import { Feed } from '../../src/entity/Feed';
+import { UserAction, UserActionType } from '../../src/entity/user/UserAction';
+import { DigestPost } from '../../src/entity/posts/DigestPost';
+import { DIGEST_SOURCE } from '../../src/entity/Source';
+import {
+  ClaimableItem,
+  ClaimableItemTypes,
+} from '../../src/entity/ClaimableItem';
+import { OpportunityJob } from '../../src/entity/opportunities/OpportunityJob';
+import { OpportunityUser } from '../../src/entity/opportunities/user';
+import { OpportunityUserType } from '../../src/entity/opportunities/types';
+import { OpportunityState } from '@dailydotdev/schema';
+import {
+  DEFAULT_NOTIFICATION_SETTINGS,
+  NotificationPreferenceStatus,
+  NotificationType,
+} from '../../src/notifications/common';
+import { generateShortId } from '../../src/ids';
 import { usersFixture } from '../fixture';
 import { ioRedisPool } from '../../src/redis';
 import * as betterAuthModule from '../../src/betterAuth';
+
+jest.mock('../../src/common/paddle/index.ts', () => ({
+  ...(jest.requireActual('../../src/common/paddle/index.ts') as Record<
+    string,
+    unknown
+  >),
+  paddleInstance: {
+    subscriptions: {
+      update: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+jest.mock('../../src/cio', () => ({
+  ...(jest.requireActual('../../src/cio') as Record<string, unknown>),
+  identifyAnonymousFunnelSubscription: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('better-auth/api', () => ({
+  ...(jest.requireActual('better-auth/api') as Record<string, unknown>),
+  getOAuthState: jest.fn().mockResolvedValue(null),
+}));
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -36,6 +80,7 @@ afterAll(async () => {
 beforeEach(async () => {
   jest.clearAllMocks();
   await ioRedisPool.execute((client) => client.flushall());
+  await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, User, usersFixture);
 });
 
@@ -66,6 +111,251 @@ describe('betterAuth routes', () => {
         storeSessionInDatabase: true,
         expiresIn: 30 * 24 * 60 * 60,
         updateAge: 12 * 60 * 60,
+      });
+    });
+
+    describe('user.create.before hook', () => {
+      const getBeforeHook = async () => {
+        const { getBetterAuthOptions } = await import('../../src/betterAuth');
+        const options = getBetterAuthOptions(
+          (con.driver as unknown as { master: Pool }).master,
+        );
+        const before = options.databaseHooks?.user?.create?.before;
+        if (!before) {
+          throw new Error('before hook not configured');
+        }
+        return before;
+      };
+
+      it('should regenerate id when tracking cookie matches a deleted user', async () => {
+        const before = await getBeforeHook();
+        const deletedUserId = 'aBcDeFgHiJkLmNoPqRsTu';
+        await con.getRepository(DeletedUser).save({ id: deletedUserId });
+
+        const result = await before(
+          {
+            email: 'new-signup@example.com',
+            name: 'New Signup',
+            emailVerified: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            request: new Request('http://localhost/auth/sign-up/email', {
+              headers: { cookie: `da2=${deletedUserId}` },
+            }),
+            body: {},
+          },
+        );
+
+        const assignedId = (result as { data: { id: string } }).data.id;
+        expect(assignedId).not.toEqual(deletedUserId);
+
+        const stillDeleted = await con
+          .getRepository(DeletedUser)
+          .findOneBy({ id: deletedUserId });
+        expect(stillDeleted).not.toBeNull();
+      });
+    });
+
+    describe('user.create.after hook', () => {
+      const getAfterHook = async () => {
+        const { getBetterAuthOptions } = await import('../../src/betterAuth');
+        const options = getBetterAuthOptions(
+          (con.driver as unknown as { master: Pool }).master,
+        );
+        const after = options.databaseHooks?.user?.create?.after;
+        if (!after) {
+          throw new Error('after hook not configured');
+        }
+        return after;
+      };
+
+      const makeContext = (
+        overrides: {
+          body?: Record<string, unknown>;
+          cookie?: string;
+        } = {},
+      ) => ({
+        request: new Request('http://localhost/auth/sign-up/email', {
+          headers: overrides.cookie ? { cookie: overrides.cookie } : undefined,
+        }),
+        body: overrides.body,
+      });
+
+      const createBaseUser = async () => {
+        const id = await generateShortId();
+        const email = `hook-${id}@test.com`;
+        await con.getRepository(User).save({
+          id,
+          name: 'Hook User',
+          email,
+          username: `u_${id}`,
+          image: 'https://daily.dev/fake.jpg',
+          createdAt: new Date(),
+        });
+        return { id, email };
+      };
+
+      it('should add feed with id equal to user id', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        await after(user, makeContext());
+
+        const feed = await con.getRepository(Feed).findOneBy({ id: user.id });
+        expect(feed).not.toBeNull();
+        expect(feed!.id).toEqual(user.id);
+        expect(feed!.userId).toEqual(user.id);
+      });
+
+      it('should create a DigestPost stub', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        await after(user, makeContext());
+
+        const digestPost = await con
+          .getRepository(DigestPost)
+          .findOneBy({ authorId: user.id });
+        expect(digestPost).not.toBeNull();
+        expect(digestPost!.sourceId).toBe(DIGEST_SOURCE);
+        expect(digestPost!.visible).toBeFalsy();
+        expect(digestPost!.private).toBeTruthy();
+      });
+
+      it('should set UserAction for cores role', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        await after(user, makeContext());
+
+        const userAction = await con.getRepository(UserAction).findOneBy({
+          userId: user.id,
+          type: UserActionType.CheckedCoresRole,
+        });
+        expect(userAction).not.toBeNull();
+      });
+
+      it('should mute marketing notifications when acceptedMarketing is false', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        await after(user, makeContext({ body: { acceptedMarketing: false } }));
+
+        const persisted = await con
+          .getRepository(User)
+          .findOneBy({ id: user.id });
+        expect(
+          persisted!.notificationFlags?.[NotificationType.Marketing],
+        ).toEqual({
+          email: NotificationPreferenceStatus.Muted,
+          inApp: NotificationPreferenceStatus.Muted,
+        });
+      });
+
+      it('should use default notification flags when acceptedMarketing is true', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        await after(user, makeContext({ body: { acceptedMarketing: true } }));
+
+        const persisted = await con
+          .getRepository(User)
+          .findOneBy({ id: user.id });
+        expect(persisted!.notificationFlags).toEqual(
+          DEFAULT_NOTIFICATION_SETTINGS,
+        );
+      });
+
+      it('should claim opportunities that user created as anonymous', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        const opportunity = await con.getRepository(OpportunityJob).save(
+          con.getRepository(OpportunityJob).create({
+            title: 'Test',
+            tldr: 'Test',
+            state: OpportunityState.DRAFT,
+          }),
+        );
+
+        await con.getRepository(ClaimableItem).save({
+          identifier: user.id,
+          type: ClaimableItemTypes.Opportunity,
+          flags: {
+            opportunityId: opportunity.id,
+          },
+        });
+
+        await after(user, makeContext());
+
+        const updatedClaimableItem = await con
+          .getRepository(ClaimableItem)
+          .findOneBy({
+            identifier: user.id,
+            type: ClaimableItemTypes.Opportunity,
+          });
+        expect(updatedClaimableItem).not.toBeNull();
+        expect(updatedClaimableItem!.claimedAt).toBeInstanceOf(Date);
+        expect(updatedClaimableItem!.claimedById).toBe(user.id);
+
+        const opportunityUser = await con
+          .getRepository(OpportunityUser)
+          .findOneBy({
+            opportunityId: opportunity.id,
+            userId: user.id,
+          });
+        expect(opportunityUser).toEqual({
+          opportunityId: opportunity.id,
+          userId: user.id,
+          type: OpportunityUserType.Recruiter,
+        });
+      });
+
+      it('should claim opportunities that user created with email', async () => {
+        const after = await getAfterHook();
+        const user = await createBaseUser();
+
+        const opportunity = await con.getRepository(OpportunityJob).save(
+          con.getRepository(OpportunityJob).create({
+            title: 'Test',
+            tldr: 'Test',
+            state: OpportunityState.DRAFT,
+          }),
+        );
+
+        await con.getRepository(ClaimableItem).save({
+          identifier: user.email,
+          type: ClaimableItemTypes.Opportunity,
+          flags: {
+            opportunityId: opportunity.id,
+          },
+        });
+
+        await after(user, makeContext());
+
+        const updatedClaimableItem = await con
+          .getRepository(ClaimableItem)
+          .findOneBy({
+            identifier: user.email,
+            type: ClaimableItemTypes.Opportunity,
+          });
+        expect(updatedClaimableItem).not.toBeNull();
+        expect(updatedClaimableItem!.claimedAt).toBeInstanceOf(Date);
+        expect(updatedClaimableItem!.claimedById).toBe(user.id);
+
+        const opportunityUser = await con
+          .getRepository(OpportunityUser)
+          .findOneBy({
+            opportunityId: opportunity.id,
+            userId: user.id,
+          });
+        expect(opportunityUser).toEqual({
+          opportunityId: opportunity.id,
+          userId: user.id,
+          type: OpportunityUserType.Recruiter,
+        });
       });
     });
 

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -315,7 +315,9 @@ const ensureNonDeletedUserId = async (
     }
     id = await generateLongId();
   }
-  return id;
+  throw new Error(
+    `Failed to generate non-deleted user id after ${MAX_DELETED_USER_COLLISION_RETRIES} retries`,
+  );
 };
 
 const resolveSignUpUserId = async (

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -18,7 +18,18 @@ import { User } from './entity/user/User';
 import { cookies, extractRootDomain } from './cookies';
 import { getGeo } from './common/geo';
 import { getUserCoresRole } from './common/user';
-import { generateLongId } from './ids';
+import { generateLongId, generateShortId } from './ids';
+import { UserActionType } from './entity/user/UserAction';
+import { insertOrIgnoreAction } from './schema/actions';
+import { DigestPost } from './entity/posts/DigestPost';
+import { DIGEST_SOURCE } from './entity/Source';
+import {
+  DEFAULT_NOTIFICATION_SETTINGS,
+  NotificationPreferenceStatus,
+  NotificationType,
+} from './notifications/common';
+import { addClaimableItemsToUser } from './entity/user/utils';
+import { claimAnonOpportunities } from './common/opportunity/user';
 
 const GOOGLE_CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
 
@@ -287,6 +298,71 @@ const cookieDomain = process.env.BETTER_AUTH_BASE_URL
   ? extractRootDomain(new URL(process.env.BETTER_AUTH_BASE_URL).hostname)
   : undefined;
 
+const MAX_DELETED_USER_COLLISION_RETRIES = 3;
+
+const ensureNonDeletedUserId = async (
+  pool: Pool,
+  candidate: string,
+): Promise<string> => {
+  let id = candidate;
+  for (let i = 0; i < MAX_DELETED_USER_COLLISION_RETRIES; i++) {
+    const { rowCount } = await pool.query(
+      'SELECT id FROM public."deleted_user" WHERE id = $1',
+      [id],
+    );
+    if (!rowCount) {
+      return id;
+    }
+    id = await generateLongId();
+  }
+  return id;
+};
+
+const resolveSignUpUserId = async (
+  pool: Pool,
+  user: { email: string },
+  ctx: unknown,
+): Promise<{ data: { id: string } }> => {
+  try {
+    const hookCtx = ctx as BetterAuthDbHookContext;
+    const cookieHeader = hookCtx?.request?.headers?.get('cookie') ?? '';
+    const trackingId = parseTrackingIdFromCookieHeader(cookieHeader);
+    if (trackingId) {
+      const existing = await pool.query<{ email: string }>(
+        'SELECT email FROM public."user" WHERE id = $1',
+        [trackingId],
+      );
+      if (existing.rowCount && existing.rowCount > 0) {
+        const existingEmail = existing.rows[0].email;
+
+        logger.warn(
+          {
+            trackingId,
+            sameEmail: existingEmail === user.email,
+          },
+          'Tracking cookie ID collision: cookie holds an existing user ID during signup',
+        );
+
+        if (existingEmail !== user.email) {
+          // user has stale tracking cookie generate new user
+          // is to safely insert since its a new email
+          // in latter stage better auth logic will correlate
+          // with existing credential if it exists for email
+          return { data: { id: await generateLongId() } };
+        }
+      }
+      return { data: { id: trackingId } };
+    }
+  } catch (err) {
+    logger.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      'Failed to extract tracking ID for new user',
+    );
+  }
+
+  return { data: { id: await generateLongId() } };
+};
+
 export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
   const trustedOrigins = process.env.BETTER_AUTH_TRUSTED_ORIGINS
     ? process.env.BETTER_AUTH_TRUSTED_ORIGINS.split(',')
@@ -416,52 +492,17 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
       user: {
         create: {
           before: async (user, ctx) => {
-            try {
-              const hookCtx = ctx as BetterAuthDbHookContext;
-              const cookieHeader =
-                hookCtx?.request?.headers?.get('cookie') ?? '';
-              const trackingId = parseTrackingIdFromCookieHeader(cookieHeader);
-              if (trackingId) {
-                const existing = await pool.query<{ email: string }>(
-                  'SELECT email FROM public."user" WHERE id = $1',
-                  [trackingId],
-                );
-                if (existing.rowCount && existing.rowCount > 0) {
-                  const existingEmail = existing.rows[0].email;
-
-                  logger.warn(
-                    {
-                      trackingId,
-                      sameEmail: existingEmail === user.email,
-                    },
-                    'Tracking cookie ID collision: cookie holds an existing user ID during signup',
-                  );
-
-                  if (existingEmail !== user.email) {
-                    // user has stale tracking cookie generate new user
-                    // is to safely insert since its a new email
-                    // in latter stage better auth logic will correlate
-                    // with existing credential if it exists for email
-                    const newId = await generateLongId();
-
-                    return { data: { id: newId } };
-                  }
-                }
-                return { data: { id: trackingId } };
-              }
-            } catch (err) {
-              logger.error(
-                { err: err instanceof Error ? err.message : String(err) },
-                'Failed to extract tracking ID for new user',
-              );
-            }
-
-            return { data: { id: await generateLongId() } };
+            const resolved = await resolveSignUpUserId(pool, user, ctx);
+            resolved.data.id = await ensureNonDeletedUserId(
+              pool,
+              resolved.data.id,
+            );
+            return resolved;
           },
           after: async (user, ctx) => {
             try {
               await pool.query(
-                'INSERT INTO feed (id, "userId") VALUES (gen_random_uuid(), $1) ON CONFLICT DO NOTHING',
+                'INSERT INTO feed (id, "userId") VALUES ($1, $1) ON CONFLICT DO NOTHING',
                 [user.id],
               );
 
@@ -503,6 +544,20 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
                 paramIndex++;
               }
 
+              const notificationFlags =
+                body?.acceptedMarketing === false
+                  ? {
+                      ...DEFAULT_NOTIFICATION_SETTINGS,
+                      [NotificationType.Marketing]: {
+                        email: NotificationPreferenceStatus.Muted,
+                        inApp: NotificationPreferenceStatus.Muted,
+                      },
+                    }
+                  : DEFAULT_NOTIFICATION_SETTINGS;
+              setClauses.push(`"notificationFlags" = $${paramIndex}`);
+              values.push(notificationFlags);
+              paramIndex++;
+
               const ip =
                 hookCtx?.request?.headers
                   ?.get('x-forwarded-for')
@@ -520,6 +575,62 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
                 `UPDATE public."user" SET ${setClauses.join(', ')} WHERE id = $1`,
                 values,
               );
+
+              await insertOrIgnoreAction(
+                AppDataSource.manager,
+                user.id,
+                UserActionType.CheckedCoresRole,
+              );
+
+              const digestPostId = await generateShortId();
+              await AppDataSource.getRepository(DigestPost)
+                .createQueryBuilder()
+                .insert()
+                .values({
+                  id: digestPostId,
+                  shortId: digestPostId,
+                  authorId: user.id,
+                  private: true,
+                  visible: false,
+                  sourceId: DIGEST_SOURCE,
+                })
+                .orIgnore()
+                .execute();
+
+              try {
+                await addClaimableItemsToUser(AppDataSource, {
+                  id: user.id,
+                  email: user.email,
+                });
+              } catch (err) {
+                logger.error(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    userId: user.id,
+                  },
+                  'Failed to add claimable items for new BA user',
+                );
+              }
+
+              try {
+                for (const identifier of [user.id, user.email].filter(
+                  Boolean,
+                )) {
+                  await claimAnonOpportunities({
+                    anonUserId: identifier,
+                    userId: user.id,
+                    con: AppDataSource.manager,
+                  });
+                }
+              } catch (err) {
+                logger.error(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    userId: user.id,
+                  },
+                  'Failed to claim anonymous opportunities for new BA user',
+                );
+              }
 
               await triggerTypedEvent(logger, 'api.v1.ba-user-created', {
                 userId: user.id,

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -8,7 +8,6 @@ import { z } from 'zod';
 import { decodeProtectedHeader, importJWK, jwtVerify } from 'jose';
 import { AppDataSource } from './data-source';
 import { logger } from './logger';
-import { triggerTypedEvent } from './common/typedPubsub';
 import { sendEmail, CioTransactionalMessageTemplateId } from './common/mailing';
 import { handleRegex } from './common/object';
 import { validateAndTransformHandle } from './common/handles';
@@ -30,6 +29,7 @@ import {
 } from './notifications/common';
 import { addClaimableItemsToUser } from './entity/user/utils';
 import { claimAnonOpportunities } from './common/opportunity/user';
+import { triggerTypedEvent } from './common/typedPubsub';
 
 const GOOGLE_CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
 
@@ -633,10 +633,6 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
                   'Failed to claim anonymous opportunities for new BA user',
                 );
               }
-
-              await triggerTypedEvent(logger, 'api.v1.ba-user-created', {
-                userId: user.id,
-              });
             } catch (err) {
               logger.error(
                 {
@@ -646,6 +642,10 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
                 'Failed to set up new user defaults after BA creation',
               );
             }
+
+            await triggerTypedEvent(logger, 'api.v1.ba-user-created', {
+              userId: user.id,
+            });
           },
         },
       },

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -569,17 +569,17 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
                 setClauses.push(`"coresRole" = $${paramIndex}`);
                 values.push(String(coresRole));
                 paramIndex++;
+
+                await insertOrIgnoreAction(
+                  AppDataSource.manager,
+                  user.id,
+                  UserActionType.CheckedCoresRole,
+                );
               }
 
               await pool.query(
                 `UPDATE public."user" SET ${setClauses.join(', ')} WHERE id = $1`,
                 values,
-              );
-
-              await insertOrIgnoreAction(
-                AppDataSource.manager,
-                user.id,
-                UserActionType.CheckedCoresRole,
               );
 
               const digestPostId = await generateShortId();

--- a/src/entity/user/utils.ts
+++ b/src/entity/user/utils.ts
@@ -397,7 +397,7 @@ export const addNewUser = async (
 
 export const addClaimableItemsToUser = async (
   con: DataSource,
-  body: AddUserData,
+  body: Pick<AddUserData, 'id' | 'email'>,
 ) => {
   const subscription = await con.getRepository(ClaimableItem).findOneBy({
     identifier: body.email,


### PR DESCRIPTION
  src/betterAuth.ts
  - resolveSignUpUserId + ensureNonDeletedUserId helpers — deleted-user collision handled once at the end of the before hook
  - user.create.after now sets: feed (id = user.id), notificationFlags (marketing muted when acceptedMarketing=false), UserAction CheckedCoresRole, DigestPost
  flags/referral/timezone/coresRole UPDATE
  - Inline calls to addClaimableItemsToUser + claimAnonOpportunities (each in its own try/catch)

  src/entity/user/utils.ts
  - addClaimableItemsToUser signature narrowed to Pick<AddUserData, 'id' | 'email'>
