### PR TITLE
feat: add live standups boot hint

### DIFF
--- a/__tests__/__snapshots__/feeds.ts.snap
+++ b/__tests__/__snapshots__/feeds.ts.snap
@@ -336,6 +336,12 @@ Object {
     },
     Object {
       "defaultEnabledState": true,
+      "description": "Live standup posts hosted on daily.dev.",
+      "id": 8,
+      "title": "Standups",
+    },
+    Object {
+      "defaultEnabledState": true,
       "description": "Description for Tech magazines",
       "id": 1,
       "title": "Tech magazines",

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -92,6 +92,8 @@ import { UserExperienceWork } from '../src/entity/user/experiences/UserExperienc
 import { UserExperienceEducation } from '../src/entity/user/experiences/UserExperienceEducation';
 import * as betterAuthModule from '../src/betterAuth';
 import { remoteConfig } from '../src/remoteConfig';
+import { LiveRoom } from '../src/entity/LiveRoom';
+import { LiveRoomStatus } from '../src/common/schema/liveRooms';
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -106,6 +108,7 @@ const BASE_BODY = {
   },
   settings: { ...SETTINGS_DEFAULT },
   notifications: { unreadNotificationsCount: 0 },
+  liveRooms: { hasLive: false },
   squads: [],
   visit: {
     sessionId: expect.any(String),
@@ -224,6 +227,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
+  await con.getRepository(LiveRoom).createQueryBuilder().delete().execute();
   await con.getRepository(User).save(usersFixture[0]);
   await con.getRepository(Source).save(sourcesFixture);
   await con.getRepository(Post).save(postsFixture);
@@ -251,6 +255,47 @@ describe('anonymous boot', () => {
       .set('User-Agent', TEST_UA)
       .expect(200);
     expect(res.body).toEqual(ANONYMOUS_BODY);
+  });
+
+  it('should indicate when there are live rooms', async () => {
+    await con.getRepository(LiveRoom).save({
+      id: '32ad3407-0d6a-4d95-98c2-bc5a3d7cf4d1',
+      hostId: '1',
+      topic: 'Live boot hint',
+      mode: 'moderated',
+      status: LiveRoomStatus.Live,
+    });
+
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .expect(200);
+
+    expect(res.body.liveRooms).toEqual({ hasLive: true });
+  });
+
+  it('should reuse the cached live rooms boot hint', async () => {
+    const first = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .expect(200);
+
+    await con.getRepository(LiveRoom).save({
+      id: '61168086-ce61-4c1a-a56e-dcf173d31150',
+      hostId: '1',
+      topic: 'Recently started room',
+      mode: 'moderated',
+      status: LiveRoomStatus.Live,
+    });
+
+    const second = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('Cookie', first.headers['set-cookie'])
+      .expect(200);
+
+    expect(first.body.liveRooms).toEqual({ hasLive: false });
+    expect(second.body.liveRooms).toEqual({ hasLive: false });
   });
 
   it('should keep the same tracking and session id', async () => {

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -176,6 +176,16 @@ const advancedSettings: Partial<AdvancedSettings>[] = [
       type: PostType.VideoYouTube,
     },
   },
+  {
+    id: 8,
+    title: 'Standups',
+    description: 'Live standup posts hosted on daily.dev.',
+    defaultEnabledState: true,
+    group: 'content_types',
+    options: {
+      type: PostType.LiveRoom,
+    },
+  },
 ];
 
 const categories: Partial<Category>[] = [
@@ -4014,6 +4024,20 @@ describe('function feedToFilters', () => {
     await saveAdvancedSettingsFiltersFixtures();
     const filters = await feedToFilters(con, '1', '1');
     expect(filters.excludeTypes).toEqual(['video:youtube']);
+  });
+
+  it('should return filters having excluded standups based on advanced settings', async () => {
+    loggedUser = '1';
+    await saveAdvancedSettingsFiltersFixtures();
+    await saveFixtures(con, FeedAdvancedSettings, [
+      { feedId: '1', advancedSettingsId: 8, enabled: false },
+    ]);
+
+    const filters = await feedToFilters(con, '1', '1');
+    expect(filters.excludeTypes).toEqual([
+      PostType.VideoYouTube,
+      PostType.LiveRoom,
+    ]);
   });
 
   it('should return filters for tags/sources based on the values from our data', async () => {

--- a/__tests__/liveRooms.ts
+++ b/__tests__/liveRooms.ts
@@ -737,6 +737,45 @@ describe('live rooms', () => {
     expect(scope.isDone()).toBe(true);
   });
 
+  it('limits active live rooms', async () => {
+    await saveFixtures(
+      con,
+      LiveRoom,
+      Array.from({ length: 6 }, (_, index) => ({
+        id: `0000000${index}-b26e-44fb-b9f8-4c977b28a123`,
+        hostId: '1',
+        topic: `Live room ${index}`,
+        mode: 'moderated',
+        status: LiveRoomStatus.Live,
+        createdAt: new Date(`2035-01-0${index + 1}T12:00:00.000Z`),
+      })),
+    );
+
+    const res = await client.query(/* GraphQL */ `
+      query ActiveLiveRooms {
+        activeLiveRooms(limit: 2) {
+          id
+          topic
+          status
+        }
+      }
+    `);
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.activeLiveRooms).toEqual([
+      {
+        id: '00000005-b26e-44fb-b9f8-4c977b28a123',
+        topic: 'Live room 5',
+        status: 'live',
+      },
+      {
+        id: '00000004-b26e-44fb-b9f8-4c977b28a123',
+        topic: 'Live room 4',
+        status: 'live',
+      },
+    ]);
+  });
+
   it('keeps active live rooms visible when the batched count lookup fails', async () => {
     await saveFixtures(con, LiveRoom, [
       {

--- a/src/common/schema/liveRooms.ts
+++ b/src/common/schema/liveRooms.ts
@@ -70,6 +70,16 @@ export const createLiveRoomSchema = z
     }
   });
 
+export const activeLiveRoomsQuerySchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .nullish()
+    .transform((value) => value ?? 5),
+});
+
 export const liveRoomIdSchema = z.uuid('Live room ID must be a valid UUID');
 
 export const liveRoomIdInputSchema = z.object({

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export enum StorageKey {
   OrganizationSubscriptionUpdatePreview = 'organization_subscription_update_preview',
   UserLastOnline = 'ulo',
   ParticipantCount = 'participant_count',
+  HasLiveRooms = 'has_live_rooms',
 }
 
 export const generateStorageKey = (

--- a/src/migration/1779100000000-StandupsContentTypeAdvancedSetting.ts
+++ b/src/migration/1779100000000-StandupsContentTypeAdvancedSetting.ts
@@ -1,0 +1,36 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class StandupsContentTypeAdvancedSetting1779100000000 implements MigrationInterface {
+  name = 'StandupsContentTypeAdvancedSetting1779100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "advanced_settings" (
+        "title",
+        "description",
+        "group",
+        "options"
+      )
+      SELECT
+        'Standups',
+        'Live standup posts hosted on daily.dev.',
+        'content_types',
+        '{"type": "live_room"}'::jsonb
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM "advanced_settings"
+        WHERE "group" = 'content_types'
+          AND "options"->>'type' = 'live_room'
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "advanced_settings"
+      WHERE "title" = 'Standups'
+        AND "group" = 'content_types'
+        AND "options"->>'type' = 'live_room'
+    `);
+  }
+}

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -54,6 +54,7 @@ import {
 
 import {
   ONE_DAY_IN_SECONDS,
+  ONE_MINUTE_IN_SECONDS,
   base64,
   getSourceLink,
   submitArticleThreshold,
@@ -104,6 +105,8 @@ import {
   skadiEngagementClient,
   type EngagementCreative,
 } from '../integrations/skadi';
+import { LiveRoom } from '../entity/LiveRoom';
+import { LiveRoomStatus } from '../common/schema/liveRooms';
 
 export type BootSquadSource = Omit<GQLSource, 'currentMember'> & {
   permalink: string;
@@ -155,6 +158,7 @@ export type BaseBoot = {
   alerts: BootAlerts;
   settings: Omit<Settings, 'userId' | 'updatedAt' | 'user'>;
   notifications: { unreadNotificationsCount: number };
+  liveRooms: { hasLive: boolean };
   squads: BootSquadSource[];
   exp?: Experimentation;
   geo: Geo;
@@ -226,6 +230,36 @@ const getBootAppPlatform = (req: FastifyRequest): string | undefined =>
 
 const isExtensionBootRequest = (req: FastifyRequest): boolean =>
   getBootAppPlatform(req) === 'extension';
+
+const LIVE_ROOMS_BOOT_CACHE_TTL_SECONDS = ONE_MINUTE_IN_SECONDS / 2;
+
+const liveRoomsBootCacheKey = (): string =>
+  generateStorageKey(StorageTopic.LiveRoom, StorageKey.HasLiveRooms, 'global');
+
+const getLiveRoomsBoot = async (
+  con: DataSource,
+): Promise<{ hasLive: boolean }> => {
+  const cacheKey = liveRoomsBootCacheKey();
+  const cached = await getRedisObject(cacheKey);
+
+  if (cached !== null) {
+    return { hasLive: cached === '1' };
+  }
+
+  const hasLive = await queryReadReplica(con, ({ queryRunner }) =>
+    queryRunner.manager.getRepository(LiveRoom).exists({
+      where: { status: LiveRoomStatus.Live },
+    }),
+  );
+
+  await setRedisObjectWithExpiry(
+    cacheKey,
+    hasLive ? '1' : '0',
+    LIVE_ROOMS_BOOT_CACHE_TTL_SECONDS,
+  );
+
+  return { hasLive };
+};
 
 const getLastExtensionUseRedisKey = (userId: string): string =>
   generateStorageKey(StorageTopic.Boot, 'last_extension_use', userId);
@@ -727,6 +761,7 @@ const loggedInBoot = async ({
       clickbaitTries,
       anonymousTheme,
       engagementCreatives,
+      liveRooms,
     ] = await Promise.all([
       visitSection(req, res),
       getRoles(userId),
@@ -755,6 +790,7 @@ const loggedInBoot = async ({
       getClickbaitTries({ userId }),
       getAnonymousTheme(userId),
       getEngagementCreatives(userId),
+      getLiveRoomsBoot(con),
     ]);
 
     const profileCompletion = calculateProfileCompletion(user, experienceFlags);
@@ -862,6 +898,7 @@ const loggedInBoot = async ({
         'bookmarkSlug',
       ]),
       notifications: { unreadNotificationsCount },
+      liveRooms,
       squads,
       accessToken,
       exp,
@@ -941,15 +978,23 @@ const anonymousBoot = async (
 ): Promise<AnonymousBoot> => {
   const geo = geoSection(req);
 
-  const [visit, extra, firstVisit, exp, existingTheme, engagementCreatives] =
-    await Promise.all([
-      visitSection(req, res),
-      middleware ? middleware(con, req, res) : {},
-      getAnonymousFirstVisit(req.trackingId),
-      getExperimentation({ userId: req.trackingId, con, ...geo }),
-      getAnonymousTheme(req.trackingId),
-      getEngagementCreatives(req.trackingId ?? ''),
-    ]);
+  const [
+    visit,
+    extra,
+    firstVisit,
+    exp,
+    existingTheme,
+    engagementCreatives,
+    liveRooms,
+  ] = await Promise.all([
+    visitSection(req, res),
+    middleware ? middleware(con, req, res) : {},
+    getAnonymousFirstVisit(req.trackingId),
+    getExperimentation({ userId: req.trackingId, con, ...geo }),
+    getAnonymousTheme(req.trackingId),
+    getEngagementCreatives(req.trackingId ?? ''),
+    getLiveRoomsBoot(con),
+  ]);
 
   // Determine theme: use existing preference or referrer-based default
   const theme = existingTheme ?? getDefaultThemeForReferrer(referrer);
@@ -976,6 +1021,7 @@ const anonymousBoot = async (
       ...(theme && { theme }),
     },
     notifications: { unreadNotificationsCount: 0 },
+    liveRooms,
     squads: [],
     exp,
     geo,

--- a/src/schema/liveRooms.ts
+++ b/src/schema/liveRooms.ts
@@ -13,6 +13,7 @@ import {
 } from '../common/contentEmbeds';
 import { renderMarkdown } from '../common/markdown';
 import {
+  activeLiveRoomsQuerySchema,
   createLiveRoomSchema,
   LiveRoomMode,
   LiveRoomParticipantRole,
@@ -84,7 +85,7 @@ export const typeDefs = /* GraphQL */ `
 
   extend type Query {
     liveRoom(id: ID!): LiveRoom
-    activeLiveRooms: [LiveRoom!]!
+    activeLiveRooms(limit: Int): [LiveRoom!]!
   }
 
   extend type Mutation {
@@ -350,11 +351,13 @@ export const resolvers: IResolvers = {
       ),
     activeLiveRooms: async (
       _,
-      __,
+      args: { limit?: number | null },
       ctx: Context,
       info,
-    ): Promise<GQLLiveRoom[]> =>
-      graphorm.query<GQLLiveRoom>(
+    ): Promise<GQLLiveRoom[]> => {
+      const input = activeLiveRoomsQuerySchema.parse(args);
+
+      return graphorm.query<GQLLiveRoom>(
         ctx,
         info,
         (builder) => {
@@ -362,11 +365,13 @@ export const resolvers: IResolvers = {
             .where(`"${builder.alias}"."status" = :status`, {
               status: LiveRoomStatus.Live,
             })
-            .orderBy(`"${builder.alias}"."createdAt"`, 'DESC');
+            .orderBy(`"${builder.alias}"."createdAt"`, 'DESC')
+            .limit(input.limit);
           return builder;
         },
         true,
-      ),
+      );
+    },
   },
   Mutation: {
     createLiveRoom: async (


### PR DESCRIPTION
## Summary

Adds a small `liveRooms.hasLive` boot hint so the webapp can reserve/render the live standups strip only when live standups may exist, without embedding live room data in boot.

Bounds `activeLiveRooms` with a validated `limit` argument while keeping it live-only and preserving the existing `participantCount` field path for the follow-up strip query.

## Validation

- `pnpm --ignore-workspace exec eslint src/routes/boot.ts src/schema/liveRooms.ts src/common/schema/liveRooms.ts src/config.ts __tests__/boot.ts __tests__/liveRooms.ts --max-warnings 0`
- `NODE_ENV=test npx jest __tests__/liveRooms.ts --testEnvironment=node --runInBand`
- `NODE_ENV=test npx jest __tests__/boot.ts --testEnvironment=node --runInBand`
- `git diff --check`
