### PR TITLE
feat(onboarding): add guessWhoQuizStep mutation

### DIFF
--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -22,6 +22,19 @@ jest.mock('../../src/integrations/recswipe/clients', () => ({
   },
 }));
 
+const mockGuessWhoQuiz = jest.fn();
+
+jest.mock('../../src/integrations/bragi', () => ({
+  getBragiClient: () => ({
+    garmr: {
+      execute: (fn: () => Promise<unknown>) => fn(),
+    },
+    instance: {
+      guessWhoQuiz: (...args: unknown[]) => mockGuessWhoQuiz(...args),
+    },
+  }),
+}));
+
 const discoverPostsMock = recswipeClient.discoverPosts as jest.MockedFunction<
   typeof recswipeClient.discoverPosts
 >;
@@ -378,6 +391,184 @@ describe('mutation onboardingRecommendTags', () => {
 
     const res = await client.mutate(MUTATION, {
       variables: { selectedTags: ['rust'] },
+    });
+
+    expect(res.errors?.length).toBeGreaterThan(0);
+    expect(res.errors?.[0].extensions?.code).toBe('UNEXPECTED');
+  });
+});
+
+describe('mutation guessWhoQuizStep', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation GuessWhoQuizStep($history: [GuessWhoQuizQAInput!]!) {
+      guessWhoQuizStep(history: $history) {
+        nextQuestion {
+          question
+          options
+        }
+        finalPersona {
+          name
+          description
+          tags
+        }
+      }
+    }
+  `;
+
+  const fiveTurns = Array.from({ length: 5 }, (_, i) => ({
+    question: `Q${i + 1}`,
+    answer: `A${i + 1}`,
+  }));
+
+  it('should require authentication', () =>
+    testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { history: fiveTurns } },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should reject input with fewer than 5 history pairs', async () => {
+    loggedUser = '1';
+    await testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { history: fiveTurns.slice(0, 3) } },
+      'ZOD_VALIDATION_ERROR',
+    );
+    expect(mockGuessWhoQuiz).not.toHaveBeenCalled();
+  });
+
+  it('should return next question without calling recswipe', async () => {
+    loggedUser = '1';
+    mockGuessWhoQuiz.mockResolvedValueOnce({
+      id: 'op-1',
+      result: {
+        case: 'nextQuestion',
+        value: {
+          question: 'How do you feel about feature flags?',
+          options: ['ship it', 'sparingly', 'avoid', 'never used'],
+        },
+      },
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { history: fiveTurns },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      guessWhoQuizStep: {
+        nextQuestion: {
+          question: 'How do you feel about feature flags?',
+          options: ['ship it', 'sparingly', 'avoid', 'never used'],
+        },
+        finalPersona: null,
+      },
+    });
+    expect(extractTagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should call recswipe.extractTags and return persona with tags on final', async () => {
+    loggedUser = '1';
+    mockGuessWhoQuiz.mockResolvedValueOnce({
+      id: 'op-2',
+      result: {
+        case: 'finalPersona',
+        value: {
+          name: 'Pragmatic Backend Architect',
+          description:
+            'You wrangle systems for a living and stay quietly suspicious of every shiny new abstraction.',
+        },
+      },
+    });
+    extractTagsMock.mockResolvedValueOnce({
+      tags: ['backend', 'systems', 'go'],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { history: fiveTurns },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      guessWhoQuizStep: {
+        nextQuestion: null,
+        finalPersona: {
+          name: 'Pragmatic Backend Architect',
+          description:
+            'You wrangle systems for a living and stay quietly suspicious of every shiny new abstraction.',
+          tags: ['backend', 'systems', 'go'],
+        },
+      },
+    });
+    expect(extractTagsMock).toHaveBeenCalledWith('1', {
+      prompt:
+        'You wrangle systems for a living and stay quietly suspicious of every shiny new abstraction.',
+    });
+  });
+
+  it('should default missing tags to empty list', async () => {
+    loggedUser = '1';
+    mockGuessWhoQuiz.mockResolvedValueOnce({
+      id: 'op-3',
+      result: {
+        case: 'finalPersona',
+        value: {
+          name: 'Curious Developer',
+          description: 'You poke at things.',
+        },
+      },
+    });
+    extractTagsMock.mockResolvedValueOnce({
+      tags: undefined as unknown as string[],
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { history: fiveTurns },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      guessWhoQuizStep: {
+        nextQuestion: null,
+        finalPersona: {
+          name: 'Curious Developer',
+          description: 'You poke at things.',
+          tags: [],
+        },
+      },
+    });
+  });
+
+  it('should error when bragi returns neither branch', async () => {
+    loggedUser = '1';
+    mockGuessWhoQuiz.mockResolvedValueOnce({
+      id: 'op-4',
+      result: { case: undefined },
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { history: fiveTurns },
+    });
+
+    expect(res.errors?.length).toBeGreaterThan(0);
+    expect(extractTagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should surface an UNEXPECTED error when recswipe extractTags fails', async () => {
+    loggedUser = '1';
+    mockGuessWhoQuiz.mockResolvedValueOnce({
+      id: 'op-5',
+      result: {
+        case: 'finalPersona',
+        value: { name: 'X', description: 'Y' },
+      },
+    });
+    extractTagsMock.mockRejectedValueOnce(
+      new HttpError('http://recswipe.local:8000/api/extract-tags', 500, 'boom'),
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: { history: fiveTurns },
     });
 
     expect(res.errors?.length).toBeGreaterThan(0);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@connectrpc/connect-fastify": "^1.6.1",
     "@connectrpc/connect-node": "^1.6.1",
     "@dailydotdev/graphql-redis-subscriptions": "^2.4.3",
-    "@dailydotdev/schema": "0.3.6",
+    "@dailydotdev/schema": "0.3.7",
     "@dailydotdev/ts-ioredis-pool": "^1.0.2",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3(graphql-subscriptions@3.0.0(graphql@16.12.0))
       '@dailydotdev/schema':
-        specifier: 0.3.6
-        version: 0.3.6(@bufbuild/protobuf@1.10.0)
+        specifier: 0.3.7
+        version: 0.3.7(@bufbuild/protobuf@1.10.0)
       '@dailydotdev/ts-ioredis-pool':
         specifier: ^1.0.2
         version: 1.0.2
@@ -879,8 +879,8 @@ packages:
     peerDependencies:
       graphql-subscriptions: ^1.0.0 || ^2.0.0
 
-  '@dailydotdev/schema@0.3.6':
-    resolution: {integrity: sha512-EnWU44LBerccr8LkJmSV0pO6FO0oUuUd/ORpXZPo4fr8qBW/F2mrMI1oKqx3b95AGPOOkVPYzpc259civOHcqw==}
+  '@dailydotdev/schema@0.3.7':
+    resolution: {integrity: sha512-sqN8Yu7dz+CVQ4fJHVEc4SX7XOfyw+fyKnXCTC2RS/nPXZxQ5bf9jRfRBOvVPlHKMyyNgo1VFpCOTnjxJycdWQ==}
     peerDependencies:
       '@bufbuild/protobuf': 1.x
 
@@ -6231,7 +6231,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dailydotdev/schema@0.3.6(@bufbuild/protobuf@1.10.0)':
+  '@dailydotdev/schema@0.3.7(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 

--- a/src/common/schema/guessWhoQuizStep.ts
+++ b/src/common/schema/guessWhoQuizStep.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const MAX_TEXT = 500;
+
+export const guessWhoQuizStepInputSchema = z.object({
+  history: z
+    .array(
+      z.object({
+        question: z.string().min(1).max(MAX_TEXT),
+        answer: z.string().min(1).max(MAX_TEXT),
+      }),
+    )
+    .min(5)
+    .max(20),
+});

--- a/src/integrations/bragi/clients.ts
+++ b/src/integrations/bragi/clients.ts
@@ -21,6 +21,9 @@ import {
   GenerateRecruiterEmailResponse,
   ExtractedProfileTag,
   GitHubProfileTagsResponse,
+  GuessWhoQuizPersona,
+  GuessWhoQuizQuestion,
+  GuessWhoQuizResponse,
   OnboardingProfileTagsResponse,
   ParseFeedbackResponse,
   Pipelines,
@@ -174,6 +177,37 @@ export const getBragiClient = (
               new ExtractedProfileTag({ name: 'go', confidence: 0.73 }),
               new ExtractedProfileTag({ name: 'ai', confidence: 0.7 }),
             ],
+          }),
+        guessWhoQuiz: async ({
+          history,
+        }: {
+          history?: { question: string; answer: string }[];
+        }) =>
+          new GuessWhoQuizResponse({
+            id: 'mock-id',
+            result:
+              (history?.length ?? 0) >= 8
+                ? {
+                    case: 'finalPersona',
+                    value: new GuessWhoQuizPersona({
+                      name: 'Pragmatic Backend Architect',
+                      description:
+                        'You wrangle systems for a living and stay quietly suspicious of every shiny new abstraction.',
+                    }),
+                  }
+                : {
+                    case: 'nextQuestion',
+                    value: new GuessWhoQuizQuestion({
+                      question:
+                        'How do you feel about feature flags in production?',
+                      options: [
+                        'Ship it gated, always',
+                        'Use them sparingly',
+                        'Avoid them, prefer canaries',
+                        'Never used one in anger',
+                      ],
+                    }),
+                  },
           }),
       } as unknown as ReturnType<typeof createClient<typeof Pipelines>>,
       garmr: new GarmrNoopService(),

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -3,6 +3,7 @@ import { Code, ConnectError } from '@connectrpc/connect';
 import { getBragiClient } from '../integrations/bragi';
 import { Keyword, KeywordStatus } from '../entity/Keyword';
 import type { z } from 'zod';
+import { guessWhoQuizStepInputSchema } from '../common/schema/guessWhoQuizStep';
 import { onboardingDiscoverPostsInputSchema } from '../common/schema/onboardingDiscoverPosts';
 import { onboardingExtractTagsInputSchema } from '../common/schema/onboardingExtractTags';
 import { onboardingProfileTagsInputSchema } from '../common/schema/onboardingProfileTags';
@@ -1833,6 +1834,15 @@ export const typeDefs = /* GraphQL */ `
       selectedTags: [String!]!
       n: Int
     ): OnboardingRecommendTagsResult! @auth
+
+    """
+    Send the current Guess Who quiz Q&A history to bragi. Returns either the
+    next clarifying question or the final persona (with tags extracted from the
+    persona description via recswipe). Stateless — caller resends history each
+    turn.
+    """
+    guessWhoQuizStep(history: [GuessWhoQuizQAInput!]!): GuessWhoQuizStepResult!
+      @auth
   }
 
   type OnboardingTagsResult {
@@ -1863,6 +1873,27 @@ export const typeDefs = /* GraphQL */ `
 
   type OnboardingRecommendTagsResult {
     tags: [String!]!
+  }
+
+  input GuessWhoQuizQAInput {
+    question: String!
+    answer: String!
+  }
+
+  type GuessWhoQuizQuestion {
+    question: String!
+    options: [String!]!
+  }
+
+  type GuessWhoQuizPersona {
+    name: String!
+    description: String!
+    tags: [String!]!
+  }
+
+  type GuessWhoQuizStepResult {
+    nextQuestion: GuessWhoQuizQuestion
+    finalPersona: GuessWhoQuizPersona
   }
 `;
 
@@ -4454,6 +4485,63 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         if (err instanceof HttpError) {
           throw new ServiceError({
             message: 'Recswipe recommendTags request failed',
+            data: err.response,
+            statusCode: err.statusCode,
+          });
+        }
+
+        throw err;
+      }
+    },
+    guessWhoQuizStep: async (
+      _,
+      args: z.input<typeof guessWhoQuizStepInputSchema>,
+      ctx: AuthContext,
+    ) => {
+      const parsed = guessWhoQuizStepInputSchema.parse(args);
+
+      try {
+        const client = getBragiClient();
+        const bragiResp = await client.garmr.execute(() =>
+          client.instance.guessWhoQuiz({
+            history: parsed.history,
+            application: 'webapp',
+          }),
+        );
+
+        const { result } = bragiResp;
+        if (result.case === 'nextQuestion') {
+          return {
+            nextQuestion: {
+              question: result.value.question,
+              options: [...result.value.options],
+            },
+            finalPersona: null,
+          };
+        }
+        if (result.case === 'finalPersona') {
+          const persona = result.value;
+          const tagData = await recswipeClient.extractTags(ctx.userId, {
+            prompt: persona.description,
+          });
+          return {
+            nextQuestion: null,
+            finalPersona: {
+              name: persona.name,
+              description: persona.description,
+              tags: tagData.tags ?? [],
+            },
+          };
+        }
+        throw new ServiceError({
+          message:
+            'Bragi guessWhoQuiz returned neither nextQuestion nor finalPersona',
+          statusCode: 502,
+        });
+      } catch (err) {
+        if (err instanceof HttpError) {
+          throw new ServiceError({
+            message: 'guessWhoQuizStep request failed',
             data: err.response,
             statusCode: err.statusCode,
           });


### PR DESCRIPTION
## Summary
- New `@auth`-gated `guessWhoQuizStep` GraphQL mutation that drives the onboarding "Guess Who" persona quiz. Stateless: client resends the Q&A history each turn, bragi returns either the next clarifying question or the final persona.
- On final persona, calls recswipe `extractTags` against the persona description so the response includes the tag list the client needs to seed downstream onboarding.
- Bumps `@dailydotdev/schema` to `0.3.7` for the new `GuessWhoQuiz*` proto types and `guessWhoQuiz` RPC, plus adds a mock-mode implementation in `src/integrations/bragi/clients.ts`.

## Test plan
- [x] \`pnpm run build\`
- [x] \`pnpm run lint\`
- [ ] \`NODE_ENV=test npx jest __tests__/schema/onboarding.ts --testEnvironment=node --runInBand\` covers: auth required, Zod validation rejects <5 history pairs, \`nextQuestion\` path skips recswipe, \`finalPersona\` path calls \`extractTags\` and returns tags, missing tags default to \`[]\`, neither-branch response errors, recswipe failure surfaces as \`UNEXPECTED\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)