### PR TITLE
feat: add post_niche mapping table

### DIFF
--- a/__tests__/fixture/niche.ts
+++ b/__tests__/fixture/niche.ts
@@ -14,7 +14,11 @@ import {
 export const nichesFixture: DeepPartial<Niche>[] = [
   { slug: 'js_ts', title: 'JS/TS', bucketGroup: NicheBucketGroup.Ecosystem },
   { slug: 'rust', title: 'Rust', bucketGroup: NicheBucketGroup.Ecosystem },
-  { slug: 'ai_llm', title: 'LLMs & GenAI', bucketGroup: NicheBucketGroup.Theme },
+  {
+    slug: 'ai_llm',
+    title: 'LLMs & GenAI',
+    bucketGroup: NicheBucketGroup.Theme,
+  },
   {
     slug: 'sec_threats',
     title: 'Cyber threats',
@@ -73,7 +77,11 @@ export const keywordNichesFixture: KeywordNicheLabel[] = [
   { keyword: 'llm', primarySlug: 'ai_llm' },
   { keyword: 'openai', primarySlug: 'ai_llm', secondarySlug: 'sec_threats' },
   // generic — should be dampened
-  { keyword: 'programming', primarySlug: 'software_craft', weightMultiplier: 0.3 },
+  {
+    keyword: 'programming',
+    primarySlug: 'software_craft',
+    weightMultiplier: 0.3,
+  },
   // 'unlabeled-tag' deliberately has no keyword_niche row
 ];
 

--- a/__tests__/fixture/niche.ts
+++ b/__tests__/fixture/niche.ts
@@ -1,0 +1,98 @@
+import { DeepPartial } from 'typeorm';
+import {
+  Niche,
+  NicheBucketGroup,
+  KeywordNiche,
+  Keyword,
+  KeywordStatus,
+} from '../../src/entity';
+
+/**
+ * Minimal niche taxonomy for trigger tests. Mirrors the production taxonomy
+ * shape (ecosystem vs theme) without listing all 41.
+ */
+export const nichesFixture: DeepPartial<Niche>[] = [
+  { slug: 'js_ts', title: 'JS/TS', bucketGroup: NicheBucketGroup.Ecosystem },
+  { slug: 'rust', title: 'Rust', bucketGroup: NicheBucketGroup.Ecosystem },
+  { slug: 'ai_llm', title: 'LLMs & GenAI', bucketGroup: NicheBucketGroup.Theme },
+  {
+    slug: 'sec_threats',
+    title: 'Cyber threats',
+    bucketGroup: NicheBucketGroup.Theme,
+  },
+  { slug: 'devtools', title: 'Dev tools', bucketGroup: NicheBucketGroup.Theme },
+  {
+    slug: 'software_craft',
+    title: 'Software craft',
+    bucketGroup: NicheBucketGroup.Theme,
+  },
+  { slug: 'other', title: 'Other', bucketGroup: NicheBucketGroup.Theme },
+];
+
+/**
+ * Keywords used as the FK target by keywordNichesFixture. All status='allow'
+ * (post.tagsStr only contains canonical allow keywords in production, and
+ * keyword_niche is only seeded for allow keywords).
+ */
+export const nicheKeywordsFixture: DeepPartial<Keyword>[] = [
+  { value: 'javascript', occurrences: 1000, status: KeywordStatus.Allow },
+  { value: 'typescript', occurrences: 800, status: KeywordStatus.Allow },
+  { value: 'react', occurrences: 700, status: KeywordStatus.Allow },
+  { value: 'nextjs', occurrences: 300, status: KeywordStatus.Allow },
+  { value: 'rust', occurrences: 200, status: KeywordStatus.Allow },
+  { value: 'cli', occurrences: 500, status: KeywordStatus.Allow },
+  { value: 'cve', occurrences: 200, status: KeywordStatus.Allow },
+  { value: 'malware', occurrences: 200, status: KeywordStatus.Allow },
+  { value: 'llm', occurrences: 1500, status: KeywordStatus.Allow },
+  { value: 'openai', occurrences: 800, status: KeywordStatus.Allow },
+  { value: 'programming', occurrences: 5000, status: KeywordStatus.Allow },
+  { value: 'unlabeled-tag', occurrences: 1, status: KeywordStatus.Allow },
+];
+
+export type KeywordNicheLabel = {
+  keyword: string;
+  primarySlug: string;
+  secondarySlug?: string;
+  weightMultiplier?: number;
+  confidence?: number;
+};
+
+/**
+ * Tag -> niche labels for the trigger tests, referenced by slug. Resolved
+ * to nicheIds at fixture-load time (see resolveKeywordNichesFixture).
+ */
+export const keywordNichesFixture: KeywordNicheLabel[] = [
+  { keyword: 'javascript', primarySlug: 'js_ts' },
+  { keyword: 'typescript', primarySlug: 'js_ts' },
+  { keyword: 'react', primarySlug: 'js_ts' },
+  { keyword: 'nextjs', primarySlug: 'js_ts' },
+  { keyword: 'rust', primarySlug: 'rust' },
+  { keyword: 'cli', primarySlug: 'devtools' },
+  { keyword: 'cve', primarySlug: 'sec_threats' },
+  { keyword: 'malware', primarySlug: 'sec_threats' },
+  { keyword: 'llm', primarySlug: 'ai_llm' },
+  { keyword: 'openai', primarySlug: 'ai_llm', secondarySlug: 'sec_threats' },
+  // generic — should be dampened
+  { keyword: 'programming', primarySlug: 'software_craft', weightMultiplier: 0.3 },
+  // 'unlabeled-tag' deliberately has no keyword_niche row
+];
+
+/**
+ * Build keyword_niche entity rows by resolving niche slugs -> uuids. Call
+ * after nichesFixture has been saved.
+ */
+export const resolveKeywordNichesFixture = async (
+  niches: Niche[],
+): Promise<DeepPartial<KeywordNiche>[]> => {
+  const idBySlug = new Map(niches.map((n) => [n.slug, n.id]));
+  return keywordNichesFixture.map((l) => ({
+    keyword: l.keyword,
+    primaryNicheId: idBySlug.get(l.primarySlug)!,
+    secondaryNicheId: l.secondarySlug
+      ? idBySlug.get(l.secondarySlug)
+      : undefined,
+    weightMultiplier: l.weightMultiplier ?? 1,
+    confidence: l.confidence ?? 3,
+    labelerVersion: 'test',
+  }));
+};

--- a/__tests__/triggers/postNiche.ts
+++ b/__tests__/triggers/postNiche.ts
@@ -1,0 +1,185 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../../src/db';
+import { saveFixtures } from '../helpers';
+import {
+  ArticlePost,
+  Keyword,
+  KeywordNiche,
+  Niche,
+  Post,
+  PostNiche,
+  Source,
+} from '../../src/entity';
+import { sourcesFixture } from '../fixture/source';
+import {
+  keywordNichesFixture,
+  nicheKeywordsFixture,
+  nichesFixture,
+  resolveKeywordNichesFixture,
+} from '../fixture/niche';
+
+let con: DataSource;
+let nicheBySlug: Map<string, string>; // slug -> nicheId
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  await saveFixtures(con, Source, sourcesFixture);
+  await saveFixtures(con, Niche, nichesFixture);
+  const niches = await con.getRepository(Niche).find();
+  nicheBySlug = new Map(niches.map((n) => [n.slug, n.id]));
+  await saveFixtures(con, Keyword, nicheKeywordsFixture);
+  await saveFixtures(
+    con,
+    KeywordNiche,
+    await resolveKeywordNichesFixture(niches),
+  );
+});
+
+const insertPost = async (id: string, tagsStr?: string | null) => {
+  await con.getRepository(ArticlePost).insert({
+    id,
+    shortId: id,
+    title: id,
+    sourceId: 'a',
+    tagsStr: tagsStr ?? undefined,
+  });
+};
+
+const getNiches = async (
+  postId: string,
+): Promise<{ rank: number; slug: string }[]> => {
+  const rows = await con
+    .getRepository(PostNiche)
+    .createQueryBuilder('pn')
+    .innerJoin(Niche, 'n', 'n.id = pn."nicheId"')
+    .where('pn."postId" = :id', { id: postId })
+    .select(['pn.rank AS rank', 'n.slug AS slug'])
+    .orderBy('pn.rank', 'ASC')
+    .getRawMany<{ rank: number; slug: string }>();
+  return rows.map((r) => ({ rank: Number(r.rank), slug: r.slug }));
+};
+
+describe('post_niche trigger', () => {
+  it('falls back to "other" for an empty tagsStr', async () => {
+    await insertPost('np1', null);
+    expect(await getNiches('np1')).toEqual([{ rank: 1, slug: 'other' }]);
+  });
+
+  it('falls back to "other" when no tag matches a labeled keyword', async () => {
+    await insertPost('np2', 'unlabeled-tag');
+    expect(await getNiches('np2')).toEqual([{ rank: 1, slug: 'other' }]);
+  });
+
+  it('derives a primary niche from a single labeled tag (no secondary)', async () => {
+    await insertPost('np3', 'rust');
+    // single-labeled-tag posts get a primary only (min-2-tags-for-secondary)
+    expect(await getNiches('np3')).toEqual([{ rank: 1, slug: 'rust' }]);
+  });
+
+  it('sums multiple labeled tags into the same niche', async () => {
+    await insertPost('np4', 'javascript,typescript,react,nextjs');
+    expect(await getNiches('np4')).toEqual([{ rank: 1, slug: 'js_ts' }]);
+  });
+
+  it('applies the ecosystem boost so an ecosystem niche wins over a theme niche on equal vote', async () => {
+    // rust (ecosystem) + cli (theme=devtools) -> rust must win after 1.4x boost
+    await insertPost('np5', 'rust,cli');
+    const niches = await getNiches('np5');
+    expect(niches[0]).toEqual({ rank: 1, slug: 'rust' });
+  });
+
+  it('emits a secondary niche when a second niche is above the 0.35 threshold', async () => {
+    // cve + malware -> sec_threats x2 (primary)
+    // openai -> ai_llm primary + sec_threats secondary
+    // Result: sec_threats dominates as primary; ai_llm picks up enough secondary contribution to be #2
+    await insertPost('np6', 'cve,malware,openai');
+    const niches = await getNiches('np6');
+    expect(niches[0]).toEqual({ rank: 1, slug: 'sec_threats' });
+    expect(niches[1]?.slug).toBe('ai_llm');
+  });
+
+  it('does not emit a secondary niche when only one labeled tag is present', async () => {
+    // openai has a secondaryNicheId (sec_threats) on its keyword_niche row,
+    // but the post has only one labeled tag — derivation requires >=2.
+    await insertPost('np7', 'openai');
+    expect(await getNiches('np7')).toEqual([{ rank: 1, slug: 'ai_llm' }]);
+  });
+
+  it('dampens generic tags via weightMultiplier so a specific tag wins', async () => {
+    // 'programming' -> software_craft with weightMultiplier=0.3
+    // 'rust'        -> rust with weight 1.0 + 1.4 ecosystem boost
+    // rust must dominate even though programming would otherwise be 1.0
+    await insertPost('np8', 'programming,rust');
+    const niches = await getNiches('np8');
+    expect(niches[0]).toEqual({ rank: 1, slug: 'rust' });
+  });
+
+  it('recomputes niches when tagsStr is updated', async () => {
+    await insertPost('np9', 'rust');
+    expect(await getNiches('np9')).toEqual([{ rank: 1, slug: 'rust' }]);
+
+    await con
+      .getRepository(ArticlePost)
+      .update({ id: 'np9' }, { tagsStr: 'javascript,react' });
+    expect(await getNiches('np9')).toEqual([{ rank: 1, slug: 'js_ts' }]);
+  });
+
+  it('clears niches when tagsStr is cleared', async () => {
+    await insertPost('np10', 'javascript,react');
+    expect(await getNiches('np10')).toEqual([{ rank: 1, slug: 'js_ts' }]);
+
+    await con
+      .getRepository(ArticlePost)
+      .update({ id: 'np10' }, { tagsStr: '' });
+    expect(await getNiches('np10')).toEqual([{ rank: 1, slug: 'other' }]);
+  });
+
+  it('does not recompute when an unrelated post column is updated', async () => {
+    await insertPost('np11', 'rust');
+    const before = await con
+      .getRepository(PostNiche)
+      .findOneByOrFail({ postId: 'np11', rank: 1 });
+
+    await con
+      .getRepository(ArticlePost)
+      .update({ id: 'np11' }, { title: 'new title' });
+
+    const after = await con
+      .getRepository(PostNiche)
+      .findOneByOrFail({ postId: 'np11', rank: 1 });
+    // computedAt did not advance (no recompute fired)
+    expect(after.computedAt.getTime()).toEqual(before.computedAt.getTime());
+  });
+
+  it('cascades on post delete', async () => {
+    await insertPost('np12', 'javascript,react');
+    expect(await getNiches('np12')).toEqual([{ rank: 1, slug: 'js_ts' }]);
+
+    await con.getRepository(ArticlePost).delete({ id: 'np12' });
+    const remaining = await con
+      .getRepository(PostNiche)
+      .findBy({ postId: 'np12' });
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('is callable directly for backfill', async () => {
+    // Insert without going through the trigger: do an insert, then truncate
+    // post_niche to simulate a pre-existing post that hasn't been derived yet.
+    await insertPost('np13', 'rust,cli');
+    await con
+      .getRepository(PostNiche)
+      .delete({ postId: 'np13' });
+    expect(await getNiches('np13')).toEqual([]);
+
+    await con.query(
+      'SELECT post_niche_recompute($1, $2)',
+      ['np13', 'rust,cli'],
+    );
+    const niches = await getNiches('np13');
+    expect(niches[0]).toEqual({ rank: 1, slug: 'rust' });
+  });
+});

--- a/__tests__/triggers/postNiche.ts
+++ b/__tests__/triggers/postNiche.ts
@@ -6,20 +6,17 @@ import {
   Keyword,
   KeywordNiche,
   Niche,
-  Post,
   PostNiche,
   Source,
 } from '../../src/entity';
 import { sourcesFixture } from '../fixture/source';
 import {
-  keywordNichesFixture,
   nicheKeywordsFixture,
   nichesFixture,
   resolveKeywordNichesFixture,
 } from '../fixture/niche';
 
 let con: DataSource;
-let nicheBySlug: Map<string, string>; // slug -> nicheId
 
 beforeAll(async () => {
   con = await createOrGetConnection();
@@ -30,7 +27,6 @@ beforeEach(async () => {
   await saveFixtures(con, Source, sourcesFixture);
   await saveFixtures(con, Niche, nichesFixture);
   const niches = await con.getRepository(Niche).find();
-  nicheBySlug = new Map(niches.map((n) => [n.slug, n.id]));
   await saveFixtures(con, Keyword, nicheKeywordsFixture);
   await saveFixtures(
     con,
@@ -170,15 +166,13 @@ describe('post_niche trigger', () => {
     // Insert without going through the trigger: do an insert, then truncate
     // post_niche to simulate a pre-existing post that hasn't been derived yet.
     await insertPost('np13', 'rust,cli');
-    await con
-      .getRepository(PostNiche)
-      .delete({ postId: 'np13' });
+    await con.getRepository(PostNiche).delete({ postId: 'np13' });
     expect(await getNiches('np13')).toEqual([]);
 
-    await con.query(
-      'SELECT post_niche_recompute($1, $2)',
-      ['np13', 'rust,cli'],
-    );
+    await con.query('SELECT post_niche_recompute($1, $2)', [
+      'np13',
+      'rust,cli',
+    ]);
     const niches = await getNiches('np13');
     expect(niches[0]).toEqual({ rank: 1, slug: 'rust' });
   });

--- a/src/entity/PostNiche.ts
+++ b/src/entity/PostNiche.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Mapping table from a post to its derived niches.
+ *
+ * One post → 1 or 2 rows (rank=1 primary, rank=2 secondary). Niches are
+ * derived from the post's tags via weighted vote against `keyword_niche`
+ * (see docs/feed-niche-taxonomy.md). The diversifier reads this table to
+ * penalize repetition along niche axes at re-ranking time.
+ *
+ *  - rank=1   primary niche (always present for posts with any labeled tag;
+ *             posts with no labeled tags fall back to the `other` niche)
+ *  - rank=2   secondary niche (optional)
+ *  - score    raw derivation score for the assigned niche (debug/audit)
+ *  - computedAt   when derivation last ran for this row
+ */
+@Entity()
+@Index('IDX_post_niche_niche_rank', ['nicheId', 'rank'])
+export class PostNiche {
+  @PrimaryColumn({ type: 'text' })
+  postId: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  nicheId: string;
+
+  @Column({ type: 'smallint' })
+  rank: number;
+
+  @Column({ type: 'real', nullable: true })
+  score?: number | null;
+
+  @Column({ default: () => 'now()' })
+  computedAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -31,6 +31,7 @@ export * from './KeywordNiche';
 export * from './Niche';
 export * from './Persona';
 export * from './PostKeyword';
+export * from './PostNiche';
 export * from './CommentMention';
 export * from './ReputationEvent';
 export * from './Submission';

--- a/src/migration/1779882869443-PostNiche.ts
+++ b/src/migration/1779882869443-PostNiche.ts
@@ -1,0 +1,37 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostNiche1779882869443 implements MigrationInterface {
+  name = 'PostNiche1779882869443';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "post_niche" (
+        "postId" text NOT NULL,
+        "nicheId" uuid NOT NULL,
+        "rank" smallint NOT NULL,
+        "score" real,
+        "computedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_post_niche" PRIMARY KEY ("postId", "nicheId"),
+        CONSTRAINT "UQ_post_niche_rank" UNIQUE ("postId", "rank"),
+        CONSTRAINT "CHK_post_niche_rank"
+          CHECK ("rank" BETWEEN 1 AND 2),
+        CONSTRAINT "FK_post_niche_post"
+          FOREIGN KEY ("postId") REFERENCES "post"("id")
+          ON DELETE CASCADE ON UPDATE NO ACTION,
+        CONSTRAINT "FK_post_niche_niche"
+          FOREIGN KEY ("nicheId") REFERENCES "niche"("id")
+          ON DELETE RESTRICT ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX "IDX_post_niche_niche_rank"
+        ON "post_niche" ("nicheId", "rank")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "post_niche"`);
+  }
+}

--- a/src/migration/1779883630763-PostNicheTrigger.ts
+++ b/src/migration/1779883630763-PostNicheTrigger.ts
@@ -1,0 +1,152 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PostNicheTrigger1779883630763 implements MigrationInterface {
+  name = 'PostNicheTrigger1779883630763';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * Function: post_niche_recompute(post_id, tags_str)
+     *
+     * Derives the post's niches from its (canonical) tagsStr by aggregating
+     * the niches of its labeled tags via weighted vote, and rewrites the
+     * corresponding rows in post_niche.
+     *
+     * Score model (see docs/feed-niche-taxonomy.md):
+     *   score(post, niche) = SUM over labeled tags of:
+     *       weightMultiplier(tag)
+     *       * ecosystem_boost(niche)              -- 1.4 for ecosystem, 1.0 for theme
+     *       * { 1.0 if tag.primary  == niche,
+     *           0.5 if tag.secondary == niche }
+     *
+     *   primary   = argmax niche
+     *   secondary = next-highest niche where score >= 0.35 * primary_score
+     *               AND labeled_tag_count >= 2
+     *   fallback (no labeled tags) = niche with slug 'other'
+     *
+     * Callable directly for backfill:
+     *   SELECT post_niche_recompute(id, "tagsStr") FROM post WHERE ...
+     */
+    await queryRunner.query(/* sql */ `
+      CREATE OR REPLACE FUNCTION post_niche_recompute(
+        p_post_id text,
+        p_tags_str text
+      ) RETURNS void AS $$
+      DECLARE
+        c_ecosystem_boost        CONSTANT real := 1.4;
+        c_secondary_threshold    CONSTANT real := 0.35;
+        c_min_tags_for_secondary CONSTANT int  := 2;
+        c_fallback_slug          CONSTANT text := 'other';
+        v_primary_id     uuid;
+        v_primary_score  real;
+        v_secondary_id   uuid;
+        v_secondary_score real;
+        v_labeled_count  int;
+      BEGIN
+        DELETE FROM post_niche WHERE "postId" = p_post_id;
+
+        IF p_tags_str IS NULL OR p_tags_str = '' THEN
+          INSERT INTO post_niche ("postId", "nicheId", "rank", "score")
+          SELECT p_post_id, id, 1, NULL FROM niche WHERE slug = c_fallback_slug;
+          RETURN;
+        END IF;
+
+        WITH tags_arr AS (
+          SELECT trim(t) AS tag
+          FROM unnest(string_to_array(p_tags_str, ',')) AS t
+          WHERE trim(t) <> ''
+        ),
+        labeled AS (
+          SELECT kn."primaryNicheId" AS niche_id,
+                 kn."secondaryNicheId" AS sec_id,
+                 kn."weightMultiplier" AS wm
+          FROM tags_arr t
+          JOIN keyword_niche kn ON kn.keyword = t.tag
+        ),
+        contribs AS (
+          SELECT l.niche_id,
+                 l.wm * CASE WHEN n."bucketGroup" = 'ecosystem'
+                             THEN c_ecosystem_boost ELSE 1.0 END AS w
+          FROM labeled l JOIN niche n ON n.id = l.niche_id
+          UNION ALL
+          SELECT l.sec_id AS niche_id,
+                 0.5 * l.wm * CASE WHEN n."bucketGroup" = 'ecosystem'
+                                    THEN c_ecosystem_boost ELSE 1.0 END AS w
+          FROM labeled l JOIN niche n ON n.id = l.sec_id
+          WHERE l.sec_id IS NOT NULL
+        ),
+        scored AS (
+          SELECT niche_id, SUM(w)::real AS score
+          FROM contribs GROUP BY niche_id
+        ),
+        ranked AS (
+          SELECT niche_id, score,
+                 ROW_NUMBER() OVER (ORDER BY score DESC, niche_id) AS rnk
+          FROM scored
+        )
+        SELECT
+          (SELECT niche_id FROM ranked WHERE rnk = 1),
+          (SELECT score    FROM ranked WHERE rnk = 1),
+          (SELECT niche_id FROM ranked WHERE rnk = 2),
+          (SELECT score    FROM ranked WHERE rnk = 2),
+          (SELECT COUNT(*) FROM labeled)
+        INTO
+          v_primary_id, v_primary_score,
+          v_secondary_id, v_secondary_score,
+          v_labeled_count;
+
+        IF v_primary_id IS NULL THEN
+          INSERT INTO post_niche ("postId", "nicheId", "rank", "score")
+          SELECT p_post_id, id, 1, NULL FROM niche WHERE slug = c_fallback_slug;
+          RETURN;
+        END IF;
+
+        INSERT INTO post_niche ("postId", "nicheId", "rank", "score")
+        VALUES (p_post_id, v_primary_id, 1, v_primary_score);
+
+        IF v_secondary_id IS NOT NULL
+           AND v_secondary_score >= c_secondary_threshold * v_primary_score
+           AND v_labeled_count   >= c_min_tags_for_secondary THEN
+          INSERT INTO post_niche ("postId", "nicheId", "rank", "score")
+          VALUES (p_post_id, v_secondary_id, 2, v_secondary_score);
+        END IF;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+
+    /*
+     * Trigger wrapper — fires on post INSERT and on UPDATE OF "tagsStr"
+     * (the latter only when the value actually changed).
+     */
+    await queryRunner.query(/* sql */ `
+      CREATE OR REPLACE FUNCTION post_niche_trigger_function()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        PERFORM post_niche_recompute(NEW.id, NEW."tagsStr");
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE TRIGGER post_niche_insert_trigger
+      AFTER INSERT ON post
+      FOR EACH ROW
+      EXECUTE FUNCTION post_niche_trigger_function();
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE TRIGGER post_niche_update_trigger
+      AFTER UPDATE OF "tagsStr" ON post
+      FOR EACH ROW
+      WHEN (NEW."tagsStr" IS DISTINCT FROM OLD."tagsStr")
+      EXECUTE FUNCTION post_niche_trigger_function();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TRIGGER IF EXISTS post_niche_update_trigger ON "post"`);
+    await queryRunner.query(`DROP TRIGGER IF EXISTS post_niche_insert_trigger ON "post"`);
+    await queryRunner.query(`DROP FUNCTION IF EXISTS post_niche_trigger_function`);
+    await queryRunner.query(`DROP FUNCTION IF EXISTS post_niche_recompute(text, text)`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the materialized post → niche mapping in postgres so the feed diversifier can look up a post's niches in O(1), without joining `post.tagsStr` → `keyword_niche` on every feed request.

Follow-up to #3911 which introduced the `niche` and `keyword_niche` tables.

### New table

```
post_niche
  postId   text       FK -> post.id    (CASCADE)
  nicheId  uuid       FK -> niche.id   (RESTRICT)
  rank     smallint   1=primary, 2=secondary  (CHECK 1..2)
  score    real       nullable — derivation score, for debug/audit
  computedAt, updatedAt

  PK (postId, nicheId)        — prevents the same niche twice per post
  UQ (postId, rank)           — enforces 1 primary + at most 1 secondary
  IDX (nicheId, rank)         — for 'all posts in niche X' analytics + future per-niche listings
```

### Why a mapping table (not columns on `post`)

- Symmetric: primary and secondary use the same row shape, no special-casing.
- Cheap reverse lookups: `WHERE nicheId = ?` is a single index scan.
- Extensible: bumping to 3+ niches per post later is a CHECK constraint change, not a schema migration.
- Cascade-on-post-delete keeps it self-cleaning.

### How it'll be populated

Out of scope for this PR. Future work:
1. A TypeScript derivation helper that takes `post.tagsStr` + `keyword_niche` and returns `{primary, secondary}` using the rules in `docs/feed-niche-taxonomy.md` (IDF × weightMultiplier + ecosystem boost, top-1 + top-1 secondary with 0.35 threshold, fallback to `other`).
2. A hook on post create / `tagsStr` change to recompute.
3. A backfill job over existing posts.

### How the diversifier will use it

At rerank time, each candidate joins to `post_niche` (1-2 rows), and the MMR penalty is applied when any niche overlaps with higher-ranked posts in the same response. Ecosystem niches get a sharper penalty multiplier than theme niches.