### PR TITLE
feat: support configurable live room speaker limits

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -227,6 +227,7 @@ describe('live rooms', () => {
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
         mode: 'free_for_all',
+        speakerLimit: 6,
       })
       .matchHeader('x-flyting-internal-key', flytingInternalKey)
       .reply(200, { room: { roomId: 'ignored' } });
@@ -236,6 +237,7 @@ describe('live rooms', () => {
         input: {
           topic: 'Open mic architecture',
           mode: 'free_for_all',
+          speakerLimit: 6,
         },
       },
     });
@@ -253,6 +255,29 @@ describe('live rooms', () => {
 
     expect(room.mode).toBe('free_for_all');
     expect(scope.isDone()).toBe(true);
+  });
+
+  it('rejects speaker limits for moderated live rooms', async () => {
+    loggedUser = '1';
+    const scope = nock(flytingOrigin)
+      .post(/\/internal\/live-rooms\/[^/]+\/prepare/)
+      .reply(200, { room: { roomId: 'ignored' } });
+
+    const res = await client.mutate(CREATE_MUTATION, {
+      variables: {
+        input: {
+          topic: 'Strictly moderated',
+          mode: 'moderated',
+          speakerLimit: 3,
+        },
+      },
+    });
+
+    expect(res.errors?.[0]?.message).toBe('Validation error');
+    expect(scope.isDone()).toBe(false);
+    await expect(
+      con.getRepository(LiveRoom).findOneBy({ topic: 'Strictly moderated' }),
+    ).resolves.toBeNull();
   });
 
   it('keeps the durable room when prepare fails ambiguously', async () => {

--- a/src/common/schema/liveRooms.ts
+++ b/src/common/schema/liveRooms.ts
@@ -26,6 +26,11 @@ export const liveRoomModeSchema = z.enum(enumValues(LiveRoomMode), {
   error: 'Invalid live room mode',
 });
 
+export const liveRoomSpeakerLimitSchema = z
+  .number()
+  .int()
+  .positive('Speaker limit must be at least 1');
+
 export const liveRoomStatusSchema = z.enum(enumValues(LiveRoomStatus), {
   error: 'Invalid live room status',
 });
@@ -44,10 +49,24 @@ export const liveRoomLifecycleEventTypeSchema = z.enum(
   },
 );
 
-export const createLiveRoomSchema = z.object({
-  topic: z.string().trim().min(1).max(280),
-  mode: liveRoomModeSchema.default(LiveRoomMode.Moderated),
-});
+export const createLiveRoomSchema = z
+  .object({
+    topic: z.string().trim().min(1).max(280),
+    mode: liveRoomModeSchema.default(LiveRoomMode.Moderated),
+    speakerLimit: liveRoomSpeakerLimitSchema.optional(),
+  })
+  .superRefine((input, ctx) => {
+    if (
+      input.mode !== LiveRoomMode.FreeForAll &&
+      input.speakerLimit !== undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['speakerLimit'],
+        message: 'Speaker limit can only be set for free-for-all rooms',
+      });
+    }
+  });
 
 export const liveRoomIdSchema = z.uuid('Live room ID must be a valid UUID');
 

--- a/src/integrations/flyting/client.ts
+++ b/src/integrations/flyting/client.ts
@@ -28,6 +28,7 @@ export class FlytingClient {
   async prepareRoom(input: {
     mode: LiveRoomMode;
     roomId: string;
+    speakerLimit?: number;
   }): Promise<void> {
     await this.garmr.execute(async () => {
       const response = await retryFetch(
@@ -41,6 +42,7 @@ export class FlytingClient {
           },
           body: JSON.stringify({
             mode: input.mode,
+            speakerLimit: input.speakerLimit,
           }),
         },
       );

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -51,6 +51,7 @@ export const typeDefs = /* GraphQL */ `
   input CreateLiveRoomInput {
     topic: String!
     mode: LiveRoomMode = moderated
+    speakerLimit: Int
   }
 
   extend type Query {
@@ -219,7 +220,13 @@ export const resolvers: IResolvers = {
   Mutation: {
     createLiveRoom: async (
       _,
-      args: { input: { mode: LiveRoomMode; topic: string } },
+      args: {
+        input: {
+          mode: LiveRoomMode;
+          speakerLimit?: number;
+          topic: string;
+        };
+      },
       ctx: Context,
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = createLiveRoomSchema.parse(args.input);
@@ -237,6 +244,7 @@ export const resolvers: IResolvers = {
         await getFlytingClient().prepareRoom({
           mode: room.mode,
           roomId: room.id,
+          speakerLimit: input.speakerLimit,
         });
       } catch (error) {
         if (shouldDeleteRoomAfterPrepareFailure(error)) {


### PR DESCRIPTION
## What changed
- added an optional `speakerLimit` field to `CreateLiveRoomInput`
- validated that only `free_for_all` rooms may set it
- forwarded the value to Flyting during room preparation
- added regression coverage to prove invalid moderated requests fail before persistence

## Why
The live-room create flow previously hard-coded the free-for-all speaker cap downstream. This makes the cap configurable at room creation while keeping the existing default behavior when the caller omits the value.

## Impact
Hosts can choose the free-for-all stage capacity when opening a room, and invalid combinations are rejected before a room is saved or prepared.

## Root cause
The speaker cap lived only as a fixed runtime default in Flyting, so daily-api had no way to carry a caller-selected limit into room setup.

## Validation
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
- `pnpm run build`
- `pnpm run lint`
