### PR TITLE
feat: proxy recswipe extract-tags through onboardingExtractTags mutation

### DIFF
--- a/__tests__/integrations/recswipe.ts
+++ b/__tests__/integrations/recswipe.ts
@@ -128,3 +128,68 @@ describe('RecswipeClient.discoverPosts', () => {
     ).rejects.toBeInstanceOf(HttpError);
   });
 });
+
+describe('RecswipeClient.extractTags', () => {
+  it('should POST prompt body to /api/extract-tags and return tags', async () => {
+    let capturedBody: unknown;
+    let capturedHeaders: Record<string, string | string[]> = {};
+
+    nock(url)
+      .post('/api/extract-tags', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(function () {
+        capturedHeaders = this.req.headers as Record<string, string | string[]>;
+        return [200, { tags: ['rust', 'systems'] }];
+      });
+
+    const client = new RecswipeClient(url);
+    const response = await client.extractTags('user-1', {
+      prompt: 'I like rust and systems programming',
+    });
+
+    expect(capturedBody).toEqual({
+      prompt: 'I like rust and systems programming',
+    });
+    expect(capturedHeaders['x-user-id']).toEqual(
+      expect.arrayContaining(['user-1']),
+    );
+    expect(capturedHeaders['content-type']).toEqual(
+      expect.arrayContaining(['application/json']),
+    );
+    expect(response).toEqual({ tags: ['rust', 'systems'] });
+  });
+
+  it('should omit X-User-Id header when userId is undefined', async () => {
+    let capturedHeaders: Record<string, string | string[]> = {};
+
+    nock(url)
+      .post('/api/extract-tags')
+      .reply(function () {
+        capturedHeaders = this.req.headers as Record<string, string | string[]>;
+        return [200, { tags: [] }];
+      });
+
+    const client = new RecswipeClient(url);
+    await client.extractTags(undefined, { prompt: 'go' });
+
+    expect(capturedHeaders['x-user-id']).toBeUndefined();
+  });
+
+  it('should throw when RECSWIPE_ORIGIN is missing', () => {
+    const client = new RecswipeClient(undefined);
+    expect(() => client.extractTags('user-1', { prompt: 'rust' })).toThrow(
+      'Missing RECSWIPE_ORIGIN',
+    );
+  });
+
+  it('should propagate HttpError on 4xx responses', async () => {
+    nock(url).post('/api/extract-tags').reply(400, 'bad request');
+
+    const client = new RecswipeClient(url);
+    await expect(
+      client.extractTags('user-1', { prompt: 'rust' }),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -284,11 +284,7 @@ describe('mutation onboardingExtractTags', () => {
   it('should surface an UNEXPECTED error when recswipe responds with HttpError', async () => {
     loggedUser = '1';
     extractTagsMock.mockRejectedValueOnce(
-      new HttpError(
-        'http://recswipe.local:8000/api/extract-tags',
-        500,
-        'boom',
-      ),
+      new HttpError('http://recswipe.local:8000/api/extract-tags', 500, 'boom'),
     );
 
     const res = await client.mutate(MUTATION, {

--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -17,11 +17,15 @@ import { HttpError } from '../../src/integrations/retry';
 jest.mock('../../src/integrations/recswipe/clients', () => ({
   recswipeClient: {
     discoverPosts: jest.fn(),
+    extractTags: jest.fn(),
   },
 }));
 
 const discoverPostsMock = recswipeClient.discoverPosts as jest.MockedFunction<
   typeof recswipeClient.discoverPosts
+>;
+const extractTagsMock = recswipeClient.extractTags as jest.MockedFunction<
+  typeof recswipeClient.extractTags
 >;
 
 let con: DataSource;
@@ -204,6 +208,84 @@ describe('mutation onboardingDiscoverPosts', () => {
     discoverPostsMock.mockRejectedValueOnce(
       new HttpError(
         'http://recswipe.local:8000/api/discover-posts',
+        500,
+        'boom',
+      ),
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: { prompt: 'rust' },
+    });
+
+    expect(res.errors?.length).toBeGreaterThan(0);
+    expect(res.errors?.[0].extensions?.code).toBe('UNEXPECTED');
+  });
+});
+
+describe('mutation onboardingExtractTags', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation OnboardingExtractTags($prompt: String!) {
+      onboardingExtractTags(prompt: $prompt) {
+        tags
+      }
+    }
+  `;
+
+  it('should require authentication', () =>
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { prompt: 'rust' } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should reject input that fails Zod validation', async () => {
+    loggedUser = '1';
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { prompt: '' } },
+      'ZOD_VALIDATION_ERROR',
+    );
+    expect(extractTagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should forward prompt to recswipe client and return tags', async () => {
+    loggedUser = '1';
+    extractTagsMock.mockResolvedValueOnce({
+      tags: ['rust', 'systems'],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { prompt: 'I like rust and systems programming' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      onboardingExtractTags: { tags: ['rust', 'systems'] },
+    });
+    expect(extractTagsMock).toHaveBeenCalledWith('1', {
+      prompt: 'I like rust and systems programming',
+    });
+  });
+
+  it('should default missing tags array to empty list', async () => {
+    loggedUser = '1';
+    extractTagsMock.mockResolvedValueOnce({
+      tags: undefined as unknown as string[],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { prompt: 'go' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({ onboardingExtractTags: { tags: [] } });
+  });
+
+  it('should surface an UNEXPECTED error when recswipe responds with HttpError', async () => {
+    loggedUser = '1';
+    extractTagsMock.mockRejectedValueOnce(
+      new HttpError(
+        'http://recswipe.local:8000/api/extract-tags',
         500,
         'boom',
       ),

--- a/src/common/schema/onboardingExtractTags.ts
+++ b/src/common/schema/onboardingExtractTags.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+const MAX_PROMPT = 2000;
+
+export const onboardingExtractTagsInputSchema = z.object({
+  prompt: z.string().min(1).max(MAX_PROMPT),
+});

--- a/src/integrations/recswipe/clients.ts
+++ b/src/integrations/recswipe/clients.ts
@@ -5,7 +5,10 @@ import { retryFetchParse } from '../retry';
 import type {
   DiscoverPostsParams,
   DiscoverPostsResponse,
+  ExtractTagsParams,
+  ExtractTagsResponse,
   RawDiscoverPostsRequest,
+  RawExtractTagsRequest,
 } from './types';
 
 export class RecswipeClient {
@@ -48,6 +51,31 @@ export class RecswipeClient {
 
     return this.garmr.execute(() =>
       retryFetchParse<DiscoverPostsResponse>(`${this.url}/api/discover-posts`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(userId ? { 'X-User-Id': userId } : {}),
+        },
+      }),
+    );
+  }
+
+  extractTags(
+    userId: string | undefined,
+    params: ExtractTagsParams,
+  ): Promise<ExtractTagsResponse> {
+    if (!this.url) {
+      throw new Error('Missing RECSWIPE_ORIGIN');
+    }
+
+    const body: RawExtractTagsRequest = {
+      prompt: params.prompt,
+    };
+
+    return this.garmr.execute(() =>
+      retryFetchParse<ExtractTagsResponse>(`${this.url}/api/extract-tags`, {
         ...this.fetchOptions,
         method: 'POST',
         body: JSON.stringify(body),

--- a/src/integrations/recswipe/types.ts
+++ b/src/integrations/recswipe/types.ts
@@ -31,3 +31,15 @@ export type DiscoverPostsResponse = {
   posts: DiscoverPostsRawItem[];
   sub_prompts: string[];
 };
+
+export type ExtractTagsParams = {
+  prompt: string;
+};
+
+export type RawExtractTagsRequest = {
+  prompt: string;
+};
+
+export type ExtractTagsResponse = {
+  tags: string[];
+};

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -4,6 +4,7 @@ import { getBragiClient } from '../integrations/bragi';
 import { Keyword, KeywordStatus } from '../entity/Keyword';
 import type { z } from 'zod';
 import { onboardingDiscoverPostsInputSchema } from '../common/schema/onboardingDiscoverPosts';
+import { onboardingExtractTagsInputSchema } from '../common/schema/onboardingExtractTags';
 import { onboardingProfileTagsInputSchema } from '../common/schema/onboardingProfileTags';
 import { recswipeClient } from '../integrations/recswipe/clients';
 import { HttpError } from '../integrations/retry';
@@ -1805,6 +1806,12 @@ export const typeDefs = /* GraphQL */ `
       saturatedTags: [String!]
       n: Int
     ): OnboardingDiscoverPostsResult! @auth
+
+    """
+    Extract candidate tags from a free-text prompt for the swipe onboarding deck.
+    Stateless proxy to the recswipe service.
+    """
+    onboardingExtractTags(prompt: String!): OnboardingExtractTagsResult! @auth
   }
 
   type OnboardingTagsResult {
@@ -1827,6 +1834,10 @@ export const typeDefs = /* GraphQL */ `
   type OnboardingDiscoverPostsResult {
     posts: [OnboardingSwipePost!]!
     subPrompts: [String!]!
+  }
+
+  type OnboardingExtractTagsResult {
+    tags: [String!]!
   }
 `;
 
@@ -4356,6 +4367,29 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         if (err instanceof HttpError) {
           throw new ServiceError({
             message: 'Recswipe discoverPosts request failed',
+            data: err.response,
+            statusCode: err.statusCode,
+          });
+        }
+
+        throw err;
+      }
+    },
+    onboardingExtractTags: async (
+      _,
+      args: z.input<typeof onboardingExtractTagsInputSchema>,
+      ctx: AuthContext,
+    ) => {
+      const parsed = onboardingExtractTagsInputSchema.parse(args);
+
+      try {
+        const data = await recswipeClient.extractTags(ctx.userId, parsed);
+
+        return { tags: data.tags ?? [] };
+      } catch (err) {
+        if (err instanceof HttpError) {
+          throw new ServiceError({
+            message: 'Recswipe extractTags request failed',
             data: err.response,
             statusCode: err.statusCode,
           });


### PR DESCRIPTION
## Summary
- Adds `RecswipeClient.extractTags` calling `POST /api/extract-tags` (Garmr breaker, retry, optional `X-User-Id` header — same pattern as `discoverPosts`).
- Exposes a new `Mutation.onboardingExtractTags(prompt: String!): OnboardingExtractTagsResult! @auth` so the webapp stops calling recswipe directly and gets auth + schema validation through the daily-api.
- Companion webapp change replaces the direct fetch in `swipingBackendApi.ts` with this mutation; no rate limit added (matches sibling `onboardingDiscoverPosts`).

## Test plan
- [x] `pnpm run build` — passes
- [x] `pnpm run lint` — 0 warnings
- [x] `__tests__/integrations/recswipe.ts` — 8/8 passing
- [x] `__tests__/schema/onboarding.ts` — 11/11 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)