### PR TITLE
feat: expose live room participant counts

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -101,6 +101,7 @@ describe('live rooms', () => {
         topic
         mode
         status
+        participantCount
         host {
           id
           username
@@ -371,6 +372,20 @@ describe('live rooms', () => {
       },
     ]);
 
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['cc4f63c0-b26e-44fb-b9f8-4c977b28a123'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        rooms: [
+          {
+            roomId: 'cc4f63c0-b26e-44fb-b9f8-4c977b28a123',
+            participantCount: 7,
+          },
+        ],
+      });
+
     const res = await client.query(ACTIVE_QUERY);
 
     expect(res.errors).toBeFalsy();
@@ -381,6 +396,7 @@ describe('live rooms', () => {
           topic: 'Live room',
           mode: 'moderated',
           status: 'live',
+          participantCount: 7,
           host: {
             id: '2',
             username: 'tsahidaily',
@@ -388,6 +404,48 @@ describe('live rooms', () => {
         },
       ],
     });
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('keeps active live rooms visible when the batched count lookup fails', async () => {
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '7c4f63c0-b26e-44fb-b9f8-4c977b28a123',
+        hostId: '2',
+        topic: 'Live room without count',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T11:00:00.000Z'),
+        createdAt: new Date('2026-04-23T11:00:00.000Z'),
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['7c4f63c0-b26e-44fb-b9f8-4c977b28a123'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(500, { message: 'boom' });
+
+    const res = await client.query(ACTIVE_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      activeLiveRooms: [
+        {
+          id: '7c4f63c0-b26e-44fb-b9f8-4c977b28a123',
+          topic: 'Live room without count',
+          mode: 'moderated',
+          status: 'live',
+          participantCount: null,
+          host: {
+            id: '2',
+            username: 'tsahidaily',
+          },
+        },
+      ],
+    });
+    expect(scope.isDone()).toBe(true);
   });
 
   it('returns a join token for the host role', async () => {

--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -3,6 +3,7 @@ import nock from 'nock';
 import type { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { LiveRoom } from '../src/entity/LiveRoom';
+import { StorageKey, StorageTopic } from '../src/config';
 import {
   disposeGraphQLTesting,
   type GraphQLTestClient,
@@ -15,6 +16,7 @@ import {
 import { usersFixture } from './fixture/user';
 import { User } from '../src/entity/user/User';
 import { LiveRoomStatus } from '../src/common/schema/liveRooms';
+import { deleteKeysByPattern } from '../src/redis';
 
 const flytingOrigin = 'http://flyting.test';
 const flytingInternalKey = 'flyting-internal-key';
@@ -56,6 +58,9 @@ beforeEach(async () => {
   loggedUser = null;
   loggedTrackingId = undefined;
   nock.cleanAll();
+  await deleteKeysByPattern(
+    `${StorageTopic.LiveRoom}:${StorageKey.ParticipantCount}:*`,
+  );
   await saveFixtures(con, User, usersFixture);
 });
 
@@ -413,6 +418,79 @@ describe('live rooms', () => {
     expect(scope.isDone()).toBe(true);
   });
 
+  it('batches participant counts for active live rooms through the field resolver', async () => {
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '11111111-b26e-44fb-b9f8-4c977b28a123',
+        hostId: '1',
+        topic: 'Live room one',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T11:00:00.000Z'),
+        createdAt: new Date('2026-04-23T11:00:00.000Z'),
+      },
+      {
+        id: '22222222-b26e-44fb-b9f8-4c977b28a123',
+        hostId: '2',
+        topic: 'Live room two',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T12:00:00.000Z'),
+        createdAt: new Date('2026-04-23T12:00:00.000Z'),
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: [
+          '22222222-b26e-44fb-b9f8-4c977b28a123',
+          '11111111-b26e-44fb-b9f8-4c977b28a123',
+        ],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        rooms: [
+          {
+            roomId: '22222222-b26e-44fb-b9f8-4c977b28a123',
+            participantCount: 11,
+          },
+          {
+            roomId: '11111111-b26e-44fb-b9f8-4c977b28a123',
+            participantCount: 7,
+          },
+        ],
+      });
+
+    const res = await client.query(ACTIVE_QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.activeLiveRooms).toEqual([
+      {
+        id: '22222222-b26e-44fb-b9f8-4c977b28a123',
+        topic: 'Live room two',
+        mode: 'moderated',
+        status: 'live',
+        participantCount: 11,
+        host: {
+          id: '2',
+          username: 'tsahidaily',
+        },
+      },
+      {
+        id: '11111111-b26e-44fb-b9f8-4c977b28a123',
+        topic: 'Live room one',
+        mode: 'moderated',
+        status: 'live',
+        participantCount: 7,
+        host: {
+          id: '1',
+          username: 'idoshamun',
+        },
+      },
+    ]);
+    expect(scope.isDone()).toBe(true);
+  });
+
   it('keeps active live rooms visible when the batched count lookup fails', async () => {
     await saveFixtures(con, LiveRoom, [
       {
@@ -431,6 +509,7 @@ describe('live rooms', () => {
         roomIds: ['7c4f63c0-b26e-44fb-b9f8-4c977b28a123'],
       })
       .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .times(6)
       .reply(500, { message: 'boom' });
 
     const res = await client.query(ACTIVE_QUERY);
@@ -452,7 +531,7 @@ describe('live rooms', () => {
       ],
     });
     expect(scope.isDone()).toBe(true);
-  });
+  }, 10000);
 
   it('returns a join token for the host role', async () => {
     loggedUser = '1';
@@ -798,6 +877,52 @@ describe('live rooms', () => {
         },
       },
     });
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('caches live room participant counts across queries', async () => {
+    loggedUser = '1';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '62e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        hostId: '2',
+        topic: 'Cached room',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['62e45613-c9f8-4823-96cb-ebd6dcbbf4fe'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .once()
+      .reply(200, {
+        rooms: [
+          {
+            roomId: '62e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+            participantCount: 13,
+          },
+        ],
+      });
+
+    const first = await client.query(GET_QUERY, {
+      variables: {
+        id: '62e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+      },
+    });
+    const second = await client.query(GET_QUERY, {
+      variables: {
+        id: '62e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+      },
+    });
+
+    expect(first.errors).toBeFalsy();
+    expect(second.errors).toBeFalsy();
+    expect(first.data.liveRoom.participantCount).toBe(13);
+    expect(second.data.liveRoom.participantCount).toBe(13);
     expect(scope.isDone()).toBe(true);
   });
 

--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -70,6 +70,7 @@ describe('live rooms', () => {
           topic
           mode
           status
+          participantCount
           host {
             id
             username
@@ -86,6 +87,7 @@ describe('live rooms', () => {
         topic
         mode
         status
+        participantCount
         host {
           id
           username
@@ -120,6 +122,7 @@ describe('live rooms', () => {
           topic
           mode
           status
+          participantCount
           host {
             id
             username
@@ -135,6 +138,7 @@ describe('live rooms', () => {
         id
         status
         endedAt
+        participantCount
       }
     }
   `;
@@ -185,6 +189,7 @@ describe('live rooms', () => {
         topic: 'GraphQL and SFUs',
         mode: 'moderated',
         status: 'created',
+        participantCount: null,
         host: {
           id: '1',
           username: 'idoshamun',
@@ -248,6 +253,7 @@ describe('live rooms', () => {
       topic: 'Open mic architecture',
       mode: 'free_for_all',
       status: 'created',
+      participantCount: null,
     });
 
     const room = await con.getRepository(LiveRoom).findOneByOrFail({
@@ -485,6 +491,7 @@ describe('live rooms', () => {
         id: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
         topic: 'Token room',
         status: 'created',
+        participantCount: null,
         host: {
           id: '1',
           username: 'idoshamun',
@@ -536,6 +543,19 @@ describe('live rooms', () => {
         participantId: 'tracking-anon-1',
         canJoin: true,
       });
+    const countsScope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['aa4bb4ae-a0af-4310-b1ff-7d6345cb5253'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        rooms: [
+          {
+            roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+            participantCount: 9,
+          },
+        ],
+      });
 
     const res = await client.mutate(JOIN_TOKEN_MUTATION, {
       variables: {
@@ -550,6 +570,7 @@ describe('live rooms', () => {
         id: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
         topic: 'Live room',
         status: 'live',
+        participantCount: 9,
       },
     });
 
@@ -571,6 +592,7 @@ describe('live rooms', () => {
       roomId: 'aa4bb4ae-a0af-4310-b1ff-7d6345cb5253',
     });
     expect(scope.isDone()).toBe(true);
+    expect(countsScope.isDone()).toBe(true);
   });
 
   it('rejects join tokens for ended rooms', async () => {
@@ -700,6 +722,7 @@ describe('live rooms', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data.endLiveRoom.status).toBe('ended');
     expect(res.data.endLiveRoom.endedAt).toBeTruthy();
+    expect(res.data.endLiveRoom.participantCount).toBeNull();
     expect(scope.isDone()).toBe(true);
   });
 
@@ -741,6 +764,19 @@ describe('live rooms', () => {
         status: LiveRoomStatus.Live,
       },
     ]);
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['42e45613-c9f8-4823-96cb-ebd6dcbbf4fe'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        rooms: [
+          {
+            roomId: '42e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+            participantCount: 5,
+          },
+        ],
+      });
 
     const res = await client.query(GET_QUERY, {
       variables: {
@@ -755,12 +791,14 @@ describe('live rooms', () => {
         topic: 'Readable room',
         mode: 'moderated',
         status: 'live',
+        participantCount: 5,
         host: {
           id: '2',
           username: 'tsahidaily',
         },
       },
     });
+    expect(scope.isDone()).toBe(true);
   });
 
   it('returns a live room by id for an anonymous caller', async () => {
@@ -776,6 +814,19 @@ describe('live rooms', () => {
         startedAt: new Date('2026-04-23T11:00:00.000Z'),
       },
     ]);
+    const scope = nock(flytingOrigin)
+      .post('/internal/live-rooms/counts', {
+        roomIds: ['52e45613-c9f8-4823-96cb-ebd6dcbbf4fe'],
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        rooms: [
+          {
+            roomId: '52e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+            participantCount: 4,
+          },
+        ],
+      });
 
     const res = await client.query(GET_QUERY, {
       variables: {
@@ -790,11 +841,13 @@ describe('live rooms', () => {
         topic: 'Public live room',
         mode: 'moderated',
         status: 'live',
+        participantCount: 4,
         host: {
           id: '2',
           username: 'tsahidaily',
         },
       },
     });
+    expect(scope.isDone()).toBe(true);
   });
 });

--- a/src/common/liveRoom/participantCount.ts
+++ b/src/common/liveRoom/participantCount.ts
@@ -1,0 +1,102 @@
+import type { Context } from '../../Context';
+import { StorageKey, StorageTopic, generateStorageKey } from '../../config';
+import { getFlytingClient } from '../../integrations/flyting/client';
+import { ioRedisPool } from '../../redis';
+import { ONE_MINUTE_IN_SECONDS } from '../constants';
+
+const LIVE_ROOM_PARTICIPANT_COUNT_CACHE_TTL_SECONDS = 2 * ONE_MINUTE_IN_SECONDS;
+
+const getParticipantCountCacheKey = (roomId: string): string =>
+  generateStorageKey(
+    StorageTopic.LiveRoom,
+    StorageKey.ParticipantCount,
+    roomId,
+  );
+
+const parseCachedParticipantCount = (value: string | null): number | null => {
+  if (value === null) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const getLiveRoomParticipantCounts = async ({
+  ctx,
+  roomIds,
+}: {
+  ctx: Context;
+  roomIds: string[];
+}): Promise<Map<string, number | null>> => {
+  if (roomIds.length === 0) {
+    return new Map();
+  }
+
+  const cacheKeys = roomIds.map(getParticipantCountCacheKey);
+  const cachedValues = await ioRedisPool.execute((client) =>
+    client.mget(cacheKeys),
+  );
+  const countsByRoomId = new Map<string, number | null>();
+  const missingRoomIds: string[] = [];
+
+  roomIds.forEach((roomId, index) => {
+    const cachedCount = parseCachedParticipantCount(cachedValues[index]);
+
+    if (cachedCount === null && cachedValues[index] === null) {
+      missingRoomIds.push(roomId);
+      return;
+    }
+
+    countsByRoomId.set(roomId, cachedCount);
+  });
+
+  if (missingRoomIds.length === 0) {
+    return countsByRoomId;
+  }
+
+  try {
+    const response = await getFlytingClient().getParticipantCounts({
+      roomIds: missingRoomIds,
+    });
+    const fetchedCountsByRoomId = new Map(
+      response.rooms.map(({ roomId, participantCount }) => [
+        roomId,
+        participantCount,
+      ]),
+    );
+
+    await ioRedisPool.execute(async (client) => {
+      const multi = client.multi();
+
+      for (const roomId of missingRoomIds) {
+        const participantCount = fetchedCountsByRoomId.get(roomId) ?? null;
+        countsByRoomId.set(roomId, participantCount);
+
+        if (typeof participantCount === 'number') {
+          multi.set(
+            getParticipantCountCacheKey(roomId),
+            participantCount.toString(),
+            'EX',
+            LIVE_ROOM_PARTICIPANT_COUNT_CACHE_TTL_SECONDS,
+          );
+        }
+      }
+
+      await multi.exec();
+    });
+  } catch (error) {
+    ctx.log.warn(
+      { err: error, roomIds: missingRoomIds },
+      'Unable to load live room participant counts from flyting',
+    );
+
+    for (const roomId of missingRoomIds) {
+      countsByRoomId.set(roomId, null);
+    }
+  }
+
+  return countsByRoomId;
+};
+
+export const liveRoomParticipantCountCacheKey = getParticipantCountCacheKey;

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ export enum StorageTopic {
   Paddle = 'paddle',
   RedisCounter = 'redis_counter',
   Cron = 'cron',
+  LiveRoom = 'live_room',
 }
 
 export enum StorageKey {
@@ -54,6 +55,7 @@ export enum StorageKey {
   PricingPreviewCores = 'pricing_preview_cores',
   OrganizationSubscriptionUpdatePreview = 'organization_subscription_update_preview',
   UserLastOnline = 'ulo',
+  ParticipantCount = 'participant_count',
 }
 
 export const generateStorageKey = (

--- a/src/dataLoaderService.ts
+++ b/src/dataLoaderService.ts
@@ -9,6 +9,7 @@ import { queryReadReplica } from './common/queryReadReplica';
 import type { FindOneOptions } from 'typeorm';
 import { getRedisObject } from './redis';
 import { generateStorageKey, StorageKey, StorageTopic } from './config';
+import { getLiveRoomParticipantCounts } from './common/liveRoom/participantCount';
 
 export const defaultCacheKeyFn = <K extends object | string>(key: K) => {
   if (typeof key === 'object') {
@@ -36,8 +37,9 @@ export class DataLoaderService {
     loadFn: (params: K) => Promise<V | null> | V;
     cacheKeyFn: (key: K) => string;
   }): DataLoader<K, V> {
-    if (!this.loaders[type]) {
-      const batchLoadFn: BatchLoadFn<K, V> = async (keys) => {
+    return this.getBatchLoader({
+      type,
+      batchLoadFn: async (keys) => {
         const results = await Promise.allSettled(keys.map(loadFn));
 
         return results.map((result) => {
@@ -47,11 +49,26 @@ export class DataLoaderService {
 
           return result.value;
         });
-      };
+      },
+      cacheKeyFn,
+    });
+  }
 
+  protected getBatchLoader<K, V>({
+    type,
+    batchLoadFn,
+    cacheKeyFn,
+    maxBatchSize = 30,
+  }: {
+    type: string;
+    batchLoadFn: BatchLoadFn<K, V>;
+    cacheKeyFn: (key: K) => string;
+    maxBatchSize?: number;
+  }): DataLoader<K, V> {
+    if (!this.loaders[type]) {
       this.loaders[type] = new DataLoader(batchLoadFn, {
         cacheKeyFn,
-        maxBatchSize: 30,
+        maxBatchSize,
         name: `${DataLoaderService.name}.${type}`,
       });
     }
@@ -218,6 +235,22 @@ export class DataLoaderService {
         });
       },
       cacheKeyFn: ({ userId, select }) => defaultCacheKeyFn({ userId, select }),
+    });
+  }
+
+  get liveRoomParticipantCount() {
+    return this.getBatchLoader<string, number | null>({
+      type: 'liveRoomParticipantCount',
+      batchLoadFn: async (roomIds) => {
+        const countsByRoomId = await getLiveRoomParticipantCounts({
+          ctx: this.ctx,
+          roomIds: [...roomIds],
+        });
+
+        return roomIds.map((roomId) => countsByRoomId.get(roomId) ?? null);
+      },
+      cacheKeyFn: defaultCacheKeyFn,
+      maxBatchSize: 100,
     });
   }
 }

--- a/src/integrations/flyting/client.ts
+++ b/src/integrations/flyting/client.ts
@@ -114,6 +114,36 @@ export class FlytingClient {
       throw new HttpError(response.url, response.status, await response.text());
     });
   }
+
+  async getParticipantCounts(input: { roomIds: string[] }): Promise<{
+    rooms: {
+      roomId: string;
+      participantCount: number | null;
+    }[];
+  }> {
+    return this.garmr.execute(async () => {
+      const response = await retryFetch(
+        `${this.url}/internal/live-rooms/counts`,
+        {
+          ...this.fetchOptions,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-flyting-internal-key': this.internalApiKey,
+          },
+          body: JSON.stringify({
+            roomIds: input.roomIds,
+          }),
+        },
+      );
+
+      if (response.ok) {
+        return response.json();
+      }
+
+      throw new HttpError(response.url, response.status, await response.text());
+    });
+  }
 }
 
 const garmrFlytingService = new GarmrService({

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -17,7 +17,9 @@ import { getFlytingClient } from '../integrations/flyting/client';
 import { AbortError, HttpError } from '../integrations/retry';
 import { Roles } from '../roles';
 
-export type GQLLiveRoom = LiveRoom;
+export type GQLLiveRoom = LiveRoom & {
+  participantCount?: number | null;
+};
 
 type GQLLiveRoomJoinToken = {
   room: LiveRoom;
@@ -200,6 +202,31 @@ const getParticipantCountsByRoomId = async ({
 };
 
 export const resolvers: IResolvers = {
+  LiveRoom: {
+    participantCount: async (
+      room: GQLLiveRoom,
+      _,
+      ctx: Context,
+    ): Promise<number | null> => {
+      if (
+        Object.prototype.hasOwnProperty.call(room, 'participantCount') &&
+        room.participantCount !== undefined
+      ) {
+        return room.participantCount ?? null;
+      }
+
+      if (room.status !== LiveRoomStatus.Live) {
+        return null;
+      }
+
+      const countsByRoomId = await getParticipantCountsByRoomId({
+        ctx,
+        roomIds: [room.id],
+      });
+
+      return countsByRoomId.get(room.id) ?? null;
+    },
+  },
   Query: {
     liveRoom: async (
       _,

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -39,6 +39,7 @@ export const typeDefs = /* GraphQL */ `
     status: LiveRoomStatus!
     startedAt: DateTime
     endedAt: DateTime
+    participantCount: Int
     host: User!
   }
 
@@ -170,6 +171,34 @@ const assertJoinAllowedByFlyting = async ({
   throw new ValidationError('Cannot join this live room');
 };
 
+const getParticipantCountsByRoomId = async ({
+  ctx,
+  roomIds,
+}: {
+  ctx: Context;
+  roomIds: string[];
+}): Promise<Map<string, number | null>> => {
+  if (roomIds.length === 0) {
+    return new Map();
+  }
+
+  try {
+    const response = await getFlytingClient().getParticipantCounts({ roomIds });
+    return new Map(
+      response.rooms.map(({ roomId, participantCount }) => [
+        roomId,
+        participantCount,
+      ]),
+    );
+  } catch (error) {
+    ctx.log.warn(
+      { err: error, roomIds },
+      'Unable to load live room participant counts from flyting',
+    );
+    return new Map();
+  }
+};
+
 export const resolvers: IResolvers = {
   Query: {
     liveRoom: async (
@@ -202,8 +231,8 @@ export const resolvers: IResolvers = {
       __,
       ctx: Context,
       info,
-    ): Promise<GQLLiveRoom[]> =>
-      graphorm.query<GQLLiveRoom>(
+    ): Promise<GQLLiveRoom[]> => {
+      const rooms = await graphorm.query<GQLLiveRoom>(
         ctx,
         info,
         (builder) => {
@@ -215,7 +244,17 @@ export const resolvers: IResolvers = {
           return builder;
         },
         true,
-      ),
+      );
+      const countsByRoomId = await getParticipantCountsByRoomId({
+        ctx,
+        roomIds: rooms.map((room) => room.id),
+      });
+
+      return rooms.map((room) => ({
+        ...room,
+        participantCount: countsByRoomId.get(room.id) ?? null,
+      }));
+    },
   },
   Mutation: {
     createLiveRoom: async (

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -17,9 +17,7 @@ import { getFlytingClient } from '../integrations/flyting/client';
 import { AbortError, HttpError } from '../integrations/retry';
 import { Roles } from '../roles';
 
-export type GQLLiveRoom = LiveRoom & {
-  participantCount?: number | null;
-};
+export type GQLLiveRoom = LiveRoom;
 
 type GQLLiveRoomJoinToken = {
   room: LiveRoom;
@@ -173,34 +171,6 @@ const assertJoinAllowedByFlyting = async ({
   throw new ValidationError('Cannot join this live room');
 };
 
-const getParticipantCountsByRoomId = async ({
-  ctx,
-  roomIds,
-}: {
-  ctx: Context;
-  roomIds: string[];
-}): Promise<Map<string, number | null>> => {
-  if (roomIds.length === 0) {
-    return new Map();
-  }
-
-  try {
-    const response = await getFlytingClient().getParticipantCounts({ roomIds });
-    return new Map(
-      response.rooms.map(({ roomId, participantCount }) => [
-        roomId,
-        participantCount,
-      ]),
-    );
-  } catch (error) {
-    ctx.log.warn(
-      { err: error, roomIds },
-      'Unable to load live room participant counts from flyting',
-    );
-    return new Map();
-  }
-};
-
 export const resolvers: IResolvers = {
   LiveRoom: {
     participantCount: async (
@@ -208,23 +178,11 @@ export const resolvers: IResolvers = {
       _,
       ctx: Context,
     ): Promise<number | null> => {
-      if (
-        Object.prototype.hasOwnProperty.call(room, 'participantCount') &&
-        room.participantCount !== undefined
-      ) {
-        return room.participantCount ?? null;
-      }
-
       if (room.status !== LiveRoomStatus.Live) {
         return null;
       }
 
-      const countsByRoomId = await getParticipantCountsByRoomId({
-        ctx,
-        roomIds: [room.id],
-      });
-
-      return countsByRoomId.get(room.id) ?? null;
+      return ctx.dataLoader.liveRoomParticipantCount.load(room.id);
     },
   },
   Query: {
@@ -258,8 +216,8 @@ export const resolvers: IResolvers = {
       __,
       ctx: Context,
       info,
-    ): Promise<GQLLiveRoom[]> => {
-      const rooms = await graphorm.query<GQLLiveRoom>(
+    ): Promise<GQLLiveRoom[]> =>
+      graphorm.query<GQLLiveRoom>(
         ctx,
         info,
         (builder) => {
@@ -271,17 +229,7 @@ export const resolvers: IResolvers = {
           return builder;
         },
         true,
-      );
-      const countsByRoomId = await getParticipantCountsByRoomId({
-        ctx,
-        roomIds: rooms.map((room) => room.id),
-      });
-
-      return rooms.map((room) => ({
-        ...room,
-        participantCount: countsByRoomId.get(room.id) ?? null,
-      }));
-    },
+      ),
   },
   Mutation: {
     createLiveRoom: async (


### PR DESCRIPTION
## Summary
- add batched Flyting participant-count fetching for active live rooms
- expose nullable `participantCount` on `LiveRoom` and decorate `activeLiveRooms`
- cover successful enrichment and best-effort fallback behavior in GraphQL tests

## Validation
- pnpm build
- pnpm exec eslint src/schema/liveRooms.ts src/integrations/flyting/client.ts __tests__/liveRooms.ts
- pnpm exec jest --testEnvironment=node --runInBand __tests__/liveRooms.ts

## Notes
- depends on the Flyting batched counts endpoint from the paired backend PR