### PR TITLE
feat(notifications): add user follow defaults

### DIFF
--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -15,6 +15,7 @@ export const notificationFlagsSchema = z.strictObject({
   [NotificationType.PostMention]: notificationPreferenceSchema,
   [NotificationType.CommentMention]: notificationPreferenceSchema,
   [NotificationType.ArticleReportApproved]: notificationPreferenceSchema,
+  [NotificationType.UserFollow]: notificationPreferenceSchema,
   [NotificationType.StreakResetRestore]: notificationPreferenceSchema,
   [UserPersonalizedDigestType.StreakReminder]: notificationPreferenceSchema,
   [NotificationType.UserTopReaderBadge]: notificationPreferenceSchema,

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -163,6 +163,10 @@ export const DEFAULT_NOTIFICATION_SETTINGS: UserNotificationFlags = {
     email: NotificationPreferenceStatus.Subscribed,
     inApp: NotificationPreferenceStatus.Subscribed,
   },
+  [NotificationType.UserFollow]: {
+    email: NotificationPreferenceStatus.Subscribed,
+    inApp: NotificationPreferenceStatus.Subscribed,
+  },
   [NotificationType.StreakResetRestore]: {
     email: NotificationPreferenceStatus.Subscribed,
     inApp: NotificationPreferenceStatus.Subscribed,


### PR DESCRIPTION
## Summary
- add `user_follow` to the default notification flags so new users inherit the existing subscribed behavior
- add `user_follow` to the strict notification flags schema so notification settings updates accept and persist the new preference

## Key Decisions
- kept the change additive and limited to the existing notification flags mechanism instead of introducing new storage or API paths
- updated shared defaults and schema together so the new preference is both surfaced consistently and validated correctly

Closes ENG-1283

---
Created by Huginn 🐦‍⬛