### PR TITLE
feat: publish post trending events

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1771,6 +1771,38 @@ describe('post', () => {
     ]);
   });
 
+  it('should notify when post becomes trending', async () => {
+    const trendingAt = new Date('2026-05-15T12:30:00.000Z');
+    const before: ChangeObject<ObjectType> = {
+      ...base,
+      trending: null,
+    };
+    const after: ChangeObject<ObjectType> = {
+      ...before,
+      trending: 42,
+      lastTrending: trendingAt.getTime() * 1000,
+    };
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before,
+        op: 'u',
+        table: 'post',
+      }),
+    );
+
+    expect(triggerTypedEvent).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(triggerTypedEvent).mock.calls[1].slice(1)).toEqual([
+      'api.v1.post-trending',
+      {
+        postId: 'p1',
+        trending: 42,
+        trendingAt: trendingAt.toISOString(),
+      },
+    ]);
+  });
+
   describe('collection', () => {
     it('should notify when collection content is updated', async () => {
       const before = {

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -190,6 +190,11 @@ export type PubSubSchema = {
   };
   'skadi.v2.campaign-updated': CampaignUpdateEventArgs;
   'api.v1.post-metrics-updated': z.infer<typeof postMetricsUpdatedTopic>;
+  'api.v1.post-trending': {
+    postId: string;
+    trending: number;
+    trendingAt: string;
+  };
   'api.v1.post-highlighted': PostHighlightedMessage;
   'api.v1.reputation-event': {
     op: ChangeMessage<unknown>['payload']['op'];

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1122,6 +1122,23 @@ const onPostChange = async (
         },
       });
     }
+
+    const trending = data.payload.after!.trending;
+    if (
+      data.payload.before!.trending == null &&
+      typeof trending === 'number' &&
+      trending > 0
+    ) {
+      const trendingAt = data.payload.after!.lastTrending
+        ? debeziumTimeToDate(data.payload.after!.lastTrending).toISOString()
+        : new Date().toISOString();
+
+      await triggerTypedEvent(logger, 'api.v1.post-trending', {
+        postId: data.payload.after!.id,
+        trending,
+        trendingAt,
+      });
+    }
   } else if (data.payload.op === 'd') {
     await notifyPostBannedOrRemoved(logger, data.payload.before!, 'hard');
   }


### PR DESCRIPTION
## Summary
- add a typed `api.v1.post-trending` Pub/Sub event
- emit it from the primary CDC worker when `post.trending` changes from nullish to a positive number
- include `trendingAt` as an ISO timestamp derived from the row after-image `lastTrending` value
- cover the CDC behavior and payload shape in the primary worker test

## Impact
Consumers can subscribe to a dedicated trending-post signal instead of inferring trendiness from visibility or generic content updates. The event now carries when the post became trending, matching the `lastTrending` timestamp written by the trendiness recalculation job.

## Validation
- `pnpm exec prettier --write src/common/typedPubsub.ts src/workers/cdc/primary.ts __tests__/workers/cdc/primary.ts`
- `pnpm exec tsc --noEmit`
- attempted `pnpm exec jest __tests__/workers/cdc/primary.ts --runInBand`, blocked locally by Postgres auth: `password authentication failed for user "postgres"`