### PR TITLE
feat: linked sources

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -24,6 +24,7 @@ import {
   Source,
   SourceMember,
   SourceType,
+  SquadSource,
   User,
   UserPost,
   View,
@@ -1804,6 +1805,53 @@ describe('query sourceFeed', () => {
       const res = await client.query(QUERY('b'));
 
       expect(res.data.sourceFeed.edges.length).toBe(4);
+    });
+  });
+
+  describe('linkedSourceIds', () => {
+    beforeEach(async () => {
+      await con
+        .getRepository(Source)
+        .update({ id: 'b' }, { type: SourceType.Squad });
+    });
+
+    it('should include posts from linked sources in the squad feed', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: ['a', 'c'] });
+
+      const res = await client.query(QUERY('b'));
+      const sourceIds = new Set(
+        res.data.sourceFeed.edges.map(({ node }) => node.source.id),
+      );
+
+      expect(sourceIds).toContain('b');
+      expect(sourceIds).toContain('a');
+      expect(sourceIds).toContain('c');
+    });
+
+    it('should ignore linked source ids that do not exist', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: ['does-not-exist'] });
+
+      const res = await client.query(QUERY('b'));
+      res.data.sourceFeed.edges.forEach(({ node }) =>
+        expect(node.source.id).toEqual('b'),
+      );
+    });
+
+    it('should filter out banned and showOnFeed=false posts from linked sources', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: ['a'] });
+      await con.getRepository(Post).update({ id: 'p1' }, { banned: true });
+      await con.getRepository(Post).update({ id: 'p4' }, { showOnFeed: false });
+
+      const res = await client.query(QUERY('b'));
+      const ids = res.data.sourceFeed.edges.map(({ node }) => node.id);
+      expect(ids).not.toContain('p1');
+      expect(ids).not.toContain('p4');
     });
   });
 });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1853,6 +1853,17 @@ describe('query sourceFeed', () => {
       expect(ids).not.toContain('p1');
       expect(ids).not.toContain('p4');
     });
+
+    it('should filter out private posts from linked sources', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: ['a'] });
+      await con.getRepository(Post).update({ id: 'p1' }, { private: true });
+
+      const res = await client.query(QUERY('b'));
+      const ids = res.data.sourceFeed.edges.map(({ node }) => node.id);
+      expect(ids).not.toContain('p1');
+    });
   });
 });
 

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1020,6 +1020,31 @@ describe('generateNotification', () => {
     ]);
   });
 
+  it('should generate squad_post_added notification without doneBy', () => {
+    const type = NotificationType.SquadPostAdded;
+    const ctx: NotificationPostContext = {
+      userIds: [userId],
+      source: {
+        ...sourcesFixture[0],
+        type: SourceType.Squad,
+      } as Reference<Source>,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.notification.title).toEqual('New post in <b>A</b>');
+    expect(actual.avatars).toEqual([
+      {
+        image: 'http://image.com/a',
+        name: 'A',
+
+        referenceId: 'a',
+        targetUrl: 'http://localhost:5002/squads/a',
+        type: 'source',
+      },
+    ]);
+  });
+
   it('should generate squad_member_joined notification', async () => {
     const type = NotificationType.SquadMemberJoined;
     await con.getRepository(Source).save(sourcesFixture[0]);

--- a/__tests__/workers/notifications/postAdded.ts
+++ b/__tests__/workers/notifications/postAdded.ts
@@ -131,13 +131,13 @@ describe('vordrPostCommentPrevented', () => {
           userId: '2',
           sourceId: 'b',
           referenceId: 'b',
-          notificationType: NotificationType.SourcePostAdded,
+          notificationType: NotificationType.SquadPostAdded,
           status: NotificationPreferenceStatus.Subscribed,
         },
       ]);
     });
 
-    it('should emit SourcePostAdded for opt-in members of squads linked to the post source', async () => {
+    it('should emit SquadPostAdded for opt-in members of squads linked to the post source', async () => {
       const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
         postAdded,
         {
@@ -147,7 +147,7 @@ describe('vordrPostCommentPrevented', () => {
 
       const squadNotif = result?.find(
         (n) =>
-          n.type === NotificationType.SourcePostAdded &&
+          n.type === NotificationType.SquadPostAdded &&
           (n.ctx.source as Source).id === 'b',
       );
       expect(squadNotif).toBeDefined();
@@ -168,7 +168,7 @@ describe('vordrPostCommentPrevented', () => {
 
       const squadNotif = result?.find(
         (n) =>
-          n.type === NotificationType.SourcePostAdded &&
+          n.type === NotificationType.SquadPostAdded &&
           (n.ctx.source as Source).id === 'b',
       );
       expect(squadNotif).toBeUndefined();
@@ -180,7 +180,7 @@ describe('vordrPostCommentPrevented', () => {
           userId: '3',
           sourceId: 'b',
           referenceId: 'b',
-          notificationType: NotificationType.SourcePostAdded,
+          notificationType: NotificationType.SquadPostAdded,
           status: NotificationPreferenceStatus.Subscribed,
         },
       ]);
@@ -200,7 +200,7 @@ describe('vordrPostCommentPrevented', () => {
 
       const squadNotif = result?.find(
         (n) =>
-          n.type === NotificationType.SourcePostAdded &&
+          n.type === NotificationType.SquadPostAdded &&
           (n.ctx.source as Source).id === 'b',
       );
       expect(squadNotif?.ctx.userIds).toEqual(['2']);
@@ -216,7 +216,7 @@ describe('vordrPostCommentPrevented', () => {
 
       const squadNotif = result?.find(
         (n) =>
-          n.type === NotificationType.SourcePostAdded &&
+          n.type === NotificationType.SquadPostAdded &&
           (n.ctx.source as Source).id === 'b',
       );
       expect(squadNotif).toBeDefined();
@@ -234,7 +234,7 @@ describe('vordrPostCommentPrevented', () => {
 
       const squadNotif = result?.find(
         (n) =>
-          n.type === NotificationType.SourcePostAdded &&
+          n.type === NotificationType.SquadPostAdded &&
           (n.ctx.source as Source).id === 'b',
       );
       expect(squadNotif).toBeUndefined();

--- a/__tests__/workers/notifications/postAdded.ts
+++ b/__tests__/workers/notifications/postAdded.ts
@@ -206,22 +206,6 @@ describe('vordrPostCommentPrevented', () => {
       expect(squadNotif?.ctx.userIds).toEqual(['2']);
     });
 
-    it('should fire even when the post has no authorId', async () => {
-      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
-        postAdded,
-        {
-          post: { id: 'p1' },
-        },
-      );
-
-      const squadNotif = result?.find(
-        (n) =>
-          n.type === NotificationType.SquadPostAdded &&
-          (n.ctx.source as Source).id === 'b',
-      );
-      expect(squadNotif).toBeDefined();
-    });
-
     it('should not emit when the post is private', async () => {
       await con.getRepository(Post).update('p1', { private: true });
 

--- a/__tests__/workers/notifications/postAdded.ts
+++ b/__tests__/workers/notifications/postAdded.ts
@@ -1,11 +1,26 @@
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../../src/db';
-import { Comment, Post, Source, User } from '../../../src/entity';
+import {
+  Comment,
+  NotificationPreferenceSource,
+  Post,
+  Source,
+  SourceMember,
+  SourceType,
+  SquadSource,
+  User,
+} from '../../../src/entity';
 import { postAdded } from '../../../src/workers/notifications/postAdded';
 import { badUsersFixture, sourcesFixture, usersFixture } from '../../fixture';
 import { postsFixture } from '../../fixture/post';
 import { workers } from '../../../src/workers/notifications';
 import { invokeTypedNotificationWorker, saveFixtures } from '../../helpers';
+import { SourceMemberRoles } from '../../../src/roles';
+import {
+  NotificationPreferenceStatus,
+  NotificationType,
+} from '../../../src/notifications/common';
+import { randomUUID } from 'crypto';
 
 let con: DataSource;
 
@@ -81,6 +96,148 @@ describe('vordrPostCommentPrevented', () => {
       );
 
       expect(result?.length).toEqual(1);
+    });
+  });
+
+  describe('linked sources', () => {
+    beforeEach(async () => {
+      await con
+        .getRepository(Post)
+        .update('p1', { authorId: null, private: false });
+      await con
+        .getRepository(Source)
+        .update({ id: 'b' }, { type: SourceType.Squad });
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: ['a'] });
+      await con.getRepository(SourceMember).save([
+        {
+          userId: '2',
+          sourceId: 'b',
+          role: SourceMemberRoles.Member,
+          referralToken: randomUUID(),
+          createdAt: new Date(),
+        },
+        {
+          userId: '3',
+          sourceId: 'b',
+          role: SourceMemberRoles.Member,
+          referralToken: randomUUID(),
+          createdAt: new Date(),
+        },
+      ]);
+      await con.getRepository(NotificationPreferenceSource).save([
+        {
+          userId: '2',
+          sourceId: 'b',
+          referenceId: 'b',
+          notificationType: NotificationType.SourcePostAdded,
+          status: NotificationPreferenceStatus.Subscribed,
+        },
+      ]);
+    });
+
+    it('should emit SourcePostAdded for opt-in members of squads linked to the post source', async () => {
+      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+        postAdded,
+        {
+          post: { id: 'p1' },
+        },
+      );
+
+      const squadNotif = result?.find(
+        (n) =>
+          n.type === NotificationType.SourcePostAdded &&
+          (n.ctx.source as Source).id === 'b',
+      );
+      expect(squadNotif).toBeDefined();
+      expect(squadNotif?.ctx.userIds).toEqual(['2']);
+    });
+
+    it('should not emit when no squad has the source in linkedSourceIds', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update({ id: 'b' }, { linkedSourceIds: [] });
+
+      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+        postAdded,
+        {
+          post: { id: 'p1' },
+        },
+      );
+
+      const squadNotif = result?.find(
+        (n) =>
+          n.type === NotificationType.SourcePostAdded &&
+          (n.ctx.source as Source).id === 'b',
+      );
+      expect(squadNotif).toBeUndefined();
+    });
+
+    it('should not notify blocked or unsubscribed members', async () => {
+      await con.getRepository(NotificationPreferenceSource).save([
+        {
+          userId: '3',
+          sourceId: 'b',
+          referenceId: 'b',
+          notificationType: NotificationType.SourcePostAdded,
+          status: NotificationPreferenceStatus.Subscribed,
+        },
+      ]);
+      await con
+        .getRepository(SourceMember)
+        .update(
+          { userId: '3', sourceId: 'b' },
+          { role: SourceMemberRoles.Blocked },
+        );
+
+      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+        postAdded,
+        {
+          post: { id: 'p1' },
+        },
+      );
+
+      const squadNotif = result?.find(
+        (n) =>
+          n.type === NotificationType.SourcePostAdded &&
+          (n.ctx.source as Source).id === 'b',
+      );
+      expect(squadNotif?.ctx.userIds).toEqual(['2']);
+    });
+
+    it('should fire even when the post has no authorId', async () => {
+      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+        postAdded,
+        {
+          post: { id: 'p1' },
+        },
+      );
+
+      const squadNotif = result?.find(
+        (n) =>
+          n.type === NotificationType.SourcePostAdded &&
+          (n.ctx.source as Source).id === 'b',
+      );
+      expect(squadNotif).toBeDefined();
+    });
+
+    it('should not emit when the post is private', async () => {
+      await con.getRepository(Post).update('p1', { private: true });
+
+      const result = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+        postAdded,
+        {
+          post: { id: 'p1' },
+        },
+      );
+
+      const squadNotif = result?.find(
+        (n) =>
+          n.type === NotificationType.SourcePostAdded &&
+          (n.ctx.source as Source).id === 'b',
+      );
+      expect(squadNotif).toBeUndefined();
     });
   });
 });

--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -454,4 +454,39 @@ describe('postAddedSlackChannelSend worker', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('linked sources', () => {
+    it('should send to slack integrations of squads with the post source in linkedSourceIds', async () => {
+      await con
+        .getRepository(SquadSource)
+        .update(
+          { id: 'squadslackchannel' },
+          { linkedSourceIds: ['a'], private: false },
+        );
+
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: 'p1',
+      });
+
+      await expectSuccessfulTypedBackground(worker, {
+        post: post as unknown as ChangeObject<ArticlePost>,
+      });
+
+      // direct integration on 'a' + linked integration on 'squadslackchannel'
+      expect(chatPostMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not send when no squad links the post source', async () => {
+      const post = await con.getRepository(ArticlePost).findOneByOrFail({
+        id: 'p1',
+      });
+
+      await expectSuccessfulTypedBackground(worker, {
+        post: post as unknown as ChangeObject<ArticlePost>,
+      });
+
+      // only the direct integration on 'a' fires
+      expect(chatPostMessage).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/__tests__/workers/postAddedSlackChannelSend.ts
+++ b/__tests__/workers/postAddedSlackChannelSend.ts
@@ -463,6 +463,11 @@ describe('postAddedSlackChannelSend worker', () => {
           { id: 'squadslackchannel' },
           { linkedSourceIds: ['a'], private: false },
         );
+      // Distinct channel so we can verify the fan-out lands on the squad's
+      // channel, not just a double-send to the direct integration's channel.
+      await con
+        .getRepository(UserSourceIntegrationSlack)
+        .update({ sourceId: 'squadslackchannel' }, { channelIds: ['2'] });
 
       const post = await con.getRepository(ArticlePost).findOneByOrFail({
         id: 'p1',
@@ -472,8 +477,9 @@ describe('postAddedSlackChannelSend worker', () => {
         post: post as unknown as ChangeObject<ArticlePost>,
       });
 
-      // direct integration on 'a' + linked integration on 'squadslackchannel'
       expect(chatPostMessage).toHaveBeenCalledTimes(2);
+      const channels = chatPostMessage.mock.calls.map(([arg]) => arg.channel);
+      expect(channels.sort()).toEqual(['1', '2']);
     });
 
     it('should not send when no squad links the post source', async () => {
@@ -485,8 +491,10 @@ describe('postAddedSlackChannelSend worker', () => {
         post: post as unknown as ChangeObject<ArticlePost>,
       });
 
-      // only the direct integration on 'a' fires
       expect(chatPostMessage).toHaveBeenCalledTimes(1);
+      expect(chatPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: '1' }),
+      );
     });
   });
 });

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -796,11 +796,16 @@ export const sourceFeedBuilder = (
     builder.andWhere(`${alias}.sourceId IN (:...sourceIds)`, {
       sourceIds: [sourceId, ...linkedSourceIds],
     });
+    // sourceFeed resolver disables removeBannedPosts/removeHiddenPosts so the
+    // squad can show its own banned/hidden/private posts. Linked-source rows
+    // should NOT inherit that override.
     builder.andWhere(
       new Brackets((qb) => {
         qb.where(`${alias}.sourceId = :primarySourceId`, {
           primarySourceId: sourceId,
-        }).orWhere(`${alias}.banned = false AND ${alias}."showOnFeed" = true`);
+        }).orWhere(
+          `${alias}.banned = false AND ${alias}."showOnFeed" = true AND ${alias}.private = false`,
+        );
       }),
     );
   } else {

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -790,8 +790,22 @@ export const sourceFeedBuilder = (
   sourceId: string,
   builder: SelectQueryBuilder<Post>,
   alias: string,
+  linkedSourceIds?: string[],
 ): SelectQueryBuilder<Post> => {
-  builder.andWhere(`${alias}.sourceId = :sourceId`, { sourceId });
+  if (linkedSourceIds?.length) {
+    builder.andWhere(`${alias}.sourceId IN (:...sourceIds)`, {
+      sourceIds: [sourceId, ...linkedSourceIds],
+    });
+    builder.andWhere(
+      new Brackets((qb) => {
+        qb.where(`${alias}.sourceId = :primarySourceId`, {
+          primarySourceId: sourceId,
+        }).orWhere(`${alias}.banned = false AND ${alias}."showOnFeed" = true`);
+      }),
+    );
+  } else {
+    builder.andWhere(`${alias}.sourceId = :sourceId`, { sourceId });
+  }
 
   if (sourceId === 'community') {
     builder.andWhere(`${alias}.banned = false`);

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -175,6 +175,7 @@ export class MachineSource extends Source {
 }
 
 @ChildEntity(SourceType.Squad)
+@Index('IDX_source_linked_source_ids', { synchronize: false })
 export class SquadSource extends Source {
   @Column({ default: 0 })
   memberPostingRank: number;
@@ -184,6 +185,9 @@ export class SquadSource extends Source {
 
   @Column({ default: false })
   moderationRequired: boolean;
+
+  @Column({ type: 'text', array: true, default: () => "'{}'" })
+  linkedSourceIds: string[];
 }
 
 @ChildEntity(SourceType.User)

--- a/src/migration/1778600393035-AddLinkedSourceIdsToSource.ts
+++ b/src/migration/1778600393035-AddLinkedSourceIdsToSource.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddLinkedSourceIdsToSource1778600393035 implements MigrationInterface {
+  name = 'AddLinkedSourceIdsToSource1778600393035';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "source"
+      ADD COLUMN IF NOT EXISTS "linkedSourceIds" text[] NOT NULL DEFAULT '{}'
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_source_linked_source_ids"
+      ON "source" USING gin ("linkedSourceIds")
+      WHERE "linkedSourceIds" <> '{}'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_source_linked_source_ids"`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "source" DROP COLUMN IF EXISTS "linkedSourceIds"`,
+    );
+  }
+}

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -103,9 +103,11 @@ export const notificationTitleMap: Record<
     UPVOTE_TITLES[ctx.upvotes as keyof typeof UPVOTE_TITLES] ??
     `<b>You rock!</b> Your comment <span class="text-theme-color-avocado">earned ${ctx.upvotes} upvotes!</span>`,
   squad_post_added: (
-    ctx: NotificationPostContext & NotificationDoneByContext,
+    ctx: NotificationPostContext & Partial<NotificationDoneByContext>,
   ) =>
-    `<b>${ctx.doneBy.name}</b> shared a new post on <b>${ctx.source.name}</b>`,
+    ctx.doneBy
+      ? `<b>${ctx.doneBy.name}</b> shared a new post on <b>${ctx.source.name}</b>`
+      : `New post in <b>${ctx.source.name}</b>`,
   squad_member_joined: (
     ctx: NotificationPostContext &
       NotificationSourceContext &
@@ -386,12 +388,13 @@ export const generateNotificationMap: Record<
       .targetPost(ctx.post, ctx.comment),
   squad_post_added: (
     builder,
-    ctx: NotificationPostContext & NotificationDoneByContext,
-  ) =>
-    builder
+    ctx: NotificationPostContext & Partial<NotificationDoneByContext>,
+  ) => {
+    const base = builder
       .icon(NotificationIcon.Bell)
-      .objectPost(ctx.post, ctx.source, ctx.sharedPost!)
-      .avatarManyUsers([ctx.doneBy]),
+      .objectPost(ctx.post, ctx.source, ctx.sharedPost!);
+    return ctx.doneBy ? base.avatarManyUsers([ctx.doneBy]) : base;
+  },
   squad_member_joined: (
     builder,
     ctx: NotificationPostContext & NotificationDoneByContext,

--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -82,8 +82,12 @@ const pushHeadingFnMap: Partial<
   Record<NotificationType, (title: string) => string>
 > = {
   [NotificationType.SquadPostAdded]: (title) => {
-    const match = title.match(/<b>([^<]+)<\/b>[^<]*<b>([^<]+)<\/b>/);
-    return match ? `New post in ${match[2]}` : 'New squad post';
+    const twoMatch = title.match(/<b>([^<]+)<\/b>[^<]*<b>([^<]+)<\/b>/);
+    if (twoMatch) {
+      return `New post in ${twoMatch[2]}`;
+    }
+    const oneMatch = title.match(/<b>([^<]+)<\/b>/);
+    return oneMatch ? `New post in ${oneMatch[1]}` : 'New squad post';
   },
   [NotificationType.SquadNewComment]: (title) => {
     const match = title.match(/<b>([^<]+)<\/b>/);

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -10,6 +10,8 @@ import {
   Post,
   PostType,
   Source,
+  SourceType,
+  SquadSource,
   UserPost,
 } from '../entity';
 import { Category } from '../entity/Category';
@@ -1881,8 +1883,15 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       );
     },
     sourceFeed: feedResolver(
-      (ctx, { source }: SourceFeedArgs, builder, alias) =>
-        sourceFeedBuilder(ctx, source, builder, alias),
+      (ctx, { source }: SourceFeedArgs, builder, alias, params) =>
+        sourceFeedBuilder(
+          ctx,
+          source,
+          builder,
+          alias,
+          (params as { linkedSourceIds?: string[] } | undefined)
+            ?.linkedSourceIds,
+        ),
       feedPageGeneratorWithPin,
       (ctx, args, page, builder, alias) =>
         applyFeedPagingWithPin(ctx, page, builder, alias),
@@ -1893,8 +1902,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         fetchQueryParams: async (
           ctx,
           { source: sourceId }: SourceFeedArgs,
-        ): Promise<void> => {
-          await ensureSourcePermissions(ctx, sourceId);
+        ): Promise<{ linkedSourceIds?: string[] }> => {
+          const source = await ensureSourcePermissions(ctx, sourceId);
+          if (source.type !== SourceType.Squad) {
+            return {};
+          }
+          const linkedSourceIds = (source as SquadSource).linkedSourceIds ?? [];
+          if (linkedSourceIds.length === 0) {
+            return {};
+          }
+          return { linkedSourceIds };
         },
       },
     ),

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -4,8 +4,10 @@ import {
   PostFlags,
   PostMention,
   PostType,
+  Source,
   SourceMember,
   SourceType,
+  SquadSource,
   User,
   UserAction,
   UserActionType,
@@ -161,6 +163,40 @@ export const postAdded: TypedNotificationWorker<'api.v1.post-visible'> = {
               userIds: members.map(({ userId }) => userId),
             } as NotificationSourceContext & NotificationPostContext,
           });
+        }
+
+        if (!post.private) {
+          const linkedSquads = await con
+            .getRepository(SquadSource)
+            .createQueryBuilder('s')
+            .where(`s.type = :type`, { type: SourceType.Squad })
+            .andWhere(`s."linkedSourceIds" @> ARRAY[:sourceId]::text[]`, {
+              sourceId: source.id,
+            })
+            .getMany();
+
+          for (const squad of linkedSquads) {
+            const subscribedMembers = await getOptInSubscribedMembers({
+              con,
+              type: NotificationType.SourcePostAdded,
+              referenceId: squad.id,
+              where: {
+                sourceId: squad.id,
+                role: Not(SourceMemberRoles.Blocked),
+              },
+            });
+
+            if (subscribedMembers.length) {
+              notifs.push({
+                type: NotificationType.SourcePostAdded,
+                ctx: {
+                  ...baseCtx,
+                  source: squad as Source,
+                  userIds: subscribedMembers.map(({ userId }) => userId),
+                } as NotificationSourceContext & NotificationPostContext,
+              });
+            }
+          }
         }
       }
     }

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -178,7 +178,7 @@ export const postAdded: TypedNotificationWorker<'api.v1.post-visible'> = {
           for (const squad of linkedSquads) {
             const subscribedMembers = await getOptInSubscribedMembers({
               con,
-              type: NotificationType.SourcePostAdded,
+              type: NotificationType.SquadPostAdded,
               referenceId: squad.id,
               where: {
                 sourceId: squad.id,
@@ -188,12 +188,13 @@ export const postAdded: TypedNotificationWorker<'api.v1.post-visible'> = {
 
             if (subscribedMembers.length) {
               notifs.push({
-                type: NotificationType.SourcePostAdded,
+                type: NotificationType.SquadPostAdded,
                 ctx: {
                   ...baseCtx,
                   source: squad as Source,
                   userIds: subscribedMembers.map(({ userId }) => userId),
-                } as NotificationSourceContext & NotificationPostContext,
+                } as NotificationPostContext &
+                  Partial<NotificationDoneByContext>,
               });
             }
           }

--- a/src/workers/notifications/postAdded.ts
+++ b/src/workers/notifications/postAdded.ts
@@ -175,19 +175,23 @@ export const postAdded: TypedNotificationWorker<'api.v1.post-visible'> = {
             })
             .getMany();
 
-          for (const squad of linkedSquads) {
-            const subscribedMembers = await getOptInSubscribedMembers({
-              con,
-              type: NotificationType.SquadPostAdded,
-              referenceId: squad.id,
-              where: {
-                sourceId: squad.id,
-                role: Not(SourceMemberRoles.Blocked),
-              },
-            });
+          const perSquadNotifs = await Promise.all(
+            linkedSquads.map(async (squad) => {
+              const subscribedMembers = await getOptInSubscribedMembers({
+                con,
+                type: NotificationType.SquadPostAdded,
+                referenceId: squad.id,
+                where: {
+                  sourceId: squad.id,
+                  role: Not(SourceMemberRoles.Blocked),
+                },
+              });
 
-            if (subscribedMembers.length) {
-              notifs.push({
+              if (!subscribedMembers.length) {
+                return null;
+              }
+
+              return {
                 type: NotificationType.SquadPostAdded,
                 ctx: {
                   ...baseCtx,
@@ -195,7 +199,13 @@ export const postAdded: TypedNotificationWorker<'api.v1.post-visible'> = {
                   userIds: subscribedMembers.map(({ userId }) => userId),
                 } as NotificationPostContext &
                   Partial<NotificationDoneByContext>,
-              });
+              };
+            }),
+          );
+
+          for (const notif of perSquadNotifs) {
+            if (notif) {
+              notifs.push(notif);
             }
           }
         }

--- a/src/workers/postAddedSlackChannelSend.ts
+++ b/src/workers/postAddedSlackChannelSend.ts
@@ -8,7 +8,9 @@ import {
   PostType,
   SourceMember,
   SourceType,
+  SquadSource,
 } from '../entity';
+import { In } from 'typeorm';
 import {
   getAttachmentForPostType,
   getSlackClient,
@@ -38,7 +40,7 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
           return;
         }
 
-        const [post, integrations] = await Promise.all([
+        const [post, linkedSquads] = await Promise.all([
           con.getRepository(Post).findOneOrFail({
             where: {
               id: data.post.id,
@@ -48,15 +50,30 @@ export const postAddedSlackChannelSendWorker: TypedWorker<'api.v1.post-visible'>
               author: true,
             },
           }),
-          con.getRepository(UserSourceIntegrationSlack).find({
-            where: {
+          con
+            .getRepository(SquadSource)
+            .createQueryBuilder('s')
+            .select('s.id', 'id')
+            .where(`s.type = :type`, { type: SourceType.Squad })
+            .andWhere(`s."linkedSourceIds" @> ARRAY[:sourceId]::text[]`, {
               sourceId: data.post.sourceId,
+            })
+            .getRawMany<{ id: string }>(),
+        ]);
+
+        const integrations = await con
+          .getRepository(UserSourceIntegrationSlack)
+          .find({
+            where: {
+              sourceId: In([
+                data.post.sourceId,
+                ...linkedSquads.map(({ id }) => id),
+              ]),
             },
             relations: {
               userIntegration: true,
             },
-          }),
-        ]);
+          });
 
         if (integrations.length === 0) {
           return;


### PR DESCRIPTION
## Summary

- Squads can mix posts from configurable linked sources into their feed; the source feed itself stays clean.
- Notifications and Slack pings fan out to linked squads so members hear about new posts without waiting for a manual re-share.
- v1 has no user-facing config — pairings seeded directly.

## Why

Members today manually re-share posts from a sibling source (e.g. Next.js source → Next.js squad) to drive community engagement. It's tedious and often late. Mixing on the read side closes the lag.

## Known v1 limits (intentional)

- No dedup if a member already manually re-shared — moderation handles it.
- Pinned linked-source posts surface as pinned in the squad feed.
- Squad analytics MV doesn't roll up linked-source engagement.