### PR TITLE
feat: add highlights canonical dual-write

### DIFF
--- a/__tests__/cron/channelHighlights.ts
+++ b/__tests__/cron/channelHighlights.ts
@@ -3,6 +3,7 @@ import createOrGetConnection from '../../src/db';
 import { ChannelDigest } from '../../src/entity/ChannelDigest';
 import { ChannelHighlightDefinition } from '../../src/entity/ChannelHighlightDefinition';
 import { ChannelHighlightRun } from '../../src/entity/ChannelHighlightRun';
+import { HighlightsCanonical } from '../../src/entity/HighlightsCanonical';
 import { AGENTS_DIGEST_SOURCE, UNKNOWN_SOURCE } from '../../src/entity/Source';
 import {
   PostHighlight,
@@ -167,6 +168,7 @@ describe('channel highlight generation cron', () => {
     await con.getRepository(ChannelHighlightRun).clear();
     await con.getRepository(ChannelHighlightDefinition).clear();
     await con.getRepository(ChannelDigest).clear();
+    await con.getRepository(HighlightsCanonical).clear();
     await con.getRepository(PostHighlight).clear();
     await con.getRepository(PostRelation).clear();
     await con
@@ -306,6 +308,13 @@ describe('channel highlight generation cron', () => {
       headline: 'Live headline',
     });
 
+    const canonicalHighlights = await con
+      .getRepository(HighlightsCanonical)
+      .find({
+        order: { highlightedAt: 'DESC' },
+      });
+    expect(canonicalHighlights).toEqual([]);
+
     const run = await con.getRepository(ChannelHighlightRun).findOneByOrFail({
       channel: 'vibes',
     });
@@ -356,6 +365,20 @@ describe('channel highlight generation cron', () => {
         headline: 'Older live headline',
       },
     ]);
+    await con.getRepository(HighlightsCanonical).save([
+      {
+        postId: 'new-live',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-03T10:00:00.000Z'),
+        headline: 'Newer live headline',
+      },
+      {
+        postId: 'old-live',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-03T09:00:00.000Z'),
+        headline: 'Older live headline',
+      },
+    ]);
 
     jest.spyOn(evaluator, 'evaluateChannelHighlights').mockResolvedValue({
       items: [
@@ -390,6 +413,31 @@ describe('channel highlight generation cron', () => {
       postId: 'old-live',
     });
     expect(retiredHighlight?.retiredAt).toBeInstanceOf(Date);
+
+    const canonicalHighlights = await con
+      .getRepository(HighlightsCanonical)
+      .find({
+        order: { highlightedAt: 'DESC' },
+      });
+    expect(canonicalHighlights).toEqual([
+      expect.objectContaining({
+        postId: 'fresh-1',
+        channels: ['vibes'],
+        headline: 'Fresh headline',
+        significance: PostHighlightSignificance.Breaking,
+        reason: 'test',
+      }),
+      expect.objectContaining({
+        postId: 'new-live',
+        channels: ['vibes'],
+        headline: 'Newer live headline',
+      }),
+      expect.objectContaining({
+        postId: 'old-live',
+        channels: ['vibes'],
+        headline: 'Older live headline',
+      }),
+    ]);
   });
 
   it('should evaluate globally and fan out admitted highlights to all enabled post channels', async () => {
@@ -464,6 +512,17 @@ describe('channel highlight generation cron', () => {
       expect.objectContaining({
         channel: 'vibes',
         postId: 'global-fresh',
+        headline: 'Global headline',
+        significance: PostHighlightSignificance.Major,
+      }),
+    ]);
+    const canonicalHighlights = await con
+      .getRepository(HighlightsCanonical)
+      .find();
+    expect(canonicalHighlights).toEqual([
+      expect.objectContaining({
+        postId: 'global-fresh',
+        channels: ['backend', 'vibes'],
         headline: 'Global headline',
         significance: PostHighlightSignificance.Major,
       }),

--- a/src/common/channelHighlight/generate.ts
+++ b/src/common/channelHighlight/generate.ts
@@ -6,7 +6,7 @@ import { UNKNOWN_SOURCE } from '../../entity/Source';
 import { getChannelDigestSourceIds } from '../channelDigest/definitions';
 import { compareSnapshots } from './decisions';
 import { evaluateChannelHighlights } from './evaluate';
-import { replaceHighlightsForChannel } from './publish';
+import { publishHighlightsForChannel } from './publish';
 import {
   fetchCollectionMembership,
   fetchCurrentHighlightsForChannels,
@@ -589,7 +589,7 @@ export const generateChannelHighlights = async ({
         );
 
         if (shouldPublish) {
-          await replaceHighlightsForChannel({
+          await publishHighlightsForChannel({
             manager,
             channel: definition.channel,
             items: internalHighlights,

--- a/src/common/channelHighlight/publish.ts
+++ b/src/common/channelHighlight/publish.ts
@@ -1,7 +1,9 @@
-import type { EntityManager } from 'typeorm';
+import { In, type EntityManager } from 'typeorm';
+import { HighlightsCanonical } from '../../entity/HighlightsCanonical';
 import {
   PostHighlight,
   toPostHighlightSignificance,
+  toPostHighlightSignificanceLabel,
 } from '../../entity/PostHighlight';
 import type { HighlightItem } from './types';
 
@@ -25,7 +27,7 @@ const normalizeHighlightItems = ({
   return [...dedupedItems.values()];
 };
 
-export const replaceHighlightsForChannel = async ({
+const replaceLegacyHighlightsForChannel = async ({
   manager,
   channel,
   items,
@@ -86,4 +88,78 @@ export const replaceHighlightsForChannel = async ({
       });
     }),
   );
+};
+
+const upsertCanonicalHighlights = async ({
+  manager,
+  channel,
+  items,
+}: {
+  manager: EntityManager;
+  channel: string;
+  items: HighlightItem[];
+}): Promise<HighlightsCanonical[]> => {
+  const repo = manager.getRepository(HighlightsCanonical);
+  const nextItems = normalizeHighlightItems({
+    items,
+    retiredPostIds: new Set(),
+  });
+
+  if (!nextItems.length) {
+    return [];
+  }
+
+  const currentByPostId = new Map(
+    (
+      await repo.findBy({
+        postId: In(nextItems.map((item) => item.postId)),
+      })
+    ).map((highlight) => [highlight.postId, highlight]),
+  );
+
+  return repo.save(
+    nextItems.map((item) => {
+      const current = currentByPostId.get(item.postId);
+
+      return repo.create({
+        id: current?.id,
+        postId: item.postId,
+        channels: [...new Set([...(current?.channels || []), channel])].sort(),
+        highlightedAt: item.highlightedAt,
+        headline: item.headline,
+        significance: toPostHighlightSignificance(item.significanceLabel),
+        reason: item.reason,
+      });
+    }),
+  );
+};
+
+export const publishHighlightsForChannel = async ({
+  manager,
+  channel,
+  items,
+}: {
+  manager: EntityManager;
+  channel: string;
+  items: HighlightItem[];
+}): Promise<void> => {
+  const canonicalHighlights = await upsertCanonicalHighlights({
+    manager,
+    channel,
+    items,
+  });
+
+  await replaceLegacyHighlightsForChannel({
+    manager,
+    channel,
+    items: canonicalHighlights.map((highlight) => ({
+      postId: highlight.postId,
+      highlightedAt: highlight.highlightedAt,
+      headline: highlight.headline,
+      significanceLabel: toPostHighlightSignificanceLabel(
+        highlight.significance,
+      ),
+      reason: highlight.reason,
+    })),
+  });
 };

--- a/src/entity/HighlightsCanonical.ts
+++ b/src/entity/HighlightsCanonical.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type { Post } from './posts/Post';
+import { PostHighlightSignificance } from './PostHighlight';
+
+@Entity()
+@Index('UQ_highlights_canonical_post', ['postId'], {
+  unique: true,
+})
+@Index('IDX_highlights_canonical_highlightedAt', ['highlightedAt'])
+@Index('IDX_highlights_canonical_channels', {
+  synchronize: false,
+})
+export class HighlightsCanonical {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  postId: string;
+
+  @Column({ type: 'text', array: true, default: () => `'{}'::text[]` })
+  channels: string[];
+
+  @Column({ type: 'timestamp' })
+  highlightedAt: Date;
+
+  @Column({ type: 'text' })
+  headline: string;
+
+  @Column({
+    type: 'smallint',
+    default: PostHighlightSignificance.Unspecified,
+  })
+  significance: PostHighlightSignificance;
+
+  @Column({ type: 'text', nullable: true })
+  reason: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne('Post', {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  post: Promise<Post>;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -52,6 +52,7 @@ export * from './Quest';
 export * from './QuestReward';
 export * from './QuestRotation';
 export * from './PostHighlight';
+export * from './HighlightsCanonical';
 export * from './ChannelHighlightDefinition';
 export * from './ChannelHighlightRun';
 export * from './Archive';

--- a/src/migration/1779088410388-HighlightsCanonical.ts
+++ b/src/migration/1779088410388-HighlightsCanonical.ts
@@ -1,0 +1,46 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HighlightsCanonical1779088410388 implements MigrationInterface {
+  name = 'HighlightsCanonical1779088410388';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "highlights_canonical" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "postId" text NOT NULL,
+        "channels" text[] NOT NULL DEFAULT '{}'::text[],
+        "highlightedAt" TIMESTAMP NOT NULL,
+        "headline" text NOT NULL,
+        "significance" smallint NOT NULL DEFAULT '0',
+        "reason" text,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_highlights_canonical_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_highlights_canonical_post"
+          FOREIGN KEY ("postId")
+          REFERENCES "post"("id")
+          ON DELETE CASCADE
+          ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_highlights_canonical_post"
+        ON "highlights_canonical" ("postId")
+    `);
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_highlights_canonical_highlightedAt"
+        ON "highlights_canonical" ("highlightedAt")
+    `);
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_highlights_canonical_channels"
+        ON "highlights_canonical" USING GIN ("channels")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP TABLE IF EXISTS "highlights_canonical"
+    `);
+  }
+}


### PR DESCRIPTION
## What
- Add a `highlights_canonical` table/entity for the stage 2 highlights migration.
- Make canonical the primary publish path: each publish first upserts canonical rows, then updates the legacy `post_highlight` table from the saved canonical rows.
- Keep canonical grow-only for now: no `retiredAt`, no stale-row deletion, and existing rows merge in newly published channels.
- Keep legacy `retiredAt` behavior only inside the legacy follower path so current reads keep working during rollout.

## Why
This prepares the read side to move toward canonical highlights while preserving the existing legacy table contract until it can be dropped.

## Validation
- `NODE_ENV=test node_modules/.bin/typeorm-ts-node-commonjs schema:drop -d src/data-source.ts && NODE_ENV=test node_modules/.bin/typeorm-ts-node-commonjs migration:run -d src/data-source.ts`
- `NODE_ENV=test node_modules/.bin/jest __tests__/cron/channelHighlights.ts --testEnvironment=node --runInBand`
- `node_modules/.bin/eslint src/common/channelHighlight/publish.ts src/common/channelHighlight/generate.ts __tests__/cron/channelHighlights.ts --max-warnings 0`
- `git diff --check`

## Known issue
- `node_modules/.bin/tsc --noEmit` still fails on existing `@dailydotdev/schema` persona quiz export/client errors in `src/integrations/bragi/clients.ts` and `src/schema/users.ts`; those are unrelated to this branch.