### PR TITLE
fix: notify all standup start subscribers

### DIFF
--- a/__tests__/workers/liveRoomLifecycle.ts
+++ b/__tests__/workers/liveRoomLifecycle.ts
@@ -14,23 +14,16 @@ import { saveFixtures, expectSuccessfulTypedBackground } from '../helpers';
 import { usersFixture } from '../fixture/user';
 import { liveRoomStartedWorker } from '../../src/workers/liveRoomStarted';
 import { liveRoomEndedWorker } from '../../src/workers/liveRoomEnded';
-import nock from 'nock';
 import { NotificationType } from '../../src/notifications/common';
-
-const flytingOrigin = 'http://flyting.test';
-const flytingInternalKey = 'flyting-internal-key';
 
 let con: DataSource;
 
 beforeAll(async () => {
   process.env.COMMENTS_PREFIX = 'http://localhost:5002';
-  process.env.FLYTING_INTERNAL_KEY = flytingInternalKey;
-  process.env.FLYTING_ORIGIN = flytingOrigin;
   con = await createOrGetConnection();
 });
 
 beforeEach(async () => {
-  nock.cleanAll();
   await saveFixtures(con, User, usersFixture);
 });
 
@@ -64,7 +57,7 @@ describe('live room lifecycle workers', () => {
     expect(room.startedAt?.toISOString()).toBe('2026-04-23T15:00:00.000Z');
   });
 
-  it('notifies disconnected subscribers and hard deletes room subscriptions when the room starts', async () => {
+  it('notifies subscribers and hard deletes room subscriptions when the room starts', async () => {
     await saveFixtures(con, LiveRoom, [
       {
         id: '7250df5f-f9e0-4b47-898a-fbb975695e83',
@@ -85,16 +78,6 @@ describe('live room lifecycle workers', () => {
         userId: '3',
       },
     ]);
-
-    const scope = nock(flytingOrigin)
-      .get(
-        '/internal/live-rooms/7250df5f-f9e0-4b47-898a-fbb975695e83/connected-users',
-      )
-      .matchHeader('x-flyting-internal-key', flytingInternalKey)
-      .reply(200, {
-        roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
-        userIds: ['3'],
-      });
 
     await expectSuccessfulTypedBackground<'flyting.v1.room-started'>(
       liveRoomStartedWorker,
@@ -132,74 +115,16 @@ describe('live room lifecycle workers', () => {
     const userNotifications = await con.getRepository(UserNotification).findBy({
       notificationId: notification.id,
     });
-    expect(userNotifications.map(({ userId }) => userId)).toEqual(['2']);
+    expect(userNotifications.map(({ userId }) => userId).sort()).toEqual([
+      '2',
+      '3',
+    ]);
     expect(
       await con.getRepository(LiveRoomSubscription).countBy({
         roomId: '7250df5f-f9e0-4b47-898a-fbb975695e83',
       }),
     ).toBe(0);
-    expect(scope.isDone()).toBe(true);
   });
-
-  it('still marks the room live when connected user lookup fails', async () => {
-    await saveFixtures(con, LiveRoom, [
-      {
-        id: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-        hostId: '1',
-        topic: 'Lookup failure lobby',
-        mode: 'moderated',
-        status: LiveRoomStatus.Created,
-        scheduledStart: new Date('2026-05-05T15:00:00.000Z'),
-      },
-    ]);
-    await saveFixtures(con, LiveRoomSubscription, [
-      {
-        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-        userId: '2',
-      },
-    ]);
-
-    const scope = nock(flytingOrigin)
-      .get(
-        '/internal/live-rooms/82ed4745-7c98-47be-a393-bc639bc6fb13/connected-users',
-      )
-      .times(6)
-      .matchHeader('x-flyting-internal-key', flytingInternalKey)
-      .reply(500, { message: 'boom' });
-
-    await expectSuccessfulTypedBackground<'flyting.v1.room-started'>(
-      liveRoomStartedWorker,
-      {
-        eventId: '2781c769-4f0b-4461-a4fd-e77af54e75cb',
-        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-        occurredAt: '2026-05-05T15:01:00.000Z',
-        type: LiveRoomLifecycleEventType.RoomStarted,
-      },
-    );
-
-    const room = await con.getRepository(LiveRoom).findOneByOrFail({
-      id: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-    });
-    const notification = await con
-      .getRepository(NotificationV2)
-      .findOneByOrFail({
-        referenceId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-        referenceType: 'live_room',
-        type: NotificationType.LiveRoomStarted,
-      });
-    const userNotifications = await con.getRepository(UserNotification).findBy({
-      notificationId: notification.id,
-    });
-
-    expect(room.status).toBe(LiveRoomStatus.Live);
-    expect(userNotifications.map(({ userId }) => userId)).toEqual(['2']);
-    expect(
-      await con.getRepository(LiveRoomSubscription).countBy({
-        roomId: '82ed4745-7c98-47be-a393-bc639bc6fb13',
-      }),
-    ).toBe(0);
-    expect(scope.isDone()).toBe(true);
-  }, 10000);
 
   it('marks a room ended when an ended event arrives', async () => {
     await saveFixtures(con, LiveRoom, [

--- a/src/workers/liveRoomStarted.ts
+++ b/src/workers/liveRoomStarted.ts
@@ -5,13 +5,11 @@ import {
   LiveRoomStatus,
   liveRoomLifecycleEventSchema,
 } from '../common/schema/liveRooms';
-import { getFlytingClient } from '../integrations/flyting/client';
 import { generateAndStoreNotificationsV2 } from '../notifications';
 import { NotificationType } from '../notifications/common';
 import type { NotificationLiveRoomContext } from '../notifications/types';
 import { TypedWorker } from './worker';
 import type { DataSource, EntityManager } from 'typeorm';
-import type { FastifyBaseLogger } from 'fastify';
 
 const markLiveRoomStarted = async ({
   con,
@@ -31,46 +29,24 @@ const markLiveRoomStarted = async ({
   );
 };
 
-const loadDisconnectedSubscriberIds = async ({
+const loadSubscriberIds = async ({
   con,
-  logger,
   roomId,
 }: {
   con: DataSource;
-  logger: FastifyBaseLogger;
   roomId: string;
 }): Promise<{ subscriberIds: string[]; subscriptionCount: number }> => {
   const subscriptions = await con.getRepository(LiveRoomSubscription).findBy({
     roomId,
   });
-  const connectedUserIds = new Set<string>();
-
-  if (subscriptions.length) {
-    try {
-      const connected = await getFlytingClient().getConnectedUsers({
-        roomId,
-      });
-
-      for (const userId of connected.userIds) {
-        connectedUserIds.add(userId);
-      }
-    } catch (err) {
-      logger.warn(
-        { err, roomId },
-        'Failed to fetch connected live room users; notifying all subscribers',
-      );
-    }
-  }
 
   return {
-    subscriberIds: subscriptions
-      .map(({ userId }) => userId)
-      .filter((userId) => !connectedUserIds.has(userId)),
+    subscriberIds: subscriptions.map(({ userId }) => userId),
     subscriptionCount: subscriptions.length,
   };
 };
 
-const notifyDisconnectedSubscribers = async ({
+const notifySubscribers = async ({
   manager,
   room,
   userIds,
@@ -102,22 +78,18 @@ const notifyDisconnectedSubscribers = async ({
 
 const notifyLiveRoomStartedSubscribers = async ({
   con,
-  logger,
   room,
 }: {
   con: DataSource;
-  logger: FastifyBaseLogger;
   room: LiveRoom;
 }): Promise<void> => {
-  const { subscriberIds, subscriptionCount } =
-    await loadDisconnectedSubscriberIds({
-      con,
-      logger,
-      roomId: room.id,
-    });
+  const { subscriberIds, subscriptionCount } = await loadSubscriberIds({
+    con,
+    roomId: room.id,
+  });
 
   await con.transaction(async (manager) => {
-    await notifyDisconnectedSubscribers({
+    await notifySubscribers({
       manager,
       room,
       userIds: subscriberIds,
@@ -156,6 +128,6 @@ export const liveRoomStartedWorker: TypedWorker<'flyting.v1.room-started'> = {
       room,
     });
 
-    await notifyLiveRoomStartedSubscribers({ con, logger, room });
+    await notifyLiveRoomStartedSubscribers({ con, room });
   },
 };


### PR DESCRIPTION
## What changed

- Removed the Flyting connected-user lookup from the live room started worker.
- Standup start notifications now target every subscribed user for the room.
- Updated the lifecycle worker test to assert all subscribers receive the notification before subscriptions are hard-deleted.

## Why

The connected-user filter meant users already connected to the lobby could be skipped when the standup started. For now, the product behavior should be simple: a start notification is generated for every explicit standup subscriber.

## Validation

- `NODE_ENV=test npx jest __tests__/workers/liveRoomLifecycle.ts --testEnvironment=node --runInBand`
- `pnpm exec eslint src/workers/liveRoomStarted.ts __tests__/workers/liveRoomLifecycle.ts --max-warnings 0`