### PR TITLE
feat(keywords): allow setting title via allowKeyword mutation

### DIFF
--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -192,8 +192,8 @@ describe('query keyword', () => {
 
 describe('mutation allowKeyword', () => {
   const MUTATION = `
-  mutation AllowKeyword($keyword: String!) {
-    allowKeyword(keyword: $keyword) {
+  mutation AllowKeyword($keyword: String!, $title: String) {
+    allowKeyword(keyword: $keyword, title: $title) {
       _
     }
   }`;
@@ -231,6 +231,65 @@ describe('mutation allowKeyword', () => {
       order: { value: 'ASC' },
     });
     expect(keywords).toMatchSnapshot();
+  });
+
+  it('should persist title to flags when provided', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: { keyword: 'ai-coding', title: 'AI Coding' },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'ai-coding' });
+    expect(keyword?.status).toEqual('allow');
+    expect(keyword?.flags).toEqual({ title: 'AI Coding' });
+  });
+
+  it('should merge title into existing flags without overwriting other keys', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'llm',
+      occurrences: 20,
+      flags: { description: 'Large language model', onboarding: true },
+    });
+    const res = await client.mutate(MUTATION, {
+      variables: { keyword: 'llm', title: 'LLM' },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'llm' });
+    expect(keyword?.status).toEqual('allow');
+    expect(keyword?.flags).toEqual({
+      title: 'LLM',
+      description: 'Large language model',
+      onboarding: true,
+    });
+  });
+
+  it('should leave existing flags untouched when title is omitted', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'rust',
+      occurrences: 20,
+      flags: { title: 'Rust', description: 'A systems language' },
+    });
+    const res = await client.mutate(MUTATION, {
+      variables: { keyword: 'rust' },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'rust' });
+    expect(keyword?.status).toEqual('allow');
+    expect(keyword?.flags).toEqual({
+      title: 'Rust',
+      description: 'A systems language',
+    });
   });
 });
 

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -10,6 +10,7 @@ import graphorm from '../graphorm';
 import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
 import { GQLEmptyResponse } from './common';
 import { MoreThanOrEqual } from 'typeorm';
+import { updateFlagsStatement } from '../common/utils';
 
 export interface GQLKeyword {
   value: string;
@@ -27,6 +28,10 @@ interface GQLKeywordSearchResults {
 
 interface GQLKeywordArgs {
   keyword: string;
+}
+
+interface GQLAllowKeywordArgs extends GQLKeywordArgs {
+  title?: string;
 }
 
 interface GQLSynonymKeywordArgs {
@@ -120,7 +125,8 @@ export const typeDefs = /* GraphQL */ `
     """
     Add keyword to the allowlist
     """
-    allowKeyword(keyword: String!): EmptyResponse @auth(requires: [MODERATOR])
+    allowKeyword(keyword: String!, title: String): EmptyResponse
+      @auth(requires: [MODERATOR])
     """
     Add keyword to the denylist
     """
@@ -228,14 +234,21 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
   Mutation: {
     allowKeyword: async (
       source,
-      { keyword }: GQLKeywordArgs,
+      { keyword, title }: GQLAllowKeywordArgs,
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
-        await entityManager.getRepository(Keyword).save({
+        const repo = entityManager.getRepository(Keyword);
+        await repo.save({
           value: keyword,
           status: KeywordStatus.Allow,
         });
+        if (title) {
+          await repo.update(
+            { value: keyword },
+            { flags: updateFlagsStatement<Keyword>({ title }) },
+          );
+        }
       });
       return { _: true };
     },

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -30,10 +30,6 @@ interface GQLKeywordArgs {
   keyword: string;
 }
 
-interface GQLAllowKeywordArgs extends GQLKeywordArgs {
-  title?: string;
-}
-
 interface GQLSynonymKeywordArgs {
   keywordToUpdate: string;
   originalKeyword: string;
@@ -234,7 +230,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
   Mutation: {
     allowKeyword: async (
       source,
-      { keyword, title }: GQLAllowKeywordArgs,
+      { keyword, title }: GQLKeywordArgs & { title?: string },
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {


### PR DESCRIPTION
## Summary

Adds an optional `title` argument to the `allowKeyword` GraphQL mutation so moderators (and the keyword-review cronjob/Smith) can persist a human-readable title at approval time without a direct DB write.

```graphql
allowKeyword(keyword: String!, title: String): EmptyResponse @auth(requires: [MODERATOR])
```

When `title` is provided, it is merged into `keyword.flags` atomically using the existing `updateFlagsStatement` JSONB helper. Other flag keys (e.g. `description`, `onboarding`) are preserved. When `title` is omitted, behavior is unchanged.

## Key decisions

- **JSONB merge over overwrite**: used `flags || '{...}'` (via `updateFlagsStatement<Keyword>`) so we don't clobber existing flag keys when a moderator only wants to set the title.
- **Two-step inside one transaction**: keep the existing `repo.save(...)` upsert for `value`/`status`, then conditionally update `flags` — this lets the JSONB merge target an existing row regardless of whether the keyword was just created or already existed.
- **No new exported type**: per `daily-api/CLAUDE.md` (prefer `type` over `interface`, inline single-use types), the title arg is inlined as `GQLKeywordArgs & { title?: string }` rather than introducing a new named type.

## Test plan

- [x] `pnpm run lint` clean on impacted files
- [x] `pnpm run build` (tsc) clean
- [x] `__tests__/keywords.ts` — 25/25 pass, including 3 new cases:
  - persists title to flags when provided
  - merges title into existing flags without overwriting other keys
  - leaves existing flags untouched when title is omitted

Closes ENG-1470

---
Created by Huginn 🐦‍⬛