### PR TITLE
fix: dedupe major highlight tweets per post

### DIFF
--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -9,6 +9,8 @@ import { createMockLogger, expectSuccessfulTypedBackground } from '../helpers';
 
 const mockPostTweet = jest.fn();
 let con: DataSource;
+const clearMajorHighlightTweetLocks = () =>
+  deleteKeysByPattern('major-highlight:tweet:*');
 
 const createEvent = (
   overrides: Partial<{
@@ -43,10 +45,11 @@ describe('majorHighlightTweet worker', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockPostTweet.mockResolvedValue('tweet-id');
+    return clearMajorHighlightTweetLocks();
   });
 
   afterEach(async () => {
-    await deleteKeysByPattern('major-highlight:tweet:*');
+    await clearMajorHighlightTweetLocks();
   });
 
   it('should be registered', () => {

--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -1,7 +1,12 @@
 import { PubSub } from '@google-cloud/pubsub';
 import { type DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
-import { deleteKeysByPattern } from '../../src/redis';
+import {
+  deleteKeysByPattern,
+  ioRedisPool,
+  redisPubSub,
+  singleRedisClient,
+} from '../../src/redis';
 import worker from '../../src/workers/majorHighlightTweet';
 import { typedWorkers } from '../../src/workers';
 import { PostHighlightSignificance } from '../../src/entity/PostHighlight';
@@ -37,9 +42,23 @@ jest.mock('../../src/integrations/twitter/clients', () => ({
   }),
 }));
 
+jest.setTimeout(30000);
+
 describe('majorHighlightTweet worker', () => {
   beforeAll(async () => {
     con = await createOrGetConnection();
+  });
+
+  afterAll(async () => {
+    if (con?.isInitialized) {
+      await con.destroy();
+    }
+
+    singleRedisClient.disconnect();
+    redisPubSub.getPublisher().disconnect();
+    redisPubSub.getSubscriber().disconnect();
+    await redisPubSub.close();
+    await ioRedisPool.end();
   });
 
   beforeEach(() => {

--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -1,6 +1,7 @@
 import { PubSub } from '@google-cloud/pubsub';
 import { type DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
+import { deleteKeysByPattern } from '../../src/redis';
 import worker from '../../src/workers/majorHighlightTweet';
 import { typedWorkers } from '../../src/workers';
 import { PostHighlightSignificance } from '../../src/entity/PostHighlight';
@@ -44,6 +45,10 @@ describe('majorHighlightTweet worker', () => {
     mockPostTweet.mockResolvedValue('tweet-id');
   });
 
+  afterEach(async () => {
+    await deleteKeysByPattern('major-highlight:tweet:*');
+  });
+
   it('should be registered', () => {
     const registeredWorker = typedWorkers.find(
       (item) => item.subscription === worker.subscription,
@@ -80,6 +85,56 @@ describe('majorHighlightTweet worker', () => {
 
     expect(mockPostTweet).toHaveBeenCalledWith({
       text: 'BREAKING: Major highlight headline',
+    });
+  });
+
+  it('should publish only one tweet for multiple highlights on the same post', async () => {
+    const postId = 'post-dedup';
+
+    await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
+      worker,
+      createEvent({
+        highlightId: 'highlight-dedup-1',
+        postId,
+        headline: 'First highlight headline',
+      }),
+    );
+
+    await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
+      worker,
+      createEvent({
+        highlightId: 'highlight-dedup-2',
+        channel: 'opensource',
+        postId,
+        headline: 'Second highlight headline',
+      }),
+    );
+
+    expect(mockPostTweet).toHaveBeenCalledTimes(1);
+    expect(mockPostTweet).toHaveBeenCalledWith({
+      text: 'BREAKING: First highlight headline',
+    });
+  });
+
+  it('should skip reprocessing the same highlight', async () => {
+    const event = createEvent({
+      highlightId: 'highlight-retry',
+      postId: 'post-retry',
+      headline: 'Retry highlight headline',
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
+      worker,
+      event,
+    );
+    await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
+      worker,
+      event,
+    );
+
+    expect(mockPostTweet).toHaveBeenCalledTimes(1);
+    expect(mockPostTweet).toHaveBeenCalledWith({
+      text: 'BREAKING: Retry highlight headline',
     });
   });
 
@@ -133,6 +188,7 @@ describe('majorHighlightTweet worker', () => {
     expect(logger.error).toHaveBeenCalledWith(
       {
         highlightId: 'highlight-error',
+        postId: 'post-error',
         messageId: 'msg',
         err: expect.any(Error),
       },

--- a/src/workers/majorHighlightTweet.ts
+++ b/src/workers/majorHighlightTweet.ts
@@ -13,7 +13,7 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
   subscription: 'api.major-highlight-tweet',
   parseMessage: (message) => PostHighlightedMessage.fromBinary(message.data),
   handler: async ({ data, messageId }, _con, logger): Promise<void> => {
-    const { highlightId, significance } = data;
+    const { highlightId, postId, significance } = data;
 
     if (
       significance !== PostHighlightSignificance.Breaking &&
@@ -30,14 +30,23 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
         lockTtlSeconds: MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS,
         doneTtlSeconds: MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS,
         execute: async () => {
-          const twitterClient = getTwitterClient();
+          await withRedisDoneLock({
+            doneKey: `major-highlight:tweet:post-done:${postId}`,
+            lockKey: `major-highlight:tweet:post-lock:${postId}`,
+            lockValue: messageId || highlightId,
+            lockTtlSeconds: MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS,
+            doneTtlSeconds: MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS,
+            execute: async () => {
+              const twitterClient = getTwitterClient();
 
-          if (!twitterClient) {
-            throw new Error('twitter client is not configured');
-          }
+              if (!twitterClient) {
+                throw new Error('twitter client is not configured');
+              }
 
-          await twitterClient.postTweet({
-            text: `${MAJOR_HIGHLIGHT_TWEET_PREFIX}${data.headline}`,
+              await twitterClient.postTweet({
+                text: `${MAJOR_HIGHLIGHT_TWEET_PREFIX}${data.headline}`,
+              });
+            },
           });
         },
       });
@@ -45,6 +54,7 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
       logger.error(
         {
           highlightId,
+          postId,
           messageId,
           err,
         },

--- a/src/workers/majorHighlightTweet.ts
+++ b/src/workers/majorHighlightTweet.ts
@@ -9,11 +9,31 @@ const MAJOR_HIGHLIGHT_TWEET_PREFIX = 'BREAKING: ';
 const MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS = 7 * ONE_DAY_IN_SECONDS;
 const MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS = 10 * ONE_MINUTE_IN_SECONDS;
 
+const withMajorHighlightTweetLock = ({
+  scope,
+  id,
+  lockValue,
+  execute,
+}: {
+  scope: 'highlight' | 'post';
+  id: string;
+  lockValue: string;
+  execute: () => Promise<void>;
+}) =>
+  withRedisDoneLock({
+    doneKey: `major-highlight:tweet:${scope}-done:${id}`,
+    lockKey: `major-highlight:tweet:${scope}-lock:${id}`,
+    lockValue,
+    lockTtlSeconds: MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS,
+    doneTtlSeconds: MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS,
+    execute,
+  });
+
 const worker: TypedWorker<'api.v1.post-highlighted'> = {
   subscription: 'api.major-highlight-tweet',
   parseMessage: (message) => PostHighlightedMessage.fromBinary(message.data),
   handler: async ({ data, messageId }, _con, logger): Promise<void> => {
-    const { highlightId, postId, significance } = data;
+    const { headline, highlightId, postId, significance } = data;
 
     if (
       significance !== PostHighlightSignificance.Breaking &&
@@ -23,19 +43,17 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
     }
 
     try {
-      await withRedisDoneLock({
-        doneKey: `major-highlight:tweet:done:${highlightId}`,
-        lockKey: `major-highlight:tweet:lock:${highlightId}`,
-        lockValue: messageId || highlightId,
-        lockTtlSeconds: MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS,
-        doneTtlSeconds: MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS,
+      const lockValue = messageId || highlightId;
+
+      await withMajorHighlightTweetLock({
+        scope: 'highlight',
+        id: highlightId,
+        lockValue,
         execute: async () => {
-          await withRedisDoneLock({
-            doneKey: `major-highlight:tweet:post-done:${postId}`,
-            lockKey: `major-highlight:tweet:post-lock:${postId}`,
-            lockValue: messageId || highlightId,
-            lockTtlSeconds: MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS,
-            doneTtlSeconds: MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS,
+          await withMajorHighlightTweetLock({
+            scope: 'post',
+            id: postId,
+            lockValue,
             execute: async () => {
               const twitterClient = getTwitterClient();
 
@@ -44,7 +62,7 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
               }
 
               await twitterClient.postTweet({
-                text: `${MAJOR_HIGHLIGHT_TWEET_PREFIX}${data.headline}`,
+                text: `${MAJOR_HIGHLIGHT_TWEET_PREFIX}${headline}`,
               });
             },
           });


### PR DESCRIPTION
## Summary
- add nested per-post Redis done/lock keys inside the existing per-highlight lock so only the first major or breaking highlight for a post publishes a tweet
- keep the existing per-highlight retry and redelivery dedup behavior, and add `postId` to the error log context for debugging
- extend the worker test coverage for same-post dedup and highlight retry dedup, and harden the test teardown so the suite closes its DB and Redis handles cleanly

## Notes
- the implementation keeps the highlight lock outermost so each highlight message is still marked done independently
- the per-post lock reuses the same 7-day done TTL and 10-minute lock TTL as the existing worker behavior

Closes ENG-1324

---
Created by Huginn 🐦‍⬛