### PR TITLE
feat: add niche + keyword_niche tables for feed diversification

### DIFF
--- a/src/entity/KeywordNiche.ts
+++ b/src/entity/KeywordNiche.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Mapping from a keyword (tag) to its niche assignment(s).
+ *
+ * Each tag maps to a single primary niche and optionally a secondary niche.
+ * The diversifier derives a post's niche(s) from the niches of its tags via
+ * weighted vote (see docs/feed-niche-taxonomy.md for the derivation rules).
+ *
+ *  - weightMultiplier  per-tag dampening factor (e.g. 0.3 for very generic
+ *                     tags like "programming"), default 1.0
+ *  - confidence       1=guess, 2=likely, 3=clear — used to prioritize audits
+ *  - labelerVersion   identifier of the labeler/taxonomy version that
+ *                     produced this row, so we can re-label deltas later
+ */
+@Entity()
+export class KeywordNiche {
+  @PrimaryColumn({ type: 'text' })
+  keyword: string;
+
+  @Column({ type: 'text' })
+  @Index('IDX_keyword_niche_primary')
+  primaryNicheId: string;
+
+  @Column({ type: 'text', nullable: true })
+  @Index('IDX_keyword_niche_secondary')
+  secondaryNicheId?: string | null;
+
+  @Column({ type: 'real', default: 1 })
+  weightMultiplier: number;
+
+  @Column({ type: 'smallint', default: 2 })
+  confidence: number;
+
+  @Column({ type: 'text', nullable: true })
+  labelerVersion?: string | null;
+
+  @Column({ default: () => 'now()' })
+  labeledAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/entity/KeywordNiche.ts
+++ b/src/entity/KeywordNiche.ts
@@ -10,7 +10,7 @@ import {
  * Mapping from a keyword (tag) to its niche assignment(s).
  *
  * Each tag maps to a single primary niche and optionally a secondary niche.
- * The diversifier derives a post's niche(s) from the niches of its tags via
+ * The diversifier derives a post's niches from the niches of its tags via
  * weighted vote (see docs/feed-niche-taxonomy.md for the derivation rules).
  *
  *  - weightMultiplier  per-tag dampening factor (e.g. 0.3 for very generic
@@ -24,11 +24,11 @@ export class KeywordNiche {
   @PrimaryColumn({ type: 'text' })
   keyword: string;
 
-  @Column({ type: 'text' })
+  @Column({ type: 'uuid' })
   @Index('IDX_keyword_niche_primary')
   primaryNicheId: string;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'uuid', nullable: true })
   @Index('IDX_keyword_niche_secondary')
   secondaryNicheId?: string | null;
 

--- a/src/entity/Niche.ts
+++ b/src/entity/Niche.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 export enum NicheBucketGroup {
   Ecosystem = 'ecosystem',
@@ -13,11 +19,20 @@ export enum NicheBucketGroup {
  * repetition. Niches split into two groups:
  *  - ecosystem  — stack identity (e.g. js_ts, rust, python)
  *  - theme      — cross-stack topics (e.g. ai_llm, sec_threats, cloud)
+ *
+ * `slug` is a stable human-readable identifier (e.g. "js_ts") used by the
+ * labeling pipeline and brain doc; `id` is a UUID for foreign keys.
  */
 @Entity()
 export class Niche {
-  @PrimaryColumn({ type: 'text' })
+  @PrimaryGeneratedColumn('uuid', {
+    primaryKeyConstraintName: 'PK_niche_id',
+  })
   id: string;
+
+  @Column({ type: 'text' })
+  @Index('IDX_niche_slug', { unique: true })
+  slug: string;
 
   @Column({ type: 'text' })
   title: string;

--- a/src/entity/Niche.ts
+++ b/src/entity/Niche.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+export enum NicheBucketGroup {
+  Ecosystem = 'ecosystem',
+  Theme = 'theme',
+}
+
+/**
+ * Catalog of post niches used by the feed diversifier.
+ *
+ * A niche represents the mental category a user uses when saying
+ * "stop showing me X" — the unit at which feed diversification penalizes
+ * repetition. Niches split into two groups:
+ *  - ecosystem  — stack identity (e.g. js_ts, rust, python)
+ *  - theme      — cross-stack topics (e.g. ai_llm, sec_threats, cloud)
+ */
+@Entity()
+export class Niche {
+  @PrimaryColumn({ type: 'text' })
+  id: string;
+
+  @Column({ type: 'text' })
+  title: string;
+
+  @Column({
+    type: 'text',
+    default: NicheBucketGroup.Theme,
+  })
+  bucketGroup: NicheBucketGroup;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -27,6 +27,8 @@ export * from './TagSegment';
 export * from './View';
 export * from './Comment';
 export * from './Keyword';
+export * from './KeywordNiche';
+export * from './Niche';
 export * from './Persona';
 export * from './PostKeyword';
 export * from './CommentMention';

--- a/src/migration/1779878138923-PostNiches.ts
+++ b/src/migration/1779878138923-PostNiches.ts
@@ -1,0 +1,62 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostNiches1779878138923 implements MigrationInterface {
+  name = 'PostNiches1779878138923';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "niche" (
+        "id" text NOT NULL,
+        "title" text NOT NULL,
+        "bucketGroup" text NOT NULL DEFAULT 'theme',
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_niche_id" PRIMARY KEY ("id"),
+        CONSTRAINT "CHK_niche_bucketGroup"
+          CHECK ("bucketGroup" IN ('ecosystem','theme'))
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "keyword_niche" (
+        "keyword" text NOT NULL,
+        "primaryNicheId" text NOT NULL,
+        "secondaryNicheId" text,
+        "weightMultiplier" real NOT NULL DEFAULT 1,
+        "confidence" smallint NOT NULL DEFAULT 2,
+        "labelerVersion" text,
+        "labeledAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_keyword_niche_keyword" PRIMARY KEY ("keyword"),
+        CONSTRAINT "CHK_keyword_niche_confidence"
+          CHECK ("confidence" BETWEEN 1 AND 3),
+        CONSTRAINT "CHK_keyword_niche_primary_neq_secondary"
+          CHECK ("secondaryNicheId" IS NULL
+                 OR "secondaryNicheId" <> "primaryNicheId"),
+        CONSTRAINT "FK_keyword_niche_keyword"
+          FOREIGN KEY ("keyword") REFERENCES "keyword"("value")
+          ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_keyword_niche_primary"
+          FOREIGN KEY ("primaryNicheId") REFERENCES "niche"("id")
+          ON DELETE RESTRICT ON UPDATE NO ACTION,
+        CONSTRAINT "FK_keyword_niche_secondary"
+          FOREIGN KEY ("secondaryNicheId") REFERENCES "niche"("id")
+          ON DELETE RESTRICT ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX "IDX_keyword_niche_primary"
+        ON "keyword_niche" ("primaryNicheId")
+    `);
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX "IDX_keyword_niche_secondary"
+        ON "keyword_niche" ("secondaryNicheId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "keyword_niche"`);
+    await queryRunner.query(`DROP TABLE "niche"`);
+  }
+}

--- a/src/migration/1779878138923-PostNiches.ts
+++ b/src/migration/1779878138923-PostNiches.ts
@@ -6,7 +6,8 @@ export class PostNiches1779878138923 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(/* sql */ `
       CREATE TABLE "niche" (
-        "id" text NOT NULL,
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "slug" text NOT NULL,
         "title" text NOT NULL,
         "bucketGroup" text NOT NULL DEFAULT 'theme',
         "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
@@ -18,10 +19,14 @@ export class PostNiches1779878138923 implements MigrationInterface {
     `);
 
     await queryRunner.query(/* sql */ `
+      CREATE UNIQUE INDEX "IDX_niche_slug" ON "niche" ("slug")
+    `);
+
+    await queryRunner.query(/* sql */ `
       CREATE TABLE "keyword_niche" (
         "keyword" text NOT NULL,
-        "primaryNicheId" text NOT NULL,
-        "secondaryNicheId" text,
+        "primaryNicheId" uuid NOT NULL,
+        "secondaryNicheId" uuid,
         "weightMultiplier" real NOT NULL DEFAULT 1,
         "confidence" smallint NOT NULL DEFAULT 2,
         "labelerVersion" text,


### PR DESCRIPTION
## Summary

Introduces the data structure (schema only) for niche-based feed diversification. Niches are the mental categories a user uses when saying "stop showing me X" — the unit at which the upcoming diversifier penalizes feed repetition.

### New tables

- **`niche`** — catalog of niches, grouped into:
  - `ecosystem` — stack identity (`js_ts`, `rust`, `python`, …)
  - `theme` — cross-stack topics (`ai_llm`, `sec_threats`, `cloud`, …)
- **`keyword_niche`** — maps each keyword (tag) to:
  - `primaryNicheId` (NOT NULL)
  - `secondaryNicheId` (nullable, must differ from primary)
  - `weightMultiplier` — per-tag dampening (e.g. 0.3 for generic tags like `programming`)
  - `confidence` — 1=guess, 2=likely, 3=clear (for prioritizing audits)
  - `labelerVersion` — identifier of the labeler/taxonomy version that produced the row

### How the diversifier will use it

A post's niches are derived from the niches of its tags via weighted vote (IDF × `weightMultiplier`, plus ecosystem boost). The MMR-style re-ranker will then penalize candidate posts whose primary or secondary niche overlaps with a higher-ranked post in the same response.

Taxonomy spec and derivation rules live in the brain doc `docs/feed-niche-taxonomy.md`.

### Scope of this PR

- **Schema only.** No niche rows or `keyword_niche` mappings are inserted; data will be populated separately.
- No API/GraphQL changes yet — those land once we wire the diversifier.

### Migration

`1779878138923-PostNiches.ts` creates both tables with FKs to `keyword.value` and `niche.id`, plus check constraints on `bucketGroup`, `confidence`, and the primary ≠ secondary invariant. Indexes on `primaryNicheId` and `secondaryNicheId` for join-from-niche queries (analytics + future per-niche listings).