### PR TITLE
fix(archive): filter out deleted posts from archive items

### DIFF
--- a/__tests__/archive.ts
+++ b/__tests__/archive.ts
@@ -692,6 +692,27 @@ describe('archive queries', () => {
     });
   });
 
+  it('should exclude items whose post has been deleted', async () => {
+    await con.getRepository(Post).update({ id: 'post-6' }, { deleted: true });
+
+    const res = await client.query(archiveQuery, {
+      variables: {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Tag,
+        scopeId: 'webdev',
+        periodType: ArchivePeriodType.Month,
+        year: 2026,
+        month: 3,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.archive).toMatchObject({
+      items: [],
+    });
+  });
+
   it('should return only published archives from archiveIndex', async () => {
     const res = await client.query(archiveIndexQuery, {
       variables: {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -2652,6 +2652,9 @@ const obj = new GraphORM({
           customRelation: (_, parentAlias, childAlias, qb): QueryBuilder =>
             qb
               .where(`${childAlias}."archiveId" = "${parentAlias}".id`)
+              .andWhere(
+                `EXISTS (SELECT 1 FROM "post" "p" WHERE "p".id = ${childAlias}."subjectId" AND "p"."deleted" = false)`,
+              )
               .orderBy(`${childAlias}.rank`, 'ASC'),
         },
       },
@@ -2689,7 +2692,9 @@ const obj = new GraphORM({
         relation: {
           isMany: false,
           customRelation: (_, parentAlias, childAlias, qb): QueryBuilder =>
-            qb.where(`${childAlias}.id = "${parentAlias}"."subjectId"`),
+            qb
+              .where(`${childAlias}.id = "${parentAlias}"."subjectId"`)
+              .andWhere(`${childAlias}."deleted" = false`),
         },
       },
     },


### PR DESCRIPTION
## Summary
- Add `EXISTS` check on `Archive.items` GraphORM relation to exclude `ArchiveItem` rows whose referenced post is deleted or missing
- Add `deleted = false` condition on `ArchiveItem.post` relation as a secondary guard
- Add integration test verifying deleted posts are excluded from archive query results

Archive pages returned 500 when `ArchiveItem` rows referenced deleted posts — the frontend crashed on `item.post.id` because `post` was `null`. The fix filters at the query level so deleted-post items never reach the client.

Closes ENG-1421

---
Created by Huginn 🐦‍⬛