### PR TITLE
fix: deny join tokens for kicked live room participants

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -378,6 +378,17 @@ describe('live rooms', () => {
       },
     ]);
 
+    const scope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/f44bb4ae-a0af-4310-b1ff-7d6345cb5253/participants/1/join-eligibility',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        participantId: '1',
+        canJoin: true,
+      });
+
     const res = await client.mutate(JOIN_TOKEN_MUTATION, {
       variables: {
         roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
@@ -415,6 +426,7 @@ describe('live rooms', () => {
       role: 'host',
       roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
     });
+    expect(scope.isDone()).toBe(true);
   });
 
   it('returns an anonymous join token for a live room using trackingId identity', async () => {
@@ -430,6 +442,17 @@ describe('live rooms', () => {
         startedAt: new Date('2026-04-23T11:00:00.000Z'),
       },
     ]);
+
+    const scope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/aa4bb4ae-a0af-4310-b1ff-7d6345cb5253/participants/tracking-anon-1/join-eligibility',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        participantId: 'tracking-anon-1',
+        canJoin: true,
+      });
 
     const res = await client.mutate(JOIN_TOKEN_MUTATION, {
       variables: {
@@ -464,6 +487,7 @@ describe('live rooms', () => {
       role: 'audience',
       roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
     });
+    expect(scope.isDone()).toBe(true);
   });
 
   it('rejects join tokens for ended rooms', async () => {
@@ -517,6 +541,47 @@ describe('live rooms', () => {
       'GRAPHQL_VALIDATION_FAILED',
       'Anonymous viewers can only join live rooms',
     );
+  });
+
+  it('rejects join tokens when flyting reports that the participant was kicked from the room', async () => {
+    loggedTrackingId = 'tracking-kicked-1';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: 'c14bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        hostId: '1',
+        topic: 'Blocked room',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T11:00:00.000Z'),
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/c14bb4ae-a0af-4310-b1ff-7d6345cb5253/participants/tracking-kicked-1/join-eligibility',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: 'c14bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        participantId: 'tracking-kicked-1',
+        canJoin: false,
+        reason: 'kicked',
+      });
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: JOIN_TOKEN_MUTATION,
+        variables: {
+          roomId: 'c14bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+      'You have been removed from this live room',
+    );
+
+    expect(scope.isDone()).toBe(true);
   });
 
   it('ends a live room for the host', async () => {

--- a/src/integrations/flyting/client.ts
+++ b/src/integrations/flyting/client.ts
@@ -81,6 +81,37 @@ export class FlytingClient {
       }
     });
   }
+
+  async getJoinEligibility(input: {
+    participantId: string;
+    roomId: string;
+  }): Promise<{
+    canJoin: boolean;
+    participantId: string;
+    reason?: 'kicked';
+    roomId: string;
+  }> {
+    return this.garmr.execute(async () => {
+      const response = await retryFetch(
+        `${this.url}/internal/live-rooms/${encodeURIComponent(
+          input.roomId,
+        )}/participants/${encodeURIComponent(input.participantId)}/join-eligibility`,
+        {
+          ...this.fetchOptions,
+          method: 'GET',
+          headers: {
+            'x-flyting-internal-key': this.internalApiKey,
+          },
+        },
+      );
+
+      if (response.ok) {
+        return response.json();
+      }
+
+      throw new HttpError(response.url, response.status, await response.text());
+    });
+  }
 }
 
 const garmrFlytingService = new GarmrService({

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -146,6 +146,29 @@ const getJoinParticipantId = (ctx: Context): string => {
   return ctx.trackingId;
 };
 
+const assertJoinAllowedByFlyting = async ({
+  participantId,
+  roomId,
+}: {
+  participantId: string;
+  roomId: string;
+}): Promise<void> => {
+  const eligibility = await getFlytingClient().getJoinEligibility({
+    participantId,
+    roomId,
+  });
+
+  if (eligibility.canJoin) {
+    return;
+  }
+
+  if (eligibility.reason === 'kicked') {
+    throw new ValidationError('You have been removed from this live room');
+  }
+
+  throw new ValidationError('Cannot join this live room');
+};
+
 export const resolvers: IResolvers = {
   Query: {
     liveRoom: async (
@@ -287,11 +310,17 @@ export const resolvers: IResolvers = {
         room.hostId === ctx.userId
           ? LiveRoomParticipantRole.Host
           : LiveRoomParticipantRole.Audience;
+      const participantId = getJoinParticipantId(ctx);
+
+      await assertJoinAllowedByFlyting({
+        participantId,
+        roomId: room.id,
+      });
 
       return createJoinTokenPayload({
         authKind,
         room,
-        participantId: getJoinParticipantId(ctx),
+        participantId,
         role,
       });
     },


### PR DESCRIPTION
## What changed
- call Flyting before minting a live-room join token to confirm the participant can still join
- return a validation error when Flyting reports the participant was kicked from that room
- update live-room resolver coverage for allowed and denied token issuance paths

## Why
Flyting now retains room-lifetime kicked-participant state, but daily-api also needs to stop issuing fresh join tokens for those participants. Without this check, a kicked participant could still request a new token and hit Flyting again.

## Impact
Join-token issuance now respects Flyting's room-authoritative kicked state. This is the daily-api half of the cross-repo change; the companion Flyting PR adds the persisted kicked state and internal eligibility endpoint.

## Validation
- `pnpm exec jest --testEnvironment=node --runInBand __tests__/liveRooms.ts`
