### PR TITLE
feat(feeds): include shared post keywords in tag feeds

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -1883,6 +1883,26 @@ describe('query tagFeed', () => {
     const res = await client.query(QUERY('javascript'));
     expect(res.data).toMatchSnapshot();
   });
+
+  it('should include share posts whose shared post matches the tag', async () => {
+    await con.getRepository(SharePost).save({
+      id: 'tagShare1',
+      shortId: 'tShr1',
+      sourceId: 'a',
+      title: 'Shared js post',
+      type: PostType.Share,
+      sharedPostId: 'p1',
+      visible: true,
+    });
+
+    const res = await client.query(`{
+      tagFeed(tag: "javascript", ranking: ${Ranking.POPULARITY}, first: 10, supportedTypes: ["article", "share"]) {
+        ${feedFields()}
+      }
+    }`);
+    const ids = res.data.tagFeed.edges.map(({ node }) => node.id);
+    expect(ids).toContain('tagShare1');
+  });
 });
 
 describe('query keywordFeed', () => {
@@ -2463,6 +2483,29 @@ describe('query mostUpvotedFeed', () => {
       expect(node.tags).toContain('javascript');
     });
   });
+
+  it('should include share posts whose shared post matches the tag', async () => {
+    await con.getRepository(SharePost).save({
+      id: 'mostUpShare1',
+      shortId: 'muShr1',
+      sourceId: 'a',
+      title: 'Shared js post',
+      type: PostType.Share,
+      sharedPostId: 'p1',
+      visible: true,
+      upvotes: 50,
+    });
+
+    const QUERY_WITH_TYPES = `{
+      mostUpvotedFeed(first: 10, period: 30, tag: "javascript", supportedTypes: ["article", "share"]) {
+        ${feedFields()}
+      }
+    }`;
+    const res = await client.query(QUERY_WITH_TYPES);
+    expect(res.errors).toBeFalsy();
+    const ids = res.data.mostUpvotedFeed.edges.map(({ node }) => node.id);
+    expect(ids).toContain('mostUpShare1');
+  });
 });
 
 describe('query mostDiscussedFeed', () => {
@@ -2536,6 +2579,29 @@ describe('query mostDiscussedFeed', () => {
     res.data.mostDiscussedFeed.edges.forEach(({ node }) => {
       expect(node.tags).toContain('javascript');
     });
+  });
+
+  it('should include share posts whose shared post matches the tag', async () => {
+    await con.getRepository(SharePost).save({
+      id: 'mostDiscShare1',
+      shortId: 'mdShr1',
+      sourceId: 'a',
+      title: 'Shared js post',
+      type: PostType.Share,
+      sharedPostId: 'p1',
+      visible: true,
+      comments: 10,
+    });
+
+    const QUERY_WITH_TYPES = `{
+      mostDiscussedFeed(first: 10, tag: "javascript", supportedTypes: ["article", "share"]) {
+        ${feedFields()}
+      }
+    }`;
+    const res = await client.query(QUERY_WITH_TYPES);
+    expect(res.errors).toBeFalsy();
+    const ids = res.data.mostDiscussedFeed.edges.map(({ node }) => node.id);
+    expect(ids).toContain('mostDiscShare1');
   });
 });
 

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -50,13 +50,17 @@ export const whereTags = (
   builder: SelectQueryBuilder<Post>,
   alias: string,
   variableAlias = 'tags',
+  { includeSharedPost = false }: { includeSharedPost?: boolean } = {},
 ): string => {
+  const postIdMatch = includeSharedPost
+    ? `pk."postId" = COALESCE(${alias}."sharedPostId", ${alias}.id)`
+    : `pk."postId" = ${alias}.id`;
   const query = builder
     .subQuery()
     .select('1')
     .from(PostKeyword, 'pk')
     .where(`pk.keyword IN (:...${variableAlias})`, { [variableAlias]: tags })
-    .andWhere(`pk.postId = ${alias}.id`)
+    .andWhere(postIdMatch)
     .getQuery();
   return `EXISTS${query}`;
 };
@@ -73,13 +77,17 @@ export const whereKeyword = (
   keyword: string,
   builder: SelectQueryBuilder<Post>,
   alias: string,
+  { includeSharedPost = false }: { includeSharedPost?: boolean } = {},
 ): string => {
+  const postIdMatch = includeSharedPost
+    ? `pk."postId" = COALESCE(${alias}."sharedPostId", ${alias}.id)`
+    : `pk."postId" = ${alias}.id`;
   const query = builder
     .subQuery()
     .select('1')
     .from(PostKeyword, 'pk')
     .where(`pk.keyword = :keyword`, { keyword })
-    .andWhere(`pk."postId" = ${alias}.id`)
+    .andWhere(postIdMatch)
     .getQuery();
   return `EXISTS${query}`;
 };
@@ -835,7 +843,9 @@ export const tagFeedBuilder = (
   builder: SelectQueryBuilder<Post>,
   alias: string,
 ): SelectQueryBuilder<Post> =>
-  builder.andWhere((subBuilder) => whereTags([tag], subBuilder, alias));
+  builder.andWhere((subBuilder) =>
+    whereTags([tag], subBuilder, alias, 'tags', { includeSharedPost: true }),
+  );
 
 export const repostFeedBuilder = (
   ctx: Context,

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -2050,7 +2050,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           .addOrderBy(`${alias}."createdAt"`, 'DESC');
         if (tag) {
           builder.andWhere((subBuilder) =>
-            whereKeyword(tag, subBuilder, alias),
+            whereKeyword(tag, subBuilder, alias, { includeSharedPost: true }),
           );
         }
         if (source) {
@@ -2092,7 +2092,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           .addOrderBy(`${alias}."createdAt"`, 'DESC');
         if (tag) {
           builder.andWhere((subBuilder) =>
-            whereKeyword(tag, subBuilder, alias),
+            whereKeyword(tag, subBuilder, alias, { includeSharedPost: true }),
           );
         }
         if (source) {


### PR DESCRIPTION
## Summary

Share posts have no rows in `post_keyword` — the existing trigger (`1706363895498-SharePostTrigger.ts`) copies `tagsStr` from the shared article onto the share, but `post_keyword` is only populated for the original article. Since `whereTags` / `whereKeyword` filter on `post_keyword`, share posts have always been invisible on tag-scoped feeds despite users adding `Share` to `supportedTypes`.

This widens the post-keyword match for `tagFeed`, `mostUpvotedFeed`, and `mostDiscussedFeed` to follow `sharedPostId`:

```sql
pk."postId" = COALESCE(post."sharedPostId", post.id)
```

A share of a `php` article now counts as a `php` post in these three feeds. The behavior is opt-in via a new `includeSharedPost` option on `whereTags`/`whereKeyword`, so `includeTags`/`blockedTags` on user feeds are unchanged.

## Test plan

- [x] New unit-integration tests for `tagFeed`, `mostUpvotedFeed`, `mostDiscussedFeed` verifying that a `SharePost` with `sharedPostId` pointing at a tagged article surfaces under that tag
- [x] Existing snapshot tests pass unchanged (default behavior preserved when `includeSharedPost` is not set)
- [x] `pnpm run build` + `pnpm run lint` clean
- [ ] Spot-check on `/tags/php` after deploy that squad shares of php articles now appear in the Top posts / Most upvoted / Best discussed / All posts sections