### PR TITLE
feat(public-api): attach userId/tokenId to spans for observability

### DIFF
--- a/src/routes/public/index.ts
+++ b/src/routes/public/index.ts
@@ -16,6 +16,10 @@ import tagsRoutes from './tags';
 import recommendRoutes from './recommend';
 import { commonSchemas } from './schemas';
 import { PUBLIC_API_PREFIX } from '../../common/constants';
+import {
+  SEMATTRS_DAILY_PUBLIC_API_USER_ID,
+  SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID,
+} from '../../telemetry/common';
 
 export { PUBLIC_API_PREFIX };
 const USER_RATE_LIMIT_PER_MINUTE = 60;
@@ -61,8 +65,8 @@ const tokenAuthHook = async (
   // per user/token in tracing (SignOz). Used for abuse detection and per-user
   // observability without re-querying the PAT table.
   request.opentelemetry().span?.setAttributes({
-    'daily.api_user_id': result.userId,
-    'daily.api_token_id': result.tokenId,
+    [SEMATTRS_DAILY_PUBLIC_API_USER_ID]: result.userId,
+    [SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID]: result.tokenId,
   });
 };
 

--- a/src/routes/public/index.ts
+++ b/src/routes/public/index.ts
@@ -17,7 +17,7 @@ import recommendRoutes from './recommend';
 import { commonSchemas } from './schemas';
 import { PUBLIC_API_PREFIX } from '../../common/constants';
 import {
-  SEMATTRS_DAILY_PUBLIC_API_USER_ID,
+  SEMATTRS_DAILY_APPS_USER_ID,
   SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID,
 } from '../../telemetry/common';
 
@@ -65,7 +65,7 @@ const tokenAuthHook = async (
   // per user/token in tracing (SignOz). Used for abuse detection and per-user
   // observability without re-querying the PAT table.
   request.opentelemetry().span?.setAttributes({
-    [SEMATTRS_DAILY_PUBLIC_API_USER_ID]: result.userId,
+    [SEMATTRS_DAILY_APPS_USER_ID]: result.userId,
     [SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID]: result.tokenId,
   });
 };

--- a/src/routes/public/index.ts
+++ b/src/routes/public/index.ts
@@ -56,6 +56,14 @@ const tokenAuthHook = async (
   // Also set userId for GraphQL injection compatibility
   request.userId = result.userId;
   request.isPlus = true;
+
+  // Attach identity to the active span so /public/v1 traffic is attributable
+  // per user/token in tracing (SignOz). Used for abuse detection and per-user
+  // observability without re-querying the PAT table.
+  request.opentelemetry().span?.setAttributes({
+    'daily.api_user_id': result.userId,
+    'daily.api_token_id': result.tokenId,
+  });
 };
 
 export default async function (

--- a/src/telemetry/common.ts
+++ b/src/telemetry/common.ts
@@ -25,6 +25,8 @@ export const getAppVersion = (req: AppVersionRequest): string => {
 export const SEMATTRS_DAILY_STAFF = 'dailydev.staff';
 export const SEMATTRS_DAILY_APPS_VERSION = 'dailydev.apps.version';
 export const SEMATTRS_DAILY_APPS_USER_ID = 'dailydev.apps.userId';
+export const SEMATTRS_DAILY_PUBLIC_API_USER_ID = 'dailydev.publicApi.userId';
+export const SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID = 'dailydev.publicApi.tokenId';
 
 export type CounterOptions = { name: string } & MetricOptions;
 

--- a/src/telemetry/common.ts
+++ b/src/telemetry/common.ts
@@ -25,7 +25,6 @@ export const getAppVersion = (req: AppVersionRequest): string => {
 export const SEMATTRS_DAILY_STAFF = 'dailydev.staff';
 export const SEMATTRS_DAILY_APPS_VERSION = 'dailydev.apps.version';
 export const SEMATTRS_DAILY_APPS_USER_ID = 'dailydev.apps.userId';
-export const SEMATTRS_DAILY_PUBLIC_API_USER_ID = 'dailydev.publicApi.userId';
 export const SEMATTRS_DAILY_PUBLIC_API_TOKEN_ID = 'dailydev.publicApi.tokenId';
 
 export type CounterOptions = { name: string } & MetricOptions;


### PR DESCRIPTION
## What

Adds two attributes to the OpenTelemetry span for every authenticated `/public/v1` request:

- `dailydev.apps.userId` — the userId of the PAT owner (reuses existing constant `SEMATTRS_DAILY_APPS_USER_ID`)
- `dailydev.publicApi.tokenId` — the PAT's UUID

Constants exported from `src/telemetry/common.ts` to match the existing `SEMATTRS_DAILY_*` / `dailydev.<scope>.<field>` convention used by `dailydev.apps.userId`, `dailydev.apps.version`, and `dailydev.staff`.

## Why

Today `/public/v1` spans only carry `http.route`, `response_status_code`, and `client.address`. We can see *which IP* and *which route* but not *which user*. This makes abuse detection and per-user observability painful — to attribute traffic we have to join SignOz traces back to the `personal_access_token` table.

This is especially relevant during the [daily.dev hackathon](https://app.daily.dev/hackathon) where participants are actively hammering the API and we want hourly visibility into:
- which users are dominant consumers
- which users are hitting 429s
- whether abuse is coming from a specific token (so we can revoke)

## How

One `span.setAttributes` call right after PAT validation succeeds in `tokenAuthHook` (`src/routes/public/index.ts`). Uses the existing `request.opentelemetry().span` accessor — same pattern as `Context.ts` and `src/routes/boot.ts`.

## Privacy

No PII added. Only the user UUID and token UUID are recorded. The token itself is **never** logged (only its hash is stored server-side anyway).

## Verification

After deploy, in SignOz, group traces by `dailydev.apps.userId` or filter by it.
