### PR TITLE
ci: add GitHub Actions workflow for lint, typecheck, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: "12345"
+          POSTGRES_DB: api_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      NODE_ENV: test
+      TYPEORM_HOST: localhost
+      TYPEORM_USERNAME: postgres
+      TYPEORM_PASSWORD: "12345"
+      TYPEORM_DATABASE: api_test
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions CI workflow that runs on every pull request and push to `main`, ensuring code quality checks happen automatically.

### Jobs

| Job | What it does | 
|-----|-------------|
| **lint** | Runs `pnpm run lint` (ESLint with `--max-warnings 0`) |
| **typecheck** | Runs `pnpm run build` (TypeScript compilation via `tsc`) |
| **test** | Runs `pnpm run test` (Jest with PostgreSQL 16 + Redis 7 service containers) |

### Why this matters

The project has excellent local tooling — ESLint, Prettier, TypeScript strict mode, and 303+ tests — but none of these run automatically in CI. This means PRs can merge without passing lint, type checks, or tests.

### Design decisions

- **PostgreSQL 16** service container with health checks — matches the `api_test` database used by tests
- **Redis 7** service container — required by test teardown/cleanup
- **Concurrency control** — cancels in-progress runs when a new push arrives on the same PR
- **pnpm/action-setup@v4** — reads `packageManager` from `package.json` automatically (no hardcoded version)
- **Separate jobs** — lint and typecheck run in parallel, test runs independently (can be made dependent if needed)

### Environment variables

The workflow sets only the database/Redis connection variables needed for tests. Secrets and external service URLs are not required since tests mock external dependencies.