### PR TITLE
feat: honor live room co-host privileges

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -805,6 +805,55 @@ describe('live rooms', () => {
     expect(scope.isDone()).toBe(true);
   });
 
+  it('ends a live room for a co-host with live authority', async () => {
+    loggedUser = '2';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: 'b8c0e8ab-7517-4f08-b44c-5c24d3df2f18',
+        hostId: '1',
+        topic: 'Co-host endable room',
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        startedAt: new Date('2026-04-23T15:00:00.000Z'),
+      },
+    ]);
+
+    const privilegesScope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/b8c0e8ab-7517-4f08-b44c-5c24d3df2f18/participants/2/privileges',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: 'b8c0e8ab-7517-4f08-b44c-5c24d3df2f18',
+        participantId: '2',
+        isHost: false,
+        isCoHost: true,
+        hasHostPrivileges: true,
+        canGrantCoHost: false,
+      });
+    const endScope = nock(flytingOrigin)
+      .post('/internal/live-rooms/b8c0e8ab-7517-4f08-b44c-5c24d3df2f18/end')
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        room: {
+          roomId: 'b8c0e8ab-7517-4f08-b44c-5c24d3df2f18',
+          status: 'ended',
+        },
+      });
+
+    const res = await client.mutate(END_MUTATION, {
+      variables: {
+        roomId: 'b8c0e8ab-7517-4f08-b44c-5c24d3df2f18',
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.endLiveRoom.status).toBe('ended');
+    expect(privilegesScope.isDone()).toBe(true);
+    expect(endScope.isDone()).toBe(true);
+  });
+
   it('rejects ending a room by a non-host', async () => {
     loggedUser = '2';
 
@@ -818,6 +867,20 @@ describe('live rooms', () => {
       },
     ]);
 
+    const privilegesScope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/13f8f8a6-bf26-4e5b-bb46-aef17389db7b/participants/2/privileges',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: '13f8f8a6-bf26-4e5b-bb46-aef17389db7b',
+        participantId: '2',
+        isHost: false,
+        isCoHost: false,
+        hasHostPrivileges: false,
+        canGrantCoHost: false,
+      });
+
     await testMutationErrorCode(
       client,
       {
@@ -829,6 +892,7 @@ describe('live rooms', () => {
       'FORBIDDEN',
       'Access denied!',
     );
+    expect(privilegesScope.isDone()).toBe(true);
   });
 
   it('returns a room by id', async () => {

--- a/src/integrations/flyting/client.ts
+++ b/src/integrations/flyting/client.ts
@@ -115,6 +115,55 @@ export class FlytingClient {
     });
   }
 
+  async getParticipantPrivileges(input: {
+    participantId: string;
+    roomId: string;
+  }): Promise<{
+    canGrantCoHost: boolean;
+    hasHostPrivileges: boolean;
+    isCoHost: boolean;
+    isHost: boolean;
+    participantId: string;
+    roomId: string;
+  } | null> {
+    return this.garmr.execute(async () => {
+      try {
+        const response = await retryFetch(
+          `${this.url}/internal/live-rooms/${encodeURIComponent(
+            input.roomId,
+          )}/participants/${encodeURIComponent(input.participantId)}/privileges`,
+          {
+            ...this.fetchOptions,
+            method: 'GET',
+            headers: {
+              'x-flyting-internal-key': this.internalApiKey,
+            },
+          },
+        );
+
+        if (response.ok) {
+          return response.json();
+        }
+
+        throw new HttpError(
+          response.url,
+          response.status,
+          await response.text(),
+        );
+      } catch (error) {
+        if (
+          error instanceof AbortError &&
+          error.originalError instanceof HttpError &&
+          error.originalError.statusCode === 404
+        ) {
+          return null;
+        }
+
+        throw error;
+      }
+    });
+  }
+
   async getParticipantCounts(input: { roomIds: string[] }): Promise<{
     rooms: {
       roomId: string;

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -101,9 +101,24 @@ const assertCanEndRoom = ({
 }: {
   ctx: Context;
   room: LiveRoom;
-}): void => {
+}): Promise<void> => {
   if (room.hostId === ctx.userId || ctx.roles.includes(Roles.Moderator)) {
-    return;
+    return Promise.resolve();
+  }
+
+  if (room.status === LiveRoomStatus.Live) {
+    return getFlytingClient()
+      .getParticipantPrivileges({
+        participantId: getJoinParticipantId(ctx),
+        roomId: room.id,
+      })
+      .then((privileges) => {
+        if (privileges?.hasHostPrivileges) {
+          return;
+        }
+
+        throw new ForbiddenError('Access denied!');
+      });
   }
 
   throw new ForbiddenError('Access denied!');
@@ -283,7 +298,7 @@ export const resolvers: IResolvers = {
       const input = liveRoomIdInputSchema.parse(args);
       const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
 
-      assertCanEndRoom({ ctx, room });
+      await assertCanEndRoom({ ctx, room });
 
       if (room.status === LiveRoomStatus.Ended) {
         return graphorm.queryOneOrFail<GQLLiveRoom>(ctx, info, (builder) => {


### PR DESCRIPTION
## Summary
- add a Flyting participant-privileges lookup for live room authority
- let `endLiveRoom` honor live co-host privileges without changing durable room ownership
- cover the co-host end-room path in the live room GraphQL tests

## Testing
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
- `pnpm run build`
