### PR TITLE
fix(highlights): link major headline notification to highlight URL and use megaphone icon

### DIFF
--- a/__tests__/workers/notifications/majorHeadlineAdded.ts
+++ b/__tests__/workers/notifications/majorHeadlineAdded.ts
@@ -76,6 +76,7 @@ describe('majorHeadlineAdded notification worker', () => {
       headline: baseMessage.headline,
       channel: baseMessage.channel,
       significance: PostHighlightSignificance.Breaking,
+      highlightId: baseMessage.highlightId,
     });
   });
 

--- a/src/common/links.ts
+++ b/src/common/links.ts
@@ -22,6 +22,9 @@ export const getDiscussionLink = (postSlug: string, commentId = ''): string =>
     commentId && `#c-${commentId}`
   }`;
 
+export const getHighlightLink = (highlightId: string): string =>
+  `${process.env.COMMENTS_PREFIX}/highlights?highlight=${highlightId}`;
+
 export const getSourceLink = (
   source: Pick<Source, 'handle' | 'type'>,
 ): string =>

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -3,6 +3,7 @@ import { NotificationBuilder } from './builder';
 import { NotificationIcon } from './icons';
 import {
   generateDevCard,
+  getHighlightLink,
   getOrganizationPermalink,
   notificationsLink,
   squadsFeaturedPage,
@@ -767,10 +768,11 @@ export const generateNotificationMap: Record<
     ctx: NotificationMajorHeadlineContext,
   ) =>
     builder
-      .icon(NotificationIcon.Bell)
+      .icon(NotificationIcon.Megaphone)
       .description(ctx.headline)
       .avatarSource(ctx.source)
       .objectPost(ctx.post, ctx.source, ctx.sharedPost)
+      .targetUrl(getHighlightLink(ctx.highlightId))
       .uniqueKey(ctx.post.id),
   live_room_started: (
     builder: NotificationBuilder,

--- a/src/notifications/icons.ts
+++ b/src/notifications/icons.ts
@@ -16,4 +16,5 @@ export enum NotificationIcon {
   Core = 'Core',
   Opportunity = 'Opportunity',
   Analytics = 'Analytics',
+  Megaphone = 'Megaphone',
 }

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -228,6 +228,7 @@ export type NotificationMajorHeadlineContext = NotificationPostContext & {
   headline: string;
   channel: string;
   significance: number;
+  highlightId: string;
 };
 
 export type NotificationLiveRoomContext = NotificationBaseContext & {

--- a/src/workers/notifications/majorHeadlineAdded.ts
+++ b/src/workers/notifications/majorHeadlineAdded.ts
@@ -21,7 +21,7 @@ export const majorHeadlineAdded: TypedNotificationWorker<'api.v1.post-highlighte
     subscription: 'api.major-headline-added-notification',
     parseMessage: (message) => PostHighlightedMessage.fromBinary(message.data),
     handler: async (data, con) => {
-      const { postId, headline, channel, significance } = data;
+      const { highlightId, postId, headline, channel, significance } = data;
 
       if (significance !== PostHighlightSignificance.Breaking) {
         return;
@@ -77,6 +77,7 @@ export const majorHeadlineAdded: TypedNotificationWorker<'api.v1.post-highlighte
             headline,
             channel,
             significance,
+            highlightId,
           } as NotificationMajorHeadlineContext,
         },
       ];


### PR DESCRIPTION
## Summary

Follow-up to #3818:

- Major headline in-app notification now deep-links to `/highlights?highlight=<id>` (added `getHighlightLink` helper) instead of the post discussion page.
- Worker carries `highlightId` from `PostHighlightedMessage` through `NotificationMajorHeadlineContext`.
- Switches the in-app notification icon from `Bell` to a new `Megaphone` icon (matches the Happening Now sidebar / Headlines mobile navbar). App-side wiring lives in dailydotdev/apps#TBD.

## Test plan

- [x] `pnpm run lint`
- [x] `NODE_ENV=test npx jest __tests__/workers/notifications/majorHeadlineAdded.ts --testEnvironment=node --runInBand` — 16/16 passing
- [ ] Verify a Breaking highlight produces a notification whose target URL opens the highlights page with the right `highlight` query param

Made with [Cursor](https://cursor.com)