### PR TITLE
fix: reuse existing standup notification rows

### DIFF
--- a/__tests__/workers/liveRoomLifecycle.ts
+++ b/__tests__/workers/liveRoomLifecycle.ts
@@ -126,6 +126,66 @@ describe('live room lifecycle workers', () => {
     ).toBe(0);
   });
 
+  it('adds user notifications when the room notification already exists', async () => {
+    const roomId = '38bf0f69-942f-412f-bd4e-a64b08b0b66e';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: roomId,
+        hostId: '1',
+        topic: 'Existing notification lobby',
+        mode: 'moderated',
+        status: LiveRoomStatus.Created,
+        scheduledStart: new Date('2026-05-05T15:00:00.000Z'),
+      },
+    ]);
+    await saveFixtures(con, NotificationV2, [
+      {
+        type: NotificationType.LiveRoomStarted,
+        icon: 'bell',
+        title: '<b>Ido</b> is live: <b>Existing notification lobby</b>',
+        targetUrl: `http://localhost:5002/standups/${roomId}`,
+        referenceId: roomId,
+        referenceType: 'live_room',
+        uniqueKey: roomId,
+        avatars: [],
+        attachments: [],
+      },
+    ]);
+    await saveFixtures(con, LiveRoomSubscription, [
+      {
+        roomId,
+        userId: '2',
+      },
+    ]);
+
+    await expectSuccessfulTypedBackground<'flyting.v1.room-started'>(
+      liveRoomStartedWorker,
+      {
+        eventId: '955f8422-87eb-4e91-8b32-4a13cf2d481d',
+        roomId,
+        occurredAt: '2026-05-05T15:01:00.000Z',
+        type: LiveRoomLifecycleEventType.RoomStarted,
+      },
+    );
+
+    const notification = await con
+      .getRepository(NotificationV2)
+      .findOneByOrFail({
+        referenceId: roomId,
+        referenceType: 'live_room',
+        type: NotificationType.LiveRoomStarted,
+      });
+    const userNotifications = await con.getRepository(UserNotification).findBy({
+      notificationId: notification.id,
+    });
+
+    expect(userNotifications.map(({ userId }) => userId)).toEqual(['2']);
+    expect(
+      await con.getRepository(LiveRoomSubscription).countBy({ roomId }),
+    ).toBe(0);
+  });
+
   it('marks a room ended when an ended event arrives', async () => {
     await saveFixtures(con, LiveRoom, [
       {

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -120,6 +120,37 @@ async function upsertAttachments(
   );
 }
 
+const getExistingNotification = async (
+  entityManager: EntityManager,
+  notification: NotificationBundleV2['notification'],
+): Promise<NotificationV2> => {
+  const query = entityManager
+    .getRepository(NotificationV2)
+    .createQueryBuilder('notification')
+    .where('notification.type = :type', { type: notification.type })
+    .andWhere('notification."uniqueKey" = :uniqueKey', {
+      uniqueKey: notification.uniqueKey ?? '0',
+    });
+
+  if (notification.referenceId) {
+    query.andWhere('notification."referenceId" = :referenceId', {
+      referenceId: notification.referenceId,
+    });
+  } else {
+    query.andWhere('notification."referenceId" IS NULL');
+  }
+
+  if (notification.referenceType) {
+    query.andWhere('notification."referenceType" = :referenceType', {
+      referenceType: notification.referenceType,
+    });
+  } else {
+    query.andWhere('notification."referenceType" IS NULL');
+  }
+
+  return query.getOneOrFail();
+};
+
 export async function storeNotificationBundleV2(
   entityManager: EntityManager,
   bundle: NotificationBundleV2,
@@ -143,11 +174,9 @@ export async function storeNotificationBundleV2(
     .orIgnore()
     .execute();
 
-  if (!generatedMaps?.[0]?.id) {
-    return [];
-  }
-
-  const notification = generatedMaps[0] as NotificationV2;
+  const notification = generatedMaps?.[0]?.id
+    ? (generatedMaps[0] as NotificationV2)
+    : await getExistingNotification(entityManager, bundle.notification);
   const uniqueKey = generateUserNotificationUniqueKey({
     ...notification,
     dedupKey,
@@ -198,7 +227,7 @@ export async function storeNotificationBundleV2(
     await entityManager.query(
       `INSERT INTO "user_notification" ("userId", "notificationId", "createdAt", "uniqueKey", "showAt", "public")
        ${query}
-       ON CONFLICT ("userId", "uniqueKey") WHERE "uniqueKey" IS NOT NULL DO NOTHING`,
+       ON CONFLICT DO NOTHING`,
       params,
     );
   }


### PR DESCRIPTION
## What changed

- Reuse an existing `notification_v2` row when notification insertion is ignored by the unique constraint.
- Continue inserting `user_notification` rows for the current recipients instead of returning early.
- Make `user_notification` insertion idempotent across both per-user unique keys and primary-key conflicts.
- Added a live-room lifecycle regression for the case where a standup start notification row already exists before subscriptions are processed.

## Why

Subscriptions could be hard-deleted while no notification appeared for the user if the room-level `live_room_started` notification already existed. The notification insert was ignored, `storeNotificationBundleV2` returned before user delivery rows were inserted, and the worker then cleaned the subscriptions.

## Validation

- `NODE_ENV=test npx jest __tests__/workers/liveRoomLifecycle.ts --testEnvironment=node --runInBand`
- `NODE_ENV=test npx jest __tests__/notifications/index.ts --testEnvironment=node --runInBand -t "storeNotificationBundle"`
- `pnpm exec eslint src/notifications/index.ts src/workers/liveRoomStarted.ts __tests__/workers/liveRoomLifecycle.ts --max-warnings 0`