### PR TITLE
perf: user_notification — covering partial index + 90-day retention

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -198,4 +198,9 @@ export const crons: Cron[] = [
     name: 'materialize-yearly-best-post-archives',
     schedule: '15 0 1 1 *',
   },
+  {
+    name: 'clean-old-notifications',
+    schedule: '13 * * * *',
+    activeDeadlineSeconds: 5 * 60,
+  },
 ];

--- a/src/cron/cleanOldNotifications.ts
+++ b/src/cron/cleanOldNotifications.ts
@@ -1,0 +1,58 @@
+import { subDays } from 'date-fns';
+import { Cron } from './cron';
+import { UserNotification } from '../entity/notifications/UserNotification';
+
+const RETENTION_DAYS = 90;
+const BATCH_SIZE = 5_000;
+const MAX_BATCHES_PER_RUN = 200;
+const MAX_DURATION_MS = 4 * 60 * 1_000;
+
+const cleanOldNotifications: Cron = {
+  name: 'clean-old-notifications',
+  handler: async (con, logger) => {
+    const cutoff = subDays(new Date(), RETENTION_DAYS);
+    const startedAt = Date.now();
+    const repo = con.getRepository(UserNotification);
+
+    let totalDeleted = 0;
+    let batches = 0;
+
+    while (
+      batches < MAX_BATCHES_PER_RUN &&
+      Date.now() - startedAt < MAX_DURATION_MS
+    ) {
+      const result = await repo
+        .createQueryBuilder()
+        .delete()
+        .where(
+          `ctid IN (
+            SELECT ctid FROM "user_notification"
+            WHERE "createdAt" < :cutoff
+            LIMIT :limit
+          )`,
+          { cutoff, limit: BATCH_SIZE },
+        )
+        .execute();
+
+      const deleted = result.affected ?? 0;
+      totalDeleted += deleted;
+      batches += 1;
+
+      if (deleted < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    logger.info(
+      {
+        totalDeleted,
+        batches,
+        durationMs: Date.now() - startedAt,
+        cutoff: cutoff.toISOString(),
+      },
+      'cleaned old user_notification rows',
+    );
+  },
+};
+
+export default cleanOldNotifications;

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -39,6 +39,7 @@ import { cleanChannelHighlights } from './cleanChannelHighlights';
 import updateTagMaterializedViews from './updateTagMaterializedViews';
 import { materializeMonthlyBestPostArchives } from './materializeMonthlyBestPostArchives';
 import { materializeYearlyBestPostArchives } from './materializeYearlyBestPostArchives';
+import cleanOldNotifications from './cleanOldNotifications';
 
 export const crons: Cron[] = [
   updateViews,
@@ -81,4 +82,5 @@ export const crons: Cron[] = [
   updateTagMaterializedViews,
   materializeMonthlyBestPostArchives,
   materializeYearlyBestPostArchives,
+  cleanOldNotifications,
 ];

--- a/src/entity/notifications/UserNotification.ts
+++ b/src/entity/notifications/UserNotification.ts
@@ -17,11 +17,9 @@ import { NotificationV2 } from './NotificationV2';
     where: `"uniqueKey" IS NOT NULL`,
   },
 )
-@Index('IDX_user_notification_userid_public_readat', [
-  'userId',
-  'public',
-  'readAt',
-])
+@Index('IDX_user_notification_unread_visible', ['userId', 'showAt'], {
+  where: `"readAt" IS NULL AND "public" = true`,
+})
 export class UserNotification {
   @PrimaryColumn({ type: 'uuid' })
   notificationId: string;

--- a/src/entity/notifications/UserNotification.ts
+++ b/src/entity/notifications/UserNotification.ts
@@ -3,12 +3,6 @@ import type { User } from '../user';
 import { NotificationV2 } from './NotificationV2';
 
 @Entity()
-@Index('IDX_user_notification_user_id_created_at', [
-  'userId',
-  'public',
-  'createdAt',
-])
-@Index('IDX_user_notification_user_id_read_at', ['userId', 'readAt'])
 @Index(
   'IDX_user_notification_userId_uniqueKey_unique',
   ['userId', 'uniqueKey'],

--- a/src/migration/1779257808707-UserNotificationUnreadVisibleIndex.ts
+++ b/src/migration/1779257808707-UserNotificationUnreadVisibleIndex.ts
@@ -1,0 +1,53 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserNotificationUnreadVisibleIndex1779257808707
+  implements MigrationInterface
+{
+  name = 'UserNotificationUnreadVisibleIndex1779257808707';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_unread_visible"
+      ON "user_notification" (
+        "userId",
+        "showAt"
+      )
+      WHERE "readAt" IS NULL AND "public" = true
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_userid_readat_null"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_userid_public_readat"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_userid_public_readat"
+      ON "user_notification" (
+        "userId",
+        "public",
+        "readAt"
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_userid_readat_null"
+      ON "user_notification" ("userId")
+      WHERE "readAt" IS NULL
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_unread_visible"
+    `);
+  }
+}

--- a/src/migration/1779257808707-UserNotificationUnreadVisibleIndex.ts
+++ b/src/migration/1779257808707-UserNotificationUnreadVisibleIndex.ts
@@ -25,17 +25,47 @@ export class UserNotificationUnreadVisibleIndex1779257808707
       DROP INDEX IF EXISTS
         "IDX_user_notification_userid_public_readat"
     `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_user_id_created_at"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_user_id_created_at_desc_public"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS
+        "IDX_user_notification_user_id_read_at"
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(/* sql */ `
       CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_user_id_read_at"
+      ON "user_notification" ("userId", "readAt")
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_user_id_created_at_desc_public"
+      ON "user_notification" ("userId", "public", "createdAt" DESC)
+      WHERE "public" = true
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
+        "IDX_user_notification_user_id_created_at"
+      ON "user_notification" ("userId", "public", "createdAt")
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS
         "IDX_user_notification_userid_public_readat"
-      ON "user_notification" (
-        "userId",
-        "public",
-        "readAt"
-      )
+      ON "user_notification" ("userId", "public", "readAt")
     `);
 
     await queryRunner.query(/* sql */ `


### PR DESCRIPTION
## Summary
Three changes targeting the read-replica overload caused by the unread-notification count query:

### 1. Replace unread indexes with a covering partial
Drop `IDX_user_notification_userid_public_readat` (2.7 GB) and `IDX_user_notification_userid_readat_null` (1.6 GB). Add `IDX_user_notification_unread_visible` (1.05 GB) — partial on `(userId, showAt) WHERE readAt IS NULL AND public = true`.

- The `unreadNotificationsCount` query is the top consumer of read-replica time (~58% of total exec time, ~794k calls/day, mean 2.87 ms, **max 65 s** tail).
- New shape includes `showAt` in the leaf so the visibility filter (`showAt IS NULL OR showAt <= NOW()`) is evaluated from the index without heap fetches.
- Partial `WHERE` keeps the index small — `public = true` covers 99.94% of unread rows.
- Verified post-apply: planner picks the new index via `Bitmap Index Scan on IDX_user_notification_unread_visible` for both branches of the showAt OR.

### 2. Drop 3 fully unused indexes
- `IDX_user_notification_user_id_created_at` (19 GB)
- `IDX_user_notification_user_id_created_at_desc_public` (14 GB)
- `IDX_user_notification_user_id_read_at` (13 GB)

All three had **zero `idx_scan`** over a 142-day `pg_stat` window on both primary and replica, superseded by `IDX_user_notification_user_id_created_at_desc` and the new `unread_visible` partial.

Net effect of (1) + (2): **`user_notification` indexes 107 GB → 58 GB** (−49 GB). Reduces WAL volume on every notification write and cuts the index working set the replica has to keep hot.

### 3. 90-day retention cron
Add `clean-old-notifications` hourly cron that deletes `user_notification` rows older than 90 days.

- Batches of 5k rows, capped at 1M rows or 4 minutes wall time per run.
- Bounds are a safety net — in steady state each run trims the rows that crossed the threshold in the past hour and exits early after 1–2 batches.
- Reduces table bloat (~209M rows / 22 GB heap today, median age ~15 months).

**Apply order:** All index creates/drops have already been applied on prod primary with `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY`. The migration uses `IF NOT EXISTS` / `IF EXISTS` so it's a safe no-op against the already-mutated prod schema and still works on fresh DBs (local/CI/staging).

**Initial backlog:** rows older than 90 days at first cron run will be cleared manually before the cron is enabled, so the cron itself never has to chew through the historic mass.

## Test plan
- [x] `EXPLAIN ANALYZE` of `getUnreadNotificationsCount` on prod replica shows planner picks `IDX_user_notification_unread_visible`
- [ ] Mean exec time on the top `pg_stat_statements` entry drops vs. baseline (2.87 ms)
- [ ] Tail (max exec time) drops vs. baseline (65 s)
- [ ] Migration runs cleanly on a fresh test DB (`db:migrate:latest`)
- [ ] `pnpm run cli cron clean-old-notifications` runs locally without errors
- [ ] After manual cleanup of historic rows, hourly cron logs show small batch counts and quick exit