### PR TITLE
fix(seo): exclude shadow-banned profiles from index and sitemap

### DIFF
--- a/__tests__/sitemaps.ts
+++ b/__tests__/sitemaps.ts
@@ -823,6 +823,26 @@ describe('GET /sitemaps/users.xml', () => {
         email: 'noposts@test.com',
         bio: 'Has no posts',
       },
+      {
+        ...userBase,
+        id: 'vordr-user',
+        name: 'Shadow Banned User',
+        image: 'https://daily.dev/vordr.jpg',
+        username: 'vordruser',
+        email: 'vordr@test.com',
+        bio: 'Looks legit but is shadow banned',
+        flags: { vordr: true },
+      },
+      {
+        ...userBase,
+        id: 'non-vordr-flagged-user',
+        name: 'Non Vordr Flagged User',
+        image: 'https://daily.dev/non-vordr.jpg',
+        username: 'nonvordrflagged',
+        email: 'nonvordrflagged@test.com',
+        bio: 'Has flags but vordr is explicitly false',
+        flags: { vordr: false, trustScore: 5 },
+      },
     ]);
 
     await con.getRepository(Post).insert([
@@ -893,6 +913,20 @@ describe('GET /sitemaps/users.xml', () => {
         authorId: 'hidden-post-user',
         visible: false,
       },
+      {
+        ...publicPostBase,
+        id: 'vordr-user-post',
+        shortId: 'vup',
+        title: 'Vordr User Post',
+        authorId: 'vordr-user',
+      },
+      {
+        ...publicPostBase,
+        id: 'non-vordr-flagged-user-post',
+        shortId: 'nvfup',
+        title: 'Non Vordr Flagged User Post',
+        authorId: 'non-vordr-flagged-user',
+      },
     ]);
 
     const res = await request(app.server)
@@ -918,6 +952,10 @@ describe('GET /sitemaps/users.xml', () => {
     expect(res.text).not.toContain('/deletedpost');
     expect(res.text).not.toContain('/hiddenpost');
     expect(res.text).not.toContain('/noposts');
+    expect(res.text).not.toContain('/vordruser');
+    expect(res.text).toContain(
+      '<loc>http://localhost:5002/nonvordrflagged</loc>',
+    );
   });
 });
 

--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -1952,6 +1952,41 @@ describe('query user', () => {
   });
 });
 
+describe('query user noindex', () => {
+  const QUERY = `query User($id: ID!) {
+    user(id: $id) {
+      noindex
+    }
+  }`;
+
+  it('should be false for a user with reputation > 10 and no vordr flag', async () => {
+    await con
+      .getRepository(User)
+      .update({ id: '1' }, { reputation: 50, flags: {} });
+    const res = await client.query(QUERY, { variables: { id: '1' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.user).toEqual({ noindex: false });
+  });
+
+  it('should be true when reputation <= 10', async () => {
+    await con
+      .getRepository(User)
+      .update({ id: '1' }, { reputation: 10, flags: {} });
+    const res = await client.query(QUERY, { variables: { id: '1' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.user).toEqual({ noindex: true });
+  });
+
+  it('should be true when shadow banned (flags.vordr) even with high reputation', async () => {
+    await con
+      .getRepository(User)
+      .update({ id: '1' }, { reputation: 100, flags: { vordr: true } });
+    const res = await client.query(QUERY, { variables: { id: '1' } });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.user).toEqual({ noindex: true });
+  });
+});
+
 describe('query user socialLinks', () => {
   const QUERY = `query User($id: ID!) {
     user(id: $id) {

--- a/src/common/users.ts
+++ b/src/common/users.ts
@@ -23,6 +23,14 @@ import type { GQLKeyword } from '../schema/keywords';
 import type { GQLUser } from '../schema/users';
 import { UserExperienceType } from '../entity/user/experiences/types';
 
+/**
+ * Reputation at or below this value is treated as "thin" and triggers
+ * `noindex` on the user's public surfaces (profile page, post pages, sitemap
+ * exclusion). Users above this threshold are indexable unless gated by
+ * another signal (e.g. shadow ban via `flags.vordr`).
+ */
+export const MIN_INDEXABLE_REPUTATION = 10;
+
 export interface User {
   id: string;
   email: string;

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -52,6 +52,7 @@ import {
   UserVote,
 } from '../types';
 import { whereVordrFilter } from '../common/vordr';
+import { MIN_INDEXABLE_REPUTATION } from '../common/users';
 import { UserCompany, Post } from '../entity';
 import {
   ContentPreferenceStatus,
@@ -321,6 +322,10 @@ const obj = new GraphORM({
       isHackathonParticipant: {
         alias: { field: 'flags', type: 'jsonb' },
         transform: (flags: UserFlags) => !!flags?.hackathonParticipant,
+      },
+      noindex: {
+        select: (_: Context, alias: string): string =>
+          `(COALESCE((${alias}.flags->>'vordr')::boolean, false) OR ${alias}.reputation <= ${MIN_INDEXABLE_REPUTATION})`,
       },
       plusMemberSince: {
         alias: { field: 'subscriptionFlags', type: 'jsonb' },

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -12,7 +12,8 @@ import {
 import { ChannelHighlightDefinition } from '../entity/ChannelHighlightDefinition';
 import { PostHighlight } from '../entity/PostHighlight';
 import { ArchivePeriodType, ArchiveScopeType } from '../common/archive';
-import { getUserProfileUrl } from '../common/users';
+import { getUserProfileUrl, MIN_INDEXABLE_REPUTATION } from '../common/users';
+import { whereVordrFilter } from '../common/vordr';
 import createOrGetConnection from '../db';
 import { Readable } from 'stream';
 import { ONE_HOUR_IN_SECONDS } from '../common/constants';
@@ -414,10 +415,11 @@ const buildUsersSitemapQuery = (
     .select('u.username', 'username')
     .addSelect('u."updatedAt"', 'lastmod')
     .from(User, 'u')
-    .where('u.reputation > :minRep', { minRep: 10 })
+    .where('u.reputation > :minRep', { minRep: MIN_INDEXABLE_REPUTATION })
     .andWhere('u.bio IS NOT NULL')
     .andWhere(`btrim(u.bio) != ''`)
     .andWhere('u.username IS NOT NULL')
+    .andWhere(whereVordrFilter('u'))
     .andWhere((qb) => {
       const subQuery = qb
         .subQuery()

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -646,6 +646,10 @@ export const typeDefs = /* GraphQL */ `
     Flexible social media links array (replaces individual social fields)
     """
     socialLinks: [UserSocialLink!]!
+    """
+    Whether search engines should not index this user's profile
+    """
+    noindex: Boolean!
   }
 
   """


### PR DESCRIPTION
## Summary

Shadow-banned (vordr) user profiles currently return 200 with full content, no `noindex`, and are listed in `users.xml` — so Google indexes them and inbound links pass equity through. This PR closes both vectors while preserving the shadow-ban illusion (page content unchanged).

- Adds derived `User.noindex: Boolean!` GraphQL field, computed from `flags.vordr || reputation <= MIN_INDEXABLE_REPUTATION`. The webapp will consume it (companion PR: dailydotdev/apps#TBD).
- Excludes vordr users from `buildUsersSitemapQuery` via the existing `whereVordrFilter` helper.
- Extracts `MIN_INDEXABLE_REPUTATION = 10` constant in `src/common/users.ts` and uses it in both places to prevent threshold drift.

## Trade-off (intentional)

`noindex` is publicly queryable. For users with `reputation > 10`, `noindex: true` deterministically reveals shadow-ban via GraphQL. We accepted this over a real 404 because 404 would be a clean tell on the rendered page itself; a GraphQL-only signal is a smaller surface than a status-code change.

## Test plan

- [x] `__tests__/users.ts` — three new `query user noindex` cases (rep > 10 + no vordr, rep <= 10, vordr + high rep).
- [x] `__tests__/sitemaps.ts` — extended `users.xml` test asserts vordr user is excluded and a non-vordr user with `flags: {vordr: false}` IS included.
- [x] Lint clean.

Made with [Cursor](https://cursor.com)