### PR TITLE
fix(highlights): keep underlying article as the stable highlight postId

### DIFF
--- a/__tests__/workers/generateChannelHighlight.ts
+++ b/__tests__/workers/generateChannelHighlight.ts
@@ -572,6 +572,114 @@ describe('generateChannelHighlight worker', () => {
     ]);
   });
 
+  it('should keep an accessible underlying article as the highlight postId when a public share appears later', async () => {
+    const now = new Date('2026-03-03T12:00:00.000Z');
+    await con.getRepository(ChannelHighlightDefinition).save({
+      channel: 'vibes',
+      mode: 'publish',
+      candidateHorizonHours: 72,
+      maxItems: 3,
+    });
+    // The article is highlighted on its underlying postId at run time.
+    await saveArticle({
+      id: 'underlying-1',
+      title: 'Original article',
+      createdAt: new Date('2026-03-03T11:00:00.000Z'),
+    });
+    await con.getRepository(PostHighlight).save({
+      channel: 'vibes',
+      postId: 'underlying-1',
+      highlightedAt: new Date('2026-03-03T11:30:00.000Z'),
+      headline: 'Original headline',
+      significance: PostHighlightSignificance.Major,
+      reason: 'previous run',
+    });
+    // A user shares the article between runs.
+    await saveShare({
+      id: 'share-1',
+      sharedPostId: 'underlying-1',
+      createdAt: new Date('2026-03-03T11:50:00.000Z'),
+      upvotes: 5,
+    });
+
+    jest
+      .spyOn(evaluator, 'evaluateChannelHighlights')
+      .mockResolvedValue({ items: [] });
+
+    await expectSuccessfulTypedBackground<'api.v1.generate-channel-highlight'>(
+      worker,
+      {
+        channel: 'vibes',
+        scheduledAt: now.toISOString(),
+      },
+    );
+
+    const allRows = await con.getRepository(PostHighlight).find({
+      where: { channel: 'vibes' },
+    });
+    expect(allRows).toHaveLength(1);
+    expect(allRows[0]).toMatchObject({
+      postId: 'underlying-1',
+      retiredAt: null,
+    });
+  });
+
+  it('should downgrade a SharePost-stored highlight back to its underlying article when accessible', async () => {
+    const now = new Date('2026-03-03T12:00:00.000Z');
+    await con.getRepository(ChannelHighlightDefinition).save({
+      channel: 'vibes',
+      mode: 'publish',
+      candidateHorizonHours: 72,
+      maxItems: 3,
+    });
+    await saveArticle({
+      id: 'underlying-2',
+      title: 'Underlying article',
+      createdAt: new Date('2026-03-03T11:00:00.000Z'),
+    });
+    await saveShare({
+      id: 'share-2',
+      sharedPostId: 'underlying-2',
+      createdAt: new Date('2026-03-03T11:20:00.000Z'),
+    });
+    // Legacy row: highlight previously stored on the share post ID.
+    await con.getRepository(PostHighlight).save({
+      channel: 'vibes',
+      postId: 'share-2',
+      highlightedAt: new Date('2026-03-03T11:30:00.000Z'),
+      headline: 'Legacy share headline',
+      significance: PostHighlightSignificance.Major,
+      reason: 'pre-fix run',
+    });
+
+    jest
+      .spyOn(evaluator, 'evaluateChannelHighlights')
+      .mockResolvedValue({ items: [] });
+
+    await expectSuccessfulTypedBackground<'api.v1.generate-channel-highlight'>(
+      worker,
+      {
+        channel: 'vibes',
+        scheduledAt: now.toISOString(),
+      },
+    );
+
+    const liveRows = await con.getRepository(PostHighlight).find({
+      where: { channel: 'vibes', retiredAt: IsNull() },
+    });
+    expect(liveRows).toEqual([
+      expect.objectContaining({
+        postId: 'underlying-2',
+        headline: 'Legacy share headline',
+      }),
+    ]);
+    const retiredRows = await con.getRepository(PostHighlight).find({
+      where: { channel: 'vibes', postId: 'share-2' },
+    });
+    expect(retiredRows).toHaveLength(1);
+    expect(retiredRows[0].retiredAt).toBeInstanceOf(Date);
+  });
+
   it('should drop admitted candidates that race with collection regeneration', async () => {
     const now = new Date('2026-03-15T12:00:00.000Z');
     await con.getRepository(ChannelHighlightDefinition).save({

--- a/src/common/channelHighlight/generate.ts
+++ b/src/common/channelHighlight/generate.ts
@@ -239,11 +239,13 @@ export const generateChannelHighlight = async ({
       if (post.sharedPostId) sharedByShareId.set(post.id, post.sharedPostId);
     }
     const retiredHighlightPostIdSet = new Set(
-      retiredHighlightPostIds.flatMap((postId) => [
-        postId,
-        fallbackPostIds.get(postId),
-        sharedByShareId.get(postId),
-      ]).filter((id): id is string => !!id),
+      retiredHighlightPostIds
+        .flatMap((postId) => [
+          postId,
+          fallbackPostIds.get(postId),
+          sharedByShareId.get(postId),
+        ])
+        .filter((id): id is string => !!id),
     );
     const retiredEvaluationPostIdSet = new Set(
       retiredEvaluationHighlights.map((item) => item.postId),

--- a/src/common/channelHighlight/generate.ts
+++ b/src/common/channelHighlight/generate.ts
@@ -141,10 +141,27 @@ export const generateChannelHighlight = async ({
       highlightedPosts,
       evaluationHistoryPosts,
     ]);
-    const relations = await fetchRelations({
-      con,
-      postIds: basePosts.map((post) => post.id),
-    });
+    // For SharePost-stored highlights we need the underlying article in the
+    // post pool so canonicalization can downgrade share → underlying when the
+    // underlying is accessible.
+    const sharedUnderlyingIds = [
+      ...new Set(
+        basePosts
+          .map((post) => post.sharedPostId)
+          .filter((id): id is string => !!id),
+      ),
+    ];
+    const [relations, sharedUnderlyingPosts] = await Promise.all([
+      fetchRelations({
+        con,
+        postIds: basePosts.map((post) => post.id),
+      }),
+      fetchPostsByIds({
+        con,
+        ids: sharedUnderlyingIds,
+        excludedSourceIds,
+      }),
+    ]);
     const relationPosts = await fetchPostsByIds({
       con,
       ids: [
@@ -157,7 +174,11 @@ export const generateChannelHighlight = async ({
       ],
       excludedSourceIds,
     });
-    const availablePosts = mergePosts([basePosts, relationPosts]);
+    const availablePosts = mergePosts([
+      basePosts,
+      relationPosts,
+      sharedUnderlyingPosts,
+    ]);
     const inaccessiblePostIds = new Set(
       availablePosts
         .filter((post) => post.sourceId === UNKNOWN_SOURCE)
@@ -178,6 +199,7 @@ export const generateChannelHighlight = async ({
         highlights: activeHighlights,
         relations,
         posts: availablePosts,
+        inaccessiblePostIds,
       }),
       inaccessiblePostIds,
       fallbackPostIds,
@@ -187,6 +209,7 @@ export const generateChannelHighlight = async ({
         highlights: evaluationHistoryHighlights.map(toHighlightItem),
         relations,
         posts: availablePosts,
+        inaccessiblePostIds,
       }),
       inaccessiblePostIds,
       fallbackPostIds,
@@ -198,6 +221,7 @@ export const generateChannelHighlight = async ({
           .map(toHighlightItem),
         relations,
         posts: availablePosts,
+        inaccessiblePostIds,
       }),
       inaccessiblePostIds,
       fallbackPostIds,
@@ -206,10 +230,20 @@ export const generateChannelHighlight = async ({
     const currentHighlightPostIds = new Set(
       liveHighlights.map((item) => item.postId),
     );
+    // A retired highlight may be stored as either the underlying post id (the
+    // new norm) or as a share-post id (legacy rows from before we stopped
+    // auto-migrating underlying → share). Dedup against both forms so a fresh
+    // candidate matching either side is filtered out.
+    const sharedByShareId = new Map<string, string>();
+    for (const post of availablePosts) {
+      if (post.sharedPostId) sharedByShareId.set(post.id, post.sharedPostId);
+    }
     const retiredHighlightPostIdSet = new Set(
-      retiredHighlightPostIds.map(
-        (postId) => fallbackPostIds.get(postId) || postId,
-      ),
+      retiredHighlightPostIds.flatMap((postId) => [
+        postId,
+        fallbackPostIds.get(postId),
+        sharedByShareId.get(postId),
+      ]).filter((id): id is string => !!id),
     );
     const retiredEvaluationPostIdSet = new Set(
       retiredEvaluationHighlights.map((item) => item.postId),
@@ -255,7 +289,7 @@ export const generateChannelHighlight = async ({
       admitted: evaluatedHighlights,
       fallbackPostIds,
       currentHighlightPostIds,
-      retiredHighlightPostIds: new Set(retiredHighlightPostIds),
+      retiredHighlightPostIds: retiredHighlightPostIdSet,
     });
 
     const internalHighlights = trimHighlights({

--- a/src/common/channelHighlight/stories.ts
+++ b/src/common/channelHighlight/stories.ts
@@ -201,25 +201,48 @@ export const toHighlightItem = (
   reason: item.reason,
 });
 
+// The only post-id transitions we allow are:
+// - share-post → underlying article when the underlying is accessible (downgrade
+//   a SharePost-stored highlight back to its source article so the rail links
+//   stay stable)
+// - child article → collection when both are present (canonical "story" upgrade)
+// Anything else keeps the highlight's stored postId as-is.
 export const canonicalizeCurrentHighlights = ({
   highlights,
   relations,
   posts,
+  inaccessiblePostIds,
 }: {
   highlights: HighlightItem[];
   relations: PostRelation[];
   posts: HighlightPost[];
+  inaccessiblePostIds: Set<string>;
 }): HighlightItem[] => {
   const postsById = new Map(posts.map((post) => [post.id, post]));
   const collectionByChildId = buildCollectionByChildId(
     relations,
     new Set(postsById.keys()),
   );
+  const sharedByShareId = new Map<string, string>();
+  for (const post of posts) {
+    if (post.sharedPostId) sharedByShareId.set(post.id, post.sharedPostId);
+  }
+
+  const downgradeShareToUnderlying = (postId: string): string => {
+    const underlyingId = sharedByShareId.get(postId);
+    if (!underlyingId) return postId;
+    if (!postsById.has(underlyingId) || inaccessiblePostIds.has(underlyingId)) {
+      return postId;
+    }
+    return underlyingId;
+  };
+
   const canonicalHighlights = new Map<string, HighlightItem>();
 
   for (const highlight of highlights) {
+    const downgradedPostId = downgradeShareToUnderlying(highlight.postId);
     const canonicalPostId =
-      collectionByChildId.get(highlight.postId) || highlight.postId;
+      collectionByChildId.get(downgradedPostId) || downgradedPostId;
     const canonicalPost = postsById.get(canonicalPostId);
 
     if (!canonicalPost) {
@@ -245,6 +268,10 @@ export const canonicalizeCurrentHighlights = ({
   );
 };
 
+// Substitute a public share for the underlying post only when the underlying
+// is inaccessible (UNKNOWN_SOURCE / banned / deleted). Accessible items keep
+// their original postId — we don't auto-migrate underlying → share when a user
+// happens to share a highlighted article.
 const applyPublicShareFallback = <T extends { postId: string }>({
   items,
   inaccessiblePostIds,
@@ -257,20 +284,18 @@ const applyPublicShareFallback = <T extends { postId: string }>({
   const mappedItems = new Map<string, T>();
 
   for (const item of items) {
-    const fallbackPostId = fallbackPostIds.get(item.postId);
-    if (!fallbackPostId && inaccessiblePostIds.has(item.postId)) {
-      continue;
+    let postId = item.postId;
+    if (inaccessiblePostIds.has(postId)) {
+      const fallbackPostId = fallbackPostIds.get(postId);
+      if (!fallbackPostId) continue;
+      postId = fallbackPostId;
     }
+    if (mappedItems.has(postId)) continue;
 
-    const postId = fallbackPostId || item.postId;
-    if (mappedItems.has(postId)) {
-      continue;
-    }
-
-    mappedItems.set(postId, {
-      ...item,
+    mappedItems.set(
       postId,
-    });
+      postId === item.postId ? item : { ...item, postId },
+    );
   }
 
   return [...mappedItems.values()];


### PR DESCRIPTION
## Summary

- The current share-fallback path always rewrites a highlight's `postId` to the share post when one exists, even if the underlying article is fully accessible. This caused a phantom-duplicate row in production: highlight `54f1608d` (`backend` channel, "Next.js ships security release patching 13 advisories…") originally stored on underlying `hMQrmCavA`, then migrated to share `KKfuWW0B7` ~3.5 hours later when a user shared the article. Same headline, same `highlightedAt`, same story — just a different `postId`, so `replaceHighlightsForChannel` retired the original row and inserted a new one.
- The only post-id transition we want is the **child article → collection** upgrade in `canonicalizeCurrentHighlights` (the canonical "story" upgrade). This PR enforces that and stops every other migration:
  1. `applyPublicShareFallback` now only swaps to a public share when the original post is **inaccessible** (`UNKNOWN_SOURCE` / banned / deleted). Accessible items keep their post id, so a user share never bumps a live highlight off its article id.
  2. `canonicalizeCurrentHighlights` gains a **share → underlying downgrade**: if a stored highlight's `postId` is a `SharePost` and the referenced article is accessible, the highlight is canonicalized back to the underlying. This both prevents the bug going forward and migrates the existing legacy share-stored rows in place on their next run.
- `retiredHighlightPostIdSet` now tolerates either form (share or underlying) for back-compat dedup against legacy rows that were stored as share ids before this PR.
- The collection-upgrade contract is unchanged. The race-guard added in #3856 still runs against the post-canonicalization id sets.

## Test plan

- [x] Two new tests in `__tests__/workers/generateChannelHighlight.ts`:
  - `should keep an accessible underlying article as the highlight postId when a public share appears later` — reproduces the production bug; asserts the highlight stays on the underlying after a share is created between runs.
  - `should downgrade a SharePost-stored highlight back to its underlying article when accessible` — covers the legacy-row migration path.
- [x] All 14 existing tests in `generateChannelHighlight.ts` still pass (no fixture changes needed; `should replace unknown-source candidates with the most upvoted public share before evaluation` and `should skip unknown-source candidates when no public share exists` both continue to pass since the inaccessible-source path is unchanged).
- [ ] After deploy, watch a few `backend` highlight runs to confirm no new phantom-share rows and that any existing share-stored live highlights migrate to their underlying on the next run.