### PR TITLE
fix: use showAt as notification timestamp for scheduled notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ The migration generator compares entities against the local database schema. Ens
 
 **After generating a migration, use the `/format-migration` skill** to format the SQL code for readability and consistency. This skill ensures proper SQL formatting with multi-line queries, correct constraint placement, and index handling best practices.
 
+**Migration SQL best practices:**
+- **Never use `CONCURRENTLY`** in migrations — TypeORM runs migrations inside a transaction, and `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` cannot run inside a transaction.
+- **Always use `IF NOT EXISTS`** for `CREATE INDEX` and **`IF EXISTS`** for `DROP INDEX` to make migrations idempotent and safe to re-run.
+
 **Building & Testing:**
 
 - `pnpm run build` - Compile TypeScript to build directory

--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -28,7 +28,7 @@ import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { usersFixture } from './fixture/user';
 import { notificationV2Fixture } from './fixture/notifications';
-import { addDays, subDays } from 'date-fns';
+import { addDays, subDays, subHours } from 'date-fns';
 import request from 'supertest';
 import { FastifyInstance } from 'fastify';
 import {
@@ -489,6 +489,46 @@ describe('query notifications', () => {
     expect(titles).toContain('visible');
     expect(titles).toContain('past showAt');
     expect(titles).not.toContain('future');
+  });
+
+  it('should return showAt as createdAt for scheduled notifications', async () => {
+    loggedUser = '1';
+    const showAt = subHours(new Date(), 1);
+    const notifs = await con
+      .getRepository(NotificationV2)
+      .save([{ ...notificationV2Fixture }]);
+    await con.getRepository(UserNotification).insert([
+      {
+        userId: '1',
+        notificationId: notifs[0].id,
+        createdAt: subHours(showAt, 2),
+        showAt,
+      },
+    ]);
+    const res = await client.query(QUERY);
+    const edges = res.data.notifications.edges;
+    expect(edges).toHaveLength(1);
+    expect(new Date(edges[0].node.createdAt).getTime()).toBe(showAt.getTime());
+  });
+
+  it('should return original createdAt when showAt is null', async () => {
+    loggedUser = '1';
+    const notifs = await con
+      .getRepository(NotificationV2)
+      .save([{ ...notificationV2Fixture }]);
+    await con.getRepository(UserNotification).insert([
+      {
+        userId: '1',
+        notificationId: notifs[0].id,
+        createdAt: notificationV2Fixture.createdAt,
+      },
+    ]);
+    const res = await client.query(QUERY);
+    const edges = res.data.notifications.edges;
+    expect(edges).toHaveLength(1);
+    expect(new Date(edges[0].node.createdAt).getTime()).toBe(
+      new Date(notificationV2Fixture.createdAt).getTime(),
+    );
   });
 });
 

--- a/__tests__/notifications.ts
+++ b/__tests__/notifications.ts
@@ -511,6 +511,33 @@ describe('query notifications', () => {
     expect(new Date(edges[0].node.createdAt).getTime()).toBe(showAt.getTime());
   });
 
+  it('should order notifications by effective timestamp using showAt', async () => {
+    loggedUser = '1';
+    const now = new Date();
+    const notifs = await con.getRepository(NotificationV2).save([
+      { ...notificationV2Fixture, title: 'scheduled' },
+      { ...notificationV2Fixture, uniqueKey: '2', title: 'regular' },
+    ]);
+    await con.getRepository(UserNotification).insert([
+      {
+        userId: '1',
+        notificationId: notifs[0].id,
+        createdAt: subHours(now, 3),
+        showAt: subHours(now, 1),
+      },
+      {
+        userId: '1',
+        notificationId: notifs[1].id,
+        createdAt: subHours(now, 2),
+      },
+    ]);
+    const res = await client.query(QUERY);
+    const titles = res.data.notifications.edges.map(
+      (e: { node: { title: string } }) => e.node.title,
+    );
+    expect(titles).toEqual(['scheduled', 'regular']);
+  });
+
   it('should return original createdAt when showAt is null', async () => {
     loggedUser = '1';
     const notifs = await con

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1302,6 +1302,10 @@ const obj = new GraphORM({
         )
         .addSelect('un."readAt"'),
     fields: {
+      createdAt: {
+        rawSelect: true,
+        select: () => `COALESCE(un."showAt", un."createdAt")`,
+      },
       avatars: {
         relation: {
           isMany: true,

--- a/src/migration/1777380340090-UserNotificationEffectiveCreatedAt.ts
+++ b/src/migration/1777380340090-UserNotificationEffectiveCreatedAt.ts
@@ -7,7 +7,7 @@ export class UserNotificationEffectiveCreatedAt1777380340090
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(/* sql */ `
-      CREATE INDEX CONCURRENTLY
+      CREATE INDEX IF NOT EXISTS
         "IDX_user_notification_user_public_effective_created"
       ON "user_notification" (
         "userId",
@@ -19,7 +19,7 @@ export class UserNotificationEffectiveCreatedAt1777380340090
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(/* sql */ `
-      DROP INDEX CONCURRENTLY
+      DROP INDEX IF EXISTS
         "IDX_user_notification_user_public_effective_created"
     `);
   }

--- a/src/migration/1777380340090-UserNotificationEffectiveCreatedAt.ts
+++ b/src/migration/1777380340090-UserNotificationEffectiveCreatedAt.ts
@@ -1,0 +1,26 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserNotificationEffectiveCreatedAt1777380340090
+  implements MigrationInterface
+{
+  name = 'UserNotificationEffectiveCreatedAt1777380340090';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX CONCURRENTLY
+        "IDX_user_notification_user_public_effective_created"
+      ON "user_notification" (
+        "userId",
+        "public",
+        (COALESCE("showAt", "createdAt")) DESC
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP INDEX CONCURRENTLY
+        "IDX_user_notification_user_public_effective_created"
+    `);
+  }
+}

--- a/src/schema/notifications.ts
+++ b/src/schema/notifications.ts
@@ -377,12 +377,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             .andWhere(`un."userId" = :user`, { user: ctx.userId })
             .andWhere(`un."public" = true`)
             .andWhere(`(un."showAt" IS NULL OR un."showAt" <= NOW())`)
-            .addOrderBy(`un."createdAt"`, 'DESC');
+            .addOrderBy(`COALESCE(un."showAt", un."createdAt")`, 'DESC');
 
           builder.queryBuilder.limit(page.limit);
           if (page.timestamp) {
             builder.queryBuilder = builder.queryBuilder.andWhere(
-              `${builder.alias}."createdAt" < :timestamp`,
+              `COALESCE(un."showAt", un."createdAt") < :timestamp`,
               { timestamp: page.timestamp },
             );
           }


### PR DESCRIPTION
## Summary

- Override `Notification.createdAt` in GraphORM to use `COALESCE(un."showAt", un."createdAt")`, so scheduled notifications (e.g., daily brief) display the delivery time instead of the record creation time
- Update `ORDER BY` and cursor pagination `WHERE` clause to use the same COALESCE expression for consistent ordering
- Add expression index `IDX_user_notification_user_public_effective_created` to efficiently serve the new ordering

## Test plan

- [x] New test: `should return showAt as createdAt for scheduled notifications` — verifies `createdAt` matches `showAt` when set
- [x] New test: `should return original createdAt when showAt is null` — verifies no behavior change for non-scheduled notifications
- [x] Existing `should hide notifications with future showAt` still passes
- [x] All 56 notification tests pass
- [x] Build and lint clean

Closes ENG-1267

---
Created by Huginn 🐦‍⬛