### PR TITLE
feat: onboarding personas query

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -33,6 +33,7 @@ import {
 import { PollOption } from '../src/entity/polls/PollOption';
 import { SourceMemberRoles } from '../src/roles';
 import { Category } from '../src/entity/Category';
+import { Persona } from '../src/entity/Persona';
 import { FastifyInstance } from 'fastify';
 import {
   feedFields,
@@ -2806,6 +2807,69 @@ describe('query tagsCategories', () => {
     const res = await client.query(QUERY);
 
     expect(res.data).toMatchSnapshot();
+  });
+});
+
+describe('query onboardingPersonas', () => {
+  const QUERY = `{
+    onboardingPersonas {
+      id
+      title
+      emoji
+      tags
+    }
+  }`;
+
+  it('should return personas ordered by sortOrder', async () => {
+    await saveFixtures(con, Persona, [
+      {
+        id: 'beta',
+        title: 'Beta Persona',
+        emoji: '🅱️',
+        tags: ['javascript', 'react'],
+        sortOrder: 2,
+      },
+      {
+        id: 'alpha',
+        title: 'Alpha Persona',
+        emoji: '🅰️',
+        tags: ['python', 'golang'],
+        sortOrder: 1,
+      },
+      {
+        id: 'gamma',
+        title: 'Gamma Persona',
+        emoji: '🅶',
+        tags: ['rust'],
+        sortOrder: 3,
+      },
+    ]);
+
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      onboardingPersonas: [
+        {
+          id: 'alpha',
+          title: 'Alpha Persona',
+          emoji: '🅰️',
+          tags: ['python', 'golang'],
+        },
+        {
+          id: 'beta',
+          title: 'Beta Persona',
+          emoji: '🅱️',
+          tags: ['javascript', 'react'],
+        },
+        {
+          id: 'gamma',
+          title: 'Gamma Persona',
+          emoji: '🅶',
+          tags: ['rust'],
+        },
+      ],
+    });
   });
 });
 

--- a/src/entity/Persona.ts
+++ b/src/entity/Persona.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity()
+export class Persona {
+  @PrimaryColumn({ type: 'text' })
+  id: string;
+
+  @Column({ type: 'text' })
+  title: string;
+
+  @Column({ type: 'text' })
+  emoji: string;
+
+  @Column({ type: 'text', array: true, default: [] })
+  tags: string[];
+
+  @Column({ type: 'int', default: 0 })
+  sortOrder: number;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -27,6 +27,7 @@ export * from './TagSegment';
 export * from './View';
 export * from './Comment';
 export * from './Keyword';
+export * from './Persona';
 export * from './PostKeyword';
 export * from './CommentMention';
 export * from './ReputationEvent';

--- a/src/migration/1777477090471-Persona.ts
+++ b/src/migration/1777477090471-Persona.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Persona1777477090471 implements MigrationInterface {
+  name = 'Persona1777477090471';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "persona" (
+        "id" text NOT NULL,
+        "title" text NOT NULL,
+        "emoji" text NOT NULL,
+        "tags" text array NOT NULL DEFAULT '{}',
+        "sortOrder" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_persona_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      /* sql */ `
+        INSERT INTO "persona" ("id", "title", "emoji", "tags", "sortOrder")
+        VALUES
+          ($1, 'Frontend Developer', '🌐',
+           ARRAY['webdev','javascript','react','css','typescript','html','nextjs','tailwind-css','vuejs','angular','frontend','ui-design']::text[], 1),
+          ($2, 'Backend Developer', '⚙️',
+           ARRAY['python','java','golang','database','architecture','microservices','rest-api','graphql','docker','postgresql','redis','kafka']::text[], 2),
+          ($3, 'AI/ML Engineer', '🤖',
+           ARRAY['ai','machine-learning','python','data-science','deep-learning','nlp','pytorch','genai','llm','computer-vision','neural-networks','ai-agents']::text[], 3),
+          ($4, 'DevOps / Cloud', '☁️',
+           ARRAY['devops','cloud','aws','docker','kubernetes','cicd','terraform','linux','containers','infrastructure','monitoring','serverless','github-actions']::text[], 4),
+          ($5, 'Mobile Developer', '📱',
+           ARRAY['mobile','react-native','swift','android','ios','flutter','kotlin','iphone','firebase','app-store']::text[], 5),
+          ($6, 'Security / Cyber', '🔒',
+           ARRAY['security','cyber','data-privacy','encryption','malware','phishing','ransomware','vulnerability','compliance','appsec','cryptography']::text[], 6),
+          ($7, 'Game Developer', '🎮',
+           ARRAY['gaming','game-development','unity','unreal-engine','game-design','3d','blender','c++','vr','c#']::text[], 7),
+          ($8, 'Data Engineer', '📊',
+           ARRAY['data-science','python','data-analysis','data-visualization','big-data','database','data-engineering','machine-learning','algorithms','math','pytorch']::text[], 8),
+          ($9, 'Tech Lead / Startup', '🚀',
+           ARRAY['startup','tech-news','leadership','architecture','open-source','career','agile','product-management','venture-capital','business','tools']::text[], 9),
+          ($10, 'Systems Programmer', '🦀',
+           ARRAY['rust','c','c++','linux','golang','performance','hardware','computing','webassembly','algorithms']::text[], 10)
+      `,
+      [
+        'frontend',
+        'backend',
+        'ai-ml',
+        'devops',
+        'mobile',
+        'security',
+        'gamedev',
+        'data',
+        'lead',
+        'systems',
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "persona"`);
+  }
+}

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -13,6 +13,7 @@ import {
   UserPost,
 } from '../entity';
 import { Category } from '../entity/Category';
+import { Persona } from '../entity/Persona';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { IFieldResolver, IResolvers } from '@graphql-tools/utils';
@@ -106,6 +107,13 @@ interface GQLTagsCategory {
   tags: string[];
 }
 
+interface GQLPersona {
+  id: string;
+  emoji: string;
+  title: string;
+  tags: string[];
+}
+
 type GQLFeed = {
   id: string;
   userId: string;
@@ -155,6 +163,13 @@ export const typeDefs = /* GraphQL */ `
     id: String!
     emoji: String
     title: String!
+    tags: [String]!
+  }
+
+  type Persona {
+    id: String!
+    title: String!
+    emoji: String!
     tags: [String]!
   }
 
@@ -873,6 +888,11 @@ export const typeDefs = /* GraphQL */ `
     Get the categories of tags
     """
     tagsCategories: [TagsCategory]!
+
+    """
+    Get persona presets for onboarding tag selection
+    """
+    onboardingPersonas: [Persona]! @cacheControl(maxAge: 600)
 
     """
     Get the list of advanced settings
@@ -2178,6 +2198,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     ),
     tagsCategories: (_, __, ctx): Promise<GQLTagsCategory[]> =>
       ctx.getRepository(Category).find({ order: { title: 'ASC' } }),
+    onboardingPersonas: (_, __, ctx): Promise<GQLPersona[]> =>
+      ctx.getRepository(Persona).find({ order: { sortOrder: 'ASC' } }),
     feedList: async (
       source,
       args: ConnectionArguments,


### PR DESCRIPTION
## Summary
- Adds `Persona` entity + table with 10 seeded role presets (Frontend, Backend, AI/ML, DevOps, Mobile, Security, GameDev, Data, Tech Lead, Systems) — each bundling a curated tag list for use as a "quick start" picker during onboarding.
- Exposes a new `onboardingPersonas: [Persona]!` GraphQL query (cached, ordered by `sortOrder`) so the frontend can render the picker; selection reuses existing `followTags` mutations.
- Includes integration test covering query shape and `sortOrder` ordering.

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 warnings)
- [x] `__tests__/feeds.ts -t onboardingPersonas` passes
- [ ] Reviewer: confirm seed tags `ai-agents`, `genai`, `llm`, `product-management` are `status='allow'` in production `keyword` table (not present in local seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)