### PR TITLE
fix: send canonical history summaries to bragi

### DIFF
--- a/__tests__/cron/channelHighlights.ts
+++ b/__tests__/cron/channelHighlights.ts
@@ -179,12 +179,22 @@ describe('channel highlight generation cron', () => {
       .delete()
       .from('post')
       .where('"sourceId" IN (:...sourceIds)', {
-        sourceIds: ['content-source', 'secondary-source', AGENTS_DIGEST_SOURCE],
+        sourceIds: [
+          'content-source',
+          'secondary-source',
+          AGENTS_DIGEST_SOURCE,
+          UNKNOWN_SOURCE,
+        ],
       })
       .execute();
     await con
       .getRepository(Source)
-      .delete(['content-source', 'secondary-source', AGENTS_DIGEST_SOURCE]);
+      .delete([
+        'content-source',
+        'secondary-source',
+        AGENTS_DIGEST_SOURCE,
+        UNKNOWN_SOURCE,
+      ]);
   });
 
   it('should be registered', () => {
@@ -453,6 +463,68 @@ describe('channel highlight generation cron', () => {
         }),
       ]),
     );
+  });
+
+  it('should send underlying post summary for canonical share fallback history', async () => {
+    const now = new Date('2026-03-03T10:30:00.000Z');
+    await con.getRepository(ChannelHighlightDefinition).save({
+      channel: 'vibes',
+      mode: 'shadow',
+      candidateHorizonHours: 72,
+      maxItems: 3,
+    });
+    await con
+      .getRepository(Source)
+      .save(
+        createSource(
+          UNKNOWN_SOURCE,
+          'Unknown',
+          'https://daily.dev/unknown.png',
+          undefined,
+          true,
+        ),
+      );
+    await saveArticle({
+      id: 'unk-under-1',
+      sourceId: UNKNOWN_SOURCE,
+      title: 'Unknown source story',
+      summary: 'Underlying story summary',
+      createdAt: new Date('2026-03-03T08:30:00.000Z'),
+    });
+    await saveShare({
+      id: 'pub-share-h',
+      sharedPostId: 'unk-under-1',
+      createdAt: new Date('2026-03-03T08:35:00.000Z'),
+    });
+    await saveArticle({
+      id: 'fresh-1',
+      title: 'Fresh story',
+      createdAt: new Date('2026-03-03T10:20:00.000Z'),
+    });
+    await con.getRepository(HighlightsCanonical).save({
+      postId: 'pub-share-h',
+      channels: ['vibes'],
+      highlightedAt: new Date('2026-03-03T09:10:00.000Z'),
+      headline: 'Canonical share headline',
+      significance: PostHighlightSignificance.Major,
+      reason: 'canonical history',
+    });
+
+    const evaluatorSpy = jest
+      .spyOn(evaluator, 'evaluateHighlights')
+      .mockResolvedValue({ items: [] });
+
+    await runChannelHighlights({ con, now });
+
+    expect(evaluatorSpy).toHaveBeenCalledTimes(1);
+    expect(evaluatorSpy.mock.calls[0][0].currentHighlights).toEqual([
+      expect.objectContaining({
+        postId: 'pub-share-h',
+        headline: 'Canonical share headline',
+        summary: 'Underlying story summary',
+        reason: 'canonical history',
+      }),
+    ]);
   });
 
   it('should publish admitted highlights in publish mode and trim FIFO by maxItems', async () => {

--- a/src/common/channelHighlight/stories.ts
+++ b/src/common/channelHighlight/stories.ts
@@ -87,6 +87,17 @@ const groupPostsByCanonicalPostId = ({
   return groupedPosts;
 };
 
+const getPostSummary = ({
+  post,
+  postsById,
+}: {
+  post: HighlightPost;
+  postsById: Map<string, HighlightPost>;
+}): string | null =>
+  post.summary ||
+  (post.sharedPostId && postsById.get(post.sharedPostId)?.summary) ||
+  null;
+
 const buildCandidate = ({
   canonicalPostId,
   memberPosts,
@@ -238,7 +249,11 @@ export const canonicalizeCurrentHighlights = ({
     canonicalHighlights.set(canonicalPostId, {
       postId: canonicalPostId,
       headline: highlight.headline,
-      summary: canonicalPost.summary || highlight.summary,
+      summary:
+        getPostSummary({
+          post: canonicalPost,
+          postsById,
+        }) || highlight.summary,
       highlightedAt: highlight.highlightedAt,
       significanceLabel: highlight.significanceLabel,
       reason: highlight.reason,


### PR DESCRIPTION
## What changed
- Populate canonical history summaries from the backing post before sending current highlights to Bragi.
- For canonical rows stored on public share fallbacks, use the underlying shared post summary.
- Add regression coverage for canonical history stored on a fallback share over an unknown-source post.

## Why
Bragi's second-pass dedup can compare candidate summaries against current highlight summaries, but canonical history rows backed by share fallbacks were reaching Bragi without the underlying post summary. This made semantic duplicate detection weaker for cases like repeated coverage of the same model launch.

## Validation
- `NODE_ENV=test npx jest __tests__/cron/channelHighlights.ts --testEnvironment=node --runInBand`
