### PR TITLE
fix(pubsub): stabilize worker subscription streams

### DIFF
--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -497,6 +497,8 @@ export const workerSubscribe = (
       maxMessages,
     },
     batching: { maxMilliseconds: 10 },
+    // The background process shares PubSub clients across many subscriptions,
+    // so we keep each subscription to a single stream to avoid silent stream starvation.
     streamingOptions: {
       maxStreams: 1,
     },

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -497,6 +497,9 @@ export const workerSubscribe = (
       maxMessages,
     },
     batching: { maxMilliseconds: 10 },
+    streamingOptions: {
+      maxStreams: 1,
+    },
   });
   const childLogger = logger.child({ subscription });
   // const histogram = meter.createHistogram('message_processing_time', {
@@ -537,4 +540,13 @@ export const workerSubscribe = (
       },
     ),
   );
+  sub.on('error', (err) => {
+    childLogger.error({ err }, 'subscription stream error');
+  });
+  sub.on('debug', (message) => {
+    childLogger.warn({ message }, 'subscription stream debug');
+  });
+  sub.on('close', () => {
+    childLogger.warn('subscription stream closed');
+  });
 };


### PR DESCRIPTION
## Summary
- force background Pub/Sub subscriptions to use a single streaming pull stream per subscription
- add subscription-level error, debug, and close logging so stream failures stop being silent

## Root cause
The background worker process multiplexes many Pub/Sub subscriptions through shared `PubSub` clients. We were not logging subscription stream lifecycle events, so stream-level failures could leave some subscriptions idle without application logs. Constraining each subscription to one streaming pull stream reduces stream pressure and keeps worker behavior aligned with our low per-subscription concurrency.

## Impact
- lowers the chance of partial background consumer starvation under stream pressure
- makes future Pub/Sub subscription failures visible in application logs
- does not change which messages are handled or how workers ack/nack them

## Validation
- `pnpm exec eslint src/common/pubsub.ts`
- `pnpm run build`
