### PR TITLE
Fix canonical collection highlight dedupe

### DIFF
--- a/__tests__/cron/channelHighlights.ts
+++ b/__tests__/cron/channelHighlights.ts
@@ -576,6 +576,14 @@ describe('channel highlight generation cron', () => {
       significance: PostHighlightSignificance.Major,
       reason: 'existing',
     });
+    await con.getRepository(HighlightsCanonical).save({
+      postId: 'child-upgrade',
+      channels: ['vibes'],
+      highlightedAt: new Date('2026-03-03T11:00:00.000Z'),
+      headline: 'Original child headline',
+      significance: PostHighlightSignificance.Major,
+      reason: 'existing',
+    });
 
     const evaluatorSpy = jest.spyOn(evaluator, 'evaluateChannelHighlights');
 
@@ -602,6 +610,18 @@ describe('channel highlight generation cron', () => {
       postId: 'child-upgrade',
     });
     expect(retiredHighlight?.retiredAt).toBeInstanceOf(Date);
+    const canonicalHighlights = await con
+      .getRepository(HighlightsCanonical)
+      .find();
+    expect(canonicalHighlights).toEqual([
+      expect.objectContaining({
+        postId: 'col-upgrade',
+        channels: ['vibes'],
+        headline: 'Original child headline',
+        significance: PostHighlightSignificance.Major,
+        reason: 'existing',
+      }),
+    ]);
   });
 
   it('should exclude retired highlights from candidates and keep them retired', async () => {

--- a/src/common/channelHighlight/generate.ts
+++ b/src/common/channelHighlight/generate.ts
@@ -593,6 +593,7 @@ export const generateChannelHighlights = async ({
             manager,
             channel: definition.channel,
             items: internalHighlights,
+            relations,
           });
           published = true;
         }

--- a/src/common/channelHighlight/publish.ts
+++ b/src/common/channelHighlight/publish.ts
@@ -5,7 +5,10 @@ import {
   toPostHighlightSignificance,
   toPostHighlightSignificanceLabel,
 } from '../../entity/PostHighlight';
+import type { PostRelation } from '../../entity/posts/PostRelation';
 import type { HighlightItem } from './types';
+
+type HighlightRelation = Pick<PostRelation, 'postId' | 'relatedPostId'>;
 
 const normalizeHighlightItems = ({
   items,
@@ -94,10 +97,12 @@ const upsertCanonicalHighlights = async ({
   manager,
   channel,
   items,
+  relations,
 }: {
   manager: EntityManager;
   channel: string;
   items: HighlightItem[];
+  relations: HighlightRelation[];
 }): Promise<HighlightsCanonical[]> => {
   const repo = manager.getRepository(HighlightsCanonical);
   const nextItems = normalizeHighlightItems({
@@ -109,17 +114,40 @@ const upsertCanonicalHighlights = async ({
     return [];
   }
 
+  const childrenByCollection = new Map<string, string[]>();
+  const collectionByChild = new Map<string, string>();
+  for (const relation of relations) {
+    const children = childrenByCollection.get(relation.postId) || [];
+    children.push(relation.relatedPostId);
+    childrenByCollection.set(relation.postId, children);
+    collectionByChild.set(relation.relatedPostId, relation.postId);
+  }
+  const familyPostIdsByPostId = new Map(
+    nextItems.map((item) => {
+      const collectionId = collectionByChild.get(item.postId) || item.postId;
+
+      return [
+        item.postId,
+        [collectionId, ...(childrenByCollection.get(collectionId) || [])],
+      ];
+    }),
+  );
+  const lookupPostIds = [
+    ...new Set([...familyPostIdsByPostId.values()].flat()),
+  ];
   const currentByPostId = new Map(
     (
       await repo.findBy({
-        postId: In(nextItems.map((item) => item.postId)),
+        postId: In(lookupPostIds),
       })
     ).map((highlight) => [highlight.postId, highlight]),
   );
 
   return repo.save(
     nextItems.map((item) => {
-      const current = currentByPostId.get(item.postId);
+      const current = (familyPostIdsByPostId.get(item.postId) || [item.postId])
+        .map((postId) => currentByPostId.get(postId))
+        .find((highlight): highlight is HighlightsCanonical => !!highlight);
 
       return repo.create({
         id: current?.id,
@@ -138,15 +166,18 @@ export const publishHighlightsForChannel = async ({
   manager,
   channel,
   items,
+  relations = [],
 }: {
   manager: EntityManager;
   channel: string;
   items: HighlightItem[];
+  relations?: HighlightRelation[];
 }): Promise<void> => {
   const canonicalHighlights = await upsertCanonicalHighlights({
     manager,
     channel,
     items,
+    relations,
   });
 
   await replaceLegacyHighlightsForChannel({


### PR DESCRIPTION
## What changed

- Pass collection relation context into highlight publishing so canonical upserts can treat article and collection post IDs as one family.
- Reuse the existing canonical row when a highlighted article is later upgraded to its collection post, updating the canonical `postId` instead of inserting a duplicate row.
- Added cron coverage for the article-to-collection upgrade path.

## Why

The stage 2 canonical highlight path can see the same story under both an article post ID and a generated collection post ID. Without checking the collection family, canonical highlights grow with duplicate rows for the same story.

## Validation

- `NODE_ENV=test npx jest __tests__/cron/channelHighlights.ts --testEnvironment=node --runInBand`
- `npx eslint src/common/channelHighlight/publish.ts src/common/channelHighlight/generate.ts __tests__/cron/channelHighlights.ts --max-warnings 0`
- `git diff --check`
