### PR TITLE
feat: expose anonymous live room join tokens

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -11,7 +11,6 @@ import {
   MockContext,
   saveFixtures,
   testMutationErrorCode,
-  testQueryErrorCode,
 } from './helpers';
 import { usersFixture } from './fixture/user';
 import { User } from '../src/entity/user/User';
@@ -24,6 +23,7 @@ let con: DataSource;
 let state: GraphQLTestingState;
 let client: GraphQLTestClient;
 let loggedUser: string | null = null;
+let loggedTrackingId: string | undefined = undefined;
 
 beforeAll(async () => {
   process.env.FLYTING_JOIN_TOKEN_SECRET = 'flyting-join-secret';
@@ -32,7 +32,17 @@ beforeAll(async () => {
 
   con = await createOrGetConnection();
   state = await initializeGraphQLTesting(
-    () => new MockContext(con, loggedUser),
+    () =>
+      new MockContext(
+        con,
+        loggedUser,
+        [],
+        undefined,
+        false,
+        false,
+        '',
+        loggedTrackingId,
+      ),
   );
   client = state.client;
 });
@@ -44,6 +54,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   loggedUser = null;
+  loggedTrackingId = undefined;
   nock.cleanAll();
   await saveFixtures(con, User, usersFixture);
 });
@@ -270,8 +281,6 @@ describe('live rooms', () => {
   });
 
   it('returns only live rooms', async () => {
-    loggedUser = '1';
-
     await saveFixtures(con, LiveRoom, [
       {
         id: '0d0bd25e-e1f9-4b7d-8ddb-82f11e882201',
@@ -363,10 +372,60 @@ describe('live rooms', () => {
     );
 
     expect(verified).toMatchObject({
+      authKind: 'authenticated',
       iat: expect.any(Number),
       participantId: '1',
       role: 'host',
       roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
+    });
+  });
+
+  it('returns an anonymous join token for a live room using trackingId identity', async () => {
+    loggedTrackingId = 'tracking-anon-1';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        hostId: '1',
+        topic: 'Live room',
+        mode: 'debate',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T11:00:00.000Z'),
+      },
+    ]);
+
+    const res = await client.mutate(JOIN_TOKEN_MUTATION, {
+      variables: {
+        roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.liveRoomJoinToken).toMatchObject({
+      role: 'audience',
+      room: {
+        id: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        topic: 'Live room',
+        status: 'live',
+      },
+    });
+
+    const verified = jwt.verify(
+      res.data.liveRoomJoinToken.token,
+      'flyting-join-secret',
+      {
+        algorithms: ['HS256'],
+        audience: 'flyting',
+        issuer: 'daily-api',
+      },
+    );
+
+    expect(verified).toMatchObject({
+      authKind: 'anonymous',
+      iat: expect.any(Number),
+      participantId: 'tracking-anon-1',
+      role: 'audience',
+      roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
     });
   });
 
@@ -394,6 +453,32 @@ describe('live rooms', () => {
       },
       'GRAPHQL_VALIDATION_FAILED',
       'Cannot join an ended live room',
+    );
+  });
+
+  it('rejects anonymous join tokens for rooms that are not live yet', async () => {
+    loggedTrackingId = 'tracking-anon-1';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: 'b14bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        hostId: '1',
+        topic: 'Created room',
+        mode: 'debate',
+        status: LiveRoomStatus.Created,
+      },
+    ]);
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: JOIN_TOKEN_MUTATION,
+        variables: {
+          roomId: 'b14bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+      'Anonymous viewers can only join live rooms',
     );
   });
 
@@ -493,15 +578,38 @@ describe('live rooms', () => {
     });
   });
 
-  it('requires authentication to query a room', () =>
-    testQueryErrorCode(
-      client,
+  it('returns a live room by id for an anonymous caller', async () => {
+    loggedTrackingId = 'tracking-anon-1';
+
+    await saveFixtures(con, LiveRoom, [
       {
-        query: GET_QUERY,
-        variables: {
-          id: '42e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        id: '52e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        hostId: '2',
+        topic: 'Public live room',
+        mode: 'debate',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T11:00:00.000Z'),
+      },
+    ]);
+
+    const res = await client.query(GET_QUERY, {
+      variables: {
+        id: '52e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      liveRoom: {
+        id: '52e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        topic: 'Public live room',
+        mode: 'debate',
+        status: 'live',
+        host: {
+          id: '2',
+          username: 'tsahidaily',
         },
       },
-      'UNAUTHENTICATED',
-    ));
+    });
+  });
 });

--- a/src/common/liveRoom/token.ts
+++ b/src/common/liveRoom/token.ts
@@ -11,6 +11,7 @@ export const DEFAULT_LIVE_ROOM_JOIN_TOKEN_TTL_SECONDS =
 export const createLiveRoomJoinToken = async (input: {
   participantId: string;
   role: LiveRoomParticipantRole;
+  authKind?: 'authenticated' | 'anonymous';
   roomId: string;
   audience?: string;
   expiresInSeconds?: number;
@@ -26,6 +27,7 @@ export const createLiveRoomJoinToken = async (input: {
       jti: randomUUID(),
       participantId: input.participantId,
       role: input.role,
+      authKind: input.authKind ?? 'authenticated',
       roomId: input.roomId,
     },
     input.secret,

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -1,6 +1,6 @@
 import type { IResolvers } from '@graphql-tools/utils';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
-import type { AuthContext } from '../Context';
+import type { Context } from '../Context';
 import { toGQLEnum } from '../common';
 import { createLiveRoomJoinToken } from '../common/liveRoom/token';
 import {
@@ -54,14 +54,14 @@ export const typeDefs = /* GraphQL */ `
   }
 
   extend type Query {
-    liveRoom(id: ID!): LiveRoom @auth
-    activeLiveRooms: [LiveRoom!]! @auth
+    liveRoom(id: ID!): LiveRoom
+    activeLiveRooms: [LiveRoom!]!
   }
 
   extend type Mutation {
     createLiveRoom(input: CreateLiveRoomInput!): LiveRoomJoinToken! @auth
     endLiveRoom(roomId: ID!): LiveRoom! @auth
-    liveRoomJoinToken(roomId: ID!): LiveRoomJoinToken! @auth
+    liveRoomJoinToken(roomId: ID!): LiveRoomJoinToken!
   }
 `;
 
@@ -82,7 +82,7 @@ const getRoomOrThrow = async ({
   ctx,
 }: {
   roomId: string;
-  ctx: AuthContext;
+  ctx: Context;
 }): Promise<LiveRoom> => {
   const room = await ctx.con.getRepository(LiveRoom).findOneBy({ id: roomId });
 
@@ -97,7 +97,7 @@ const assertCanEndRoom = ({
   ctx,
   room,
 }: {
-  ctx: AuthContext;
+  ctx: Context;
   room: LiveRoom;
 }): void => {
   if (room.hostId === ctx.userId || ctx.roles.includes(Roles.Moderator)) {
@@ -108,10 +108,12 @@ const assertCanEndRoom = ({
 };
 
 const createJoinTokenPayload = async ({
+  authKind,
   room,
   participantId,
   role,
 }: {
+  authKind: 'anonymous' | 'authenticated';
   room: LiveRoom;
   participantId: string;
   role: LiveRoomParticipantRole;
@@ -122,6 +124,7 @@ const createJoinTokenPayload = async ({
   }
 
   const token = await createLiveRoomJoinToken({
+    authKind,
     participantId,
     role,
     roomId: room.id,
@@ -135,12 +138,20 @@ const createJoinTokenPayload = async ({
   };
 };
 
+const getJoinParticipantId = (ctx: Context): string => {
+  if (!ctx.trackingId) {
+    throw new ValidationError('Tracking ID is required to join a live room');
+  }
+
+  return ctx.trackingId;
+};
+
 export const resolvers: IResolvers = {
   Query: {
     liveRoom: async (
       _,
       args: { id: string },
-      ctx: AuthContext,
+      ctx: Context,
       info,
     ): Promise<GQLLiveRoom> =>
       graphorm.queryOneOrFail<GQLLiveRoom>(
@@ -150,6 +161,11 @@ export const resolvers: IResolvers = {
           builder.queryBuilder.where(`"${builder.alias}"."id" = :id`, {
             id: args.id,
           });
+          if (!ctx.userId) {
+            builder.queryBuilder.andWhere(`"${builder.alias}"."status" = :status`, {
+              status: LiveRoomStatus.Live,
+            });
+          }
           return builder;
         },
         LiveRoom,
@@ -157,7 +173,7 @@ export const resolvers: IResolvers = {
     activeLiveRooms: async (
       _,
       __,
-      ctx: AuthContext,
+      ctx: Context,
       info,
     ): Promise<GQLLiveRoom[]> =>
       graphorm.query<GQLLiveRoom>(
@@ -178,7 +194,7 @@ export const resolvers: IResolvers = {
     createLiveRoom: async (
       _,
       args: { input: { mode: LiveRoomMode; topic: string } },
-      ctx: AuthContext,
+      ctx: Context,
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = createLiveRoomSchema.parse(args.input);
       const roomRepo = ctx.con.getRepository(LiveRoom);
@@ -204,15 +220,16 @@ export const resolvers: IResolvers = {
       }
 
       return createJoinTokenPayload({
+        authKind: 'authenticated',
         room,
-        participantId: ctx.userId,
+        participantId: getJoinParticipantId(ctx),
         role: LiveRoomParticipantRole.Host,
       });
     },
     endLiveRoom: async (
       _,
       args: { roomId: string },
-      ctx: AuthContext,
+      ctx: Context,
       info,
     ): Promise<GQLLiveRoom> => {
       const input = liveRoomIdInputSchema.parse(args);
@@ -249,7 +266,7 @@ export const resolvers: IResolvers = {
     liveRoomJoinToken: async (
       _,
       args: { roomId: string },
-      ctx: AuthContext,
+      ctx: Context,
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = liveRoomIdInputSchema.parse(args);
       const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
@@ -258,9 +275,9 @@ export const resolvers: IResolvers = {
         throw new ValidationError('Cannot join an ended live room');
       }
 
-      const secret = process.env.FLYTING_JOIN_TOKEN_SECRET;
-      if (!secret) {
-        throw new Error('FLYTING_JOIN_TOKEN_SECRET is not configured');
+      const authKind = ctx.userId ? 'authenticated' : 'anonymous';
+      if (authKind === 'anonymous' && room.status !== LiveRoomStatus.Live) {
+        throw new ValidationError('Anonymous viewers can only join live rooms');
       }
 
       const role =
@@ -269,8 +286,9 @@ export const resolvers: IResolvers = {
           : LiveRoomParticipantRole.Audience;
 
       return createJoinTokenPayload({
+        authKind,
         room,
-        participantId: ctx.userId,
+        participantId: getJoinParticipantId(ctx),
         role,
       });
     },

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -162,9 +162,12 @@ export const resolvers: IResolvers = {
             id: args.id,
           });
           if (!ctx.userId) {
-            builder.queryBuilder.andWhere(`"${builder.alias}"."status" = :status`, {
-              status: LiveRoomStatus.Live,
-            });
+            builder.queryBuilder.andWhere(
+              `"${builder.alias}"."status" = :status`,
+              {
+                status: LiveRoomStatus.Live,
+              },
+            );
           }
           return builder;
         },


### PR DESCRIPTION
## Summary
- make live-room read and join-token access available to anonymous viewers for live sessions
- issue join tokens keyed by trackingId with explicit anonymous/authenticated authKind claims
- keep coverage repo-local with live room schema tests and typecheck verification

## Testing
- pnpm jest __tests__/liveRooms.ts --runInBand
- pnpm exec tsc --noEmit