### PR TITLE
feat: add content embeds

### DIFF
--- a/__tests__/comments.ts
+++ b/__tests__/comments.ts
@@ -22,6 +22,7 @@ import {
   SourceType,
   User,
 } from '../src/entity';
+import { ContentEmbed } from '../src/entity/ContentEmbed';
 import { SourceMemberRoles } from '../src/roles';
 import { sourcesFixture } from './fixture/source';
 import {
@@ -967,6 +968,98 @@ describe('mutation commentOnPost', () => {
     expect(post.comments).toEqual(6);
   });
 
+  it('should extract standalone post links as content embeds', async () => {
+    loggedUser = '1';
+    const firstUrl = 'http://localhost:5002/posts/p2';
+    const secondUrl = 'http://localhost:5002/posts/p3';
+    const secondLink = `[related](${secondUrl})`;
+    const content = `check these\n\n${firstUrl}\n\n${secondLink}`;
+    const mutation = `
+      mutation CommentOnPost($postId: ID!, $content: String!) {
+        commentOnPost(postId: $postId, content: $content) {
+          id
+          contentEmbeds {
+            url
+            referenceType
+            referenceId
+            sortOrder
+            startOffset
+            endOffset
+            post {
+              id
+              title
+            }
+          }
+        }
+      }
+    `;
+
+    const res = await client.mutate(mutation, {
+      variables: { postId: 'p1', content },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.commentOnPost.contentEmbeds).toEqual([
+      {
+        url: firstUrl,
+        referenceType: 'post',
+        referenceId: 'p2',
+        sortOrder: 0,
+        startOffset: content.indexOf(firstUrl),
+        endOffset: content.indexOf(firstUrl) + firstUrl.length,
+        post: {
+          id: 'p2',
+          title: 'P2',
+        },
+      },
+      {
+        url: secondUrl,
+        referenceType: 'post',
+        referenceId: 'p3',
+        sortOrder: 1,
+        startOffset: content.indexOf('[related]'),
+        endOffset: content.indexOf(secondLink) + secondLink.length,
+        post: {
+          id: 'p3',
+          title: 'P3',
+        },
+      },
+    ]);
+  });
+
+  it('should extract inline markdown post links as content embeds', async () => {
+    loggedUser = '1';
+    const url = 'http://localhost:5002/posts/p2';
+    const link = `[${url}](${url})`;
+    const content = `hello world ${link}`;
+    const mutation = `
+      mutation CommentOnPost($postId: ID!, $content: String!) {
+        commentOnPost(postId: $postId, content: $content) {
+          contentEmbeds {
+            url
+            referenceId
+            startOffset
+            endOffset
+          }
+        }
+      }
+    `;
+
+    const res = await client.mutate(mutation, {
+      variables: { postId: 'p1', content },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.commentOnPost.contentEmbeds).toEqual([
+      {
+        url,
+        referenceId: 'p2',
+        startOffset: content.indexOf(link),
+        endOffset: content.indexOf(link) + link.length,
+      },
+    ]);
+  });
+
   it('should comment markdown on a post with user mention', async () => {
     loggedUser = '1';
     await saveCommentMentionFixtures();
@@ -1463,6 +1556,30 @@ describe('mutation deleteComment', () => {
     );
   });
 
+  it('should delete comment content embeds', async () => {
+    loggedUser = '1';
+    const editMutation = `
+      mutation EditComment($id: ID!, $content: String!) {
+        editComment(id: $id, content: $content) {
+          id
+        }
+      }
+    `;
+
+    await client.mutate(editMutation, {
+      variables: {
+        id: 'c2',
+        content: 'http://localhost:5002/posts/p2',
+      },
+    });
+    expect(await con.getRepository(ContentEmbed).count()).toEqual(1);
+
+    const res = await client.mutate(MUTATION, { variables: { id: 'c2' } });
+
+    expect(res.errors).toBeFalsy();
+    expect(await con.getRepository(ContentEmbed).count()).toEqual(0);
+  });
+
   it('should delete a comment and its children', async () => {
     loggedUser = '1';
     const before = await con.getRepository(Comment).findBy({ postId: 'p1' });
@@ -1610,6 +1727,35 @@ describe('mutation editComment', () => {
       lastUpdatedAt: expect.any(String),
       content: 'Edit',
     });
+  });
+
+  it('should replace content embeds when editing a comment', async () => {
+    loggedUser = '1';
+    const linkedContent = 'http://localhost:5002/posts/p2';
+    const mutation = `
+      mutation EditComment($id: ID!, $content: String!) {
+        editComment(id: $id, content: $content) {
+          id
+          contentEmbeds {
+            referenceId
+          }
+        }
+      }
+    `;
+
+    const linked = await client.mutate(mutation, {
+      variables: { id: 'c2', content: linkedContent },
+    });
+    expect(linked.errors).toBeFalsy();
+    expect(linked.data.editComment.contentEmbeds).toEqual([
+      { referenceId: 'p2' },
+    ]);
+
+    const unlinked = await client.mutate(mutation, {
+      variables: { id: 'c2', content: 'Edit' },
+    });
+    expect(unlinked.errors).toBeFalsy();
+    expect(unlinked.data.editComment.contentEmbeds).toEqual([]);
   });
 
   describe('vordr', () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -19,6 +19,9 @@ import {
   BookmarkList,
   clearPostTranslations,
   Comment,
+  ContentEmbed,
+  ContentEmbedParentType,
+  ContentEmbedReferenceType,
   Feed,
   FeedType,
   FreeformPost,
@@ -2048,6 +2051,38 @@ describe('mutation deletePost', () => {
     loggedUser = '1';
     roles = [Roles.Moderator];
     await verifyPostDeleted('p1', loggedUser);
+  });
+
+  it('should delete owned and referenced content embeds', async () => {
+    loggedUser = '1';
+    roles = [Roles.Moderator];
+    await con.getRepository(ContentEmbed).save([
+      {
+        parentType: ContentEmbedParentType.Post,
+        parentId: 'p1',
+        referenceType: ContentEmbedReferenceType.Post,
+        referenceId: 'p2',
+        url: 'http://localhost:5002/posts/p2',
+        sortOrder: 0,
+        startOffset: 0,
+        endOffset: 31,
+      },
+      {
+        parentType: ContentEmbedParentType.Post,
+        parentId: 'p2',
+        referenceType: ContentEmbedReferenceType.Post,
+        referenceId: 'p1',
+        url: 'http://localhost:5002/posts/p1',
+        sortOrder: 0,
+        startOffset: 0,
+        endOffset: 31,
+      },
+    ]);
+
+    const res = await client.mutate(MUTATION, { variables: { id: 'p1' } });
+
+    expect(res.errors).toBeFalsy();
+    expect(await con.getRepository(ContentEmbed).count()).toEqual(0);
   });
 
   it('should do nothing if post is already deleted', async () => {
@@ -5354,6 +5389,135 @@ describe('mutation createFreeformPost', () => {
     expect(res.data.createFreeformPost.contentHtml).toMatchSnapshot();
   });
 
+  it('should extract standalone post links as content embeds', async () => {
+    loggedUser = '1';
+    const content = 'http://localhost:5002/posts/p2';
+    const mutation = /* GraphQL */ `
+      mutation CreateFreeformPost(
+        $sourceId: ID!
+        $title: String!
+        $content: String!
+      ) {
+        createFreeformPost(
+          sourceId: $sourceId
+          title: $title
+          content: $content
+        ) {
+          id
+          contentEmbeds {
+            url
+            referenceType
+            referenceId
+            sortOrder
+            startOffset
+            endOffset
+            post {
+              id
+              title
+            }
+          }
+        }
+      }
+    `;
+
+    const res = await client.mutate(mutation, {
+      variables: { ...params, content },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.createFreeformPost.contentEmbeds).toEqual([
+      {
+        url: content,
+        referenceType: 'post',
+        referenceId: 'p2',
+        sortOrder: 0,
+        startOffset: 0,
+        endOffset: content.length,
+        post: {
+          id: 'p2',
+          title: 'P2',
+        },
+      },
+    ]);
+  });
+
+  it('should resolve dly.to links as content embeds', async () => {
+    loggedUser = '1';
+    const content = 'https://dly.to/post2';
+    nock('https://dly.to')
+      .head('/post2')
+      .reply(302, undefined, { location: 'http://localhost:5002/posts/p2' });
+    const mutation = /* GraphQL */ `
+      mutation CreateFreeformPost(
+        $sourceId: ID!
+        $title: String!
+        $content: String!
+      ) {
+        createFreeformPost(
+          sourceId: $sourceId
+          title: $title
+          content: $content
+        ) {
+          id
+          contentEmbeds {
+            url
+            referenceType
+            referenceId
+            post {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const res = await client.mutate(mutation, {
+      variables: { ...params, content },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.createFreeformPost.contentEmbeds).toEqual([
+      {
+        url: content,
+        referenceType: 'post',
+        referenceId: 'p2',
+        post: {
+          id: 'p2',
+        },
+      },
+    ]);
+  });
+
+  it('should not extract private post links as content embeds', async () => {
+    loggedUser = '1';
+    const content = 'http://localhost:5002/posts/p6';
+    const mutation = /* GraphQL */ `
+      mutation CreateFreeformPost(
+        $sourceId: ID!
+        $title: String!
+        $content: String!
+      ) {
+        createFreeformPost(
+          sourceId: $sourceId
+          title: $title
+          content: $content
+        ) {
+          id
+          contentEmbeds {
+            referenceId
+          }
+        }
+      }
+    `;
+
+    const res = await client.mutate(mutation, {
+      variables: { ...params, content },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.createFreeformPost.contentEmbeds).toEqual([]);
+  });
+
   it('should increment source total posts', async () => {
     loggedUser = '1';
     const sourceId = 'a';
@@ -6777,6 +6941,33 @@ describe('mutation editPost', () => {
     });
     expect(res.errors).toBeFalsy();
     expect(res.data.editPost.contentHtml).toMatchSnapshot();
+  });
+
+  it('should replace content embeds when editing a post', async () => {
+    loggedUser = '1';
+    const linkedContent = 'http://localhost:5002/posts/p2';
+    const mutation = /* GraphQL */ `
+      mutation EditPost($id: ID!, $content: String) {
+        editPost(id: $id, content: $content) {
+          id
+          contentEmbeds {
+            referenceId
+          }
+        }
+      }
+    `;
+
+    const linked = await client.mutate(mutation, {
+      variables: { id: 'p1', content: linkedContent },
+    });
+    expect(linked.errors).toBeFalsy();
+    expect(linked.data.editPost.contentEmbeds).toEqual([{ referenceId: 'p2' }]);
+
+    const unlinked = await client.mutate(mutation, {
+      variables: { id: 'p1', content: 'Updated content' },
+    });
+    expect(unlinked.errors).toBeFalsy();
+    expect(unlinked.data.editPost.contentEmbeds).toEqual([]);
   });
 
   it('should allow mention as part of the content', async () => {

--- a/src/common/contentEmbeds.ts
+++ b/src/common/contentEmbeds.ts
@@ -1,0 +1,408 @@
+import { DataSource, EntityManager, In } from 'typeorm';
+import fetch from 'node-fetch';
+import type { Token } from 'markdown-it';
+import {
+  ContentEmbed,
+  ContentEmbedParentType,
+  ContentEmbedReferenceType,
+} from '../entity/ContentEmbed';
+import { Post } from '../entity/posts/Post';
+import { markdown } from './markdown';
+
+export const MAX_POST_CONTENT_EMBEDS = 10;
+export const MAX_COMMENT_CONTENT_EMBEDS = 3;
+
+const DLY_TO_REDIRECT_LIMIT = 5;
+const DLY_TO_RESOLVE_TIMEOUT_MS = 1500;
+
+type ConnectionManager = DataSource | EntityManager;
+
+type ExtractedContentEmbed = Pick<
+  ContentEmbed,
+  | 'referenceType'
+  | 'referenceId'
+  | 'url'
+  | 'sortOrder'
+  | 'startOffset'
+  | 'endOffset'
+>;
+
+type ContentEmbedParent = Pick<ContentEmbed, 'parentType' | 'parentId'>;
+
+const getCommentsHost = (): string | undefined => {
+  if (!process.env.COMMENTS_PREFIX) {
+    return undefined;
+  }
+
+  try {
+    return new URL(process.env.COMMENTS_PREFIX).host;
+  } catch {
+    return undefined;
+  }
+};
+
+const isAllowedDailyDevUrl = (url: URL): boolean => {
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    return false;
+  }
+
+  return url.host === getCommentsHost();
+};
+
+const isDlyToUrl = (url: URL): boolean =>
+  url.protocol === 'https:' && url.host === 'dly.to';
+
+const getPostReferenceFromUrl = (url: URL): string | undefined => {
+  const parts = url.pathname.split('/').filter(Boolean);
+
+  if (parts.length === 2 && parts[0] === 'posts') {
+    return parts[1];
+  }
+
+  return undefined;
+};
+
+const findReferencedPostId = async (
+  con: ConnectionManager,
+  url: URL,
+): Promise<string | undefined> => {
+  if (!isAllowedDailyDevUrl(url)) {
+    return undefined;
+  }
+
+  const reference = getPostReferenceFromUrl(url);
+  if (!reference) {
+    return undefined;
+  }
+
+  const post = await con.getRepository(Post).findOne({
+    select: ['id'],
+    where: [
+      {
+        slug: reference,
+        deleted: false,
+        visible: true,
+        private: false,
+      },
+      {
+        id: reference,
+        deleted: false,
+        visible: true,
+        private: false,
+      },
+    ],
+  });
+
+  return post?.id;
+};
+
+const fetchRedirectLocation = async (url: URL): Promise<string | undefined> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    DLY_TO_RESOLVE_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'HEAD',
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+
+    return response.headers.get('location') ?? undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const resolveDlyToUrl = async (url: URL): Promise<URL | undefined> => {
+  let current = url;
+
+  for (let index = 0; index < DLY_TO_REDIRECT_LIMIT; index += 1) {
+    const location = await fetchRedirectLocation(current);
+    if (!location) {
+      return undefined;
+    }
+
+    const next = new URL(location, current);
+    if (!isDlyToUrl(next)) {
+      return next;
+    }
+
+    current = next;
+  }
+
+  return undefined;
+};
+
+const getLinkHref = (token: Token): string | undefined =>
+  token.attrs?.find(([name]) => name === 'href')?.[1];
+
+const getLineStartOffsets = (content: string): number[] => {
+  const offsets = [0];
+
+  for (const line of content.split('\n')) {
+    offsets.push(offsets[offsets.length - 1] + line.length + 1);
+  }
+
+  return offsets;
+};
+
+const getLinkText = ({
+  children,
+  linkStartIndex,
+}: {
+  children: Token[];
+  linkStartIndex: number;
+}): string => {
+  let text = '';
+
+  for (
+    let index = linkStartIndex + 1;
+    index < children.length && children[index].type !== 'link_close';
+    index += 1
+  ) {
+    text += children[index].content;
+  }
+
+  return text;
+};
+
+const findLinkSourceOffset = ({
+  line,
+  href,
+  text,
+  cursor,
+}: {
+  line: string;
+  href: string;
+  text: string;
+  cursor: number;
+}): { start: number; end: number } | undefined => {
+  const markdownLink = `[${text}](${href})`;
+  const markdownLinkStart = line.indexOf(markdownLink, cursor);
+
+  if (markdownLinkStart >= 0) {
+    return {
+      start: markdownLinkStart,
+      end: markdownLinkStart + markdownLink.length,
+    };
+  }
+
+  const hrefStart = line.indexOf(href, cursor);
+
+  if (hrefStart >= 0) {
+    const markdownHrefStart = line.lastIndexOf('](', hrefStart);
+    const markdownTextStart = line.lastIndexOf('[', markdownHrefStart);
+    const markdownHrefEnd = line.indexOf(')', hrefStart + href.length);
+
+    if (
+      markdownTextStart >= cursor &&
+      markdownHrefStart >= 0 &&
+      markdownHrefEnd >= 0
+    ) {
+      return {
+        start: markdownTextStart,
+        end: markdownHrefEnd + 1,
+      };
+    }
+
+    if (line[hrefStart - 1] === '<' && line[hrefStart + href.length] === '>') {
+      return {
+        start: hrefStart - 1,
+        end: hrefStart + href.length + 1,
+      };
+    }
+
+    return {
+      start: hrefStart,
+      end: hrefStart + href.length,
+    };
+  }
+
+  if (!text) {
+    return undefined;
+  }
+
+  const textStart = line.indexOf(`[${text}]`, cursor);
+
+  if (textStart >= 0) {
+    return {
+      start: textStart,
+      end: textStart + text.length + 2,
+    };
+  }
+
+  return undefined;
+};
+
+const extractMarkdownLinks = ({
+  content,
+  tokens,
+}: {
+  content: string;
+  tokens: Token[];
+}): Array<{ url: string; startOffset: number; endOffset: number }> => {
+  const lineStartOffsets = getLineStartOffsets(content);
+  const lines = content.split('\n');
+
+  return tokens.reduce<
+    Array<{ url: string; startOffset: number; endOffset: number }>
+  >((links, token) => {
+    const [lineStart, lineEnd] = token.map ?? [];
+    if (
+      token.type !== 'inline' ||
+      lineStart === undefined ||
+      lineEnd !== lineStart + 1
+    ) {
+      return links;
+    }
+
+    const line = lines[lineStart] ?? '';
+    const contentOffset = line.indexOf(token.content);
+    const inlineOffset = Math.max(contentOffset, 0);
+    let cursor = inlineOffset;
+
+    token.children?.forEach((child, index, children) => {
+      if (child.type !== 'link_open') {
+        return;
+      }
+
+      const url = getLinkHref(child);
+      if (!url) {
+        return;
+      }
+
+      const offset = findLinkSourceOffset({
+        line,
+        href: url,
+        text: getLinkText({ children, linkStartIndex: index }),
+        cursor,
+      });
+
+      if (!offset) {
+        return;
+      }
+
+      links.push({
+        url,
+        startOffset: lineStartOffsets[lineStart] + offset.start,
+        endOffset: lineStartOffsets[lineStart] + offset.end,
+      });
+      cursor = offset.end;
+    });
+
+    return links;
+  }, []);
+};
+
+const resolveContentEmbedUrl = async (
+  con: ConnectionManager,
+  rawUrl: string,
+): Promise<string | undefined> => {
+  try {
+    const url = new URL(rawUrl);
+
+    if (isDlyToUrl(url)) {
+      const resolved = await resolveDlyToUrl(url);
+      return resolved ? findReferencedPostId(con, resolved) : undefined;
+    }
+
+    return findReferencedPostId(con, url);
+  } catch {
+    return undefined;
+  }
+};
+
+export const extractContentEmbeds = async ({
+  con,
+  content,
+  tokens,
+  limit,
+}: {
+  con: ConnectionManager;
+  content: string;
+  tokens?: Token[];
+  limit: number;
+}): Promise<ExtractedContentEmbed[]> => {
+  const markdownLinks = extractMarkdownLinks({
+    content,
+    tokens: tokens ?? markdown.parse(content, {}),
+  });
+  const embeds: ExtractedContentEmbed[] = [];
+
+  for (const link of markdownLinks) {
+    const referenceId = await resolveContentEmbedUrl(con, link.url);
+    if (!referenceId) {
+      continue;
+    }
+
+    embeds.push({
+      referenceType: ContentEmbedReferenceType.Post,
+      referenceId,
+      url: link.url,
+      sortOrder: embeds.length,
+      startOffset: link.startOffset,
+      endOffset: link.endOffset,
+    });
+
+    if (embeds.length >= limit) {
+      break;
+    }
+  }
+
+  return embeds;
+};
+
+export const replaceContentEmbeds = async ({
+  con,
+  parentType,
+  parentId,
+  content,
+  tokens,
+  limit,
+}: {
+  con: ConnectionManager;
+  content: string;
+  tokens?: Token[];
+  limit: number;
+} & ContentEmbedParent): Promise<void> => {
+  const repo = con.getRepository(ContentEmbed);
+  const embeds = await extractContentEmbeds({ con, content, tokens, limit });
+
+  await repo.delete({ parentType, parentId });
+
+  if (!embeds.length) {
+    return;
+  }
+
+  await repo.insert(
+    embeds.map((embed) =>
+      repo.create({
+        ...embed,
+        parentType,
+        parentId,
+      }),
+    ),
+  );
+};
+
+export const deleteContentEmbedsByParent = async ({
+  con,
+  parentType,
+  parentIds,
+}: {
+  con: ConnectionManager;
+  parentType: ContentEmbedParentType;
+  parentIds: string[];
+}): Promise<void> => {
+  if (!parentIds.length) {
+    return;
+  }
+
+  await con.getRepository(ContentEmbed).delete({
+    parentType,
+    parentId: In(parentIds),
+  });
+};

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -49,6 +49,16 @@ export const markdown: MarkdownIt = MarkdownIt({
   },
 });
 
+export const renderMarkdown = (
+  content: string,
+  env: Record<string, unknown> = {},
+): { contentHtml: string; tokens: Token[] } => {
+  const tokens = markdown.parse(content, env);
+  const contentHtml = markdown.renderer.render(tokens, markdown.options, env);
+
+  return { contentHtml, tokens };
+};
+
 export const getMentionLink = ({ id, username }: MarkdownMention): string => {
   const href = getUserProfileUrl(username || ghostUser.id);
 

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -1,4 +1,5 @@
 import { DataSource, EntityManager, In, Not } from 'typeorm';
+import type { Token } from 'markdown-it';
 import {
   ArticlePost,
   Comment,
@@ -25,7 +26,12 @@ import {
 } from '../entity';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { isValidHttpUrl, standardizeURL } from './links';
-import { findMarkdownTag, markdown, saveMentions } from './markdown';
+import {
+  findMarkdownTag,
+  markdown,
+  renderMarkdown,
+  saveMentions,
+} from './markdown';
 import { generateShortId } from '../ids';
 import { GQLPost } from '../schema/posts';
 // @ts-expect-error - no types
@@ -66,6 +72,8 @@ import { pollCreationSchema } from './schema/polls';
 import { generateDeduplicationKey } from '../entity/posts/hooks';
 import { z } from 'zod';
 import { canPostToSquad } from '../schema/sources';
+import { MAX_POST_CONTENT_EMBEDS, replaceContentEmbeds } from './contentEmbeds';
+import { ContentEmbedParentType } from '../entity/ContentEmbed';
 
 export type SourcePostModerationArgs = ConnectionArguments & {
   sourceId: string;
@@ -269,11 +277,12 @@ export type CreatePost = Pick<
   'title' | 'content' | 'image' | 'contentHtml' | 'authorId' | 'sourceId' | 'id'
 >;
 
-interface CreateFreeformPostArgs {
+type CreateFreeformPostArgs = {
   con: DataSource | EntityManager;
   ctx?: AuthContext;
   args: CreatePost;
-}
+  contentTokens?: Token[];
+};
 
 interface CreatePollPostArgs {
   con: DataSource | EntityManager;
@@ -357,6 +366,7 @@ export const insertFreeformPost = async ({
   con,
   args,
   ctx,
+  contentTokens,
 }: CreateFreeformPostArgs) => {
   const { private: privacy } = await con.getRepository(Source).findOneByOrFail({
     id: args.sourceId,
@@ -383,7 +393,20 @@ export const insertFreeformPost = async ({
     req: ctx?.req,
   });
 
-  return con.getRepository(FreeformPost).save(createdPost);
+  const savedPost = await con.getRepository(FreeformPost).save(createdPost);
+
+  if (savedPost.content) {
+    await replaceContentEmbeds({
+      con,
+      parentType: ContentEmbedParentType.Post,
+      parentId: savedPost.id,
+      content: savedPost.content,
+      tokens: contentTokens,
+      limit: MAX_POST_CONTENT_EMBEDS,
+    });
+  }
+
+  return savedPost;
 };
 
 export interface CreateSourcePostModeration
@@ -1425,7 +1448,7 @@ export const createFreeformPost = async (
 
   await con.transaction(async (manager) => {
     const mentions = await getMentions(manager, content, userId, sourceId);
-    const contentHtml = markdown.render(content, { mentions });
+    const { contentHtml, tokens } = renderMarkdown(content, { mentions });
     const params: CreatePost = {
       id,
       title,
@@ -1445,7 +1468,12 @@ export const createFreeformPost = async (
       params.image = coverImageUrl;
     }
 
-    await insertFreeformPost({ con: manager, ctx, args: params });
+    await insertFreeformPost({
+      con: manager,
+      ctx,
+      args: params,
+      contentTokens: tokens,
+    });
     await saveMentions(manager, id, userId, mentions, PostMention);
   });
 

--- a/src/entity/ContentEmbed.ts
+++ b/src/entity/ContentEmbed.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum ContentEmbedParentType {
+  Post = 'post',
+  Comment = 'comment',
+}
+
+export enum ContentEmbedReferenceType {
+  Post = 'post',
+}
+
+@Entity()
+@Index('IDX_content_embed_parent', ['parentType', 'parentId'])
+@Index('IDX_content_embed_reference', ['referenceType', 'referenceId'])
+export class ContentEmbed {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  parentType: ContentEmbedParentType;
+
+  @Column({ type: 'text' })
+  parentId: string;
+
+  @Column({ type: 'text' })
+  referenceType: ContentEmbedReferenceType;
+
+  @Column({ type: 'text' })
+  referenceId: string;
+
+  @Column({ type: 'text' })
+  url: string;
+
+  @Column({ type: 'integer' })
+  sortOrder: number;
+
+  @Column({ type: 'integer' })
+  startOffset: number;
+
+  @Column({ type: 'integer' })
+  endOffset: number;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ default: () => 'now()' })
+  updatedAt: Date;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -55,3 +55,4 @@ export * from './ChannelHighlightDefinition';
 export * from './ChannelHighlightRun';
 export * from './Archive';
 export * from './ArchiveItem';
+export * from './ContentEmbed';

--- a/src/entity/posts/utils.ts
+++ b/src/entity/posts/utils.ts
@@ -40,6 +40,12 @@ import {
   applyVordrHook,
   applyVordrHookForUpdate,
 } from './hooks';
+import {
+  ContentEmbed,
+  ContentEmbedParentType,
+  ContentEmbedReferenceType,
+} from '../ContentEmbed';
+import { Comment } from '../Comment';
 
 export type PostStats = {
   numPosts: number;
@@ -60,8 +66,8 @@ interface DeletePostProps {
   userId?: string;
 }
 
-export const deletePost = async ({ con, id, userId }: DeletePostProps) =>
-  con.getRepository(Post).update(
+export const deletePost = async ({ con, id, userId }: DeletePostProps) => {
+  const result = await con.getRepository(Post).update(
     { id },
     {
       deleted: true,
@@ -71,6 +77,34 @@ export const deletePost = async ({ con, id, userId }: DeletePostProps) =>
       }),
     },
   );
+
+  const embedRepo = con.getRepository(ContentEmbed);
+  const postCommentIds = embedRepo
+    .createQueryBuilder()
+    .subQuery()
+    .select('comment.id')
+    .from(Comment, 'comment')
+    .where('comment."postId" = :postId')
+    .getQuery();
+
+  await embedRepo
+    .createQueryBuilder()
+    .delete()
+    .where('"referenceType" = :referenceType AND "referenceId" = :postId')
+    .orWhere('"parentType" = :postParentType AND "parentId" = :postId')
+    .orWhere(
+      `"parentType" = :commentParentType AND "parentId" IN ${postCommentIds}`,
+    )
+    .setParameters({
+      referenceType: ContentEmbedReferenceType.Post,
+      postParentType: ContentEmbedParentType.Post,
+      commentParentType: ContentEmbedParentType.Comment,
+      postId: id,
+    })
+    .execute();
+
+  return result;
+};
 
 export const getAuthorPostStats = async (
   con: DataSource,

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -68,6 +68,10 @@ import {
   ContentPreferenceOrganization,
   ContentPreferenceOrganizationStatus,
 } from '../entity/contentPreference/ContentPreferenceOrganization';
+import {
+  ContentEmbedParentType,
+  ContentEmbedReferenceType,
+} from '../entity/ContentEmbed';
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
 import { UserExperienceType } from '../entity/user/experiences/types';
@@ -586,6 +590,19 @@ const obj = new GraphORM({
         select: 'tagsStr',
         transform: (value: string): string[] => value?.split(',') ?? [],
       },
+      contentEmbeds: {
+        relation: {
+          isMany: true,
+          sort: 'sortOrder',
+          order: 'ASC',
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
+            qb
+              .where(`"${childAlias}"."parentId" = "${parentAlias}"."id"`)
+              .andWhere(`"${childAlias}"."parentType" = :embedPostParent`, {
+                embedPostParent: ContentEmbedParentType.Post,
+              }),
+        },
+      },
       clickbaitTitleDetected: {
         transform: (_, ctx: Context, parent): boolean => {
           const typedParent = parent as {
@@ -1063,11 +1080,43 @@ const obj = new GraphORM({
       createdAt: { transform: transformDate },
     },
   },
+  ContentEmbed: {
+    requiredColumns: ['id', 'referenceId', 'referenceType'],
+    fields: {
+      post: {
+        relation: {
+          isMany: false,
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
+            qb
+              .where(`"${childAlias}"."id" = "${parentAlias}"."referenceId"`)
+              .andWhere(`"${parentAlias}"."referenceType" = :embedReference`, {
+                embedReference: ContentEmbedReferenceType.Post,
+              })
+              .andWhere(`"${childAlias}"."deleted" = false`)
+              .andWhere(`"${childAlias}"."visible" = true`)
+              .andWhere(`"${childAlias}"."private" = false`),
+        },
+      },
+    },
+  },
   Comment: {
     requiredColumns: ['id', 'postId', 'createdAt'],
     fields: {
       createdAt: { transform: transformDate },
       lastUpdatedAt: { transform: transformDate },
+      contentEmbeds: {
+        relation: {
+          isMany: true,
+          sort: 'sortOrder',
+          order: 'ASC',
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
+            qb
+              .where(`"${childAlias}"."parentId" = "${parentAlias}"."id"`)
+              .andWhere(`"${childAlias}"."parentType" = :embedCommentParent`, {
+                embedCommentParent: ContentEmbedParentType.Comment,
+              }),
+        },
+      },
       upvoted: {
         select: (ctx: Context, alias: string, qb: QueryBuilder): string => {
           const query = qb

--- a/src/migration/1778000000000-ContentEmbed.ts
+++ b/src/migration/1778000000000-ContentEmbed.ts
@@ -1,0 +1,39 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ContentEmbed1778000000000 implements MigrationInterface {
+  name = 'ContentEmbed1778000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "content_embed" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "parentType" text NOT NULL,
+        "parentId" text NOT NULL,
+        "referenceType" text NOT NULL,
+        "referenceId" text NOT NULL,
+        "url" text NOT NULL,
+        "sortOrder" integer NOT NULL,
+        "startOffset" integer NOT NULL,
+        "endOffset" integer NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_content_embed_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_content_embed_parent"
+        ON "content_embed" ("parentType", "parentId")
+    `);
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_content_embed_reference"
+        ON "content_embed" ("referenceType", "referenceId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP TABLE IF EXISTS "content_embed"
+    `);
+  }
+}

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -37,6 +37,7 @@ import {
 import {
   markdown,
   mentionSpecialCharacters,
+  renderMarkdown,
   saveMentions,
 } from '../common/markdown';
 import { ensureSourcePermissions, SourcePermissions } from './sources';
@@ -54,6 +55,12 @@ import { toGQLEnum } from '../common/utils';
 import { ensureCommentRateLimit } from '../common/rateLimit';
 import { whereNotUserBlocked } from '../common/contentPreference';
 import type { GQLProduct } from './njord';
+import {
+  deleteContentEmbedsByParent,
+  MAX_COMMENT_CONTENT_EMBEDS,
+  replaceContentEmbeds,
+} from '../common/contentEmbeds';
+import { ContentEmbedParentType } from '../entity/ContentEmbed';
 
 export interface GQLComment {
   id: string;
@@ -70,6 +77,7 @@ export interface GQLComment {
   userState?: GQLUserComment;
   fromAward: boolean;
   award?: GQLProduct;
+  contentEmbeds?: unknown[];
 }
 
 interface GQLMentionUserArgs {
@@ -131,6 +139,11 @@ export const typeDefs = /* GraphQL */ `
     HTML Parsed content of the comment
     """
     contentHtml: String!
+
+    """
+    Embeds extracted from standalone links in the comment body.
+    """
+    contentEmbeds: [ContentEmbed!]!
 
     """
     Time when comment was created
@@ -609,7 +622,7 @@ export const saveComment = async (
     comment.userId,
     sourceId,
   );
-  const contentHtml = markdown.render(comment.content, { mentions });
+  const { contentHtml, tokens } = renderMarkdown(comment.content, { mentions });
   comment.contentHtml = contentHtml;
   const savedComment = await con.getRepository(Comment).save(comment);
   await saveMentions(
@@ -619,6 +632,14 @@ export const saveComment = async (
     mentions,
     CommentMention,
   );
+  await replaceContentEmbeds({
+    con,
+    parentType: ContentEmbedParentType.Comment,
+    parentId: savedComment.id,
+    content: savedComment.content,
+    tokens,
+    limit: MAX_COMMENT_CONTENT_EMBEDS,
+  });
 
   return savedComment;
 };
@@ -1184,9 +1205,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
         const repo = entityManager.getRepository(Comment);
-        const comment = await ctx.con.getRepository(Comment).findOneOrFail({
+        const comment = await repo.findOneOrFail({
           where: { id },
           relations: ['post'],
+        });
+        const childComments = await repo.find({
+          select: ['id'],
+          where: { parentId: id },
         });
         const post = await comment.post;
         if (
@@ -1200,6 +1225,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         ) {
           throw new ForbiddenError("Cannot delete someone else's comment");
         }
+        await deleteContentEmbedsByParent({
+          con: entityManager,
+          parentType: ContentEmbedParentType.Comment,
+          parentIds: [
+            comment.id,
+            ...childComments.map((childComment) => childComment.id),
+          ],
+        });
         await repo.delete({ id: comment.id });
       });
       return { _: true };

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -111,7 +111,12 @@ import {
 } from '../common/datePageGenerator';
 import { GraphQLResolveInfo } from 'graphql';
 import { Roles } from '../roles';
-import { markdown, saveMentions } from '../common/markdown';
+import { renderMarkdown, saveMentions } from '../common/markdown';
+import {
+  MAX_POST_CONTENT_EMBEDS,
+  replaceContentEmbeds,
+} from '../common/contentEmbeds';
+import { ContentEmbed, ContentEmbedParentType } from '../entity/ContentEmbed';
 // @ts-expect-error - no types
 import { FileUpload } from 'graphql-upload/GraphQLUpload';
 import { insertOrIgnoreAction } from './actions';
@@ -209,6 +214,7 @@ export interface GQLPost {
   feedMeta?: string;
   content?: string;
   contentHtml?: string;
+  contentEmbeds?: ContentEmbed[];
   downvoted?: boolean;
   flags?: PostFlagsPublic;
   userState?: GQLUserPost;
@@ -777,6 +783,11 @@ export const typeDefs = /* GraphQL */ `
     contentHtml: String
 
     """
+    Embeds extracted from standalone links in the post body.
+    """
+    contentEmbeds: [ContentEmbed!]!
+
+    """
     Whether the user downvoted this post
     """
     downvoted: Boolean
@@ -926,6 +937,17 @@ export const typeDefs = /* GraphQL */ `
     The original query in case of a search operation
     """
     query: String
+  }
+
+  type ContentEmbed {
+    id: ID!
+    referenceType: String!
+    referenceId: String!
+    url: String!
+    sortOrder: Int!
+    startOffset: Int!
+    endOffset: Int!
+    post: Post
   }
 
   type LinkPreview {
@@ -2588,7 +2610,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       if (ctx.roles.includes(Roles.Moderator)) {
-        await deletePost({ con: ctx.con, id, userId: ctx.userId });
+        await ctx.con.transaction(async (manager) => {
+          await deletePost({ con: manager, id, userId: ctx.userId });
+        });
         return { _: true };
       }
 
@@ -2792,7 +2816,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             post.sourceId,
           );
           updated.content = content;
-          updated.contentHtml = markdown.render(content, { mentions });
+          const { contentHtml, tokens } = renderMarkdown(content, { mentions });
+          updated.contentHtml = contentHtml;
           await saveMentions(
             manager,
             post.id,
@@ -2800,6 +2825,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             mentions,
             PostMention,
           );
+          await replaceContentEmbeds({
+            con: manager,
+            parentType: ContentEmbedParentType.Post,
+            parentId: post.id,
+            content,
+            tokens,
+            limit: MAX_POST_CONTENT_EMBEDS,
+          });
         }
 
         if (post.type === PostType.Welcome) {


### PR DESCRIPTION
## What changed
- Add a `ContentEmbed` table/entity for write-time post-link references owned by posts or comments.
- Extract standalone daily.dev post links and `dly.to` redirects when creating/editing freeform posts and comments.
- Expose `contentEmbeds` on `Post` and `Comment` through GraphORM, including nested public target post data.
- Clean up owned embeds and references when posts/comments are deleted.

## Why
Post links in our own content should be treated as first-class embeds without triggering page preview fetches when clients read a page.

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- `NODE_ENV=test npx jest __tests__/posts.ts --testEnvironment=node --runInBand -t "content embeds|standalone post links|dly.to|private post links"`
- `NODE_ENV=test npx jest __tests__/comments.ts --testEnvironment=node --runInBand -t "content embeds|standalone post links"`
- `git diff --check`