### PR TITLE
feat: diversify highlight tweet prefixes

### DIFF
--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -121,7 +121,7 @@ describe('majorHighlightTweet worker', () => {
     );
 
     expect(mockPostTweet).toHaveBeenCalledWith({
-      text: 'URGENT: Breaking variant headline',
+      text: 'FLASH: Breaking variant headline',
     });
   });
 

--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -16,6 +16,7 @@ const mockPostTweet = jest.fn();
 let con: DataSource;
 const clearMajorHighlightTweetLocks = () =>
   deleteKeysByPattern('major-highlight:tweet:*');
+const mockMathRandom = jest.spyOn(Math, 'random');
 
 const createEvent = (
   overrides: Partial<{
@@ -63,12 +64,18 @@ describe('majorHighlightTweet worker', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    mockMathRandom.mockReturnValue(0);
     mockPostTweet.mockResolvedValue('tweet-id');
     return clearMajorHighlightTweetLocks();
   });
 
   afterEach(async () => {
+    mockMathRandom.mockReset();
     await clearMajorHighlightTweetLocks();
+  });
+
+  afterAll(() => {
+    mockMathRandom.mockRestore();
   });
 
   it('should be registered', () => {
@@ -106,7 +113,24 @@ describe('majorHighlightTweet worker', () => {
     );
 
     expect(mockPostTweet).toHaveBeenCalledWith({
-      text: 'BREAKING: Major highlight headline',
+      text: 'JUST IN: Major highlight headline',
+    });
+  });
+
+  it('should vary the prefix within the configured breaking options', async () => {
+    mockMathRandom.mockReturnValue(0.9);
+
+    await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
+      worker,
+      createEvent({
+        highlightId: 'highlight-breaking-variant',
+        postId: 'post-breaking-variant',
+        headline: 'Breaking variant headline',
+      }),
+    );
+
+    expect(mockPostTweet).toHaveBeenCalledWith({
+      text: 'URGENT: Breaking variant headline',
     });
   });
 

--- a/__tests__/workers/majorHighlightTweet.ts
+++ b/__tests__/workers/majorHighlightTweet.ts
@@ -16,7 +16,6 @@ const mockPostTweet = jest.fn();
 let con: DataSource;
 const clearMajorHighlightTweetLocks = () =>
   deleteKeysByPattern('major-highlight:tweet:*');
-const mockMathRandom = jest.spyOn(Math, 'random');
 
 const createEvent = (
   overrides: Partial<{
@@ -28,7 +27,7 @@ const createEvent = (
     highlightedAt: string;
   }> = {},
 ) => ({
-  highlightId: 'highlight-id',
+  highlightId: 'c',
   channel: 'ai',
   postId: 'post-id',
   headline: 'Highlight headline',
@@ -64,18 +63,12 @@ describe('majorHighlightTweet worker', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockMathRandom.mockReturnValue(0);
     mockPostTweet.mockResolvedValue('tweet-id');
     return clearMajorHighlightTweetLocks();
   });
 
   afterEach(async () => {
-    mockMathRandom.mockReset();
     await clearMajorHighlightTweetLocks();
-  });
-
-  afterAll(() => {
-    mockMathRandom.mockRestore();
   });
 
   it('should be registered', () => {
@@ -90,7 +83,7 @@ describe('majorHighlightTweet worker', () => {
     await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
       worker,
       createEvent({
-        highlightId: 'highlight-breaking',
+        highlightId: 'c',
         postId: 'post-breaking',
         headline: 'Breaking highlight headline',
       }),
@@ -105,7 +98,7 @@ describe('majorHighlightTweet worker', () => {
     await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
       worker,
       createEvent({
-        highlightId: 'highlight-major',
+        highlightId: 'c',
         postId: 'post-major',
         headline: 'Major highlight headline',
         significance: PostHighlightSignificance.Major,
@@ -118,12 +111,10 @@ describe('majorHighlightTweet worker', () => {
   });
 
   it('should vary the prefix within the configured breaking options', async () => {
-    mockMathRandom.mockReturnValue(0.9);
-
     await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
       worker,
       createEvent({
-        highlightId: 'highlight-breaking-variant',
+        highlightId: 'b',
         postId: 'post-breaking-variant',
         headline: 'Breaking variant headline',
       }),
@@ -140,7 +131,7 @@ describe('majorHighlightTweet worker', () => {
     await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
       worker,
       createEvent({
-        highlightId: 'highlight-dedup-1',
+        highlightId: 'c',
         postId,
         headline: 'First highlight headline',
       }),
@@ -164,7 +155,7 @@ describe('majorHighlightTweet worker', () => {
 
   it('should skip reprocessing the same highlight', async () => {
     const event = createEvent({
-      highlightId: 'highlight-retry',
+      highlightId: 'c',
       postId: 'post-retry',
       headline: 'Retry highlight headline',
     });
@@ -202,6 +193,7 @@ describe('majorHighlightTweet worker', () => {
     await expectSuccessfulTypedBackground<'api.v1.post-highlighted'>(
       worker,
       createEvent({
+        highlightId: 'c',
         headline: `  ${'a'.repeat(400)}  `,
       }),
     );
@@ -220,7 +212,7 @@ describe('majorHighlightTweet worker', () => {
         {
           messageId: 'msg',
           data: createEvent({
-            highlightId: 'highlight-error',
+            highlightId: 'c',
             postId: 'post-error',
             headline: 'Error highlight headline',
           }),
@@ -233,7 +225,7 @@ describe('majorHighlightTweet worker', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       {
-        highlightId: 'highlight-error',
+        highlightId: 'c',
         postId: 'post-error',
         messageId: 'msg',
         err: expect.any(Error),

--- a/src/workers/AGENTS.md
+++ b/src/workers/AGENTS.md
@@ -22,6 +22,8 @@ Use background workers when:
 4. **Heavy computations**: Image processing, data transformations, analytics calculations
 5. **Distributed transactions**: When you need to coordinate changes across multiple systems without blocking the primary transaction
 
+When worker behavior includes user-facing copy variants, prefer deterministic selection derived from stable message data over runtime randomness. Retryable workers should produce the same external side effects for the same logical event so retries stay idempotent and tests do not depend on global random state.
+
 ### Examples of Worker Use Cases
 
 - Sending notifications (email, push, real-time)

--- a/src/workers/majorHighlightTweet.ts
+++ b/src/workers/majorHighlightTweet.ts
@@ -5,9 +5,26 @@ import { getTwitterClient } from '../integrations/twitter/clients';
 import { withRedisDoneLock } from './withRedisDoneLock';
 import type { TypedWorker } from './worker';
 
-const MAJOR_HIGHLIGHT_TWEET_PREFIX = 'BREAKING: ';
+const HIGHLIGHT_TWEET_PREFIXES: Record<
+  PostHighlightSignificance.Breaking | PostHighlightSignificance.Major,
+  string[]
+> = {
+  [PostHighlightSignificance.Breaking]: ['BREAKING', 'ALERT', 'URGENT'],
+  [PostHighlightSignificance.Major]: ['JUST IN', 'NOW', 'UPDATE'],
+};
 const MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS = 7 * ONE_DAY_IN_SECONDS;
 const MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS = 10 * ONE_MINUTE_IN_SECONDS;
+
+const getHighlightTweetPrefix = (
+  significance:
+    | PostHighlightSignificance.Breaking
+    | PostHighlightSignificance.Major,
+): string => {
+  const prefixes = HIGHLIGHT_TWEET_PREFIXES[significance];
+  const index = Math.floor(Math.random() * prefixes.length);
+
+  return `${prefixes[index]}: `;
+};
 
 const withMajorHighlightTweetLock = ({
   scope,
@@ -62,7 +79,7 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
               }
 
               await twitterClient.postTweet({
-                text: `${MAJOR_HIGHLIGHT_TWEET_PREFIX}${headline}`,
+                text: `${getHighlightTweetPrefix(significance)}${headline}`,
               });
             },
           });

--- a/src/workers/majorHighlightTweet.ts
+++ b/src/workers/majorHighlightTweet.ts
@@ -16,12 +16,17 @@ const MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS = 7 * ONE_DAY_IN_SECONDS;
 const MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS = 10 * ONE_MINUTE_IN_SECONDS;
 
 const getHighlightTweetPrefix = (
+  highlightId: string,
   significance:
     | PostHighlightSignificance.Breaking
     | PostHighlightSignificance.Major,
 ): string => {
   const prefixes = HIGHLIGHT_TWEET_PREFIXES[significance];
-  const index = Math.floor(Math.random() * prefixes.length);
+  const seed = [...highlightId].reduce(
+    (total, character) => total + character.charCodeAt(0),
+    0,
+  );
+  const index = seed % prefixes.length;
 
   return `${prefixes[index]}: `;
 };
@@ -79,7 +84,7 @@ const worker: TypedWorker<'api.v1.post-highlighted'> = {
               }
 
               await twitterClient.postTweet({
-                text: `${getHighlightTweetPrefix(significance)}${headline}`,
+                text: `${getHighlightTweetPrefix(highlightId, significance)}${headline}`,
               });
             },
           });

--- a/src/workers/majorHighlightTweet.ts
+++ b/src/workers/majorHighlightTweet.ts
@@ -9,8 +9,8 @@ const HIGHLIGHT_TWEET_PREFIXES: Record<
   PostHighlightSignificance.Breaking | PostHighlightSignificance.Major,
   string[]
 > = {
-  [PostHighlightSignificance.Breaking]: ['BREAKING', 'ALERT', 'URGENT'],
-  [PostHighlightSignificance.Major]: ['JUST IN', 'NOW', 'UPDATE'],
+  [PostHighlightSignificance.Breaking]: ['BREAKING', 'ALERT', 'FLASH'],
+  [PostHighlightSignificance.Major]: ['JUST IN', 'MAJOR', 'NEW'],
 };
 const MAJOR_HIGHLIGHT_TWEET_DONE_TTL_SECONDS = 7 * ONE_DAY_IN_SECONDS;
 const MAJOR_HIGHLIGHT_TWEET_LOCK_TTL_SECONDS = 10 * ONE_MINUTE_IN_SECONDS;


### PR DESCRIPTION
## Summary
- diversify highlight tweet prefixes for breaking and major highlights
- keep tweet deduplication behavior unchanged while varying copy by significance
- make prefix selection deterministic per highlight so retries stay stable and tests stay simple

## Verification
- ran focused eslint on the worker and its test
- ran a project TypeScript no-emit check
- ran the focused `majorHighlightTweet` Jest suite

Closes ENG-1326

---
Created by Huginn 🐦‍⬛