### PR TITLE
feat(persona-quiz): add bragi-backed GraphQL mutations

### DIFF
--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -667,8 +667,18 @@ describe('mutation personaQuizNextQuestion', () => {
         axis: 'tooling',
         cols: 3,
         options: [
-          { id: 'yes', label: 'Spot on', emoji: '', tagHints: ['vector-search'] },
-          { id: 'sort_of', label: 'Sort of', emoji: '', tagHints: ['machine-learning'] },
+          {
+            id: 'yes',
+            label: 'Spot on',
+            emoji: '',
+            tagHints: ['vector-search'],
+          },
+          {
+            id: 'sort_of',
+            label: 'Sort of',
+            emoji: '',
+            tagHints: ['machine-learning'],
+          },
           { id: 'no', label: 'Nope', emoji: '', tagHints: [] },
         ],
         rationale: 'ML user, retrieval is adjacent.',
@@ -694,8 +704,18 @@ describe('mutation personaQuizNextQuestion', () => {
           axis: 'tooling',
           cols: 3,
           options: [
-            { id: 'yes', label: 'Spot on', emoji: null, tagHints: ['vector-search'] },
-            { id: 'sort_of', label: 'Sort of', emoji: null, tagHints: ['machine-learning'] },
+            {
+              id: 'yes',
+              label: 'Spot on',
+              emoji: null,
+              tagHints: ['vector-search'],
+            },
+            {
+              id: 'sort_of',
+              label: 'Sort of',
+              emoji: null,
+              tagHints: ['machine-learning'],
+            },
             { id: 'no', label: 'Nope', emoji: null, tagHints: [] },
           ],
         },
@@ -742,7 +762,11 @@ describe('mutation personaQuizNextQuestion', () => {
   it('should still call bragi when recswipe candidate-topics fetch fails', async () => {
     loggedUser = '1';
     recommendTagsMock.mockRejectedValueOnce(
-      new HttpError('http://recswipe.local:8000/api/recommend-tags', 500, 'boom'),
+      new HttpError(
+        'http://recswipe.local:8000/api/recommend-tags',
+        500,
+        'boom',
+      ),
     );
     mockNextPersonaQuizQuestion.mockResolvedValueOnce({
       id: 'op-3',
@@ -829,7 +853,8 @@ describe('mutation personaQuizReveal', () => {
       ],
       reveal: {
         headline: 'Friday-shipper, refactor addict',
-        description: 'Feed tuned for someone who reads dev drama and ships anyway.',
+        description:
+          'Feed tuned for someone who reads dev drama and ships anyway.',
       },
     });
     recommendTagsMock.mockResolvedValueOnce({ tags: ['css'] });
@@ -845,7 +870,8 @@ describe('mutation personaQuizReveal', () => {
     expect(res.errors).toBeFalsy();
     expect(res.data?.personaQuizReveal.reveal).toEqual({
       headline: 'Friday-shipper, refactor addict',
-      description: 'Feed tuned for someone who reads dev drama and ships anyway.',
+      description:
+        'Feed tuned for someone who reads dev drama and ships anyway.',
     });
     // Order: bragi tags first (canonical-only), then recsys fillers.
     expect(res.data?.personaQuizReveal.includeTags).toEqual([
@@ -913,7 +939,11 @@ describe('mutation personaQuizReveal', () => {
       reveal: { headline: 'h', description: 'd' },
     });
     recommendTagsMock.mockRejectedValueOnce(
-      new HttpError('http://recswipe.local:8000/api/recommend-tags', 500, 'boom'),
+      new HttpError(
+        'http://recswipe.local:8000/api/recommend-tags',
+        500,
+        'boom',
+      ),
     );
 
     const res = await client.mutate(MUTATION, {

--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -656,7 +656,11 @@ describe('mutation personaQuizNextQuestion', () => {
   it('should pass recswipe candidate_topics to bragi and return structured question', async () => {
     loggedUser = '1';
     recommendTagsMock.mockResolvedValueOnce({
-      tags: ['machine-learning', 'recommendation-systems', 'vector-search'],
+      recommended_tags: [
+        { tag: 'machine-learning', score: 0.95 },
+        { tag: 'recommendation-systems', score: 0.85 },
+        { tag: 'vector-search', score: 0.75 },
+      ],
     });
     mockNextPersonaQuizQuestion.mockResolvedValueOnce({
       id: 'op-1',
@@ -738,7 +742,7 @@ describe('mutation personaQuizNextQuestion', () => {
 
   it('should propagate isFinal=true with null question', async () => {
     loggedUser = '1';
-    recommendTagsMock.mockResolvedValueOnce({ tags: [] });
+    recommendTagsMock.mockResolvedValueOnce({ recommended_tags: [] });
     mockNextPersonaQuizQuestion.mockResolvedValueOnce({
       id: 'op-2',
       isFinal: true,
@@ -857,7 +861,9 @@ describe('mutation personaQuizReveal', () => {
           'Feed tuned for someone who reads dev drama and ships anyway.',
       },
     });
-    recommendTagsMock.mockResolvedValueOnce({ tags: ['css'] });
+    recommendTagsMock.mockResolvedValueOnce({
+      recommended_tags: [{ tag: 'css', score: 0.6 }],
+    });
 
     const res = await client.mutate(MUTATION, {
       variables: {
@@ -892,7 +898,7 @@ describe('mutation personaQuizReveal', () => {
       includeTags: ['react', 'typescript', 'tailwindcss', 'css'],
       reveal: { headline: 'h', description: 'd' },
     });
-    recommendTagsMock.mockResolvedValueOnce({ tags: [] });
+    recommendTagsMock.mockResolvedValueOnce({ recommended_tags: [] });
 
     const res = await client.mutate(MUTATION, {
       variables: {
@@ -917,7 +923,9 @@ describe('mutation personaQuizReveal', () => {
       includeTags: ['nonsense-1', 'nonsense-2'],
       reveal: { headline: 'h', description: 'd' },
     });
-    recommendTagsMock.mockResolvedValueOnce({ tags: ['another-nonsense'] });
+    recommendTagsMock.mockResolvedValueOnce({
+      recommended_tags: [{ tag: 'another-nonsense', score: 0.5 }],
+    });
 
     const res = await client.mutate(MUTATION, {
       variables: {

--- a/__tests__/schema/onboarding.ts
+++ b/__tests__/schema/onboarding.ts
@@ -13,6 +13,7 @@ import { User } from '../../src/entity/user/User';
 import { usersFixture } from '../fixture/user';
 import { recswipeClient } from '../../src/integrations/recswipe/clients';
 import { HttpError } from '../../src/integrations/retry';
+import { Keyword, KeywordStatus } from '../../src/entity/Keyword';
 
 jest.mock('../../src/integrations/recswipe/clients', () => ({
   recswipeClient: {
@@ -23,6 +24,8 @@ jest.mock('../../src/integrations/recswipe/clients', () => ({
 }));
 
 const mockGuessWhoQuiz = jest.fn();
+const mockNextPersonaQuizQuestion = jest.fn();
+const mockPersonaQuizReveal = jest.fn();
 
 jest.mock('../../src/integrations/bragi', () => ({
   getBragiClient: () => ({
@@ -31,6 +34,9 @@ jest.mock('../../src/integrations/bragi', () => ({
     },
     instance: {
       guessWhoQuiz: (...args: unknown[]) => mockGuessWhoQuiz(...args),
+      nextPersonaQuizQuestion: (...args: unknown[]) =>
+        mockNextPersonaQuizQuestion(...args),
+      personaQuizReveal: (...args: unknown[]) => mockPersonaQuizReveal(...args),
     },
   }),
 }));
@@ -573,5 +579,352 @@ describe('mutation guessWhoQuizStep', () => {
 
     expect(res.errors?.length).toBeGreaterThan(0);
     expect(res.errors?.[0].extensions?.code).toBe('UNEXPECTED');
+  });
+});
+
+describe('mutation personaQuizNextQuestion', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation PersonaQuizNextQuestion(
+      $priorAnswers: [PersonaQuizQAInput!]!
+      $seedTags: [String!]!
+      $askedCount: Int!
+      $maxQuestions: Int
+    ) {
+      personaQuizNextQuestion(
+        priorAnswers: $priorAnswers
+        seedTags: $seedTags
+        askedCount: $askedCount
+        maxQuestions: $maxQuestions
+      ) {
+        isFinal
+        question {
+          id
+          prompt
+          axis
+          cols
+          options {
+            id
+            label
+            emoji
+            tagHints
+          }
+        }
+      }
+    }
+  `;
+
+  const oneAnswer = [
+    {
+      questionId: 'q_domain',
+      question: 'Where do you spend most of your dev hours?',
+      optionId: 'data-ml',
+      answer: 'Data, ML, or AI engineering — broad lane',
+    },
+  ];
+
+  it('should require authentication', () =>
+    testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          priorAnswers: oneAnswer,
+          seedTags: ['machine-learning'],
+          askedCount: 1,
+        },
+      },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should reject askedCount < 1', async () => {
+    loggedUser = '1';
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          priorAnswers: oneAnswer,
+          seedTags: ['machine-learning'],
+          askedCount: 0,
+        },
+      },
+      'ZOD_VALIDATION_ERROR',
+    );
+    expect(mockNextPersonaQuizQuestion).not.toHaveBeenCalled();
+  });
+
+  it('should pass recswipe candidate_topics to bragi and return structured question', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockResolvedValueOnce({
+      tags: ['machine-learning', 'recommendation-systems', 'vector-search'],
+    });
+    mockNextPersonaQuizQuestion.mockResolvedValueOnce({
+      id: 'op-1',
+      isFinal: false,
+      question: {
+        id: 'q_llm_1',
+        prompt: 'Vector databases anchor your retrieval pipeline.',
+        axis: 'tooling',
+        cols: 3,
+        options: [
+          { id: 'yes', label: 'Spot on', emoji: '', tagHints: ['vector-search'] },
+          { id: 'sort_of', label: 'Sort of', emoji: '', tagHints: ['machine-learning'] },
+          { id: 'no', label: 'Nope', emoji: '', tagHints: [] },
+        ],
+        rationale: 'ML user, retrieval is adjacent.',
+      },
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        priorAnswers: oneAnswer,
+        seedTags: ['machine-learning'],
+        askedCount: 1,
+        maxQuestions: 14,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      personaQuizNextQuestion: {
+        isFinal: false,
+        question: {
+          id: 'q_llm_1',
+          prompt: 'Vector databases anchor your retrieval pipeline.',
+          axis: 'tooling',
+          cols: 3,
+          options: [
+            { id: 'yes', label: 'Spot on', emoji: null, tagHints: ['vector-search'] },
+            { id: 'sort_of', label: 'Sort of', emoji: null, tagHints: ['machine-learning'] },
+            { id: 'no', label: 'Nope', emoji: null, tagHints: [] },
+          ],
+        },
+      },
+    });
+
+    // Seed tag must be excluded from candidate_topics; pass-through to bragi.
+    expect(recommendTagsMock).toHaveBeenCalledWith('1', {
+      selectedTags: ['machine-learning'],
+      n: 12,
+    });
+    expect(mockNextPersonaQuizQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateTopics: ['recommendation-systems', 'vector-search'],
+        askedCount: 1,
+        seedTags: ['machine-learning'],
+      }),
+    );
+  });
+
+  it('should propagate isFinal=true with null question', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockResolvedValueOnce({ tags: [] });
+    mockNextPersonaQuizQuestion.mockResolvedValueOnce({
+      id: 'op-2',
+      isFinal: true,
+      question: undefined,
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        priorAnswers: oneAnswer,
+        seedTags: ['machine-learning'],
+        askedCount: 10,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data).toEqual({
+      personaQuizNextQuestion: { isFinal: true, question: null },
+    });
+  });
+
+  it('should still call bragi when recswipe candidate-topics fetch fails', async () => {
+    loggedUser = '1';
+    recommendTagsMock.mockRejectedValueOnce(
+      new HttpError('http://recswipe.local:8000/api/recommend-tags', 500, 'boom'),
+    );
+    mockNextPersonaQuizQuestion.mockResolvedValueOnce({
+      id: 'op-3',
+      isFinal: true,
+      question: undefined,
+    });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        priorAnswers: oneAnswer,
+        seedTags: ['machine-learning'],
+        askedCount: 1,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(mockNextPersonaQuizQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateTopics: [] }),
+    );
+  });
+});
+
+describe('mutation personaQuizReveal', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation PersonaQuizReveal(
+      $answers: [PersonaQuizQAInput!]!
+      $seedTags: [String!]!
+      $targetCount: Int
+    ) {
+      personaQuizReveal(
+        answers: $answers
+        seedTags: $seedTags
+        targetCount: $targetCount
+      ) {
+        includeTags
+        reveal {
+          headline
+          description
+        }
+      }
+    }
+  `;
+
+  const oneAnswer = [
+    {
+      questionId: 'q_domain',
+      question: 'Where do you spend most of your dev hours?',
+      optionId: 'frontend',
+      answer: 'Frontend / UI craft',
+    },
+  ];
+
+  beforeEach(async () => {
+    await saveFixtures(con, Keyword, [
+      { value: 'react', occurrences: 100, status: KeywordStatus.Allow },
+      { value: 'typescript', occurrences: 100, status: KeywordStatus.Allow },
+      { value: 'tailwindcss', occurrences: 50, status: KeywordStatus.Allow },
+      { value: 'css', occurrences: 80, status: KeywordStatus.Allow },
+    ]);
+  });
+
+  it('should require authentication', () =>
+    testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          answers: oneAnswer,
+          seedTags: ['react'],
+        },
+      },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should filter bragi tags through the Keyword table and return reveal copy', async () => {
+    loggedUser = '1';
+    mockPersonaQuizReveal.mockResolvedValueOnce({
+      id: 'op-r-1',
+      includeTags: [
+        'react',
+        'typescript',
+        'hallucinated-slug', // not in Keyword table — must be dropped
+        'tailwindcss',
+      ],
+      reveal: {
+        headline: 'Friday-shipper, refactor addict',
+        description: 'Feed tuned for someone who reads dev drama and ships anyway.',
+      },
+    });
+    recommendTagsMock.mockResolvedValueOnce({ tags: ['css'] });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        answers: oneAnswer,
+        seedTags: ['react'],
+        targetCount: 6,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data?.personaQuizReveal.reveal).toEqual({
+      headline: 'Friday-shipper, refactor addict',
+      description: 'Feed tuned for someone who reads dev drama and ships anyway.',
+    });
+    // Order: bragi tags first (canonical-only), then recsys fillers.
+    expect(res.data?.personaQuizReveal.includeTags).toEqual([
+      'react',
+      'typescript',
+      'tailwindcss',
+      'css',
+    ]);
+    expect(res.data?.personaQuizReveal.includeTags).not.toContain(
+      'hallucinated-slug',
+    );
+  });
+
+  it('should cap returned tags at targetCount', async () => {
+    loggedUser = '1';
+    mockPersonaQuizReveal.mockResolvedValueOnce({
+      id: 'op-r-2',
+      includeTags: ['react', 'typescript', 'tailwindcss', 'css'],
+      reveal: { headline: 'h', description: 'd' },
+    });
+    recommendTagsMock.mockResolvedValueOnce({ tags: [] });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        answers: oneAnswer,
+        seedTags: ['react'],
+        targetCount: 2,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data?.personaQuizReveal.includeTags).toHaveLength(2);
+    expect(res.data?.personaQuizReveal.includeTags).toEqual([
+      'react',
+      'typescript',
+    ]);
+  });
+
+  it('should return empty tag list when nothing matches the Keyword table', async () => {
+    loggedUser = '1';
+    mockPersonaQuizReveal.mockResolvedValueOnce({
+      id: 'op-r-3',
+      includeTags: ['nonsense-1', 'nonsense-2'],
+      reveal: { headline: 'h', description: 'd' },
+    });
+    recommendTagsMock.mockResolvedValueOnce({ tags: ['another-nonsense'] });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        answers: oneAnswer,
+        seedTags: ['react'],
+        targetCount: 8,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data?.personaQuizReveal.includeTags).toEqual([]);
+  });
+
+  it('should still call bragi when recswipe fillers fetch fails', async () => {
+    loggedUser = '1';
+    mockPersonaQuizReveal.mockResolvedValueOnce({
+      id: 'op-r-4',
+      includeTags: ['react'],
+      reveal: { headline: 'h', description: 'd' },
+    });
+    recommendTagsMock.mockRejectedValueOnce(
+      new HttpError('http://recswipe.local:8000/api/recommend-tags', 500, 'boom'),
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        answers: oneAnswer,
+        seedTags: ['react'],
+        targetCount: 6,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data?.personaQuizReveal.includeTags).toEqual(['react']);
   });
 });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@connectrpc/connect-fastify": "^1.6.1",
     "@connectrpc/connect-node": "^1.6.1",
     "@dailydotdev/graphql-redis-subscriptions": "^2.4.3",
-    "@dailydotdev/schema": "0.3.7",
+    "@dailydotdev/schema": "0.3.8",
     "@dailydotdev/ts-ioredis-pool": "^1.0.2",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3(graphql-subscriptions@3.0.0(graphql@16.12.0))
       '@dailydotdev/schema':
-        specifier: 0.3.7
-        version: 0.3.7(@bufbuild/protobuf@1.10.0)
+        specifier: 0.3.8
+        version: 0.3.8(@bufbuild/protobuf@1.10.0)
       '@dailydotdev/ts-ioredis-pool':
         specifier: ^1.0.2
         version: 1.0.2
@@ -879,8 +879,8 @@ packages:
     peerDependencies:
       graphql-subscriptions: ^1.0.0 || ^2.0.0
 
-  '@dailydotdev/schema@0.3.7':
-    resolution: {integrity: sha512-sqN8Yu7dz+CVQ4fJHVEc4SX7XOfyw+fyKnXCTC2RS/nPXZxQ5bf9jRfRBOvVPlHKMyyNgo1VFpCOTnjxJycdWQ==}
+  '@dailydotdev/schema@0.3.8':
+    resolution: {integrity: sha512-gpgTzF916iuENtSguYYv7Sdz4O6stKfuPwCsJ22/Tbd9LpBGlTSBulHAB++p66bWjIuci+zO/ZQlMZ/YS0f21A==}
     peerDependencies:
       '@bufbuild/protobuf': 1.x
 
@@ -6231,7 +6231,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dailydotdev/schema@0.3.7(@bufbuild/protobuf@1.10.0)':
+  '@dailydotdev/schema@0.3.8(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 

--- a/src/common/schema/personaQuizNextQuestion.ts
+++ b/src/common/schema/personaQuizNextQuestion.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const MAX_TEXT = 500;
+const MAX_TAG = 80;
+
+export const personaQuizQAPairSchema = z.object({
+  questionId: z.string().min(1).max(MAX_TAG),
+  question: z.string().min(1).max(MAX_TEXT),
+  optionId: z.string().min(1).max(MAX_TAG),
+  answer: z.string().min(1).max(MAX_TEXT),
+});
+
+export const personaQuizNextQuestionInputSchema = z.object({
+  priorAnswers: z.array(personaQuizQAPairSchema).min(1).max(20),
+  seedTags: z.array(z.string().min(1).max(MAX_TAG)).max(32).default([]),
+  askedCount: z.number().int().min(1).max(20),
+  maxQuestions: z.number().int().min(1).max(20).default(14),
+});
+
+export type PersonaQuizNextQuestionInput = z.infer<
+  typeof personaQuizNextQuestionInputSchema
+>;

--- a/src/common/schema/personaQuizReveal.ts
+++ b/src/common/schema/personaQuizReveal.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { personaQuizQAPairSchema } from './personaQuizNextQuestion';
+
+const MAX_TAG = 80;
+
+export const personaQuizRevealInputSchema = z.object({
+  answers: z.array(personaQuizQAPairSchema).min(1).max(20),
+  seedTags: z.array(z.string().min(1).max(MAX_TAG)).max(32).default([]),
+  targetCount: z.number().int().min(1).max(20).default(8),
+});
+
+export type PersonaQuizRevealInput = z.infer<
+  typeof personaQuizRevealInputSchema
+>;

--- a/src/integrations/bragi/clients.ts
+++ b/src/integrations/bragi/clients.ts
@@ -24,7 +24,12 @@ import {
   GuessWhoQuizPersona,
   GuessWhoQuizQuestion,
   GuessWhoQuizResponse,
+  NextPersonaQuizQuestionResponse,
   OnboardingProfileTagsResponse,
+  PersonaQuizOption,
+  PersonaQuizQuestion,
+  PersonaQuizRevealResponse,
+  PersonaQuizRevealText,
   ParseFeedbackResponse,
   Pipelines,
   SentimentDigestResponse,
@@ -208,6 +213,66 @@ export const getBragiClient = (
                       ],
                     }),
                   },
+          }),
+        nextPersonaQuizQuestion: async ({
+          askedCount,
+          maxQuestions,
+        }: {
+          askedCount?: number;
+          maxQuestions?: number;
+        }) => {
+          const reached = (askedCount ?? 0) >= (maxQuestions ?? 14);
+          if (reached) {
+            return new NextPersonaQuizQuestionResponse({
+              id: 'mock-id',
+              isFinal: true,
+            });
+          }
+          return new NextPersonaQuizQuestionResponse({
+            id: 'mock-id',
+            isFinal: false,
+            question: new PersonaQuizQuestion({
+              id: `mock-q-${askedCount ?? 0}`,
+              prompt: 'Vector databases anchor your retrieval pipeline.',
+              axis: 'tooling',
+              cols: 3,
+              options: [
+                new PersonaQuizOption({
+                  id: 'yes',
+                  label: 'Spot on',
+                  tagHints: ['vector-search'],
+                }),
+                new PersonaQuizOption({
+                  id: 'sort_of',
+                  label: 'Sort of',
+                  tagHints: ['machine-learning'],
+                }),
+                new PersonaQuizOption({
+                  id: 'no',
+                  label: 'Nope',
+                  tagHints: [],
+                }),
+              ],
+              rationale: 'Mock rationale.',
+            }),
+          });
+        },
+        personaQuizReveal: async () =>
+          new PersonaQuizRevealResponse({
+            id: 'mock-id',
+            includeTags: [
+              'machine-learning',
+              'python',
+              'recommendation-systems',
+              'vector-search',
+              'mlops',
+              'data-engineering',
+            ],
+            reveal: new PersonaQuizRevealText({
+              headline: 'Recsys-curious, production-leaning',
+              description:
+                'You actually run model.fit() and squint at retrieval. Feed will lean recsys, vector search, and MLOps.',
+            }),
           }),
       } as unknown as ReturnType<typeof createClient<typeof Pipelines>>,
       garmr: new GarmrNoopService(),

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -1866,7 +1866,7 @@ export const typeDefs = /* GraphQL */ `
     Final-screen reveal: bragi turns the Q&A history into canonical tag
     suggestions + a reveal headline / description; daily-api merges with
     recswipe NMF recommendations and filters everything through the canonical
-    Keyword table so only existing keywords reach `feedSettings.includeTags`.
+    Keyword table so only existing keywords reach \`feedSettings.includeTags\`.
     """
     personaQuizReveal(
       answers: [PersonaQuizQAInput!]!
@@ -4634,7 +4634,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             n: 12,
           });
           const seen = new Set(parsed.seedTags.map((t) => t.toLowerCase()));
-          candidateTopics = (recs.tags ?? [])
+          candidateTopics = (recs.recommended_tags ?? [])
+            .map((t) => t.tag)
             .filter((t) => !seen.has(t.toLowerCase()))
             .slice(0, 12);
         } catch {
@@ -4713,7 +4714,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
               selectedTags: parsed.seedTags,
               n: parsed.targetCount * 2,
             });
-            recsysFillers = recs.tags ?? [];
+            recsysFillers = (recs.recommended_tags ?? []).map((t) => t.tag);
           } catch {
             recsysFillers = [];
           }

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -8,6 +8,8 @@ import { onboardingDiscoverPostsInputSchema } from '../common/schema/onboardingD
 import { onboardingExtractTagsInputSchema } from '../common/schema/onboardingExtractTags';
 import { onboardingProfileTagsInputSchema } from '../common/schema/onboardingProfileTags';
 import { onboardingRecommendTagsInputSchema } from '../common/schema/onboardingRecommendTags';
+import { personaQuizNextQuestionInputSchema } from '../common/schema/personaQuizNextQuestion';
+import { personaQuizRevealInputSchema } from '../common/schema/personaQuizReveal';
 import { recswipeClient } from '../integrations/recswipe/clients';
 import { HttpError } from '../integrations/retry';
 import { ServiceError } from '../errors';
@@ -1847,6 +1849,30 @@ export const typeDefs = /* GraphQL */ `
     """
     guessWhoQuizStep(history: [GuessWhoQuizQAInput!]!): GuessWhoQuizStepResult!
       @auth
+
+    """
+    Akinator-style persona quiz: ask bragi for the next guess based on prior
+    Q&A. daily-api fetches NMF candidate_topics from recswipe and passes them
+    to bragi as steering signals. Stateless — caller resends history each turn.
+    """
+    personaQuizNextQuestion(
+      priorAnswers: [PersonaQuizQAInput!]!
+      seedTags: [String!]!
+      askedCount: Int!
+      maxQuestions: Int
+    ): PersonaQuizNextQuestionResult! @auth
+
+    """
+    Final-screen reveal: bragi turns the Q&A history into canonical tag
+    suggestions + a reveal headline / description; daily-api merges with
+    recswipe NMF recommendations and filters everything through the canonical
+    Keyword table so only existing keywords reach `feedSettings.includeTags`.
+    """
+    personaQuizReveal(
+      answers: [PersonaQuizQAInput!]!
+      seedTags: [String!]!
+      targetCount: Int
+    ): PersonaQuizRevealResult! @auth
   }
 
   type OnboardingTagsResult {
@@ -1898,6 +1924,43 @@ export const typeDefs = /* GraphQL */ `
   type GuessWhoQuizStepResult {
     nextQuestion: GuessWhoQuizQuestion
     finalPersona: GuessWhoQuizPersona
+  }
+
+  input PersonaQuizQAInput {
+    questionId: String!
+    question: String!
+    optionId: String!
+    answer: String!
+  }
+
+  type PersonaQuizOption {
+    id: String!
+    label: String!
+    emoji: String
+    tagHints: [String!]!
+  }
+
+  type PersonaQuizQuestion {
+    id: String!
+    prompt: String!
+    axis: String!
+    cols: Int
+    options: [PersonaQuizOption!]!
+  }
+
+  type PersonaQuizNextQuestionResult {
+    isFinal: Boolean!
+    question: PersonaQuizQuestion
+  }
+
+  type PersonaQuizRevealText {
+    headline: String!
+    description: String!
+  }
+
+  type PersonaQuizRevealResult {
+    includeTags: [String!]!
+    reveal: PersonaQuizRevealText
   }
 `;
 
@@ -4551,6 +4614,155 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           });
         }
 
+        throw err;
+      }
+    },
+    personaQuizNextQuestion: async (
+      _,
+      args: z.input<typeof personaQuizNextQuestionInputSchema>,
+      ctx: AuthContext,
+    ) => {
+      const parsed = personaQuizNextQuestionInputSchema.parse(args);
+
+      // Fetch NMF candidate_topics from recswipe to steer bragi's next guess.
+      // Best-effort — if recswipe is down we still call bragi without steering.
+      let candidateTopics: string[] = [];
+      if (parsed.seedTags.length > 0) {
+        try {
+          const recs = await recswipeClient.recommendTags(ctx.userId, {
+            selectedTags: parsed.seedTags,
+            n: 12,
+          });
+          const seen = new Set(parsed.seedTags.map((t) => t.toLowerCase()));
+          candidateTopics = (recs.tags ?? [])
+            .filter((t) => !seen.has(t.toLowerCase()))
+            .slice(0, 12);
+        } catch {
+          candidateTopics = [];
+        }
+      }
+
+      try {
+        const client = getBragiClient();
+        const bragiResp = await client.garmr.execute(() =>
+          client.instance.nextPersonaQuizQuestion({
+            priorAnswers: parsed.priorAnswers,
+            seedTags: parsed.seedTags,
+            askedCount: parsed.askedCount,
+            maxQuestions: parsed.maxQuestions,
+            candidateTopics,
+            application: 'webapp',
+          }),
+        );
+
+        if (bragiResp.isFinal || !bragiResp.question) {
+          return { isFinal: true, question: null };
+        }
+        const q = bragiResp.question;
+        return {
+          isFinal: false,
+          question: {
+            id: q.id,
+            prompt: q.prompt,
+            axis: q.axis,
+            cols: q.cols || null,
+            options: q.options.map((o) => ({
+              id: o.id,
+              label: o.label,
+              emoji: o.emoji || null,
+              tagHints: [...o.tagHints],
+            })),
+          },
+        };
+      } catch (err) {
+        if (err instanceof HttpError) {
+          throw new ServiceError({
+            message: 'personaQuizNextQuestion request failed',
+            data: err.response,
+            statusCode: err.statusCode,
+          });
+        }
+        throw err;
+      }
+    },
+    personaQuizReveal: async (
+      _,
+      args: z.input<typeof personaQuizRevealInputSchema>,
+      ctx: AuthContext,
+    ) => {
+      const parsed = personaQuizRevealInputSchema.parse(args);
+
+      try {
+        const client = getBragiClient();
+        const bragiResp = await client.garmr.execute(() =>
+          client.instance.personaQuizReveal({
+            answers: parsed.answers,
+            seedTags: parsed.seedTags,
+            targetCount: parsed.targetCount,
+            application: 'webapp',
+          }),
+        );
+
+        // Fetch recsys-grounded fillers in parallel-friendly fashion. Used to
+        // pad the LLM tag list up to targetCount once we've filtered through
+        // the canonical Keyword table.
+        let recsysFillers: string[] = [];
+        if (parsed.seedTags.length > 0) {
+          try {
+            const recs = await recswipeClient.recommendTags(ctx.userId, {
+              selectedTags: parsed.seedTags,
+              n: parsed.targetCount * 2,
+            });
+            recsysFillers = recs.tags ?? [];
+          } catch {
+            recsysFillers = [];
+          }
+        }
+
+        const seen = new Set<string>();
+        const merged: string[] = [];
+        const push = (tag: string) => {
+          const key = tag.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            merged.push(tag);
+          }
+        };
+        bragiResp.includeTags.forEach(push);
+        recsysFillers.forEach(push);
+
+        // Canonical filter: only keep tags that exist in the Keyword table.
+        // ContentPreferenceKeyword.keywordId is a FK to Keyword — unknown
+        // tags would raise a FK violation when followTags persists them.
+        let canonical: string[] = [];
+        if (merged.length > 0) {
+          const known = await ctx.con
+            .getRepository(Keyword)
+            .createQueryBuilder()
+            .select(['value'])
+            .where('value IN (:...values)', { values: merged })
+            .getRawMany<{ value: string }>();
+          const valid = new Set(known.map((k) => k.value));
+          canonical = merged.filter((t) => valid.has(t));
+        }
+
+        return {
+          includeTags: canonical.slice(0, parsed.targetCount),
+          reveal: bragiResp.reveal
+            ? {
+                headline: bragiResp.reveal.headline,
+                description: bragiResp.reveal.description,
+              }
+            : null,
+        };
+      } catch (err) {
+        if (err instanceof HttpError) {
+          throw new ServiceError({
+            message: 'personaQuizReveal request failed',
+            data: err.response,
+            statusCode: err.statusCode,
+          });
+        }
         throw err;
       }
     },


### PR DESCRIPTION
## Summary
- Adds `personaQuizNextQuestion` GraphQL mutation that proxies `bragi.NextPersonaQuizQuestion`, pulling NMF `candidate_topics` from recswipe as steering signals on each turn
- Adds `personaQuizReveal` GraphQL mutation that proxies `bragi.PersonaQuizReveal`, merges with recswipe `recommendTags` fillers, and filters the result through the canonical `Keyword` table so unknown slugs can't FK-violate downstream `followTags` inserts
- Bragi mock client extended with both RPCs for local + test runs

The canonical-filter step is load-bearing: `ContentPreferenceKeyword.keywordId` is a `@ManyToOne` FK to `Keyword`, so a hallucinated tag from bragi would crash the `addFiltersToFeed` resolver when the user hits "Looks good" on the quiz reveal screen.

This depends on a `schema-python` (and `@dailydotdev/schema`) bump including the new `bragi/pipelines.proto` types (`NextPersonaQuizQuestionRequest/Response`, `PersonaQuizRevealRequest/Response`, etc.).

## Test plan
- [ ] `pnpm install` resolves cleanly after `@dailydotdev/schema` bump
- [ ] `pnpm lint` passes
- [ ] `pnpm test __tests__/schema/onboarding.ts` passes the 8 new persona-quiz specs (4 for `personaQuizNextQuestion`, 4 for `personaQuizReveal`)
- [ ] Manual: with `BRAGI_ORIGIN` set, hit the new mutations end-to-end against a bragi instance carrying the matching schema rev — verify the structured question / reveal copy / filtered tag list shape
- [ ] Manual: confirm hallucinated bragi tag (e.g. `"definitely-not-a-keyword"`) does NOT appear in `personaQuizReveal.includeTags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)