### PR TITLE
fix: return only live rooms from active query

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -269,7 +269,7 @@ describe('live rooms', () => {
     expect(rooms).toHaveLength(0);
   });
 
-  it('returns all active live rooms', async () => {
+  it('returns only live rooms', async () => {
     loggedUser = '1';
 
     await saveFixtures(con, LiveRoom, [
@@ -313,15 +313,6 @@ describe('live rooms', () => {
           host: {
             id: '2',
             username: 'tsahidaily',
-          },
-        },
-        {
-          id: '0d0bd25e-e1f9-4b7d-8ddb-82f11e882201',
-          topic: 'Created room',
-          status: 'created',
-          host: {
-            id: '1',
-            username: 'idoshamun',
           },
         },
       ],

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -25,8 +25,6 @@ type GQLLiveRoomJoinToken = {
   token: string;
 };
 
-const activeLiveRoomStatuses = [LiveRoomStatus.Created, LiveRoomStatus.Live];
-
 export const typeDefs = /* GraphQL */ `
   ${toGQLEnum(LiveRoomMode, 'LiveRoomMode')}
   ${toGQLEnum(LiveRoomStatus, 'LiveRoomStatus')}
@@ -167,8 +165,8 @@ export const resolvers: IResolvers = {
         info,
         (builder) => {
           builder.queryBuilder
-            .where(`"${builder.alias}"."status" IN (:...statuses)`, {
-              statuses: activeLiveRoomStatuses,
+            .where(`"${builder.alias}"."status" = :status`, {
+              status: LiveRoomStatus.Live,
             })
             .orderBy(`"${builder.alias}"."createdAt"`, 'DESC');
           return builder;


### PR DESCRIPTION
## Summary
- restrict `activeLiveRooms` to rooms with `status = live`
- remove the broader active-status filter that also included pre-live rooms
- tighten the integration test to prove `created` rooms are excluded

## Root cause
The resolver reused an "active" status set containing both `created` and `live`, so rooms that had only been prepared were returned by the live-room listing.

## Validation
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
