### PR TITLE
feat: widen HOT trending criteria

### DIFF
--- a/src/cron/updateTrending.ts
+++ b/src/cron/updateTrending.ts
@@ -20,9 +20,9 @@ from (
             and post."createdAt" <= timezone('utc', now()) - interval '30 minutes'
         group by "postId"
     ) res
-    where res."partial" != res."total" and res."total" >= 30 and (res."partial" * 1.0 / res."total") >= 0.55
+    where res."partial" != res."total" and res."total" >= 15 and (res."partial" * 1.0 / res."total") >= 0.55
     order by (res."partial" * 1.0 / res."total") desc
-    limit 3
+    limit 25
 ) as res
 where "post".id = res."postId"
 `);


### PR DESCRIPTION
## Summary
- Lower hourly view floor from 30 to 15 in `update-trending` cron.
- Raise top-N from 3 to 25.
- Keep "spiking" semantics (acceleration ratio unchanged).

Pairs with daily-apps PR `feat/hot-pill-copy-tier` which tiers the HOT pill tooltip copy so lower trending counts read well. Ship together.

## Test plan
- [x] `pnpm run lint` (0 warnings)
- [x] `pnpm run build` (clean)
- No existing tests for this cron; integration test is out of scope.

Made with [Cursor](https://cursor.com)