### PR TITLE
chore: sync highlights_canonical to clickhouse

### DIFF
--- a/.infra/clickhouse-sync.yml
+++ b/.infra/clickhouse-sync.yml
@@ -25,7 +25,7 @@ schema.include.list: "public"
 plugin.name: "pgoutput"
 
 # table.include.list: An optional list of regular expressions that match fully-qualified table identifiers for tables to be monitored;
-table.include.list: "public.post,public.source,public.keyword,public.user,public.content_preference,public.post_keyword,public.comment,public.campaign,public.post_relation,public.user_personalized_digest,public.user_company,public.post_highlight"
+table.include.list: "public.post,public.source,public.keyword,public.user,public.content_preference,public.post_keyword,public.comment,public.campaign,public.post_relation,public.user_personalized_digest,public.user_company,public.post_highlight,public.highlights_canonical"
 
 column.exclude.list: "public\\.user\\.(email|name)"
 


### PR DESCRIPTION
## Summary
- Add `public.highlights_canonical` to the Debezium `table.include.list` so it is replicated from Postgres to ClickHouse.

## Test plan
- [ ] Verify connector picks up the new table after deploy and rows appear in ClickHouse.