### PR TITLE
feat: create posts for scheduled live rooms

### DIFF
--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -3,13 +3,15 @@ import nock from 'nock';
 import type { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
 import { Feature, FeatureType, FeatureValue } from '../src/entity/Feature';
+import { Feed } from '../src/entity/Feed';
 import {
   ContentEmbed,
   ContentEmbedParentType,
 } from '../src/entity/ContentEmbed';
 import { LiveRoom } from '../src/entity/LiveRoom';
 import { LiveRoomSubscription } from '../src/entity/LiveRoomSubscription';
-import { Post } from '../src/entity/posts/Post';
+import { Post, PostType } from '../src/entity/posts/Post';
+import { LiveRoomPost } from '../src/entity/posts/LiveRoomPost';
 import { Source } from '../src/entity/Source';
 import { StorageKey, StorageTopic } from '../src/config';
 import {
@@ -29,6 +31,7 @@ import { LiveRoomStatus } from '../src/common/schema/liveRooms';
 import { deleteKeysByPattern } from '../src/redis';
 import { postsFixture } from './fixture/post';
 import { sourcesFixture } from './fixture/source';
+import { LIVE_ROOM_POST_PROMOTION_SECONDS } from '../src/schema/liveRooms';
 
 const {
   mock: temporalMock,
@@ -209,6 +212,21 @@ describe('live rooms', () => {
         status
         endedAt
         participantCount
+      }
+    }
+  `;
+
+  const POST_QUERY = /* GraphQL */ `
+    query LiveRoomPost($id: ID!) {
+      post(id: $id) {
+        id
+        type
+        title
+        permalink
+        liveRoom {
+          id
+          topic
+        }
       }
     }
   `;
@@ -435,6 +453,7 @@ describe('live rooms', () => {
     await grantStandupAccess(loggedUser);
     await saveFixtures(con, Source, sourcesFixture);
     await saveFixtures(con, Post, [postsFixture[0]]);
+    await con.getRepository(Feed).save({ id: '1', userId: '1' });
     jest
       .useFakeTimers({ doNotFake })
       .setSystemTime(new Date('2026-05-05T14:55:00.000Z'));
@@ -475,6 +494,45 @@ describe('live rooms', () => {
     });
 
     const roomId = res.data.createLiveRoom.room.id;
+    const post = await con.getRepository(LiveRoomPost).findOneByOrFail({
+      liveRoomId: roomId,
+    });
+    const expectedPromotion = Math.floor(
+      (new Date('2026-05-05T14:55:00.000Z').getTime() +
+        LIVE_ROOM_POST_PROMOTION_SECONDS * 1000) /
+        1000,
+    );
+    expect(post).toMatchObject({
+      type: PostType.LiveRoom,
+      title: 'Scheduled GraphQL and SFUs',
+      sourceId: '1',
+      authorId: '1',
+      visible: true,
+      showOnFeed: true,
+      private: false,
+      flags: {
+        visible: true,
+        private: false,
+        promoteToPublic: expectedPromotion,
+      },
+    });
+
+    const postRes = await client.query(POST_QUERY, {
+      variables: { id: post.id },
+    });
+
+    expect(postRes.errors).toBeFalsy();
+    expect(postRes.data.post).toEqual({
+      id: post.id,
+      type: 'live_room',
+      title: 'Scheduled GraphQL and SFUs',
+      permalink: `http://localhost:5002/standups/${roomId}`,
+      liveRoom: {
+        id: roomId,
+        topic: 'Scheduled GraphQL and SFUs',
+      },
+    });
+
     const embeds = await con.getRepository(ContentEmbed).findBy({
       parentId: roomId,
       parentType: ContentEmbedParentType.LiveRoom,
@@ -503,6 +561,7 @@ describe('live rooms', () => {
     await grantStandupAccess(loggedUser);
     await saveFixtures(con, Source, sourcesFixture);
     await saveFixtures(con, Post, [postsFixture[0]]);
+    await con.getRepository(Feed).save({ id: '1', userId: '1' });
 
     const scope = nock(flytingOrigin)
       .post(/\/internal\/live-rooms\/[^/]+\/prepare/, {
@@ -516,6 +575,7 @@ describe('live rooms', () => {
         input: {
           topic: 'Invalid prepare',
           mode: 'moderated',
+          scheduledStart: '2026-05-05T15:10:00.000Z',
           description:
             'Review [this post](http://localhost:5002/posts/p1) before we start.',
         },
@@ -536,6 +596,7 @@ describe('live rooms', () => {
         parentType: ContentEmbedParentType.LiveRoom,
       }),
     ).toBe(0);
+    expect(await con.getRepository(LiveRoomPost).count()).toBe(0);
   });
 
   it('returns only live rooms', async () => {

--- a/src/common/userIntegration.ts
+++ b/src/common/userIntegration.ts
@@ -17,6 +17,7 @@ import {
   FreeformPost,
   WelcomePost,
   SharePost,
+  LiveRoomPost,
 } from '../entity/posts';
 
 export type GQLUserIntegration = {
@@ -125,8 +126,9 @@ export const getAttachmentForPostType = async <TPostType extends PostType>({
     }
     case PostType.Freeform:
     case PostType.Welcome:
+    case PostType.LiveRoom:
     case PostType.Brief: {
-      const freeformPost = post as FreeformPost & WelcomePost;
+      const freeformPost = post as FreeformPost & WelcomePost & LiveRoomPost;
 
       if (freeformPost.title) {
         attachment.title = freeformPost.title;

--- a/src/entity/posts/LiveRoomPost.ts
+++ b/src/entity/posts/LiveRoomPost.ts
@@ -1,0 +1,16 @@
+import { ChildEntity, Column, JoinColumn, ManyToOne } from 'typeorm';
+import { type LiveRoom } from '../LiveRoom';
+import { Post, PostType } from './Post';
+
+@ChildEntity(PostType.LiveRoom)
+export class LiveRoomPost extends Post {
+  @Column({ type: 'uuid', nullable: true })
+  liveRoomId: string;
+
+  @ManyToOne('LiveRoom', {
+    createForeignKeyConstraints: false,
+    lazy: true,
+  })
+  @JoinColumn({ name: 'liveRoomId' })
+  liveRoom: Promise<LiveRoom>;
+}

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -26,6 +26,7 @@ export enum PostType {
   Digest = 'digest',
   Poll = 'poll',
   SocialTwitter = 'social:twitter',
+  LiveRoom = 'live_room',
 }
 
 export const postTypes: string[] = Object.values(PostType);

--- a/src/entity/posts/index.ts
+++ b/src/entity/posts/index.ts
@@ -10,3 +10,4 @@ export * from './PostRelation';
 export * from './CollectionPost';
 export * from './YouTubePost';
 export * from './SocialTwitterPost';
+export * from './LiveRoomPost';

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -572,6 +572,7 @@ const obj = new GraphORM({
       'scoutId',
       'private',
       'type',
+      'liveRoomId',
       'subType',
       'slug',
       'translation',
@@ -723,6 +724,13 @@ const obj = new GraphORM({
             qb
               .where(`${childAlias}.id = ${parentAlias}."sharedPostId"`)
               .andWhere(`${childAlias}."deleted" = false`),
+        },
+      },
+      liveRoom: {
+        relation: {
+          isMany: false,
+          childColumn: 'id',
+          parentColumn: 'liveRoomId',
         },
       },
       downvoted: {

--- a/src/migration/1779033341380-LiveRoomPost.ts
+++ b/src/migration/1779033341380-LiveRoomPost.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class LiveRoomPost1779033341380 implements MigrationInterface {
+  name = 'LiveRoomPost1779033341380';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "post"
+        ADD "liveRoomId" uuid
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "post"
+        DROP COLUMN "liveRoomId"
+    `);
+  }
+}

--- a/src/notifications/builder.ts
+++ b/src/notifications/builder.ts
@@ -36,6 +36,7 @@ import {
   type NotificationOrganizationContext,
   type NotificationUserTopReaderContext,
 } from './types';
+import type { LiveRoomPost } from '../entity/posts/LiveRoomPost';
 import { NotificationIcon } from './icons';
 import { SourceMemberRoles } from '../roles';
 import { NotificationType } from './common';
@@ -274,6 +275,16 @@ export class NotificationBuilder {
     post: Reference<Post>,
     comment?: Reference<Comment>,
   ): NotificationBuilder {
+    if (post.type === PostType.LiveRoom) {
+      const liveRoomPost = post as Reference<LiveRoomPost>;
+
+      if (liveRoomPost.liveRoomId) {
+        return this.enrichNotification({
+          targetUrl: `${process.env.COMMENTS_PREFIX}/standups/${liveRoomPost.liveRoomId}`,
+        });
+      }
+    }
+
     return this.enrichNotification({
       targetUrl: getDiscussionLink(post.id, comment?.id),
     });

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -1,8 +1,9 @@
 import type { IResolvers } from '@graphql-tools/utils';
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import type { GraphQLResolveInfo } from 'graphql';
+import type { EntityManager } from 'typeorm';
 import type { Context } from '../Context';
-import { toGQLEnum } from '../common';
+import { ONE_HOUR_IN_SECONDS, toGQLEnum } from '../common';
 import { GQLEmptyResponse } from './common';
 import { createLiveRoomJoinToken } from '../common/liveRoom/token';
 import {
@@ -23,13 +24,20 @@ import { NotFoundError } from '../errors';
 import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import { LiveRoom } from '../entity/LiveRoom';
 import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
+import { LiveRoomPost } from '../entity/posts/LiveRoomPost';
+import { PostOrigin } from '../entity/posts/Post';
+import { generateTitleHtml } from '../entity/posts/utils';
 import graphorm from '../graphorm';
 import { getFlytingClient } from '../integrations/flyting/client';
 import { AbortError, HttpError } from '../integrations/retry';
 import { Roles } from '../roles';
 import { scheduleLiveRoomStartingSoonReminder } from '../temporal/notifications/liveRoom';
+import { generateShortId } from '../ids';
+import { ensureUserSourceExists } from './sources';
 
 export type GQLLiveRoom = LiveRoom;
+
+export const LIVE_ROOM_POST_PROMOTION_SECONDS = 6 * ONE_HOUR_IN_SECONDS;
 
 type GQLLiveRoomJoinToken = {
   room: LiveRoom;
@@ -114,6 +122,43 @@ const getRoomOrThrow = async ({
   }
 
   return room;
+};
+
+const getLiveRoomPromotionExpiresAt = (): number =>
+  Math.floor((Date.now() + LIVE_ROOM_POST_PROMOTION_SECONDS * 1000) / 1000);
+
+const createScheduledLiveRoomPost = async ({
+  manager,
+  room,
+  userId,
+}: {
+  manager: EntityManager;
+  room: LiveRoom;
+  userId: string;
+}): Promise<void> => {
+  const id = await generateShortId();
+
+  await manager.getRepository(LiveRoomPost).save(
+    manager.getRepository(LiveRoomPost).create({
+      id,
+      shortId: id,
+      liveRoomId: room.id,
+      sourceId: userId,
+      authorId: userId,
+      title: room.topic,
+      titleHtml: generateTitleHtml(room.topic, []),
+      visible: true,
+      visibleAt: new Date(),
+      private: false,
+      origin: PostOrigin.UserGenerated,
+      showOnFeed: true,
+      flags: {
+        visible: true,
+        private: false,
+        promoteToPublic: getLiveRoomPromotionExpiresAt(),
+      },
+    }),
+  );
 };
 
 const assertCanEndRoom = ({
@@ -339,33 +384,44 @@ export const resolvers: IResolvers = {
     ): Promise<GQLLiveRoomJoinToken> => {
       const input = createLiveRoomSchema.parse(args.input);
       await assertCanCreateRoom({ ctx });
+      const userId = ctx.userId;
+      if (!userId) {
+        throw new ForbiddenError('Access denied!');
+      }
       const description = input.description || null;
       const renderedDescription = description
         ? renderMarkdown(description)
         : null;
-      const roomRepo = ctx.con.getRepository(LiveRoom);
-      const room = await roomRepo.save(
-        roomRepo.create({
-          description,
-          descriptionHtml: renderedDescription?.contentHtml ?? null,
-          hostId: ctx.userId,
-          mode: input.mode,
-          scheduledStart: input.scheduledStart ?? null,
-          topic: input.topic,
-          status: LiveRoomStatus.Created,
-        }),
-      );
 
-      if (description) {
-        await replaceContentEmbeds({
-          con: ctx.con,
-          parentType: ContentEmbedParentType.LiveRoom,
-          parentId: room.id,
-          content: description,
-          tokens: renderedDescription?.tokens,
-          limit: MAX_LIVE_ROOM_CONTENT_EMBEDS,
-        });
-      }
+      const room = await ctx.con.transaction(async (manager) => {
+        const roomRepo = manager.getRepository(LiveRoom);
+        const savedRoom = await roomRepo.save(
+          roomRepo.create({
+            description,
+            descriptionHtml: renderedDescription?.contentHtml ?? null,
+            hostId: userId,
+            mode: input.mode,
+            scheduledStart: input.scheduledStart ?? null,
+            topic: input.topic,
+            status: LiveRoomStatus.Created,
+          }),
+        );
+
+        if (description) {
+          await replaceContentEmbeds({
+            con: manager,
+            parentType: ContentEmbedParentType.LiveRoom,
+            parentId: savedRoom.id,
+            content: description,
+            tokens: renderedDescription?.tokens,
+            limit: MAX_LIVE_ROOM_CONTENT_EMBEDS,
+          });
+        }
+
+        return savedRoom;
+      });
+
+      const roomRepo = ctx.con.getRepository(LiveRoom);
 
       try {
         await getFlytingClient().prepareRoom({
@@ -388,6 +444,15 @@ export const resolvers: IResolvers = {
       }
 
       if (room.scheduledStart) {
+        await ensureUserSourceExists(userId, ctx.con);
+        await ctx.con.transaction(async (manager) =>
+          createScheduledLiveRoomPost({
+            manager,
+            room,
+            userId,
+          }),
+        );
+
         await scheduleLiveRoomStartingSoonReminder({
           roomId: room.id,
           entityTableName: roomRepo.metadata.tableName,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -164,6 +164,7 @@ import {
 import { pollCreationSchema } from '../common/schema/polls';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { PollPost } from '../entity/posts/PollPost';
+import type { LiveRoom } from '../entity/LiveRoom';
 
 export interface GQLPollOption {
   id: string;
@@ -211,6 +212,8 @@ export interface GQLPost {
   isScout?: number;
   isAuthor?: number;
   sharedPost?: GQLPost;
+  liveRoom?: LiveRoom;
+  liveRoomId?: string | null;
   feedMeta?: string;
   content?: string;
   contentHtml?: string;
@@ -611,6 +614,11 @@ export const typeDefs = /* GraphQL */ `
     URL to the post
     """
     url: String
+
+    """
+    Live room promoted by this post
+    """
+    liveRoom: LiveRoom
 
     """
     Title of the post
@@ -1880,8 +1888,15 @@ const nullableImageType = [
 
 const editablePostTypes = [PostType.Welcome, PostType.Freeform];
 
-export const getPostPermalink = (post: Pick<GQLPost, 'shortId'>): string =>
-  `${process.env.URL_PREFIX}/r/${post.shortId}`;
+export const getPostPermalink = (
+  post: Pick<GQLPost, 'shortId' | 'type' | 'liveRoomId'>,
+): string => {
+  if (post.type === PostType.LiveRoom && post.liveRoomId) {
+    return `${process.env.COMMENTS_PREFIX}/standups/${post.liveRoomId}`;
+  }
+
+  return `${process.env.URL_PREFIX}/r/${post.shortId}`;
+};
 
 export const getPostByUrl = async (
   ctx: Context,

--- a/src/workers/postUpdated/shared.ts
+++ b/src/workers/postUpdated/shared.ts
@@ -29,6 +29,7 @@ import { updateFlagsStatement } from '../../common';
 import { counters } from '../../telemetry';
 import { BriefPost } from '../../entity/posts/BriefPost';
 import { DigestPost } from '../../entity/posts/DigestPost';
+import { LiveRoomPost } from '../../entity/posts/LiveRoomPost';
 import { PollPost } from '../../entity/posts/PollPost';
 import { isTwitterSocialType } from '../../common/twitterSocial';
 import type {
@@ -108,6 +109,7 @@ export const contentTypeFromPostType: Record<PostType, typeof Post> = {
   [PostType.Digest]: DigestPost,
   [PostType.Poll]: PollPost,
   [PostType.SocialTwitter]: SocialTwitterPost,
+  [PostType.LiveRoom]: LiveRoomPost,
 };
 
 export const createPost = async ({


### PR DESCRIPTION
## What changed
- Added a `live_room` post subtype backed by `LiveRoomPost` and a nullable `post.liveRoomId` migration.
- Scheduled live-room creation now creates a normal visible post authored by the creator, linked to the creator's user source, and promoted for six hours.
- The promo post is created only after Flyting `prepareRoom` succeeds, so prepare failures do not create post-visible side effects.
- Added GraphORM and GraphQL support for `Post.liveRoom`, with live-room post permalinks pointing to `/standups/:id`.
- Covered scheduled lobby post creation, promotion expiry, GraphORM relation hydration, permalink behavior, and no-post cleanup semantics on definitive Flyting prepare failure.

## Validation
- `pnpm --ignore-workspace exec eslint src/schema/liveRooms.ts src/schema/posts.ts src/graphorm/index.ts src/entity/posts/Post.ts src/entity/posts/LiveRoomPost.ts src/entity/posts/index.ts src/common/userIntegration.ts src/workers/postUpdated/shared.ts src/notifications/builder.ts __tests__/liveRooms.ts --max-warnings 0`
- `NODE_ENV=test pnpm --ignore-workspace exec jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
- `git diff --check`

## Notes
- Applied the new migration locally to `api_test` before running the focused Jest suite.
- Full `pnpm --ignore-workspace run build` is currently blocked by unrelated Bragi/persona schema-package drift in `src/integrations/bragi/clients.ts` and `src/schema/users.ts`.
