### PR TITLE
feat: digest cs experiment

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -261,6 +261,8 @@ config:
       secure: AAABABe5GePYDxcK+9QGqmQV7zE3Pv5wWtGkfFOV1MosH+KVFIfK6Is=
     googleIosClientId:
       secure: AAABAENK/HL3DH78uShJwePe91GmOlM4YkNuaLsXkPrWp8p6tvW5XAlTMCN5XCSFCkQog94YZHEO0idbBTKPF1H727qb7XvUqVjkEP8yY7Sf77geK2VHUN+NMAkkeuaFar5dlJUkqCY=
+    snotraUserApiOrigin:
+      secure: AAABADX/8nmDxoZRpWxaAYCBL52wANtG5kR34DGnQgBkZKd0DKaxc8DQyXbRt/XuhNfj2+vI3xfDeSThDWlzKQFCNK0fAO4IUcuRBdDx6Q==
   api:k8s:
     host: subs.daily.dev
     namespace: daily

--- a/__tests__/integrations/snotra.ts
+++ b/__tests__/integrations/snotra.ts
@@ -1,0 +1,37 @@
+import nock from 'nock';
+import { SnotraClient } from '../../src/integrations/snotra/clients';
+import { PersonaliseState } from '../../src/integrations/snotra/types';
+
+const url = 'http://snotra.local:3000';
+
+beforeEach(() => {
+  nock.cleanAll();
+});
+
+describe('SnotraClient.getUserProfile', () => {
+  it('should POST to /api/v1/user/profile and return parsed response', async () => {
+    let capturedBody: unknown;
+    nock(url)
+      .post('/api/v1/user/profile', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        personalise: { state: PersonaliseState.Personalised },
+      });
+
+    const client = new SnotraClient(url);
+    const response = await client.getUserProfile({
+      user_id: 'u1',
+      providers: { personalise: {} },
+    });
+
+    expect(capturedBody).toEqual({
+      user_id: 'u1',
+      providers: { personalise: {} },
+    });
+    expect(response).toEqual({
+      personalise: { state: PersonaliseState.Personalised },
+    });
+  });
+});

--- a/__tests__/workers/personalizedDigestEmail.ts
+++ b/__tests__/workers/personalizedDigestEmail.ts
@@ -46,6 +46,9 @@ import {
   NotificationPreferenceStatus,
   NotificationType,
 } from '../../src/notifications/common';
+import { personalizedDigestSnotraClient } from '../../src/common/personalizedDigest';
+import { PersonaliseState } from '../../src/integrations/snotra/types';
+import { FeedConfigName } from '../../src/integrations/feed/types';
 
 jest.mock('../../src/common', () => ({
   ...(jest.requireActual('../../src/common') as Record<string, unknown>),
@@ -1189,6 +1192,101 @@ describe('personalizedDigestEmail worker', () => {
     expect(nockBody).toMatchSnapshot({
       date_from: expect.any(String),
       date_to: expect.any(String),
+    });
+  });
+
+  describe('digest_cs_v1 experiment', () => {
+    const experimentConfig = {
+      templateId: '48',
+      maxPosts: 5,
+      feedConfig: FeedConfigName.DigestCsV1,
+    };
+
+    it('should use digest_v2 when snotra reports any state other than non_personalised', async () => {
+      const spy = jest
+        .spyOn(personalizedDigestSnotraClient, 'getUserProfile')
+        .mockResolvedValue({
+          personalise: { state: 'some_other_state' as PersonaliseState },
+        });
+
+      const personalizedDigest = await con
+        .getRepository(UserPersonalizedDigest)
+        .findOneBy({ userId: '1' });
+
+      await expectSuccessfulBackground(worker, {
+        personalizedDigest,
+        ...getDates(personalizedDigest!, Date.now()),
+        emailBatchId: 'test-email-batch-id',
+        config: experimentConfig,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        user_id: '1',
+        providers: { personalise: {} },
+      });
+      expect(nockBody.feed_config_name).toBe(FeedConfigName.DigestV2);
+    });
+
+    it('should use digest_cs_v1 when snotra reports user is non_personalised', async () => {
+      jest
+        .spyOn(personalizedDigestSnotraClient, 'getUserProfile')
+        .mockResolvedValue({
+          personalise: { state: PersonaliseState.NonPersonalised },
+        });
+
+      const personalizedDigest = await con
+        .getRepository(UserPersonalizedDigest)
+        .findOneBy({ userId: '1' });
+
+      await expectSuccessfulBackground(worker, {
+        personalizedDigest,
+        ...getDates(personalizedDigest!, Date.now()),
+        emailBatchId: 'test-email-batch-id',
+        config: experimentConfig,
+      });
+
+      expect(nockBody.feed_config_name).toBe(FeedConfigName.DigestCsV1);
+    });
+
+    it('should fall back to digest_v2 when snotra call fails', async () => {
+      jest
+        .spyOn(personalizedDigestSnotraClient, 'getUserProfile')
+        .mockRejectedValue(new Error('snotra down'));
+
+      const personalizedDigest = await con
+        .getRepository(UserPersonalizedDigest)
+        .findOneBy({ userId: '1' });
+
+      await expectSuccessfulBackground(worker, {
+        personalizedDigest,
+        ...getDates(personalizedDigest!, Date.now()),
+        emailBatchId: 'test-email-batch-id',
+        config: experimentConfig,
+      });
+
+      expect(nockBody.feed_config_name).toBe(FeedConfigName.DigestV2);
+    });
+
+    it('should not call snotra when feedConfig is not the experiment marker', async () => {
+      const spy = jest.spyOn(personalizedDigestSnotraClient, 'getUserProfile');
+
+      const personalizedDigest = await con
+        .getRepository(UserPersonalizedDigest)
+        .findOneBy({ userId: '1' });
+
+      await expectSuccessfulBackground(worker, {
+        personalizedDigest,
+        ...getDates(personalizedDigest!, Date.now()),
+        emailBatchId: 'test-email-batch-id',
+        config: {
+          templateId: '48',
+          maxPosts: 5,
+          feedConfig: 'some_other_config',
+        },
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(nockBody.feed_config_name).toBe('some_other_config');
     });
   });
 

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -36,6 +36,8 @@ import { queryReadReplica } from './queryReadReplica';
 import { counters } from '../telemetry/metrics';
 import { SkadiAd, skadiPersonalizedDigestClient } from '../integrations/skadi';
 import { NotificationType } from '../notifications/common';
+import { SnotraClient } from '../integrations/snotra/clients';
+import { PersonaliseState } from '../integrations/snotra/types';
 
 type TemplatePostData = Pick<
   ArticlePost,
@@ -255,7 +257,7 @@ const personalizedDigestFeedClient = new FeedClient(
         queuedRequests: 1000,
       },
       retryOpts: {
-        maxAttempts: 0,
+        maxAttempts: 1,
       },
       events: {
         onBreak: ({ meta }) => {
@@ -282,6 +284,84 @@ const personalizedDigestFeedClient = new FeedClient(
     }),
   },
 );
+
+export const personalizedDigestSnotraClient = new SnotraClient(
+  process.env.SNOTRA_ORIGIN as string,
+  {
+    fetchOptions: {
+      timeout: 10 * 1000,
+    },
+    garmr: new GarmrService({
+      service: 'snotra-client-digest',
+      breakerOpts: {
+        halfOpenAfter: 5 * 1000,
+        threshold: 0.1,
+        duration: 10 * 1000,
+        minimumRps: 1,
+      },
+      limits: {
+        maxRequests: 300,
+        queuedRequests: 1000,
+      },
+      retryOpts: {
+        maxAttempts: 1,
+      },
+      events: {
+        onBreak: ({ meta }) => {
+          counters?.['personalized-digest']?.garmrBreak?.add(1, {
+            service: meta.service,
+          });
+        },
+        onHalfOpen: ({ meta }) => {
+          counters?.['personalized-digest']?.garmrHalfOpen?.add(1, {
+            service: meta.service,
+          });
+        },
+        onReset: ({ meta }) => {
+          counters?.['personalized-digest']?.garmrReset?.add(1, {
+            service: meta.service,
+          });
+        },
+        onRetry: ({ meta }) => {
+          counters?.['personalized-digest']?.garmrRetry?.add(1, {
+            service: meta.service,
+          });
+        },
+      },
+    }),
+  },
+);
+
+const resolveDigestFeedConfigName = async ({
+  personalizedDigest,
+  feature,
+  logger,
+}: {
+  personalizedDigest: UserPersonalizedDigest;
+  feature: PersonalizedDigestFeatureConfig;
+  logger: FastifyBaseLogger;
+}): Promise<FeedConfigName> => {
+  if (feature.feedConfig !== FeedConfigName.DigestCsV1) {
+    return feature.feedConfig as FeedConfigName;
+  }
+
+  try {
+    const profile = await personalizedDigestSnotraClient.getUserProfile({
+      user_id: personalizedDigest.userId,
+      providers: { personalise: {} },
+    });
+
+    return profile.personalise.state === PersonaliseState.NonPersonalised
+      ? FeedConfigName.DigestCsV1
+      : FeedConfigName.DigestV2;
+  } catch (err) {
+    logger.error(
+      { err, personalizedDigest },
+      'failed to fetch snotra user profile for digest, falling back to digest_v2',
+    );
+    return FeedConfigName.DigestV2;
+  }
+};
 
 export type DigestEmailPayloadResult = {
   emailPayload: SendEmailRequestWithTemplate;
@@ -319,6 +399,12 @@ export const getPersonalizedDigestEmailPayload = async ({
     );
   });
 
+  const feedConfigName = await resolveDigestFeedConfigName({
+    personalizedDigest,
+    feature,
+    logger,
+  });
+
   const feedConfigPayload = {
     user_id: personalizedDigest.userId,
     total_posts: feature.maxPosts,
@@ -327,7 +413,7 @@ export const getPersonalizedDigestEmailPayload = async ({
     allowed_tags: feedConfig.includeTags,
     blocked_tags: feedConfig.blockedTags,
     blocked_sources: feedConfig.excludeSources,
-    feed_config_name: feature.feedConfig as FeedConfigName,
+    feed_config_name: feedConfigName,
     source_types:
       baseFeedConfig.source_types?.filter(
         (el) => !feedConfig.excludeSourceTypes?.includes(el),

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -286,7 +286,7 @@ const personalizedDigestFeedClient = new FeedClient(
 );
 
 export const personalizedDigestSnotraClient = new SnotraClient(
-  process.env.SNOTRA_ORIGIN as string,
+  process.env.SNOTRA_USER_API_ORIGIN as string,
   {
     fetchOptions: {
       timeout: 10 * 1000,

--- a/src/common/personalizedDigest.ts
+++ b/src/common/personalizedDigest.ts
@@ -257,7 +257,7 @@ const personalizedDigestFeedClient = new FeedClient(
         queuedRequests: 1000,
       },
       retryOpts: {
-        maxAttempts: 1,
+        maxAttempts: 0,
       },
       events: {
         onBreak: ({ meta }) => {

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -47,6 +47,8 @@ export enum FeedConfigName {
   // currently used when sorting custom feed by other option then recommended
   CustomFeedNaV1 = 'custom_feed_na_v1',
   ForYouByDate = 'for_you_by_date',
+  DigestV2 = 'digest_v2',
+  DigestCsV1 = 'digest_cs_v1',
 }
 
 export type FeedProvider = {

--- a/src/integrations/retry.ts
+++ b/src/integrations/retry.ts
@@ -9,7 +9,7 @@ import {
   ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions';
 import { Message } from '@bufbuild/protobuf';
-import { isTest } from '../common';
+import { isTest } from '../common/utils';
 
 export class AbortError extends Error {
   public originalError: Error;

--- a/src/integrations/snotra/clients.ts
+++ b/src/integrations/snotra/clients.ts
@@ -1,8 +1,14 @@
 import { RequestInit } from 'node-fetch';
 import { GarmrNoopService, IGarmrService, GarmrService } from '../garmr';
 import { fetchOptions as globalFetchOptions } from '../../http';
-import { retryFetchParse } from '../retry';
-import { ISnotraClient, ProfileRequest, ProfileResponse } from './types';
+import { fetchParse } from '../retry';
+import {
+  ISnotraClient,
+  ProfileRequest,
+  ProfileResponse,
+  UserProfileRequest,
+  UserProfileResponse,
+} from './types';
 import {
   isMockEnabled,
   mockSnotraEngagementProfile,
@@ -35,8 +41,24 @@ export class SnotraClient implements ISnotraClient {
     }
 
     return this.garmr.execute(() => {
-      return retryFetchParse<ProfileResponse>(
+      return fetchParse<ProfileResponse>(
         `${this.url}/api/v1/memstore/shortprofile`,
+        {
+          ...this.fetchOptions,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(request),
+        },
+      );
+    });
+  }
+
+  getUserProfile(request: UserProfileRequest): Promise<UserProfileResponse> {
+    return this.garmr.execute(() => {
+      return fetchParse<UserProfileResponse>(
+        `${this.url}/api/v1/user/profile`,
         {
           ...this.fetchOptions,
           method: 'POST',

--- a/src/integrations/snotra/clients.ts
+++ b/src/integrations/snotra/clients.ts
@@ -1,7 +1,7 @@
 import { RequestInit } from 'node-fetch';
 import { GarmrNoopService, IGarmrService, GarmrService } from '../garmr';
 import { fetchOptions as globalFetchOptions } from '../../http';
-import { fetchParse } from '../retry';
+import { retryFetchParse } from '../retry';
 import {
   ISnotraClient,
   ProfileRequest,
@@ -12,6 +12,7 @@ import {
 import {
   isMockEnabled,
   mockSnotraEngagementProfile,
+  mockSnotraUserProfile,
 } from '../../mocks/opportunity/services';
 
 export class SnotraClient implements ISnotraClient {
@@ -41,7 +42,7 @@ export class SnotraClient implements ISnotraClient {
     }
 
     return this.garmr.execute(() => {
-      return fetchParse<ProfileResponse>(
+      return retryFetchParse<ProfileResponse>(
         `${this.url}/api/v1/memstore/shortprofile`,
         {
           ...this.fetchOptions,
@@ -56,8 +57,13 @@ export class SnotraClient implements ISnotraClient {
   }
 
   getUserProfile(request: UserProfileRequest): Promise<UserProfileResponse> {
+    // Mock path: return mock user profile
+    if (isMockEnabled()) {
+      return Promise.resolve(mockSnotraUserProfile);
+    }
+
     return this.garmr.execute(() => {
-      return fetchParse<UserProfileResponse>(
+      return retryFetchParse<UserProfileResponse>(
         `${this.url}/api/v1/user/profile`,
         {
           ...this.fetchOptions,

--- a/src/integrations/snotra/types.ts
+++ b/src/integrations/snotra/types.ts
@@ -1,13 +1,32 @@
 // Keep the type flexible to allow for future changes
-export interface ProfileRequest {
+export type ProfileRequest = {
   user_id: string;
-}
+};
 
-export interface ProfileResponse {
+export type ProfileResponse = {
   profile_text: string;
   update_at: string;
+};
+
+export enum PersonaliseState {
+  Personalised = 'personalised',
+  NonPersonalised = 'non_personalised',
 }
+
+export type UserProfileRequest = {
+  user_id: string;
+  providers: {
+    personalise: Record<string, never>;
+  };
+};
+
+export type UserProfileResponse = {
+  personalise: {
+    state: PersonaliseState;
+  };
+};
 
 export interface ISnotraClient {
   getProfile(request: ProfileRequest): Promise<ProfileResponse>;
+  getUserProfile(request: UserProfileRequest): Promise<UserProfileResponse>;
 }

--- a/src/mocks/opportunity/services.ts
+++ b/src/mocks/opportunity/services.ts
@@ -9,6 +9,7 @@ import {
   SalaryPeriod,
   SeniorityLevel,
 } from '@dailydotdev/schema';
+import { PersonaliseState } from '../../integrations/snotra';
 
 /**
  * Check if external services should be mocked
@@ -122,4 +123,13 @@ export const mockSnotraEngagementProfile = {
   profile_text:
     'Active developer with strong engagement in React and TypeScript communities. Regular contributor to open source projects and frequent reader of frontend development content. Shows consistent interest in modern web technologies and best practices.',
   update_at: new Date().toISOString(),
+};
+
+/**
+ * Mock user profile returned from Snotra getUserProfile
+ */
+export const mockSnotraUserProfile = {
+  personalise: {
+    state: PersonaliseState.Personalised,
+  },
 };


### PR DESCRIPTION
Adds a `digest_cs_v1` experiment that switches the digest `feed_config_name` based on Snotra's personalisation signal.

- New `getUserProfile` on `SnotraClient` → `POST /api/v1/user/profile`
- New `personalizedDigestSnotraClient` (dedicated Garmr + metrics, matches the digest feed client)
- New `FeedConfigName.DigestV2` / `DigestCsV1`
- In `getPersonalizedDigestEmailPayload`: when `feature.feedConfig === 'digest_cs_v1'`, call Snotra and map `non_personalised → digest_cs_v1`, anything else (or error) → `digest_v2`. Otherwise passthrough.
