### PR TITLE
fix: resolve dly.to content embeds

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -5443,10 +5443,10 @@ describe('mutation createFreeformPost', () => {
 
   it('should resolve dly.to links as content embeds', async () => {
     loggedUser = '1';
-    const content = 'https://dly.to/post2';
-    nock('https://dly.to')
-      .head('/post2')
-      .reply(302, undefined, { location: 'http://localhost:5002/posts/p2' });
+    const content = 'https://dly.to/lT26is7oC0k';
+    nock('https://dly.to').get('/lT26is7oC0k').reply(302, undefined, {
+      location: 'http://localhost:5002/posts/p2?userid=1&cid=share_post',
+    });
     const mutation = /* GraphQL */ `
       mutation CreateFreeformPost(
         $sourceId: ID!

--- a/src/common/contentEmbeds.ts
+++ b/src/common/contentEmbeds.ts
@@ -106,7 +106,7 @@ const fetchRedirectLocation = async (url: URL): Promise<string | undefined> => {
 
   try {
     const response = await fetch(url.toString(), {
-      method: 'HEAD',
+      method: 'GET',
       redirect: 'manual',
       signal: controller.signal,
     });


### PR DESCRIPTION
## What changed

- Resolve `dly.to` short links for content embeds using the browser redirect path.
- Update the regression test to cover the real short-link shape and share query params.

## Why

`HEAD https://dly.to/lT26is7oC0k` redirects to `https://daily.dev`, while a normal browser `GET` redirects to the actual post URL under `https://app.daily.dev/posts/...`. The content embed resolver used `HEAD`, so it never saw the post URL and skipped the embed.

## Validation

- `pnpm exec eslint src/common/contentEmbeds.ts __tests__/posts.ts`
- `NODE_ENV=test npx jest __tests__/posts.ts --testEnvironment=node --runInBand -t "should resolve dly.to links as content embeds"`
