### PR TITLE
fix: ensure only verified github emails

### DIFF
--- a/__tests__/routes/betterAuth.ts
+++ b/__tests__/routes/betterAuth.ts
@@ -146,7 +146,7 @@ describe('betterAuth routes', () => {
               body: {},
             },
           ),
-        ).rejects.toMatchObject({ message: 'github_email_not_verified' });
+        ).rejects.toThrow('github_email_not_verified');
       });
 
       it('should allow GitHub OAuth sign-ups when email is verified', async () => {

--- a/__tests__/routes/betterAuth.ts
+++ b/__tests__/routes/betterAuth.ts
@@ -129,6 +129,66 @@ describe('betterAuth routes', () => {
         return before;
       };
 
+      it('should reject GitHub OAuth sign-ups when email is not verified', async () => {
+        const before = await getBeforeHook();
+
+        await expect(
+          before(
+            {
+              email: 'unverified@github.example',
+              name: 'Unverified GitHub User',
+              emailVerified: false,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+            {
+              request: new Request('http://localhost/auth/callback/github'),
+              body: {},
+            },
+          ),
+        ).rejects.toMatchObject({ message: 'github_email_not_verified' });
+      });
+
+      it('should allow GitHub OAuth sign-ups when email is verified', async () => {
+        const before = await getBeforeHook();
+
+        const result = await before(
+          {
+            email: 'verified@github.example',
+            name: 'Verified GitHub User',
+            emailVerified: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            request: new Request('http://localhost/auth/callback/github'),
+            body: {},
+          },
+        );
+
+        expect((result as { data: { id: string } }).data.id).toBeDefined();
+      });
+
+      it('should not reject email/password sign-ups when email is unverified', async () => {
+        const before = await getBeforeHook();
+
+        const result = await before(
+          {
+            email: 'pending@example.com',
+            name: 'Pending User',
+            emailVerified: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            request: new Request('http://localhost/auth/sign-up/email'),
+            body: {},
+          },
+        );
+
+        expect((result as { data: { id: string } }).data.id).toBeDefined();
+      });
+
       it('should regenerate id when tracking cookie matches a deleted user', async () => {
         const before = await getBeforeHook();
         const deletedUserId = 'aBcDeFgHiJkLmNoPqRsTu';

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -1,5 +1,5 @@
-import { APIError, betterAuth, type BetterAuthOptions } from 'better-auth';
-import { createAuthMiddleware, getOAuthState } from 'better-auth/api';
+import { betterAuth, type BetterAuthOptions } from 'better-auth';
+import { APIError, createAuthMiddleware, getOAuthState } from 'better-auth/api';
 import { captcha, emailOTP } from 'better-auth/plugins';
 import type { Pool } from 'pg';
 import * as argon2 from 'argon2';
@@ -548,7 +548,9 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
               requestPath.endsWith('/callback/github') &&
               user.emailVerified === false
             ) {
-              throwBadRequest('github_email_not_verified');
+              const err = new Error('github_email_not_verified');
+              err.name = 'APIError';
+              throw err;
             }
 
             const resolved = await resolveSignUpUserId(pool, user, ctx);

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -540,6 +540,17 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
       user: {
         create: {
           before: async (user, ctx) => {
+            const hookCtx = ctx as BetterAuthDbHookContext;
+            const requestPath = hookCtx?.request?.url
+              ? new URL(hookCtx.request.url).pathname
+              : '';
+            if (
+              requestPath.endsWith('/callback/github') &&
+              user.emailVerified === false
+            ) {
+              throwBadRequest('github_email_not_verified');
+            }
+
             const resolved = await resolveSignUpUserId(pool, user, ctx);
             resolved.data.id = await ensureNonDeletedUserId(
               pool,

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -1,5 +1,5 @@
-import { betterAuth, type BetterAuthOptions } from 'better-auth';
-import { APIError, createAuthMiddleware, getOAuthState } from 'better-auth/api';
+import { APIError, betterAuth, type BetterAuthOptions } from 'better-auth';
+import { createAuthMiddleware, getOAuthState } from 'better-auth/api';
 import { captcha, emailOTP } from 'better-auth/plugins';
 import type { Pool } from 'pg';
 import * as argon2 from 'argon2';


### PR DESCRIPTION
Apparently one can set unverified github email (I couldn't reproduce what user managed to do myself)
But output is something like this:
```
github oauth debug: raw responses
      githubProfile: {
        "login": "rebelchris",
        "id": 554874,
        "node_id": "MDQ6VXNlcjU1NDg3NA==",
        "avatar_url": "https://avatars.githubusercontent.com/u/554874?v=4",
        "gravatar_id": "",
        "url": "https://api.github.com/users/rebelchris",
        "html_url": "https://github.com/rebelchris",
        "followers_url": "https://api.github.com/users/rebelchris/followers",
        "following_url": "https://api.github.com/users/rebelchris/following{/other_user}",
        "gists_url": "https://api.github.com/users/rebelchris/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/rebelchris/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/rebelchris/subscriptions",
        "organizations_url": "https://api.github.com/users/rebelchris/orgs",
        "repos_url": "https://api.github.com/users/rebelchris/repos",
        "events_url": "https://api.github.com/users/rebelchris/events{/privacy}",
        "received_events_url": "https://api.github.com/users/rebelchris/received_events",
        "type": "User",
        "user_view_type": "public",
        "site_admin": false,
        "name": "Chris Bongers",
        "company": "daily.dev",
        "blog": "https://daily-dev-tips.com",
        "location": "Cape Town",
        "email": "chrisbongers@gmail.com",
        "hireable": null,
        "bio": "Developer, wide range of languages but ❤️JavaScript.",
        "twitter_username": "DailyDevTips1",
        "notification_email": "chrisbongers@gmail.com",
        "public_repos": 131,
        "public_gists": 35,
        "followers": 876,
        "following": 446,
        "created_at": "2011-01-10T01:27:55Z",
        "updated_at": "2026-03-02T11:24:01Z"
      }
      githubEmails: [
        {
          "email": "chris_bongers@hotmail.com",
          "primary": false,
          "verified": true,
          "visibility": null
        },
        {
          "email": "chrisbongers@gmail.com",
          "primary": true,
          "verified": true,
          "visibility": "public"
        }
      ]
      profileStatus: 200
      emailsStatus: 200
```

So for primary one we now check verified status (ba apparently does it underwater to link to user.emailVerified)
I couldn't reproduce the original issue so can't 100% guarantee it.