### PR TITLE
fix: add substack.com to known platform domains to prevent mastodon misdetection

### DIFF
--- a/__tests__/common/socials.ts
+++ b/__tests__/common/socials.ts
@@ -107,6 +107,21 @@ describe('detectPlatformFromUrl', () => {
     expect(result).toBe('medium');
   });
 
+  it('should detect substack.com', () => {
+    expect(detectPlatformFromUrl('https://substack.com/@devnp2007')).toBe(
+      'substack',
+    );
+    expect(detectPlatformFromUrl('https://www.substack.com/@user')).toBe(
+      'substack',
+    );
+  });
+
+  it('should NOT detect substack.com as mastodon', () => {
+    // Substack URLs have /@ pattern but should NOT be detected as Mastodon
+    const result = detectPlatformFromUrl('https://substack.com/@devnp2007');
+    expect(result).toBe('substack');
+  });
+
   it('should return null for unknown domains', () => {
     expect(detectPlatformFromUrl('https://example.com/profile')).toBeNull();
     expect(detectPlatformFromUrl('https://mysite.io/about')).toBeNull();
@@ -123,6 +138,12 @@ describe('extractHandleFromUrl', () => {
     expect(extractHandleFromUrl('https://medium.com/@testuser', 'medium')).toBe(
       'testuser',
     );
+  });
+
+  it('should extract handle from substack URL', () => {
+    expect(
+      extractHandleFromUrl('https://substack.com/@devnp2007', 'substack'),
+    ).toBe('devnp2007');
   });
 
   it('should extract handle from twitter URL', () => {

--- a/src/common/schema/socials.ts
+++ b/src/common/schema/socials.ts
@@ -126,6 +126,7 @@ const PLATFORM_DOMAINS: Record<string, string> = {
   'bitbucket.org': 'bitbucket',
   'kaggle.com': 'kaggle',
   'medium.com': 'medium',
+  'substack.com': 'substack',
 };
 
 /**
@@ -243,6 +244,9 @@ export function extractHandleFromUrl(
         return pathname.replace(/^\/profile\//, '') || null;
       case 'medium':
         // https://medium.com/@username
+        return pathname.replace(/^\/@?/, '') || null;
+      case 'substack':
+        // https://substack.com/@username
         return pathname.replace(/^\/@?/, '') || null;
       case 'mastodon':
         // Full URL is stored for mastodon


### PR DESCRIPTION
## Summary
- Added `substack.com` to `PLATFORM_DOMAINS` map so Substack profile URLs (e.g. `https://substack.com/@devnp2007`) are correctly identified as `substack` instead of being caught by the Mastodon `/@` heuristic
- Added `substack` case to `extractHandleFromUrl()` for handle extraction
- Added tests for detection, mastodon exclusion, and handle extraction

## Test plan
- [x] `detectPlatformFromUrl('https://substack.com/@devnp2007')` returns `'substack'`
- [x] `detectPlatformFromUrl('https://www.substack.com/@user')` returns `'substack'`
- [x] Substack URLs are NOT detected as mastodon
- [x] `extractHandleFromUrl('https://substack.com/@devnp2007', 'substack')` returns `'devnp2007'`
- [x] All 28 existing + new tests pass

Closes ENG-1361

---
Created by Huginn 🐦‍⬛