### PR TITLE
feat: proxy recswipe recommend-tags through onboardingRecommendTags mutation

### DIFF
--- a/__tests__/integrations/recswipe.ts
+++ b/__tests__/integrations/recswipe.ts
@@ -193,3 +193,104 @@ describe('RecswipeClient.extractTags', () => {
     ).rejects.toBeInstanceOf(HttpError);
   });
 });
+
+describe('RecswipeClient.recommendTags', () => {
+  it('should POST snake_case body with default n to /api/recommend-tags and return ranked tags', async () => {
+    let capturedBody: unknown;
+    let capturedHeaders: Record<string, string | string[]> = {};
+
+    nock(url)
+      .post('/api/recommend-tags', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(function () {
+        capturedHeaders = this.req.headers as Record<string, string | string[]>;
+        return [
+          200,
+          {
+            recommended_tags: [
+              { tag: 'rust', score: 0.9 },
+              { tag: 'systems', score: 0.7 },
+            ],
+          },
+        ];
+      });
+
+    const client = new RecswipeClient(url);
+    const response = await client.recommendTags('user-1', {
+      selectedTags: ['rust'],
+    });
+
+    expect(capturedBody).toEqual({
+      selected_tags: ['rust'],
+      n: 20,
+    });
+    expect(capturedHeaders['x-user-id']).toEqual(
+      expect.arrayContaining(['user-1']),
+    );
+    expect(capturedHeaders['content-type']).toEqual(
+      expect.arrayContaining(['application/json']),
+    );
+    expect(response).toEqual({
+      recommended_tags: [
+        { tag: 'rust', score: 0.9 },
+        { tag: 'systems', score: 0.7 },
+      ],
+    });
+  });
+
+  it('should forward an explicit n value', async () => {
+    let capturedBody: unknown;
+
+    nock(url)
+      .post('/api/recommend-tags', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, { recommended_tags: [] });
+
+    const client = new RecswipeClient(url);
+    await client.recommendTags('user-1', {
+      selectedTags: ['rust', 'systems'],
+      n: 5,
+    });
+
+    expect(capturedBody).toEqual({
+      selected_tags: ['rust', 'systems'],
+      n: 5,
+    });
+  });
+
+  it('should omit X-User-Id header when userId is undefined', async () => {
+    let capturedHeaders: Record<string, string | string[]> = {};
+
+    nock(url)
+      .post('/api/recommend-tags')
+      .reply(function () {
+        capturedHeaders = this.req.headers as Record<string, string | string[]>;
+        return [200, { recommended_tags: [] }];
+      });
+
+    const client = new RecswipeClient(url);
+    await client.recommendTags(undefined, { selectedTags: ['rust'] });
+
+    expect(capturedHeaders['x-user-id']).toBeUndefined();
+  });
+
+  it('should throw when RECSWIPE_ORIGIN is missing', () => {
+    const client = new RecswipeClient(undefined);
+    expect(() =>
+      client.recommendTags('user-1', { selectedTags: ['rust'] }),
+    ).toThrow('Missing RECSWIPE_ORIGIN');
+  });
+
+  it('should propagate HttpError on 4xx responses', async () => {
+    nock(url).post('/api/recommend-tags').reply(400, 'bad request');
+
+    const client = new RecswipeClient(url);
+    await expect(
+      client.recommendTags('user-1', { selectedTags: ['rust'] }),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -18,6 +18,7 @@ jest.mock('../../src/integrations/recswipe/clients', () => ({
   recswipeClient: {
     discoverPosts: jest.fn(),
     extractTags: jest.fn(),
+    recommendTags: jest.fn(),
   },
 }));
 
@@ -26,6 +27,9 @@ const discoverPostsMock = recswipeClient.discoverPosts as jest.MockedFunction<
 >;
 const extractTagsMock = recswipeClient.extractTags as jest.MockedFunction<
   typeof recswipeClient.extractTags
+>;
+const recommendTagsMock = recswipeClient.recommendTags as jest.MockedFunction<
+  typeof recswipeClient.recommendTags
 >;
 
 let con: DataSource;
@@ -289,6 +293,91 @@ describe('mutation onboardingExtractTags', () => {
 
     const res = await client.mutate(MUTATION, {
       variables: { prompt: 'rust' },
+    });
+
+    expect(res.errors?.length).toBeGreaterThan(0);
+    expect(res.errors?.[0].extensions?.code).toBe('UNEXPECTED');
+  });
+});
+
+describe('mutation onboardingRecommendTags', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation OnboardingRecommendTags($selectedTags: [String!]!, $n: Int) {
+      onboardingRecommendTags(selectedTags: $selectedTags, n: $n) {
+        tags
+      }
+    }
+  `;
+
+  it('should require authentication', () =>
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { selectedTags: ['rust'] } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should reject empty selectedTags via Zod', async () => {
+    loggedUser = '1';
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { selectedTags: [] } },
+      'ZOD_VALIDATION_ERROR',
+    );
+    expect(recommendTagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should forward args and flatten recommended_tags to tag names', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockResolvedValueOnce({
+      recommended_tags: [
+        { tag: 'rust', score: 0.9 },
+        { tag: 'systems', score: 0.7 },
+      ],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { selectedTags: ['rust'], n: 5 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      onboardingRecommendTags: { tags: ['rust', 'systems'] },
+    });
+    expect(recommendTagsMock).toHaveBeenCalledWith('1', {
+      selectedTags: ['rust'],
+      n: 5,
+    });
+  });
+
+  it('should default missing recommended_tags array to empty list', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockResolvedValueOnce({
+      recommended_tags: undefined as unknown as {
+        tag: string;
+        score: number;
+      }[],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { selectedTags: ['rust'] },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({ onboardingRecommendTags: { tags: [] } });
+  });
+
+  it('should surface an UNEXPECTED error when recswipe responds with HttpError', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockRejectedValueOnce(
+      new HttpError(
+        'http://recswipe.local:8000/api/recommend-tags',
+        500,
+        'boom',
+      ),
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: { selectedTags: ['rust'] },
     });
 
     expect(res.errors?.length).toBeGreaterThan(0);

--- a/src/common/schema/onboardingRecommendTags.ts
+++ b/src/common/schema/onboardingRecommendTags.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const MAX_TAGS = 100;
+const MAX_N = 100;
+
+export const onboardingRecommendTagsInputSchema = z.object({
+  selectedTags: z.array(z.string().min(1)).min(1).max(MAX_TAGS),
+  n: z.number().int().min(1).max(MAX_N).optional(),
+});

--- a/src/integrations/recswipe/clients.ts
+++ b/src/integrations/recswipe/clients.ts
@@ -9,6 +9,9 @@ import type {
   ExtractTagsResponse,
   RawDiscoverPostsRequest,
   RawExtractTagsRequest,
+  RawRecommendTagsRequest,
+  RecommendTagsParams,
+  RecommendTagsResponse,
 } from './types';
 
 export class RecswipeClient {
@@ -76,6 +79,32 @@ export class RecswipeClient {
 
     return this.garmr.execute(() =>
       retryFetchParse<ExtractTagsResponse>(`${this.url}/api/extract-tags`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(userId ? { 'X-User-Id': userId } : {}),
+        },
+      }),
+    );
+  }
+
+  recommendTags(
+    userId: string | undefined,
+    params: RecommendTagsParams,
+  ): Promise<RecommendTagsResponse> {
+    if (!this.url) {
+      throw new Error('Missing RECSWIPE_ORIGIN');
+    }
+
+    const body: RawRecommendTagsRequest = {
+      selected_tags: params.selectedTags,
+      n: params.n ?? 20,
+    };
+
+    return this.garmr.execute(() =>
+      retryFetchParse<RecommendTagsResponse>(`${this.url}/api/recommend-tags`, {
         ...this.fetchOptions,
         method: 'POST',
         body: JSON.stringify(body),

--- a/src/integrations/recswipe/types.ts
+++ b/src/integrations/recswipe/types.ts
@@ -43,3 +43,22 @@ export type RawExtractTagsRequest = {
 export type ExtractTagsResponse = {
   tags: string[];
 };
+
+export type RecommendTagsParams = {
+  selectedTags: string[];
+  n?: number;
+};
+
+export type RawRecommendTagsRequest = {
+  selected_tags: string[];
+  n: number;
+};
+
+export type RecommendedTagRaw = {
+  tag: string;
+  score: number;
+};
+
+export type RecommendTagsResponse = {
+  recommended_tags: RecommendedTagRaw[];
+};

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -6,6 +6,7 @@ import type { z } from 'zod';
 import { onboardingDiscoverPostsInputSchema } from '../common/schema/onboardingDiscoverPosts';
 import { onboardingExtractTagsInputSchema } from '../common/schema/onboardingExtractTags';
 import { onboardingProfileTagsInputSchema } from '../common/schema/onboardingProfileTags';
+import { onboardingRecommendTagsInputSchema } from '../common/schema/onboardingRecommendTags';
 import { recswipeClient } from '../integrations/recswipe/clients';
 import { HttpError } from '../integrations/retry';
 import { ServiceError } from '../errors';
@@ -1823,6 +1824,15 @@ export const typeDefs = /* GraphQL */ `
     Stateless proxy to the recswipe service.
     """
     onboardingExtractTags(prompt: String!): OnboardingExtractTagsResult! @auth
+
+    """
+    Recommend related tags from a set of selected tags for the swipe onboarding deck.
+    Stateless proxy to the recswipe service.
+    """
+    onboardingRecommendTags(
+      selectedTags: [String!]!
+      n: Int
+    ): OnboardingRecommendTagsResult! @auth
   }
 
   type OnboardingTagsResult {
@@ -1848,6 +1858,10 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type OnboardingExtractTagsResult {
+    tags: [String!]!
+  }
+
+  type OnboardingRecommendTagsResult {
     tags: [String!]!
   }
 `;
@@ -4415,6 +4429,31 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         if (err instanceof HttpError) {
           throw new ServiceError({
             message: 'Recswipe extractTags request failed',
+            data: err.response,
+            statusCode: err.statusCode,
+          });
+        }
+
+        throw err;
+      }
+    },
+    onboardingRecommendTags: async (
+      _,
+      args: z.input<typeof onboardingRecommendTagsInputSchema>,
+      ctx: AuthContext,
+    ) => {
+      const parsed = onboardingRecommendTagsInputSchema.parse(args);
+
+      try {
+        const data = await recswipeClient.recommendTags(ctx.userId, parsed);
+
+        return {
+          tags: (data.recommended_tags ?? []).map((t) => t.tag),
+        };
+      } catch (err) {
+        if (err instanceof HttpError) {
+          throw new ServiceError({
+            message: 'Recswipe recommendTags request failed',
             data: err.response,
             statusCode: err.statusCode,
           });


### PR DESCRIPTION
## Summary
- Add `onboardingRecommendTags(selectedTags: [String!]!, n: Int)` GraphQL mutation that proxies recswipe's `POST /api/recommend-tags`, mirroring the existing `onboardingExtractTags`/`onboardingDiscoverPosts` pattern.
- Resolver flattens the upstream `recommended_tags: [{tag, score}]` to `tags: [String!]!`, dropping scores to match the existing onboarding tag-result shape.
- Adds Zod input validation, `RecswipeClient.recommendTags` (defaults `n=20`, forwards `X-User-Id`), and full integration + schema test coverage.

## Test plan
- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `NODE_ENV=test npx jest __tests__/integrations/recswipe.ts --testEnvironment=node --runInBand` (13/13 pass)
- [x] `NODE_ENV=test npx jest __tests__/schema/onboarding.ts --testEnvironment=node --runInBand` (16/16 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)