### PR TITLE
feat: add live room lobby api

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -725,7 +725,6 @@ describe('live rooms', () => {
       participantId: '1',
       role: 'host',
       roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
-      userId: '1',
     });
     expect(scope.isDone()).toBe(true);
   });

--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -144,6 +144,15 @@ describe('live rooms', () => {
     }
   `;
 
+  const SUBSCRIBED_QUERY = /* GraphQL */ `
+    query LiveRoomSubscribed($id: ID!) {
+      liveRoom(id: $id) {
+        id
+        subscribed
+      }
+    }
+  `;
+
   const JOIN_TOKEN_MUTATION = /* GraphQL */ `
     mutation LiveRoomJoinToken($roomId: ID!) {
       liveRoomJoinToken(roomId: $roomId) {
@@ -178,8 +187,7 @@ describe('live rooms', () => {
   const SUBSCRIBE_MUTATION = /* GraphQL */ `
     mutation SubscribeToLiveRoom($roomId: ID!) {
       subscribeToLiveRoom(roomId: $roomId) {
-        id
-        subscribed
+        _
       }
     }
   `;
@@ -187,8 +195,7 @@ describe('live rooms', () => {
   const UNSUBSCRIBE_MUTATION = /* GraphQL */ `
     mutation UnsubscribeFromLiveRoom($roomId: ID!) {
       unsubscribeFromLiveRoom(roomId: $roomId) {
-        id
-        subscribed
+        _
       }
     }
   `;
@@ -749,7 +756,13 @@ describe('live rooms', () => {
       },
     });
     expect(subscribed.errors).toBeFalsy();
-    expect(subscribed.data.subscribeToLiveRoom.subscribed).toBe(true);
+    expect(subscribed.data.subscribeToLiveRoom._).toBe(true);
+    const subscribedRoom = await client.query(SUBSCRIBED_QUERY, {
+      variables: {
+        id: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      },
+    });
+    expect(subscribedRoom.data.liveRoom.subscribed).toBe(true);
     expect(
       await con.getRepository(LiveRoomSubscription).countBy({
         roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
@@ -763,7 +776,13 @@ describe('live rooms', () => {
       },
     });
     expect(unsubscribed.errors).toBeFalsy();
-    expect(unsubscribed.data.unsubscribeFromLiveRoom.subscribed).toBe(false);
+    expect(unsubscribed.data.unsubscribeFromLiveRoom._).toBe(true);
+    const unsubscribedRoom = await client.query(SUBSCRIBED_QUERY, {
+      variables: {
+        id: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      },
+    });
+    expect(unsubscribedRoom.data.liveRoom.subscribed).toBe(false);
     expect(
       await con.getRepository(LiveRoomSubscription).countBy({
         roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',

--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -3,7 +3,14 @@ import nock from 'nock';
 import type { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { Feature, FeatureType, FeatureValue } from '../src/entity/Feature';
+import {
+  ContentEmbed,
+  ContentEmbedParentType,
+} from '../src/entity/ContentEmbed';
 import { LiveRoom } from '../src/entity/LiveRoom';
+import { LiveRoomSubscription } from '../src/entity/LiveRoomSubscription';
+import { Post } from '../src/entity/posts/Post';
+import { Source } from '../src/entity/Source';
 import { StorageKey, StorageTopic } from '../src/config';
 import {
   disposeGraphQLTesting,
@@ -18,6 +25,8 @@ import { usersFixture } from './fixture/user';
 import { User } from '../src/entity/user/User';
 import { LiveRoomStatus } from '../src/common/schema/liveRooms';
 import { deleteKeysByPattern } from '../src/redis';
+import { postsFixture } from './fixture/post';
+import { sourcesFixture } from './fixture/source';
 
 const flytingOrigin = 'http://flyting.test';
 const flytingInternalKey = 'flyting-internal-key';
@@ -85,6 +94,15 @@ describe('live rooms', () => {
           mode
           status
           participantCount
+          scheduledStart
+          description
+          descriptionHtml
+          subscribed
+          contentEmbeds {
+            referenceId
+            url
+            sortOrder
+          }
           host {
             id
             username
@@ -153,6 +171,24 @@ describe('live rooms', () => {
         status
         endedAt
         participantCount
+      }
+    }
+  `;
+
+  const SUBSCRIBE_MUTATION = /* GraphQL */ `
+    mutation SubscribeToLiveRoom($roomId: ID!) {
+      subscribeToLiveRoom(roomId: $roomId) {
+        id
+        subscribed
+      }
+    }
+  `;
+
+  const UNSUBSCRIBE_MUTATION = /* GraphQL */ `
+    mutation UnsubscribeFromLiveRoom($roomId: ID!) {
+      unsubscribeFromLiveRoom(roomId: $roomId) {
+        id
+        subscribed
       }
     }
   `;
@@ -358,9 +394,61 @@ describe('live rooms', () => {
     expect(rooms).toHaveLength(1);
   }, 10000);
 
+  it('creates a scheduled lobby with markdown description and post embeds', async () => {
+    loggedUser = '1';
+    await grantStandupAccess(loggedUser);
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, Post, [postsFixture[0]]);
+
+    const scope = nock(flytingOrigin)
+      .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
+        mode: 'moderated',
+      })
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, { room: { roomId: 'ignored' } });
+
+    const res = await client.mutate(CREATE_MUTATION, {
+      variables: {
+        input: {
+          topic: 'Scheduled GraphQL and SFUs',
+          mode: 'moderated',
+          scheduledStart: '2026-05-05T15:00:00.000Z',
+          description:
+            'Review [this post](http://localhost:5002/posts/p1) before we start.',
+        },
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.createLiveRoom.room).toMatchObject({
+      scheduledStart: '2026-05-05T15:00:00.000Z',
+      description:
+        'Review [this post](http://localhost:5002/posts/p1) before we start.',
+      descriptionHtml:
+        '<p>Review <a href="http://localhost:5002/posts/p1" target="_blank" rel="noopener nofollow">this post</a> before we start.</p>\n',
+      contentEmbeds: [
+        {
+          referenceId: 'p1',
+          url: 'http://localhost:5002/posts/p1',
+          sortOrder: 0,
+        },
+      ],
+    });
+
+    const roomId = res.data.createLiveRoom.room.id;
+    const embeds = await con.getRepository(ContentEmbed).findBy({
+      parentId: roomId,
+      parentType: ContentEmbedParentType.LiveRoom,
+    });
+    expect(embeds).toHaveLength(1);
+    expect(scope.isDone()).toBe(true);
+  }, 10000);
+
   it('removes the durable room when prepare fails definitively', async () => {
     loggedUser = '1';
     await grantStandupAccess(loggedUser);
+    await saveFixtures(con, Source, sourcesFixture);
+    await saveFixtures(con, Post, [postsFixture[0]]);
 
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
@@ -374,6 +462,8 @@ describe('live rooms', () => {
         input: {
           topic: 'Invalid prepare',
           mode: 'moderated',
+          description:
+            'Review [this post](http://localhost:5002/posts/p1) before we start.',
         },
       },
     });
@@ -387,6 +477,11 @@ describe('live rooms', () => {
 
     expect(scope.isDone()).toBe(true);
     expect(rooms).toHaveLength(0);
+    expect(
+      await con.getRepository(ContentEmbed).countBy({
+        parentType: ContentEmbedParentType.LiveRoom,
+      }),
+    ).toBe(0);
   });
 
   it('returns only live rooms', async () => {
@@ -630,8 +725,52 @@ describe('live rooms', () => {
       participantId: '1',
       role: 'host',
       roomId: 'f44bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      userId: '1',
     });
     expect(scope.isDone()).toBe(true);
+  });
+
+  it('subscribes and unsubscribes from scheduled lobby notifications', async () => {
+    loggedUser = '2';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        hostId: '1',
+        topic: 'Scheduled room',
+        mode: 'moderated',
+        scheduledStart: new Date('2026-05-05T15:00:00.000Z'),
+        status: LiveRoomStatus.Created,
+      },
+    ]);
+
+    const subscribed = await client.mutate(SUBSCRIBE_MUTATION, {
+      variables: {
+        roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      },
+    });
+    expect(subscribed.errors).toBeFalsy();
+    expect(subscribed.data.subscribeToLiveRoom.subscribed).toBe(true);
+    expect(
+      await con.getRepository(LiveRoomSubscription).countBy({
+        roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        userId: '2',
+      }),
+    ).toBe(1);
+
+    const unsubscribed = await client.mutate(UNSUBSCRIBE_MUTATION, {
+      variables: {
+        roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+      },
+    });
+    expect(unsubscribed.errors).toBeFalsy();
+    expect(unsubscribed.data.unsubscribeFromLiveRoom.subscribed).toBe(false);
+    expect(
+      await con.getRepository(LiveRoomSubscription).countBy({
+        roomId: 'cd4bb4ae-a0af-4310-b1ff-7d6345cb5253',
+        userId: '2',
+      }),
+    ).toBe(0);
   });
 
   it('returns an anonymous join token for a live room using trackingId identity', async () => {

--- a/__tests__/workers/liveRoomLifecycle.ts
+++ b/__tests__/workers/liveRoomLifecycle.ts
@@ -1,6 +1,9 @@
 import type { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { LiveRoom } from '../../src/entity/LiveRoom';
+import { LiveRoomSubscription } from '../../src/entity/LiveRoomSubscription';
+import { NotificationV2 } from '../../src/entity/notifications/NotificationV2';
+import { UserNotification } from '../../src/entity/notifications/UserNotification';
 import { User } from '../../src/entity/user/User';
 import {
   LiveRoomLifecycleEventType,
@@ -10,14 +13,23 @@ import { saveFixtures, expectSuccessfulTypedBackground } from '../helpers';
 import { usersFixture } from '../fixture/user';
 import { liveRoomStartedWorker } from '../../src/workers/liveRoomStarted';
 import { liveRoomEndedWorker } from '../../src/workers/liveRoomEnded';
+import nock from 'nock';
+import { NotificationType } from '../../src/notifications/common';
+
+const flytingOrigin = 'http://flyting.test';
+const flytingInternalKey = 'flyting-internal-key';
 
 let con: DataSource;
 
 beforeAll(async () => {
+  process.env.COMMENTS_PREFIX = 'http://localhost:5002';
+  process.env.FLYTING_INTERNAL_KEY = flytingInternalKey;
+  process.env.FLYTING_ORIGIN = flytingOrigin;
   con = await createOrGetConnection();
 });
 
 beforeEach(async () => {
+  nock.cleanAll();
   await saveFixtures(con, User, usersFixture);
 });
 
@@ -50,6 +62,131 @@ describe('live room lifecycle workers', () => {
     expect(room.status).toBe(LiveRoomStatus.Live);
     expect(room.startedAt?.toISOString()).toBe('2026-04-23T15:00:00.000Z');
   });
+
+  it('notifies disconnected subscribers and hard deletes room subscriptions when the room starts', async () => {
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        hostId: '1',
+        topic: 'Scheduled lobby',
+        mode: 'moderated',
+        status: LiveRoomStatus.Created,
+        scheduledStart: new Date('2026-05-05T15:00:00.000Z'),
+      },
+    ]);
+    await saveFixtures(con, LiveRoomSubscription, [
+      {
+        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        userId: '2',
+      },
+      {
+        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        userId: '3',
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/7250df5f-f9e0-4b47-898a-fbb975695e83/connected-users',
+      )
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(200, {
+        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        userIds: ['3'],
+      });
+
+    await expectSuccessfulTypedBackground<'flyting.v1.room-started'>(
+      liveRoomStartedWorker,
+      {
+        eventId: '9e56ed30-440f-40ef-bb0b-59e8d871a30a',
+        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        occurredAt: '2026-05-05T15:01:00.000Z',
+        type: LiveRoomLifecycleEventType.RoomStarted,
+      },
+    );
+
+    const notification = await con
+      .getRepository(NotificationV2)
+      .findOneByOrFail({
+        referenceId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+        referenceType: 'live_room',
+        type: NotificationType.LiveRoomStarted,
+      });
+    expect(notification.targetUrl).toBe(
+      'http://localhost:5002/live/7250df5f-f9e0-4b47-898a-fbb975695e83',
+    );
+
+    const userNotifications = await con.getRepository(UserNotification).findBy({
+      notificationId: notification.id,
+    });
+    expect(userNotifications.map(({ userId }) => userId)).toEqual(['2']);
+    expect(
+      await con.getRepository(LiveRoomSubscription).countBy({
+        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
+      }),
+    ).toBe(0);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('still marks the room live when connected user lookup fails', async () => {
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+        hostId: '1',
+        topic: 'Lookup failure lobby',
+        mode: 'moderated',
+        status: LiveRoomStatus.Created,
+        scheduledStart: new Date('2026-05-05T15:00:00.000Z'),
+      },
+    ]);
+    await saveFixtures(con, LiveRoomSubscription, [
+      {
+        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+        userId: '2',
+      },
+    ]);
+
+    const scope = nock(flytingOrigin)
+      .get(
+        '/internal/live-rooms/82ed4745-7c98-47be-a393-bc639bc6fb13/connected-users',
+      )
+      .times(6)
+      .matchHeader('x-flyting-internal-key', flytingInternalKey)
+      .reply(500, { message: 'boom' });
+
+    await expectSuccessfulTypedBackground<'flyting.v1.room-started'>(
+      liveRoomStartedWorker,
+      {
+        eventId: '2781c769-4f0b-4461-a4fd-e77af54e75cb',
+        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+        occurredAt: '2026-05-05T15:01:00.000Z',
+        type: LiveRoomLifecycleEventType.RoomStarted,
+      },
+    );
+
+    const room = await con.getRepository(LiveRoom).findOneByOrFail({
+      id: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+    });
+    const notification = await con
+      .getRepository(NotificationV2)
+      .findOneByOrFail({
+        referenceId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+        referenceType: 'live_room',
+        type: NotificationType.LiveRoomStarted,
+      });
+    const userNotifications = await con.getRepository(UserNotification).findBy({
+      notificationId: notification.id,
+    });
+
+    expect(room.status).toBe(LiveRoomStatus.Live);
+    expect(userNotifications.map(({ userId }) => userId)).toEqual(['2']);
+    expect(
+      await con.getRepository(LiveRoomSubscription).countBy({
+        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
+      }),
+    ).toBe(0);
+    expect(scope.isDone()).toBe(true);
+  }, 10000);
 
   it('marks a room ended when an ended event arrives', async () => {
     await saveFixtures(con, LiveRoom, [

--- a/__tests__/workers/liveRoomLifecycle.ts
+++ b/__tests__/workers/liveRoomLifecycle.ts
@@ -113,6 +113,9 @@ describe('live room lifecycle workers', () => {
         referenceType: 'live_room',
         type: NotificationType.LiveRoomStarted,
       });
+    expect(notification.title).toBe(
+      '<b>Ido</b> is live: <b>Scheduled lobby</b>',
+    );
     expect(notification.targetUrl).toBe(
       'http://localhost:5002/standups/7250df5f-f9e0-4b47-898a-fbb975695e83',
     );

--- a/__tests__/workers/liveRoomLifecycle.ts
+++ b/__tests__/workers/liveRoomLifecycle.ts
@@ -3,6 +3,7 @@ import createOrGetConnection from '../../src/db';
 import { LiveRoom } from '../../src/entity/LiveRoom';
 import { LiveRoomSubscription } from '../../src/entity/LiveRoomSubscription';
 import { NotificationV2 } from '../../src/entity/notifications/NotificationV2';
+import { NotificationAvatarV2 } from '../../src/entity/notifications/NotificationAvatarV2';
 import { UserNotification } from '../../src/entity/notifications/UserNotification';
 import { User } from '../../src/entity/user/User';
 import {
@@ -113,8 +114,17 @@ describe('live room lifecycle workers', () => {
         type: NotificationType.LiveRoomStarted,
       });
     expect(notification.targetUrl).toBe(
-      'http://localhost:5002/live/7250df5f-f9e0-4b47-898a-fbb975695e83',
+      'http://localhost:5002/standups/7250df5f-f9e0-4b47-898a-fbb975695e83',
     );
+    const avatars = await con.getRepository(NotificationAvatarV2).findBy({
+      id: notification.avatars[0],
+    });
+    expect(avatars).toMatchObject([
+      {
+        referenceId: '1',
+        type: 'user',
+      },
+    ]);
 
     const userNotifications = await con.getRepository(UserNotification).findBy({
       notificationId: notification.id,

--- a/src/common/contentEmbeds.ts
+++ b/src/common/contentEmbeds.ts
@@ -11,6 +11,7 @@ import { markdown } from './markdown';
 
 export const MAX_POST_CONTENT_EMBEDS = 10;
 export const MAX_COMMENT_CONTENT_EMBEDS = 3;
+export const MAX_LIVE_ROOM_CONTENT_EMBEDS = 10;
 
 const DLY_TO_REDIRECT_LIMIT = 5;
 const DLY_TO_RESOLVE_TIMEOUT_MS = 1500;

--- a/src/common/liveRoom/token.ts
+++ b/src/common/liveRoom/token.ts
@@ -13,7 +13,6 @@ export const createLiveRoomJoinToken = async (input: {
   role: LiveRoomParticipantRole;
   authKind?: 'authenticated' | 'anonymous';
   roomId: string;
-  userId?: string;
   audience?: string;
   expiresInSeconds?: number;
   issuer?: string;
@@ -30,7 +29,6 @@ export const createLiveRoomJoinToken = async (input: {
       role: input.role,
       authKind: input.authKind ?? 'authenticated',
       roomId: input.roomId,
-      userId: input.userId,
     },
     input.secret,
     {

--- a/src/common/liveRoom/token.ts
+++ b/src/common/liveRoom/token.ts
@@ -13,6 +13,7 @@ export const createLiveRoomJoinToken = async (input: {
   role: LiveRoomParticipantRole;
   authKind?: 'authenticated' | 'anonymous';
   roomId: string;
+  userId?: string;
   audience?: string;
   expiresInSeconds?: number;
   issuer?: string;
@@ -29,6 +30,7 @@ export const createLiveRoomJoinToken = async (input: {
       role: input.role,
       authKind: input.authKind ?? 'authenticated',
       roomId: input.roomId,
+      userId: input.userId,
     },
     input.secret,
     {

--- a/src/common/schema/liveRooms.ts
+++ b/src/common/schema/liveRooms.ts
@@ -52,8 +52,10 @@ export const liveRoomLifecycleEventTypeSchema = z.enum(
 export const createLiveRoomSchema = z
   .object({
     topic: z.string().trim().min(1).max(280),
+    description: z.string().trim().max(20_000).optional().nullable(),
     mode: liveRoomModeSchema.default(LiveRoomMode.Moderated),
     speakerLimit: liveRoomSpeakerLimitSchema.optional(),
+    scheduledStart: z.coerce.date().optional().nullable(),
   })
   .superRefine((input, ctx) => {
     if (

--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -56,4 +56,5 @@ export const notificationFlagsSchema = z.strictObject({
   [NotificationType.AchievementUnlocked]: notificationPreferenceSchema,
   [NotificationType.DigestReady]: notificationPreferenceSchema,
   [NotificationType.MajorHeadlineAdded]: notificationPreferenceSchema,
+  [NotificationType.LiveRoomStarted]: notificationPreferenceSchema,
 });

--- a/src/entity/ContentEmbed.ts
+++ b/src/entity/ContentEmbed.ts
@@ -9,6 +9,7 @@ import {
 export enum ContentEmbedParentType {
   Post = 'post',
   Comment = 'comment',
+  LiveRoom = 'live_room',
 }
 
 export enum ContentEmbedReferenceType {

--- a/src/entity/LiveRoom.ts
+++ b/src/entity/LiveRoom.ts
@@ -43,6 +43,12 @@ export class LiveRoom {
   @Column({ type: 'text' })
   topic: string;
 
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  descriptionHtml: string | null;
+
   @Column({ type: 'text' })
   mode: z.infer<typeof liveRoomModeSchema>;
 
@@ -54,4 +60,7 @@ export class LiveRoom {
 
   @Column({ type: 'timestamptz', nullable: true })
   endedAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  scheduledStart: Date | null;
 }

--- a/src/entity/LiveRoomSubscription.ts
+++ b/src/entity/LiveRoomSubscription.ts
@@ -1,0 +1,49 @@
+import {
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import type { LiveRoom } from './LiveRoom';
+import type { User } from './user/User';
+
+@Entity({ name: 'live_room_subscription' })
+@Index('IDX_live_room_subscription_user_created', ['userId', 'createdAt'])
+export class LiveRoomSubscription {
+  @PrimaryColumn({
+    type: 'uuid',
+    primaryKeyConstraintName: 'PK_live_room_subscription',
+  })
+  roomId: LiveRoom['id'];
+
+  @PrimaryColumn({
+    type: 'text',
+    primaryKeyConstraintName: 'PK_live_room_subscription',
+  })
+  userId: User['id'];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne('LiveRoom', {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'roomId',
+    foreignKeyConstraintName: 'FK_live_room_subscription_room',
+  })
+  room: Promise<LiveRoom>;
+
+  @ManyToOne('User', {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'userId',
+    foreignKeyConstraintName: 'FK_live_room_subscription_user',
+  })
+  user: Promise<User>;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -42,6 +42,7 @@ export * from './SquadPublicRequest';
 export * from './UserCompany';
 export * from './Organization';
 export * from './LiveRoom';
+export * from './LiveRoomSubscription';
 export * from './campaign';
 export * from './PersonalAccessToken';
 export * from './Feedback';

--- a/src/entity/notifications/NotificationV2.ts
+++ b/src/entity/notifications/NotificationV2.ts
@@ -19,7 +19,8 @@ export type NotificationReferenceType =
   | 'user'
   | 'opportunity'
   | 'feedback'
-  | 'achievement';
+  | 'achievement'
+  | 'live_room';
 
 @Entity()
 @Index('ID_notification_v2_reference', ['referenceId', 'referenceType'])

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -2481,6 +2481,22 @@ const obj = new GraphORM({
       endedAt: {
         transform: transformDate,
       },
+      scheduledStart: {
+        transform: transformDate,
+      },
+      contentEmbeds: {
+        relation: {
+          isMany: true,
+          sort: 'sortOrder',
+          order: 'ASC',
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
+            qb
+              .where(`"${childAlias}"."parentId" = "${parentAlias}"."id"`)
+              .andWhere(`"${childAlias}"."parentType" = :embedLiveRoomParent`, {
+                embedLiveRoomParent: ContentEmbedParentType.LiveRoom,
+              }),
+        },
+      },
       host: {
         relation: {
           isMany: false,

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -72,6 +72,7 @@ import {
   ContentEmbedParentType,
   ContentEmbedReferenceType,
 } from '../entity/ContentEmbed';
+import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
 import { UserExperienceType } from '../entity/user/experiences/types';
@@ -2484,6 +2485,24 @@ const obj = new GraphORM({
       scheduledStart: {
         transform: transformDate,
       },
+      subscribed: {
+        select: (ctx: Context, alias: string, qb: QueryBuilder): string => {
+          if (!ctx.userId) {
+            return 'FALSE';
+          }
+
+          const query = qb
+            .select('1')
+            .from(LiveRoomSubscription, 'lrs')
+            .where(`lrs."roomId" = ${alias}.id`)
+            .andWhere(`lrs."userId" = :liveRoomSubscriptionUserId`, {
+              liveRoomSubscriptionUserId: ctx.userId,
+            })
+            .limit(1);
+
+          return `EXISTS${query.getQuery()}`;
+        },
+      },
       contentEmbeds: {
         relation: {
           isMany: true,
@@ -2491,7 +2510,7 @@ const obj = new GraphORM({
           order: 'ASC',
           customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
             qb
-              .where(`"${childAlias}"."parentId" = "${parentAlias}"."id"`)
+              .where(`"${childAlias}"."parentId" = "${parentAlias}"."id"::text`)
               .andWhere(`"${childAlias}"."parentType" = :embedLiveRoomParent`, {
                 embedLiveRoomParent: ContentEmbedParentType.LiveRoom,
               }),

--- a/src/integrations/flyting/client.ts
+++ b/src/integrations/flyting/client.ts
@@ -193,6 +193,32 @@ export class FlytingClient {
       throw new HttpError(response.url, response.status, await response.text());
     });
   }
+
+  async getConnectedUsers(input: { roomId: string }): Promise<{
+    roomId: string;
+    userIds: string[];
+  }> {
+    return this.garmr.execute(async () => {
+      const response = await retryFetch(
+        `${this.url}/internal/live-rooms/${encodeURIComponent(
+          input.roomId,
+        )}/connected-users`,
+        {
+          ...this.fetchOptions,
+          method: 'GET',
+          headers: {
+            'x-flyting-internal-key': this.internalApiKey,
+          },
+        },
+      );
+
+      if (response.ok) {
+        return response.json();
+      }
+
+      throw new HttpError(response.url, response.status, await response.text());
+    });
+  }
 }
 
 const garmrFlytingService = new GarmrService({

--- a/src/migration/1778100000000-LiveRoomLobby.ts
+++ b/src/migration/1778100000000-LiveRoomLobby.ts
@@ -1,0 +1,52 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LiveRoomLobby1778100000000 implements MigrationInterface {
+  name = 'LiveRoomLobby1778100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "live_room"
+        ADD "description" text,
+        ADD "descriptionHtml" text,
+        ADD "scheduledStart" TIMESTAMPTZ
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "live_room_subscription" (
+        "roomId" uuid NOT NULL,
+        "userId" text NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_live_room_subscription"
+          PRIMARY KEY ("roomId", "userId"),
+        CONSTRAINT "FK_live_room_subscription_room"
+          FOREIGN KEY ("roomId")
+          REFERENCES "live_room"("id")
+          ON DELETE CASCADE
+          ON UPDATE NO ACTION,
+        CONSTRAINT "FK_live_room_subscription_user"
+          FOREIGN KEY ("userId")
+          REFERENCES "user"("id")
+          ON DELETE CASCADE
+          ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_live_room_subscription_user_created"
+        ON "live_room_subscription" ("userId", "createdAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP TABLE "live_room_subscription"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "live_room"
+        DROP COLUMN "scheduledStart",
+        DROP COLUMN "descriptionHtml",
+        DROP COLUMN "description"
+    `);
+  }
+}

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -241,6 +241,13 @@ export class NotificationBuilder {
     });
   }
 
+  referenceLiveRoom(roomId: string): NotificationBuilder {
+    return this.enrichNotification({
+      referenceId: roomId,
+      referenceType: 'live_room',
+    });
+  }
+
   icon(icon: NotificationIcon): NotificationBuilder {
     return this.enrichNotification({ icon });
   }

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -89,6 +89,7 @@ export enum NotificationType {
   AchievementUnlocked = 'achievement_unlocked',
   DigestReady = 'digest_ready',
   MajorHeadlineAdded = 'major_headline_added',
+  LiveRoomStarted = 'live_room_started',
 }
 
 export enum NotificationPreferenceType {
@@ -318,7 +319,11 @@ export const DEFAULT_NOTIFICATION_SETTINGS: UserNotificationFlags = {
   },
   [NotificationType.MajorHeadlineAdded]: {
     email: NotificationPreferenceStatus.Muted,
-    inApp: NotificationPreferenceStatus.Muted,
+    inApp: NotificationPreferenceStatus.Subscribed,
+  },
+  [NotificationType.LiveRoomStarted]: {
+    email: NotificationPreferenceStatus.Muted,
+    inApp: NotificationPreferenceStatus.Subscribed,
   },
 };
 

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -246,7 +246,7 @@ export const notificationTitleMap: Record<
   major_headline_added: (ctx: NotificationMajorHeadlineContext) =>
     `<b>${ctx.headline}</b>`,
   live_room_started: (ctx: NotificationLiveRoomContext) =>
-    `<b>${ctx.room.topic}</b> is live`,
+    `<b>${ctx.host.name || ctx.host.username}</b> is live: <b>${ctx.room.topic}</b>`,
 };
 
 export const generateNotificationMap: Record<

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -41,6 +41,7 @@ import {
   type NotificationFeedbackResolvedContext,
   type NotificationAchievementContext,
   type NotificationMajorHeadlineContext,
+  type NotificationLiveRoomContext,
 } from './types';
 import { UPVOTE_TITLES } from '../workers/notifications/utils';
 import { checkHasMention } from '../common/markdown';
@@ -244,6 +245,8 @@ export const notificationTitleMap: Record<
   digest_ready: () => `<strong>Your personalized digest is ready</strong>`,
   major_headline_added: (ctx: NotificationMajorHeadlineContext) =>
     `<b>${ctx.headline}</b>`,
+  live_room_started: (ctx: NotificationLiveRoomContext) =>
+    `<b>${ctx.room.topic}</b> is live`,
 };
 
 export const generateNotificationMap: Record<
@@ -769,4 +772,13 @@ export const generateNotificationMap: Record<
       .avatarSource(ctx.source)
       .objectPost(ctx.post, ctx.source, ctx.sharedPost)
       .uniqueKey(ctx.post.id),
+  live_room_started: (
+    builder: NotificationBuilder,
+    ctx: NotificationLiveRoomContext,
+  ) =>
+    builder
+      .icon(NotificationIcon.Bell)
+      .referenceLiveRoom(ctx.room.id)
+      .targetUrl(`${process.env.COMMENTS_PREFIX}/live/${ctx.room.id}`)
+      .uniqueKey(ctx.room.id),
 };

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -779,6 +779,7 @@ export const generateNotificationMap: Record<
     builder
       .icon(NotificationIcon.Bell)
       .referenceLiveRoom(ctx.room.id)
-      .targetUrl(`${process.env.COMMENTS_PREFIX}/live/${ctx.room.id}`)
+      .avatarUser(ctx.host)
+      .targetUrl(`${process.env.COMMENTS_PREFIX}/standups/${ctx.room.id}`)
       .uniqueKey(ctx.room.id),
 };

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -16,6 +16,7 @@ import {
   SquadSource,
   type Organization,
   type Campaign,
+  type LiveRoom,
 } from '../entity';
 import { ChangeObject } from '../types';
 import { DeepPartial } from 'typeorm';
@@ -227,6 +228,10 @@ export type NotificationMajorHeadlineContext = NotificationPostContext & {
   headline: string;
   channel: string;
   significance: number;
+};
+
+export type NotificationLiveRoomContext = NotificationBaseContext & {
+  room: Reference<LiveRoom>;
 };
 
 declare module 'fs' {

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -231,6 +231,7 @@ export type NotificationMajorHeadlineContext = NotificationPostContext & {
 };
 
 export type NotificationLiveRoomContext = NotificationBaseContext & {
+  host: Reference<User>;
   room: Reference<LiveRoom>;
 };
 

--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -92,6 +92,10 @@ const pushHeadingFnMap: Partial<
     const match = title.match(/<b>([^<]+)<\/b>/);
     return match ? `${match[1]} commented` : 'New comment';
   },
+  [NotificationType.LiveRoomStarted]: (title) => {
+    const match = title.match(/<b>([^<]+)<\/b>/);
+    return match ? `${match[1]} is live` : 'Room is live';
+  },
 };
 
 const getPushHeading = (type: string, title?: string): string => {

--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -74,6 +74,7 @@ const pushHeadingMap: Partial<Record<NotificationType, string>> = {
   [NotificationType.SourcePostSubmitted]: 'Post pending review',
   [NotificationType.SquadSubscribeToNotification]: 'Squad notifications',
   [NotificationType.MajorHeadlineAdded]: 'Happening now',
+  [NotificationType.LiveRoomStarted]: 'Room is live',
 };
 
 const pushHeadingFnMap: Partial<

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -3,6 +3,7 @@ import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import type { GraphQLResolveInfo } from 'graphql';
 import type { Context } from '../Context';
 import { toGQLEnum } from '../common';
+import { GQLEmptyResponse } from './common';
 import { createLiveRoomJoinToken } from '../common/liveRoom/token';
 import {
   deleteContentEmbedsByParent,
@@ -17,7 +18,7 @@ import {
   liveRoomIdInputSchema,
   LiveRoomStatus,
 } from '../common/schema/liveRooms';
-import { ContentEmbed, ContentEmbedParentType } from '../entity/ContentEmbed';
+import { ContentEmbedParentType } from '../entity/ContentEmbed';
 import { NotFoundError } from '../errors';
 import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import { LiveRoom } from '../entity/LiveRoom';
@@ -81,8 +82,8 @@ export const typeDefs = /* GraphQL */ `
     createLiveRoom(input: CreateLiveRoomInput!): LiveRoomJoinToken! @auth
     endLiveRoom(roomId: ID!): LiveRoom! @auth
     liveRoomJoinToken(roomId: ID!): LiveRoomJoinToken!
-    subscribeToLiveRoom(roomId: ID!): LiveRoom! @auth
-    unsubscribeFromLiveRoom(roomId: ID!): LiveRoom! @auth
+    subscribeToLiveRoom(roomId: ID!): EmptyResponse! @auth
+    unsubscribeFromLiveRoom(roomId: ID!): EmptyResponse! @auth
   }
 `;
 
@@ -248,6 +249,14 @@ const queryLiveRoomById = (
   });
 
 export const resolvers: IResolvers = {
+  LiveRoomJoinToken: {
+    room: (
+      payload: GQLLiveRoomJoinToken,
+      _,
+      ctx: Context,
+      info: GraphQLResolveInfo,
+    ): Promise<GQLLiveRoom> => queryLiveRoomById(ctx, info, payload.room.id),
+  },
   LiveRoom: {
     participantCount: async (
       room: GQLLiveRoom,
@@ -260,30 +269,6 @@ export const resolvers: IResolvers = {
 
       return ctx.dataLoader.liveRoomParticipantCount.load(room.id);
     },
-    subscribed: async (
-      room: GQLLiveRoom,
-      _,
-      ctx: Context,
-    ): Promise<boolean> => {
-      if (!ctx.userId) {
-        return false;
-      }
-
-      return ctx.con.getRepository(LiveRoomSubscription).existsBy({
-        roomId: room.id,
-        userId: ctx.userId,
-      });
-    },
-    contentEmbeds: async (room: GQLLiveRoom, _, ctx: Context) =>
-      ctx.con.getRepository(ContentEmbed).find({
-        where: {
-          parentId: room.id,
-          parentType: ContentEmbedParentType.LiveRoom,
-        },
-        order: {
-          sortOrder: 'ASC',
-        },
-      }),
   },
   Query: {
     liveRoom: async (
@@ -478,8 +463,7 @@ export const resolvers: IResolvers = {
       _,
       args: { roomId: string },
       ctx: Context,
-      info,
-    ): Promise<GQLLiveRoom> => {
+    ): Promise<GQLEmptyResponse> => {
       const input = liveRoomIdInputSchema.parse(args);
       const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
       assertCanSubscribeToRoom(room);
@@ -495,14 +479,13 @@ export const resolvers: IResolvers = {
         .orIgnore()
         .execute();
 
-      return queryLiveRoomById(ctx, info, room.id);
+      return { _: true };
     },
     unsubscribeFromLiveRoom: async (
       _,
       args: { roomId: string },
       ctx: Context,
-      info,
-    ): Promise<GQLLiveRoom> => {
+    ): Promise<GQLEmptyResponse> => {
       const input = liveRoomIdInputSchema.parse(args);
       const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
 
@@ -511,7 +494,7 @@ export const resolvers: IResolvers = {
         userId: ctx.userId,
       });
 
-      return queryLiveRoomById(ctx, info, room.id);
+      return { _: true };
     },
   },
 };

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -1,8 +1,15 @@
 import type { IResolvers } from '@graphql-tools/utils';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
+import type { GraphQLResolveInfo } from 'graphql';
 import type { Context } from '../Context';
 import { toGQLEnum } from '../common';
 import { createLiveRoomJoinToken } from '../common/liveRoom/token';
+import {
+  deleteContentEmbedsByParent,
+  MAX_LIVE_ROOM_CONTENT_EMBEDS,
+  replaceContentEmbeds,
+} from '../common/contentEmbeds';
+import { renderMarkdown } from '../common/markdown';
 import {
   createLiveRoomSchema,
   LiveRoomMode,
@@ -10,9 +17,11 @@ import {
   liveRoomIdInputSchema,
   LiveRoomStatus,
 } from '../common/schema/liveRooms';
+import { ContentEmbed, ContentEmbedParentType } from '../entity/ContentEmbed';
 import { NotFoundError } from '../errors';
 import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import { LiveRoom } from '../entity/LiveRoom';
+import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
 import graphorm from '../graphorm';
 import { getFlytingClient } from '../integrations/flyting/client';
 import { AbortError, HttpError } from '../integrations/retry';
@@ -40,6 +49,11 @@ export const typeDefs = /* GraphQL */ `
     status: LiveRoomStatus!
     startedAt: DateTime
     endedAt: DateTime
+    scheduledStart: DateTime
+    description: String
+    descriptionHtml: String
+    subscribed: Boolean!
+    contentEmbeds: [ContentEmbed!]!
     participantCount: Int
     host: User!
   }
@@ -54,6 +68,8 @@ export const typeDefs = /* GraphQL */ `
     topic: String!
     mode: LiveRoomMode = moderated
     speakerLimit: Int
+    scheduledStart: DateTime
+    description: String
   }
 
   extend type Query {
@@ -65,6 +81,8 @@ export const typeDefs = /* GraphQL */ `
     createLiveRoom(input: CreateLiveRoomInput!): LiveRoomJoinToken! @auth
     endLiveRoom(roomId: ID!): LiveRoom! @auth
     liveRoomJoinToken(roomId: ID!): LiveRoomJoinToken!
+    subscribeToLiveRoom(roomId: ID!): LiveRoom! @auth
+    unsubscribeFromLiveRoom(roomId: ID!): LiveRoom! @auth
   }
 `;
 
@@ -150,11 +168,13 @@ const createJoinTokenPayload = async ({
   room,
   participantId,
   role,
+  userId,
 }: {
   authKind: 'anonymous' | 'authenticated';
   room: LiveRoom;
   participantId: string;
   role: LiveRoomParticipantRole;
+  userId?: string | null;
 }): Promise<GQLLiveRoomJoinToken> => {
   const secret = process.env.FLYTING_JOIN_TOKEN_SECRET;
   if (!secret) {
@@ -167,6 +187,7 @@ const createJoinTokenPayload = async ({
     role,
     roomId: room.id,
     secret,
+    userId: authKind === 'authenticated' ? (userId ?? undefined) : undefined,
   });
 
   return {
@@ -207,6 +228,24 @@ const assertJoinAllowedByFlyting = async ({
   throw new ValidationError('Cannot join this live room');
 };
 
+const assertCanSubscribeToRoom = (room: LiveRoom): void => {
+  if (room.status !== LiveRoomStatus.Created || !room.scheduledStart) {
+    throw new ValidationError('Cannot subscribe to this live room');
+  }
+};
+
+const queryLiveRoomById = (
+  ctx: Context,
+  info: GraphQLResolveInfo,
+  roomId: string,
+): Promise<GQLLiveRoom> =>
+  graphorm.queryOneOrFail<GQLLiveRoom>(ctx, info, (builder) => {
+    builder.queryBuilder.where(`"${builder.alias}"."id" = :id`, {
+      id: roomId,
+    });
+    return builder;
+  });
+
 export const resolvers: IResolvers = {
   LiveRoom: {
     participantCount: async (
@@ -220,6 +259,30 @@ export const resolvers: IResolvers = {
 
       return ctx.dataLoader.liveRoomParticipantCount.load(room.id);
     },
+    subscribed: async (
+      room: GQLLiveRoom,
+      _,
+      ctx: Context,
+    ): Promise<boolean> => {
+      if (!ctx.userId) {
+        return false;
+      }
+
+      return ctx.con.getRepository(LiveRoomSubscription).existsBy({
+        roomId: room.id,
+        userId: ctx.userId,
+      });
+    },
+    contentEmbeds: async (room: GQLLiveRoom, _, ctx: Context) =>
+      ctx.con.getRepository(ContentEmbed).find({
+        where: {
+          parentId: room.id,
+          parentType: ContentEmbedParentType.LiveRoom,
+        },
+        order: {
+          sortOrder: 'ASC',
+        },
+      }),
   },
   Query: {
     liveRoom: async (
@@ -272,8 +335,10 @@ export const resolvers: IResolvers = {
       _,
       args: {
         input: {
+          description?: string | null;
           mode: LiveRoomMode;
           speakerLimit?: number;
+          scheduledStart?: string | null;
           topic: string;
         };
       },
@@ -281,15 +346,33 @@ export const resolvers: IResolvers = {
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = createLiveRoomSchema.parse(args.input);
       await assertCanCreateRoom({ ctx });
+      const description = input.description || null;
+      const renderedDescription = description
+        ? renderMarkdown(description)
+        : null;
       const roomRepo = ctx.con.getRepository(LiveRoom);
       const room = await roomRepo.save(
         roomRepo.create({
+          description,
+          descriptionHtml: renderedDescription?.contentHtml ?? null,
           hostId: ctx.userId,
           mode: input.mode,
+          scheduledStart: input.scheduledStart ?? null,
           topic: input.topic,
           status: LiveRoomStatus.Created,
         }),
       );
+
+      if (description) {
+        await replaceContentEmbeds({
+          con: ctx.con,
+          parentType: ContentEmbedParentType.LiveRoom,
+          parentId: room.id,
+          content: description,
+          tokens: renderedDescription?.tokens,
+          limit: MAX_LIVE_ROOM_CONTENT_EMBEDS,
+        });
+      }
 
       try {
         await getFlytingClient().prepareRoom({
@@ -299,7 +382,14 @@ export const resolvers: IResolvers = {
         });
       } catch (error) {
         if (shouldDeleteRoomAfterPrepareFailure(error)) {
-          await roomRepo.delete({ id: room.id });
+          await ctx.con.transaction(async (manager) => {
+            await deleteContentEmbedsByParent({
+              con: manager,
+              parentType: ContentEmbedParentType.LiveRoom,
+              parentIds: [room.id],
+            });
+            await manager.getRepository(LiveRoom).delete({ id: room.id });
+          });
         }
         throw error;
       }
@@ -309,6 +399,7 @@ export const resolvers: IResolvers = {
         room,
         participantId: getJoinParticipantId(ctx),
         role: LiveRoomParticipantRole.Host,
+        userId: ctx.userId,
       });
     },
     endLiveRoom: async (
@@ -381,7 +472,47 @@ export const resolvers: IResolvers = {
         room,
         participantId,
         role,
+        userId: ctx.userId,
       });
+    },
+    subscribeToLiveRoom: async (
+      _,
+      args: { roomId: string },
+      ctx: Context,
+      info,
+    ): Promise<GQLLiveRoom> => {
+      const input = liveRoomIdInputSchema.parse(args);
+      const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
+      assertCanSubscribeToRoom(room);
+
+      await ctx.con
+        .getRepository(LiveRoomSubscription)
+        .createQueryBuilder()
+        .insert()
+        .values({
+          roomId: room.id,
+          userId: ctx.userId,
+        })
+        .orIgnore()
+        .execute();
+
+      return queryLiveRoomById(ctx, info, room.id);
+    },
+    unsubscribeFromLiveRoom: async (
+      _,
+      args: { roomId: string },
+      ctx: Context,
+      info,
+    ): Promise<GQLLiveRoom> => {
+      const input = liveRoomIdInputSchema.parse(args);
+      const room = await getRoomOrThrow({ roomId: input.roomId, ctx });
+
+      await ctx.con.getRepository(LiveRoomSubscription).delete({
+        roomId: room.id,
+        userId: ctx.userId,
+      });
+
+      return queryLiveRoomById(ctx, info, room.id);
     },
   },
 };

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -168,13 +168,11 @@ const createJoinTokenPayload = async ({
   room,
   participantId,
   role,
-  userId,
 }: {
   authKind: 'anonymous' | 'authenticated';
   room: LiveRoom;
   participantId: string;
   role: LiveRoomParticipantRole;
-  userId?: string | null;
 }): Promise<GQLLiveRoomJoinToken> => {
   const secret = process.env.FLYTING_JOIN_TOKEN_SECRET;
   if (!secret) {
@@ -187,7 +185,6 @@ const createJoinTokenPayload = async ({
     role,
     roomId: room.id,
     secret,
-    userId: authKind === 'authenticated' ? (userId ?? undefined) : undefined,
   });
 
   return {
@@ -198,6 +195,10 @@ const createJoinTokenPayload = async ({
 };
 
 const getJoinParticipantId = (ctx: Context): string => {
+  if (ctx.userId) {
+    return ctx.userId;
+  }
+
   if (!ctx.trackingId) {
     throw new ValidationError('Tracking ID is required to join a live room');
   }
@@ -399,7 +400,6 @@ export const resolvers: IResolvers = {
         room,
         participantId: getJoinParticipantId(ctx),
         role: LiveRoomParticipantRole.Host,
-        userId: ctx.userId,
       });
     },
     endLiveRoom: async (
@@ -472,7 +472,6 @@ export const resolvers: IResolvers = {
         room,
         participantId,
         role,
-        userId: ctx.userId,
       });
     },
     subscribeToLiveRoom: async (

--- a/src/workers/liveRoomStarted.ts
+++ b/src/workers/liveRoomStarted.ts
@@ -1,38 +1,86 @@
 import { LiveRoom } from '../entity/LiveRoom';
+import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
 import {
   LiveRoomStatus,
   liveRoomLifecycleEventSchema,
 } from '../common/schema/liveRooms';
+import { getFlytingClient } from '../integrations/flyting/client';
+import { generateAndStoreNotificationsV2 } from '../notifications';
+import { NotificationType } from '../notifications/common';
+import type { NotificationLiveRoomContext } from '../notifications/types';
 import { TypedWorker } from './worker';
 
 export const liveRoomStartedWorker: TypedWorker<'flyting.v1.room-started'> = {
   subscription: 'api.live-room-started',
   handler: async ({ data }, con, logger) => {
     const input = liveRoomLifecycleEventSchema.parse(data);
+    const roomRepo = con.getRepository(LiveRoom);
+    const room = await roomRepo.findOneBy({ id: input.roomId });
+
+    if (!room) {
+      logger.warn(
+        { roomId: input.roomId },
+        'Live room not found for lifecycle event',
+      );
+      return;
+    }
+
+    if (room.status === LiveRoomStatus.Ended) {
+      return;
+    }
+
+    const subscriptions = await con.getRepository(LiveRoomSubscription).findBy({
+      roomId: room.id,
+    });
+    const connectedUserIds = new Set<string>();
+    if (subscriptions.length) {
+      try {
+        const connected = await getFlytingClient().getConnectedUsers({
+          roomId: room.id,
+        });
+
+        for (const userId of connected.userIds) {
+          connectedUserIds.add(userId);
+        }
+      } catch (err) {
+        logger.warn(
+          { err, roomId: room.id },
+          'Failed to fetch connected live room users; notifying all subscribers',
+        );
+      }
+    }
+    const disconnectedSubscriberIds = subscriptions
+      .map(({ userId }) => userId)
+      .filter((userId) => !connectedUserIds.has(userId));
 
     await con.transaction(async (manager) => {
-      const roomRepo = manager.getRepository(LiveRoom);
-      const room = await roomRepo.findOneBy({ id: input.roomId });
-
-      if (!room) {
-        logger.warn(
-          { roomId: input.roomId },
-          'Live room not found for lifecycle event',
-        );
-        return;
-      }
-
-      if (room.status === LiveRoomStatus.Ended) {
-        return;
-      }
-
-      await roomRepo.update(
+      await manager.getRepository(LiveRoom).update(
         { id: input.roomId },
         {
           status: LiveRoomStatus.Live,
           startedAt: room.startedAt ?? new Date(input.occurredAt),
         },
       );
+
+      if (disconnectedSubscriberIds.length) {
+        const notificationContext: NotificationLiveRoomContext = {
+          userIds: disconnectedSubscriberIds,
+          room,
+        };
+
+        await generateAndStoreNotificationsV2(manager, [
+          {
+            type: NotificationType.LiveRoomStarted,
+            ctx: notificationContext,
+          },
+        ]);
+      }
+
+      if (subscriptions.length) {
+        await manager.getRepository(LiveRoomSubscription).delete({
+          roomId: room.id,
+        });
+      }
     });
   },
 };

--- a/src/workers/liveRoomStarted.ts
+++ b/src/workers/liveRoomStarted.ts
@@ -1,5 +1,6 @@
 import { LiveRoom } from '../entity/LiveRoom';
 import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
+import { User } from '../entity/user/User';
 import {
   LiveRoomStatus,
   liveRoomLifecycleEventSchema,
@@ -9,6 +10,126 @@ import { generateAndStoreNotificationsV2 } from '../notifications';
 import { NotificationType } from '../notifications/common';
 import type { NotificationLiveRoomContext } from '../notifications/types';
 import { TypedWorker } from './worker';
+import type { DataSource, EntityManager } from 'typeorm';
+import type { FastifyBaseLogger } from 'fastify';
+
+const markLiveRoomStarted = async ({
+  con,
+  occurredAt,
+  room,
+}: {
+  con: DataSource;
+  occurredAt: string;
+  room: LiveRoom;
+}): Promise<void> => {
+  await con.getRepository(LiveRoom).update(
+    { id: room.id },
+    {
+      status: LiveRoomStatus.Live,
+      startedAt: room.startedAt ?? new Date(occurredAt),
+    },
+  );
+};
+
+const loadDisconnectedSubscriberIds = async ({
+  con,
+  logger,
+  roomId,
+}: {
+  con: DataSource;
+  logger: FastifyBaseLogger;
+  roomId: string;
+}): Promise<{ subscriberIds: string[]; subscriptionCount: number }> => {
+  const subscriptions = await con.getRepository(LiveRoomSubscription).findBy({
+    roomId,
+  });
+  const connectedUserIds = new Set<string>();
+
+  if (subscriptions.length) {
+    try {
+      const connected = await getFlytingClient().getConnectedUsers({
+        roomId,
+      });
+
+      for (const userId of connected.userIds) {
+        connectedUserIds.add(userId);
+      }
+    } catch (err) {
+      logger.warn(
+        { err, roomId },
+        'Failed to fetch connected live room users; notifying all subscribers',
+      );
+    }
+  }
+
+  return {
+    subscriberIds: subscriptions
+      .map(({ userId }) => userId)
+      .filter((userId) => !connectedUserIds.has(userId)),
+    subscriptionCount: subscriptions.length,
+  };
+};
+
+const notifyDisconnectedSubscribers = async ({
+  manager,
+  room,
+  userIds,
+}: {
+  manager: EntityManager;
+  room: LiveRoom;
+  userIds: string[];
+}): Promise<void> => {
+  if (!userIds.length) {
+    return;
+  }
+
+  const host = await manager.getRepository(User).findOneByOrFail({
+    id: room.hostId,
+  });
+  const notificationContext: NotificationLiveRoomContext = {
+    host,
+    userIds,
+    room,
+  };
+
+  await generateAndStoreNotificationsV2(manager, [
+    {
+      type: NotificationType.LiveRoomStarted,
+      ctx: notificationContext,
+    },
+  ]);
+};
+
+const notifyLiveRoomStartedSubscribers = async ({
+  con,
+  logger,
+  room,
+}: {
+  con: DataSource;
+  logger: FastifyBaseLogger;
+  room: LiveRoom;
+}): Promise<void> => {
+  const { subscriberIds, subscriptionCount } =
+    await loadDisconnectedSubscriberIds({
+      con,
+      logger,
+      roomId: room.id,
+    });
+
+  await con.transaction(async (manager) => {
+    await notifyDisconnectedSubscribers({
+      manager,
+      room,
+      userIds: subscriberIds,
+    });
+
+    if (subscriptionCount) {
+      await manager.getRepository(LiveRoomSubscription).delete({
+        roomId: room.id,
+      });
+    }
+  });
+};
 
 export const liveRoomStartedWorker: TypedWorker<'flyting.v1.room-started'> = {
   subscription: 'api.live-room-started',
@@ -29,58 +150,12 @@ export const liveRoomStartedWorker: TypedWorker<'flyting.v1.room-started'> = {
       return;
     }
 
-    const subscriptions = await con.getRepository(LiveRoomSubscription).findBy({
-      roomId: room.id,
+    await markLiveRoomStarted({
+      con,
+      occurredAt: input.occurredAt,
+      room,
     });
-    const connectedUserIds = new Set<string>();
-    if (subscriptions.length) {
-      try {
-        const connected = await getFlytingClient().getConnectedUsers({
-          roomId: room.id,
-        });
 
-        for (const userId of connected.userIds) {
-          connectedUserIds.add(userId);
-        }
-      } catch (err) {
-        logger.warn(
-          { err, roomId: room.id },
-          'Failed to fetch connected live room users; notifying all subscribers',
-        );
-      }
-    }
-    const disconnectedSubscriberIds = subscriptions
-      .map(({ userId }) => userId)
-      .filter((userId) => !connectedUserIds.has(userId));
-
-    await con.transaction(async (manager) => {
-      await manager.getRepository(LiveRoom).update(
-        { id: input.roomId },
-        {
-          status: LiveRoomStatus.Live,
-          startedAt: room.startedAt ?? new Date(input.occurredAt),
-        },
-      );
-
-      if (disconnectedSubscriberIds.length) {
-        const notificationContext: NotificationLiveRoomContext = {
-          userIds: disconnectedSubscriberIds,
-          room,
-        };
-
-        await generateAndStoreNotificationsV2(manager, [
-          {
-            type: NotificationType.LiveRoomStarted,
-            ctx: notificationContext,
-          },
-        ]);
-      }
-
-      if (subscriptions.length) {
-        await manager.getRepository(LiveRoomSubscription).delete({
-          roomId: room.id,
-        });
-      }
-    });
+    await notifyLiveRoomStartedSubscribers({ con, logger, room });
   },
 };

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -138,6 +138,7 @@ export const notificationToTemplateId: Record<NotificationType, string> = {
   feedback_cancelled: '',
   achievement_unlocked: '', // No email for achievement unlocks
   major_headline_added: '',
+  live_room_started: '',
 };
 
 type TemplateData = Record<string, unknown> & {
@@ -1293,6 +1294,9 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
     return null; // No email for achievement unlocks
   },
   major_headline_added: async () => {
+    return null;
+  },
+  live_room_started: async () => {
     return null;
   },
 };


### PR DESCRIPTION
## Summary
- add scheduled live-room lobby fields, markdown descriptions, and post embed support
- add live-room subscriptions with hard-delete unsubscribe and cleanup after go-live
- add default-enabled live-room-started notifications that skip currently connected subscribers when Flyting can report them

## Validation
- `NODE_ENV=test pnpm run db:migrate:reset`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec jest __tests__/liveRooms.ts __tests__/workers/liveRoomLifecycle.ts --runInBand`
