### PR TITLE
feat(settings): replace highlightsFirstEnabled with highlightsPlacement

### DIFF
--- a/__tests__/__snapshots__/settings.ts.snap
+++ b/__tests__/__snapshots__/settings.ts.snap
@@ -11,7 +11,7 @@ Object {
     "flags": Object {
       "clickbaitShieldEnabled": null,
       "defaultWriteTab": null,
-      "highlightsFirstEnabled": null,
+      "highlightsPlacement": null,
       "sidebarBookmarksExpanded": null,
       "sidebarCustomFeedsExpanded": null,
       "sidebarOtherExpanded": null,
@@ -49,7 +49,7 @@ Object {
     "flags": Object {
       "clickbaitShieldEnabled": null,
       "defaultWriteTab": null,
-      "highlightsFirstEnabled": null,
+      "highlightsPlacement": null,
       "sidebarBookmarksExpanded": null,
       "sidebarCustomFeedsExpanded": null,
       "sidebarOtherExpanded": null,
@@ -89,7 +89,7 @@ Object {
     "flags": Object {
       "clickbaitShieldEnabled": null,
       "defaultWriteTab": null,
-      "highlightsFirstEnabled": null,
+      "highlightsPlacement": null,
       "sidebarBookmarksExpanded": null,
       "sidebarCustomFeedsExpanded": null,
       "sidebarOtherExpanded": null,
@@ -129,7 +129,7 @@ Object {
     "flags": Object {
       "clickbaitShieldEnabled": null,
       "defaultWriteTab": null,
-      "highlightsFirstEnabled": null,
+      "highlightsPlacement": null,
       "sidebarBookmarksExpanded": null,
       "sidebarCustomFeedsExpanded": null,
       "sidebarOtherExpanded": null,

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -1403,7 +1403,7 @@ describe('boot misc', () => {
         sidebarBookmarksExpanded: true,
         clickbaitShieldEnabled: true,
         browsingContextEnabled: false,
-        highlightsFirstEnabled: false,
+        highlightsPlacement: 'default',
         legacyPostLayoutOptOut: false,
       },
     });

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -27,6 +27,7 @@ import {
   Keyword,
   PostType,
   postTypes,
+  HighlightsPlacement,
   Settings,
   Source,
   SourceMember,
@@ -774,10 +775,10 @@ describe('FeedPreferencesConfigGenerator', () => {
     expect(actual.config.country).toBe('US');
   });
 
-  it('should set highlights_first when user enabled it in settings', async () => {
+  it('should set highlights_first when highlightsPlacement is pinned', async () => {
     await con.getRepository(Settings).save({
       userId: '1',
-      flags: { highlightsFirstEnabled: true },
+      flags: { highlightsPlacement: HighlightsPlacement.Pinned },
     });
 
     const generator: FeedConfigGenerator = new FeedPreferencesConfigGenerator(
@@ -791,12 +792,13 @@ describe('FeedPreferencesConfigGenerator', () => {
     });
 
     expect(actual.config.highlights_first).toBe(true);
+    expect(actual.config.highlights_limit).toBeUndefined();
   });
 
-  it('should not set highlights_first when setting is disabled', async () => {
+  it('should zero out highlights_limit when highlightsPlacement is disabled', async () => {
     await con.getRepository(Settings).save({
       userId: '1',
-      flags: { highlightsFirstEnabled: false },
+      flags: { highlightsPlacement: HighlightsPlacement.Disabled },
     });
 
     const generator: FeedConfigGenerator = new FeedPreferencesConfigGenerator(
@@ -807,9 +809,32 @@ describe('FeedPreferencesConfigGenerator', () => {
       user_id: '1',
       page_size: 2,
       offset: 3,
+      highlights_limit: 2,
+    });
+
+    expect(actual.config.highlights_limit).toBe(0);
+    expect(actual.config.highlights_first).toBeUndefined();
+  });
+
+  it('should leave highlights config untouched when placement is default', async () => {
+    await con.getRepository(Settings).save({
+      userId: '1',
+      flags: { highlightsPlacement: HighlightsPlacement.Default },
+    });
+
+    const generator: FeedConfigGenerator = new FeedPreferencesConfigGenerator(
+      config,
+    );
+
+    const actual = await generator.generate(ctx, {
+      user_id: '1',
+      page_size: 2,
+      offset: 3,
+      highlights_limit: 2,
     });
 
     expect(actual.config.highlights_first).toBeUndefined();
+    expect(actual.config.highlights_limit).toBe(2);
   });
 });
 

--- a/__tests__/settings.ts
+++ b/__tests__/settings.ts
@@ -121,7 +121,7 @@ describe('mutation updateUserSettings', () => {
       sidebarSquadExpanded
       sidebarBookmarksExpanded
       clickbaitShieldEnabled
-      highlightsFirstEnabled
+      highlightsPlacement
       defaultWriteTab
     }
   }
@@ -158,7 +158,7 @@ describe('mutation updateUserSettings', () => {
       sidebarSquadExpanded: null,
       sidebarBookmarksExpanded: null,
       clickbaitShieldEnabled: null,
-      highlightsFirstEnabled: null,
+      highlightsPlacement: null,
       defaultWriteTab: null,
     });
   });
@@ -178,7 +178,7 @@ describe('mutation updateUserSettings', () => {
       sidebarSquadExpanded: null,
       sidebarBookmarksExpanded: null,
       clickbaitShieldEnabled: null,
-      highlightsFirstEnabled: null,
+      highlightsPlacement: null,
       defaultWriteTab: null,
     });
 
@@ -315,25 +315,40 @@ describe('mutation updateUserSettings', () => {
       sidebarSquadExpanded: null,
       sidebarBookmarksExpanded: null,
       clickbaitShieldEnabled: null,
-      highlightsFirstEnabled: null,
+      highlightsPlacement: null,
       defaultWriteTab: null,
     });
   });
 
-  it('should persist highlightsFirstEnabled in user settings flags', async () => {
+  it('should persist highlightsPlacement in user settings flags', async () => {
     loggedUser = '1';
 
     const repo = con.getRepository(Settings);
     await repo.save(repo.create({ userId: '1' }));
 
     const res = await client.mutate(MUTATION, {
-      variables: { data: { flags: { highlightsFirstEnabled: true } } },
+      variables: { data: { flags: { highlightsPlacement: 'pinned' } } },
     });
 
-    expect(res.data.updateUserSettings.flags.highlightsFirstEnabled).toBe(true);
+    expect(res.data.updateUserSettings.flags.highlightsPlacement).toBe(
+      'pinned',
+    );
 
     const updated = await repo.findOneByOrFail({ userId: '1' });
-    expect(updated.flags.highlightsFirstEnabled).toBe(true);
+    expect(updated.flags.highlightsPlacement).toBe('pinned');
+  });
+
+  it('should reject invalid highlightsPlacement values', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { data: { flags: { highlightsPlacement: 'bogus' } } },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
   });
 
   it('should update but not remove user settings flags', async () => {
@@ -367,7 +382,7 @@ describe('mutation updateUserSettings', () => {
       sidebarSquadExpanded: null,
       sidebarBookmarksExpanded: null,
       clickbaitShieldEnabled: null,
-      highlightsFirstEnabled: null,
+      highlightsPlacement: null,
       defaultWriteTab: null,
     });
   });

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -1,4 +1,4 @@
-import type { Settings } from '../entity';
+import { HighlightsPlacement, type Settings } from '../entity';
 
 export const transformSettingFlags = ({ flags }: Pick<Settings, 'flags'>) => {
   const {
@@ -9,7 +9,7 @@ export const transformSettingFlags = ({ flags }: Pick<Settings, 'flags'>) => {
     sidebarBookmarksExpanded,
     clickbaitShieldEnabled,
     browsingContextEnabled,
-    highlightsFirstEnabled,
+    highlightsPlacement,
     prompt,
     timezoneMismatchIgnore,
     lastPrompt,
@@ -29,7 +29,7 @@ export const transformSettingFlags = ({ flags }: Pick<Settings, 'flags'>) => {
     sidebarBookmarksExpanded: sidebarBookmarksExpanded ?? true,
     clickbaitShieldEnabled: clickbaitShieldEnabled ?? true,
     browsingContextEnabled: browsingContextEnabled ?? false,
-    highlightsFirstEnabled: highlightsFirstEnabled ?? false,
+    highlightsPlacement: highlightsPlacement ?? HighlightsPlacement.Default,
     prompt,
     timezoneMismatchIgnore,
     lastPrompt,

--- a/src/entity/Settings.ts
+++ b/src/entity/Settings.ts
@@ -37,6 +37,12 @@ export enum ShortcutsAppearance {
   Chip = 'chip',
 }
 
+export enum HighlightsPlacement {
+  Default = 'default',
+  Pinned = 'pinned',
+  Disabled = 'disabled',
+}
+
 export type ShortcutMeta = {
   name?: string;
   iconUrl?: string;
@@ -51,7 +57,7 @@ export type SettingsFlags = Partial<{
   sidebarBookmarksExpanded: boolean;
   clickbaitShieldEnabled: boolean;
   browsingContextEnabled: boolean;
-  highlightsFirstEnabled: boolean;
+  highlightsPlacement: HighlightsPlacement;
   prompt: object;
   timezoneMismatchIgnore: string;
   lastPrompt: string;
@@ -72,7 +78,7 @@ export type SettingsFlagsPublic = Pick<
   | 'sidebarBookmarksExpanded'
   | 'clickbaitShieldEnabled'
   | 'browsingContextEnabled'
-  | 'highlightsFirstEnabled'
+  | 'highlightsPlacement'
   | 'prompt'
   | 'timezoneMismatchIgnore'
   | 'lastPrompt'

--- a/src/integrations/feed/configs.ts
+++ b/src/integrations/feed/configs.ts
@@ -7,7 +7,7 @@ import {
   FeedVersion,
 } from './types';
 import { AnonymousFeedFilters, feedToFilters } from '../../common';
-import { postTypes, Settings } from '../../entity';
+import { HighlightsPlacement, postTypes, Settings } from '../../entity';
 import { User } from '../../entity/user/User';
 import { runInSpan } from '../../telemetry';
 import { ILofnClient } from '../lofn';
@@ -243,8 +243,15 @@ export class FeedPreferencesConfigGenerator implements FeedConfigGenerator {
       if (user?.flags?.country) {
         config.country = user.flags.country;
       }
-      if (settings?.flags?.highlightsFirstEnabled) {
-        config.highlights_first = true;
+      switch (settings?.flags?.highlightsPlacement) {
+        case HighlightsPlacement.Pinned:
+          config.highlights_first = true;
+          break;
+        case HighlightsPlacement.Disabled:
+          config.highlights_limit = 0;
+          break;
+        default:
+          break;
       }
 
       return { config };

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -98,7 +98,7 @@ export const typeDefs = /* GraphQL */ `
     sidebarBookmarksExpanded: Boolean
     clickbaitShieldEnabled: Boolean
     browsingContextEnabled: Boolean
-    highlightsPlacement: HighlightsPlacement
+    highlightsPlacement: String
     prompt: JSONObject
     timezoneMismatchIgnore: String
     lastPrompt: String

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -4,6 +4,7 @@ import {
   CampaignCtaPlacement,
   ChecklistViewState,
   DefaultWriteTab,
+  HighlightsPlacement,
   Settings,
   SETTINGS_DEFAULT,
   SettingsFlagsPublic,
@@ -68,6 +69,7 @@ export const typeDefs = /* GraphQL */ `
   ${toGQLEnum(DefaultWriteTab, 'DefaultWriteTab')}
   ${toGQLEnum(ShortcutsMode, 'ShortcutsMode')}
   ${toGQLEnum(ShortcutsAppearance, 'ShortcutsAppearance')}
+  ${toGQLEnum(HighlightsPlacement, 'HighlightsPlacement')}
 
   type SettingsFlagsPublic {
     sidebarSquadExpanded: Boolean
@@ -77,7 +79,7 @@ export const typeDefs = /* GraphQL */ `
     sidebarBookmarksExpanded: Boolean
     clickbaitShieldEnabled: Boolean
     browsingContextEnabled: Boolean
-    highlightsFirstEnabled: Boolean
+    highlightsPlacement: HighlightsPlacement
     timezoneMismatchIgnore: String
     lastPrompt: String
     defaultWriteTab: DefaultWriteTab
@@ -96,7 +98,7 @@ export const typeDefs = /* GraphQL */ `
     sidebarBookmarksExpanded: Boolean
     clickbaitShieldEnabled: Boolean
     browsingContextEnabled: Boolean
-    highlightsFirstEnabled: Boolean
+    highlightsPlacement: HighlightsPlacement
     prompt: JSONObject
     timezoneMismatchIgnore: String
     lastPrompt: String
@@ -443,6 +445,15 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         )
       ) {
         throw new ValidationError(`Invalid value for 'shortcutsAppearance'`);
+      }
+
+      if (
+        data?.flags?.highlightsPlacement &&
+        !Object.values(HighlightsPlacement).includes(
+          data.flags.highlightsPlacement,
+        )
+      ) {
+        throw new ValidationError(`Invalid value for 'highlightsPlacement'`);
       }
 
       const promptSchema = z.record(z.string(), z.boolean());


### PR DESCRIPTION
## Summary
Some users wanted to **disable** the Happening Now card entirely, not just choose between random vs pinned placement. Replaces the `highlightsFirstEnabled` boolean with a 3-state `highlightsPlacement` enum:

- `default` — current behavior (random slot within the first half of page one)
- `pinned` — slot 0 (what `highlightsFirstEnabled: true` did)
- `disabled` — no highlight is injected at all

### How disabling works end-to-end
`FeedPreferencesConfigGenerator.generate()` checks the user's stored `highlightsPlacement` and:
- `pinned` → sets `config.highlights_first = true` (daily-feed pins to slot 0)
- `disabled` → sets `config.highlights_limit = 0` (daily-feed's existing `HighlightsLimit > 0` guard skips injection — no daily-feed change required)
- `default` / unset → no override

### Migration
The `highlightsFirstEnabled` boolean is removed cleanly. Anyone who toggled "pin" since the feature shipped resets to default and can pick the new placement.

### Supersedes
- Closes #3866 (the boot-exposure fix is folded into this PR via `transformSettingFlags`).

## Test plan
- [x] `pnpm run lint` clean
- [x] `__tests__/integrations/feed.ts` — three new cases asserting pinned/disabled/default behavior end-to-end through `FeedPreferencesConfigGenerator`
- [x] `__tests__/settings.ts` — mutation round-trip + invalid-enum rejection
- [x] `__tests__/boot.ts` — boot settings.flags assertion updated
- [x] Snapshot updated
- [ ] CI runs full Jest suite