### PR TITLE
feat: send highlight context to bragi

### DIFF
--- a/__tests__/cron/channelHighlights.ts
+++ b/__tests__/cron/channelHighlights.ts
@@ -41,6 +41,7 @@ const saveArticle = async ({
   channels = [channel],
   sourceId = 'content-source',
   contentCuration = [] as string[],
+  summary,
 }: {
   id: string;
   title: string;
@@ -51,11 +52,13 @@ const saveArticle = async ({
   channels?: string[];
   sourceId?: string;
   contentCuration?: string[];
+  summary?: string;
 }) =>
   con.getRepository(ArticlePost).save({
     id,
     shortId: id,
     title,
+    summary,
     url: `https://example.com/${id}`,
     canonicalUrl: `https://example.com/${id}`,
     score: 0,
@@ -250,6 +253,7 @@ describe('channel highlight generation cron', () => {
     await saveArticle({
       id: 'live-1',
       title: 'Live story',
+      summary: 'Live story summary',
       createdAt: new Date('2026-03-03T08:00:00.000Z'),
     });
     await saveArticle({
@@ -288,6 +292,7 @@ describe('channel highlight generation cron', () => {
       expect.objectContaining({
         postId: 'live-1',
         headline: 'Live headline',
+        summary: 'Live story summary',
       }),
     ]);
     expect(evaluatorSpy.mock.calls[0][0].newCandidates).toEqual([

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@connectrpc/connect-fastify": "1.6.1",
     "@connectrpc/connect-node": "1.6.1",
     "@dailydotdev/graphql-redis-subscriptions": "2.4.3",
-    "@dailydotdev/schema": "0.3.8",
+    "@dailydotdev/schema": "0.3.9",
     "@dailydotdev/ts-ioredis-pool": "1.0.2",
     "@fastify/cookie": "11.0.2",
     "@fastify/cors": "11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 2.4.3
         version: 2.4.3(graphql-subscriptions@3.0.0(graphql@16.12.0))
       '@dailydotdev/schema':
-        specifier: 0.3.8
-        version: 0.3.8(@bufbuild/protobuf@1.10.0)
+        specifier: 0.3.9
+        version: 0.3.9(@bufbuild/protobuf@1.10.0)
       '@dailydotdev/ts-ioredis-pool':
         specifier: 1.0.2
         version: 1.0.2
@@ -879,8 +879,8 @@ packages:
     peerDependencies:
       graphql-subscriptions: ^1.0.0 || ^2.0.0
 
-  '@dailydotdev/schema@0.3.8':
-    resolution: {integrity: sha512-gpgTzF916iuENtSguYYv7Sdz4O6stKfuPwCsJ22/Tbd9LpBGlTSBulHAB++p66bWjIuci+zO/ZQlMZ/YS0f21A==}
+  '@dailydotdev/schema@0.3.9':
+    resolution: {integrity: sha512-GJY05je6coMhUGcSe9Ngb7YAOapCGrZqhnYqZfUNyhyBX37wsPJ2C5oRlycpC0tX44PBVf7ZZyfh1ZxueKMbJw==}
     peerDependencies:
       '@bufbuild/protobuf': 1.x
 
@@ -6229,7 +6229,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dailydotdev/schema@0.3.8(@bufbuild/protobuf@1.10.0)':
+  '@dailydotdev/schema@0.3.9(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 

--- a/src/common/channelHighlight/evaluate.ts
+++ b/src/common/channelHighlight/evaluate.ts
@@ -68,6 +68,8 @@ const toCurrentHighlight = (item: HighlightItem): ChannelHighlightCurrentItem =>
   new ChannelHighlightCurrentItem({
     postId: item.postId,
     headline: item.headline,
+    summary: item.summary || undefined,
+    reason: item.reason || undefined,
     highlightedAt: toTimestamp(item.highlightedAt),
     significance: toProtoSignificance(item.significanceLabel),
   });

--- a/src/common/channelHighlight/generate.ts
+++ b/src/common/channelHighlight/generate.ts
@@ -538,6 +538,7 @@ export const generateChannelHighlights = async ({
           ).items.map<HighlightItem>((item) => ({
             postId: item.postId,
             headline: item.headline,
+            summary: null,
             highlightedAt: now,
             significanceLabel: item.significanceLabel,
             reason: item.reason,

--- a/src/common/channelHighlight/publish.ts
+++ b/src/common/channelHighlight/publish.ts
@@ -187,6 +187,7 @@ export const publishHighlightsForChannel = async ({
       postId: highlight.postId,
       highlightedAt: highlight.highlightedAt,
       headline: highlight.headline,
+      summary: null,
       significanceLabel: toPostHighlightSignificanceLabel(
         highlight.significance,
       ),

--- a/src/common/channelHighlight/stories.ts
+++ b/src/common/channelHighlight/stories.ts
@@ -196,6 +196,7 @@ export const toHighlightItem = (
 ): HighlightItem => ({
   postId: item.postId,
   headline: item.headline,
+  summary: null,
   highlightedAt: item.highlightedAt,
   significanceLabel: toPostHighlightSignificanceLabel(item.significance),
   reason: item.reason,
@@ -256,6 +257,7 @@ export const canonicalizeCurrentHighlights = ({
     canonicalHighlights.set(canonicalPostId, {
       postId: canonicalPostId,
       headline: highlight.headline,
+      summary: canonicalPost.summary || highlight.summary,
       highlightedAt: highlight.highlightedAt,
       significanceLabel: highlight.significanceLabel,
       reason: highlight.reason,

--- a/src/common/channelHighlight/types.ts
+++ b/src/common/channelHighlight/types.ts
@@ -63,6 +63,7 @@ export type CurrentHighlight = {
 export type HighlightItem = {
   postId: string;
   headline: string;
+  summary: string | null;
   highlightedAt: Date;
   significanceLabel: string | null;
   reason: string | null;


### PR DESCRIPTION
## What changed
- Bump `@dailydotdev/schema` to `0.3.9` for the new Bragi highlight current-item fields.
- Carry current highlight post summaries through canonicalization and send `summary` / `reason` to Bragi.
- Cover the evaluator request shape in the channel highlight cron test.

## Why
Bragi was deduping story-level follow-ups with only generated highlight headlines for existing highlights. Sending the post summary and prior editorial reason gives it enough context to reject same-story candidates without giving Bragi control over which existing rows retire.

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `NODE_ENV=test npx jest __tests__/cron/channelHighlights.ts --testEnvironment=node --runInBand`
