### PR TITLE
fix(standups): expose ended rooms by id

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -1330,4 +1330,41 @@ describe('live rooms', () => {
       },
     });
   });
+
+  it('returns an ended room by id for an anonymous caller', async () => {
+    loggedTrackingId = 'tracking-anon-1';
+
+    await saveFixtures(con, LiveRoom, [
+      {
+        id: '54e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        hostId: '2',
+        topic: 'Public ended room',
+        mode: 'moderated',
+        status: LiveRoomStatus.Ended,
+        startedAt: new Date('2026-05-05T15:00:00.000Z'),
+        endedAt: new Date('2026-05-05T15:20:00.000Z'),
+      },
+    ]);
+
+    const res = await client.query(GET_QUERY, {
+      variables: {
+        id: '54e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      liveRoom: {
+        id: '54e45613-c9f8-4823-96cb-ebd6dcbbf4fe',
+        topic: 'Public ended room',
+        mode: 'moderated',
+        status: 'ended',
+        participantCount: null,
+        host: {
+          id: '2',
+          username: 'tsahidaily',
+        },
+      },
+    });
+  });
 });

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -290,9 +290,10 @@ export const resolvers: IResolvers = {
           });
           if (!ctx.userId) {
             builder.queryBuilder.andWhere(
-              `("${builder.alias}"."status" = :liveStatus OR ("${builder.alias}"."status" = :createdStatus AND "${builder.alias}"."scheduledStart" IS NOT NULL))`,
+              `("${builder.alias}"."status" = :liveStatus OR "${builder.alias}"."status" = :endedStatus OR ("${builder.alias}"."status" = :createdStatus AND "${builder.alias}"."scheduledStart" IS NOT NULL))`,
               {
                 createdStatus: LiveRoomStatus.Created,
+                endedStatus: LiveRoomStatus.Ended,
                 liveStatus: LiveRoomStatus.Live,
               },
             );


### PR DESCRIPTION
## What changed
- allow anonymous `liveRoom(id)` reads to return ended standups by id, alongside live rooms and scheduled lobbies
- add regression coverage for anonymous ended-room fetches

## Why
The standup page SSR fetch treated ended rooms as not found for anonymous viewers, which caused ended standup URLs to return `404` before the apps UI could render the ended state.

## Validation
- `pnpm exec eslint src/schema/liveRooms.ts __tests__/liveRooms.ts --max-warnings 0`
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand` currently fails before this coverage runs because the local test DB cleanup is missing relation `spotlight_action` in `__tests__/setup.ts`
