### PR TITLE
fix: invalidate marketing CTA cache on user_marketing_cta delete

### DIFF
--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1656,6 +1656,23 @@ const onMarketingCtaChange = async (
   }
 };
 
+const onUserMarketingCtaChange = async (
+  data: ChangeMessage<UserMarketingCta>,
+) => {
+  if (data.payload.op !== 'd') {
+    return;
+  }
+
+  const userId = data.payload.before?.userId;
+  if (!userId) {
+    return;
+  }
+
+  await deleteRedisKey(
+    generateStorageKey(StorageTopic.Boot, StorageKey.MarketingCta, userId),
+  );
+};
+
 const onSquadPublicRequestChange = async (
   con: DataSource,
   logger: FastifyBaseLogger,
@@ -2872,6 +2889,9 @@ const worker: Worker = {
           break;
         case getTableName(con, MarketingCta):
           await onMarketingCtaChange(con, data);
+          break;
+        case getTableName(con, UserMarketingCta):
+          await onUserMarketingCtaChange(data);
           break;
         case getTableName(con, UserStreak):
           await onUserStreakChange(con, logger, data);


### PR DESCRIPTION
## Summary

- Bulk SQL deletes of `user_marketing_cta` rows (and cascade deletes from a `marketing_cta` removal) left `boot:marketing_cta:<userId>` keys serving stale CTAs for up to a week. The existing `onMarketingCtaChange` handler only fires on `marketing_cta` row updates, so per-user removals were never propagated to Redis.
- Add `onUserMarketingCtaChange`: on any `user_marketing_cta` delete, clear that user's boot cache so the next boot rebuilds it.

Discovered while investigating users still receiving the `dailydev-show-e02` CTA after its `user_marketing_cta` rows were emptied. Production Redis had ~42.6k stale keys for that campaign — those have been cleared manually; this PR prevents recurrence.

## Test plan

- [ ] Deploy and confirm CDC processing for `user_marketing_cta` deletes runs without errors.
- [ ] Monitor `boot:marketing_cta:*` cache hit rate / stale-key count after the next bulk CTA cleanup.