### PR TITLE
fix(feedV2): drop retiredAt re-filter on highlight IDs from feed

### DIFF
--- a/src/schema/feedV2.ts
+++ b/src/schema/feedV2.ts
@@ -315,7 +315,6 @@ export const feedV2QueryResolver: IFieldResolver<
               .where(`${builder.alias}.id IN (:...ids)`, {
                 ids: highlightIds,
               })
-              .andWhere(`${builder.alias}."retiredAt" IS NULL`)
               .limit(highlightIds.length);
             return builder;
           },


### PR DESCRIPTION
## Summary
- Removes the `retiredAt IS NULL` filter when resolving highlight IDs returned by feed in `feedV2`
- Feed already filters retired highlights upstream (ClickHouse MV + in-memory cache)

## Context
When a highlight was retired within the feed cache staleness window, feed still served the ID but this query silently dropped it via the postgres join. The result was users intermittently seeing fewer highlights than feed sent (e.g. 1-2 rendered when feed served 4).

By trusting feed's filtering, the two services stay consistent. Pairs with the daily-feed change that lowers the cache staleness window to ~4 minutes worst case.

## Test plan
- [ ] Verify highlights render for valid IDs returned from feed
- [ ] Confirm no leakage of retired highlights (feed-side filter is authoritative)