### PR TITLE
fix: restrict live room creation to standup users

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import nock from 'nock';
 import type { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
+import { Feature, FeatureType, FeatureValue } from '../src/entity/Feature';
 import { LiveRoom } from '../src/entity/LiveRoom';
 import { StorageKey, StorageTopic } from '../src/config';
 import {
@@ -65,6 +66,14 @@ beforeEach(async () => {
 });
 
 describe('live rooms', () => {
+  const grantStandupAccess = async (userId: string): Promise<void> => {
+    await con.getRepository(Feature).save({
+      feature: FeatureType.Standup,
+      userId,
+      value: FeatureValue.Allow,
+    });
+  };
+
   const CREATE_MUTATION = /* GraphQL */ `
     mutation CreateLiveRoom($input: CreateLiveRoomInput!) {
       createLiveRoom(input: $input) {
@@ -163,8 +172,32 @@ describe('live rooms', () => {
       'UNAUTHENTICATED',
     ));
 
+  it('requires standup feature access to create a live room', async () => {
+    loggedUser = '1';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: CREATE_MUTATION,
+        variables: {
+          input: {
+            topic: 'A room topic',
+            mode: 'moderated',
+          },
+        },
+      },
+      'FORBIDDEN',
+      'Access denied!',
+    );
+
+    expect(
+      await con.getRepository(LiveRoom).findOneBy({ topic: 'A room topic' }),
+    ).toBeNull();
+  });
+
   it('creates a live room and prepares it in flyting', async () => {
     loggedUser = '1';
+    await grantStandupAccess(loggedUser);
 
     let preparePath = '';
     const scope = nock(flytingOrigin)
@@ -234,6 +267,7 @@ describe('live rooms', () => {
 
   it('creates a free-for-all live room and forwards its mode to flyting', async () => {
     loggedUser = '1';
+    await grantStandupAccess(loggedUser);
 
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
@@ -294,6 +328,7 @@ describe('live rooms', () => {
 
   it('keeps the durable room when prepare fails ambiguously', async () => {
     loggedUser = '1';
+    await grantStandupAccess(loggedUser);
 
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
@@ -325,6 +360,7 @@ describe('live rooms', () => {
 
   it('removes the durable room when prepare fails definitively', async () => {
     loggedUser = '1';
+    await grantStandupAccess(loggedUser);
 
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {

--- a/src/entity/Feature.ts
+++ b/src/entity/Feature.ts
@@ -5,6 +5,7 @@ export enum FeatureType {
   Team = 'team',
   Squad = 'squad',
   Search = 'search',
+  Standup = 'standup',
 }
 
 export enum FeatureValue {

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -11,6 +11,7 @@ import {
   LiveRoomStatus,
 } from '../common/schema/liveRooms';
 import { NotFoundError } from '../errors';
+import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import { LiveRoom } from '../entity/LiveRoom';
 import graphorm from '../graphorm';
 import { getFlytingClient } from '../integrations/flyting/client';
@@ -103,6 +104,26 @@ const assertCanEndRoom = ({
   room: LiveRoom;
 }): void => {
   if (room.hostId === ctx.userId || ctx.roles.includes(Roles.Moderator)) {
+    return;
+  }
+
+  throw new ForbiddenError('Access denied!');
+};
+
+const assertCanCreateRoom = async ({
+  ctx,
+}: {
+  ctx: Context;
+}): Promise<void> => {
+  const hasStandupAccess = await ctx.con.getRepository(Feature).exists({
+    where: {
+      userId: ctx.userId,
+      feature: FeatureType.Standup,
+      value: FeatureValue.Allow,
+    },
+  });
+
+  if (hasStandupAccess) {
     return;
   }
 
@@ -244,6 +265,7 @@ export const resolvers: IResolvers = {
       ctx: Context,
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = createLiveRoomSchema.parse(args.input);
+      await assertCanCreateRoom({ ctx });
       const roomRepo = ctx.con.getRepository(LiveRoom);
       const room = await roomRepo.save(
         roomRepo.create({


### PR DESCRIPTION
## Summary
- gate `createLiveRoom` behind the existing `feature` table so only users with `standup` access can create live rooms
- add the shared `standup` feature key to `FeatureType`
- cover both the forbidden path and the allowed create-room flows in the live-room integration tests

## Why
Live-room creation was previously available to any authenticated user. This change moves the entitlement check onto the existing per-user feature access mechanism so rollout can be managed through the current feature table.

## Validation
- `pnpm exec eslint src/entity/Feature.ts src/schema/liveRooms.ts __tests__/liveRooms.ts`
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
