### PR TITLE
feat: render topical digest links

### DIFF
--- a/__tests__/common/channelDigestGenerate.ts
+++ b/__tests__/common/channelDigestGenerate.ts
@@ -1,10 +1,19 @@
 import type { DataSource } from 'typeorm';
+import {
+  Pipelines,
+  TopicalDigest,
+  TopicalDigestItem,
+  TopicalDigestRequest,
+} from '@dailydotdev/schema';
 import createOrGetConnection from '../../src/db';
 import { ChannelDigest } from '../../src/entity/ChannelDigest';
 import { AGENTS_DIGEST_SOURCE, Source } from '../../src/entity/Source';
 import { FreeformPost } from '../../src/entity/posts/FreeformPost';
 import { generateChannelDigest } from '../../src/common/channelDigest/generate';
 import { createSource } from '../fixture/source';
+import * as bragiClients from '../../src/integrations/bragi/clients';
+import type { ServiceClient } from '../../src/types';
+import { createGarmrMock } from '../helpers';
 
 let con: DataSource;
 
@@ -57,6 +66,10 @@ const savePost = async ({
   });
 
 describe('generateChannelDigest', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should save the generated post when channel posts exist', async () => {
     const now = new Date('2026-03-03T10:00:00.000Z');
 
@@ -98,8 +111,16 @@ describe('generateChannelDigest', () => {
 
     expect(result).toMatchObject({
       sourceId: AGENTS_DIGEST_SOURCE,
-      title: 'Mock sentiment digest',
-      content: 'Mock digest content',
+      title: 'Mock topical digest',
+      content: [
+        '**TLDR:** Mock digest summary',
+        '---',
+        '## Mock main item',
+        'Mock main item body [Read more](http://localhost:5002/posts/post-1)',
+        '---',
+        '## Also notable',
+        '- **Mock notable item:** Mock notable item body',
+      ].join('\n\n'),
     });
   });
 
@@ -178,7 +199,97 @@ describe('generateChannelDigest', () => {
 
     expect(insideWindow).toMatchObject({
       sourceId: 'weekly-source',
-      title: 'Mock sentiment digest',
+      title: 'Mock topical digest',
     });
+  });
+
+  it('should send the previous digest markdown and post ids to Bragi', async () => {
+    const now = new Date('2026-03-03T10:00:00.000Z');
+    let request: TopicalDigestRequest | undefined;
+
+    jest.spyOn(bragiClients, 'getBragiClient').mockImplementation(
+      (): ServiceClient<typeof Pipelines> => ({
+        instance: {
+          generateTopicalDigest: async (data: TopicalDigestRequest) => {
+            request = data;
+
+            return new TopicalDigest({
+              title: 'New digest',
+              tldr: 'New summary',
+              mainItems: [
+                new TopicalDigestItem({
+                  title: 'New item',
+                  body: 'New body',
+                  postIds: ['new-post'],
+                }),
+              ],
+            });
+          },
+        } as ServiceClient<typeof Pipelines>['instance'],
+        garmr: createGarmrMock(),
+      }),
+    );
+
+    await con
+      .getRepository(Source)
+      .save([
+        createSource(
+          'content-source',
+          'Content',
+          'https://daily.dev/content.png',
+        ),
+        createSource('previous-source', 'Digest', 'https://daily.dev/d.png'),
+      ]);
+    const definition = await saveDefinition({
+      key: 'previous-test',
+      sourceId: 'previous-source',
+      channel: 'previous',
+      frequency: 'daily',
+    });
+    await con.getRepository(FreeformPost).save({
+      id: 'prev-digest',
+      shortId: 'prev-digest',
+      sourceId: definition.sourceId,
+      title: 'Previous digest',
+      content: '## Previous item\n\nAlready covered',
+      contentHtml: '<h2>Previous item</h2><p>Already covered</p>',
+      createdAt: new Date('2026-03-03T08:00:00.000Z'),
+    });
+    await savePost({
+      id: 'old-post',
+      title: 'Old post',
+      content: 'Should be outside the digest window',
+      createdAt: new Date('2026-03-03T07:00:00.000Z'),
+      channel: 'previous',
+    });
+    await savePost({
+      id: 'new-post',
+      title: 'New post',
+      content: 'Should be in the digest window',
+      createdAt: new Date('2026-03-03T09:00:00.000Z'),
+      channel: 'previous',
+    });
+
+    await generateChannelDigest({
+      con,
+      definition,
+      now,
+    });
+
+    expect(request).toEqual(
+      new TopicalDigestRequest({
+        date: '2026-03-03',
+        targetAudience: 'audience',
+        frequency: 'daily',
+        previousDigestMd: '## Previous item\n\nAlready covered',
+        posts: [
+          {
+            postId: 'new-post',
+            title: 'New post',
+            summary: 'Should be in the digest window',
+          },
+        ],
+      }),
+    );
   });
 });

--- a/__tests__/workers/generateChannelDigest.ts
+++ b/__tests__/workers/generateChannelDigest.ts
@@ -239,12 +239,20 @@ describe('generateChannelDigest worker', () => {
 
     const digest = await con.getRepository(FreeformPost).findOneBy({
       sourceId: AGENTS_DIGEST_SOURCE,
-      title: 'Mock sentiment digest',
+      title: 'Mock topical digest',
     });
     expect(digest).toMatchObject({
       sourceId: AGENTS_DIGEST_SOURCE,
-      title: 'Mock sentiment digest',
-      content: 'Mock digest content',
+      title: 'Mock topical digest',
+      content: [
+        '**TLDR:** Mock digest summary',
+        '---',
+        '## Mock main item',
+        'Mock main item body [Read more](http://localhost:5002/posts/post-1)',
+        '---',
+        '## Also notable',
+        '- **Mock notable item:** Mock notable item body',
+      ].join('\n\n'),
     });
     expect(
       await checkRedisObjectExists(getDoneKey('agentic', scheduledAt)),
@@ -317,7 +325,7 @@ describe('generateChannelDigest worker', () => {
     });
     expect(digests).toHaveLength(digestCountBefore);
     expect(
-      digests.find((digest) => digest.title === 'Mock sentiment digest'),
+      digests.find((digest) => digest.title === 'Mock topical digest'),
     ).toBeUndefined();
   });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@connectrpc/connect-fastify": "1.6.1",
     "@connectrpc/connect-node": "1.6.1",
     "@dailydotdev/graphql-redis-subscriptions": "2.4.3",
-    "@dailydotdev/schema": "0.3.9",
+    "@dailydotdev/schema": "0.3.10",
     "@dailydotdev/ts-ioredis-pool": "1.0.2",
     "@fastify/cookie": "11.0.2",
     "@fastify/cors": "11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 2.4.3
         version: 2.4.3(graphql-subscriptions@3.0.0(graphql@16.12.0))
       '@dailydotdev/schema':
-        specifier: 0.3.9
-        version: 0.3.9(@bufbuild/protobuf@1.10.0)
+        specifier: 0.3.10
+        version: 0.3.10(@bufbuild/protobuf@1.10.0)
       '@dailydotdev/ts-ioredis-pool':
         specifier: 1.0.2
         version: 1.0.2
@@ -879,8 +879,8 @@ packages:
     peerDependencies:
       graphql-subscriptions: ^1.0.0 || ^2.0.0
 
-  '@dailydotdev/schema@0.3.9':
-    resolution: {integrity: sha512-GJY05je6coMhUGcSe9Ngb7YAOapCGrZqhnYqZfUNyhyBX37wsPJ2C5oRlycpC0tX44PBVf7ZZyfh1ZxueKMbJw==}
+  '@dailydotdev/schema@0.3.10':
+    resolution: {integrity: sha512-ouLX6GEvKdxna6C4CIoU2gkYoF194eKQDN+Zz6k1oilaN2g8aCTWoOAiBMO0IR+galZ1z4g/fVQazoJ/s7LFCQ==}
     peerDependencies:
       '@bufbuild/protobuf': 1.x
 
@@ -6229,7 +6229,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dailydotdev/schema@0.3.9(@bufbuild/protobuf@1.10.0)':
+  '@dailydotdev/schema@0.3.10(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 

--- a/src/common/channelDigest/generate.ts
+++ b/src/common/channelDigest/generate.ts
@@ -1,7 +1,8 @@
 import {
-  SentimentDigestItem,
-  SentimentDigestRequest,
-  SentimentDigestPost,
+  TopicalDigest,
+  TopicalDigestItem,
+  TopicalDigestPost,
+  TopicalDigestRequest,
 } from '@dailydotdev/schema';
 import type { DataSource } from 'typeorm';
 import type { ChannelDigest } from '../../entity/ChannelDigest';
@@ -20,29 +21,29 @@ import {
 } from './definitions';
 
 type DigestPostRow = {
+  id: string;
   title: string | null;
   summary: string | null;
   content: string | null;
 };
 
+type PreviousDigestPost = Pick<FreeformPost, 'createdAt' | 'content'>;
+
+const digestPostIdsMaxItems = 10;
+
 const toDigestDate = (date: Date): string => date.toISOString().slice(0, 10);
 
-const getDigestWindowStart = async ({
+const getPreviousDigestPost = async ({
   con,
-  now,
   definition,
 }: {
   con: DataSource;
-  now: Date;
   definition: ChannelDigest;
-}): Promise<Date> => {
-  const fallback = new Date(
-    now.getTime() - getChannelDigestLookbackSeconds(definition) * 1000,
-  );
-  const lastDigest = await con.getRepository(FreeformPost).findOne({
+}): Promise<PreviousDigestPost | null> => {
+  return con.getRepository(FreeformPost).findOne({
     select: {
-      id: true,
       createdAt: true,
+      content: true,
     },
     where: {
       sourceId: definition.sourceId,
@@ -52,12 +53,28 @@ const getDigestWindowStart = async ({
       createdAt: 'DESC',
     },
   });
+};
 
-  if (!lastDigest) {
+const getDigestWindowStart = ({
+  now,
+  definition,
+  previousDigest,
+}: {
+  now: Date;
+  definition: ChannelDigest;
+  previousDigest: PreviousDigestPost | null;
+}): Date => {
+  const fallback = new Date(
+    now.getTime() - getChannelDigestLookbackSeconds(definition) * 1000,
+  );
+
+  if (!previousDigest) {
     return fallback;
   }
 
-  return lastDigest.createdAt > fallback ? lastDigest.createdAt : fallback;
+  return previousDigest.createdAt > fallback
+    ? previousDigest.createdAt
+    : fallback;
 };
 
 const findDigestPosts = async ({
@@ -86,7 +103,8 @@ const findDigestPosts = async ({
         relationType: PostRelationType.Collection,
       },
     )
-    .select('post.title', 'title')
+    .select('post.id', 'id')
+    .addSelect('post.title', 'title')
     .addSelect('post.summary', 'summary')
     .addSelect('post.content', 'content')
     .where('post.createdAt >= :from', { from })
@@ -109,14 +127,82 @@ const buildDigestPosts = ({
   posts,
 }: {
   posts: DigestPostRow[];
-}): SentimentDigestPost[] =>
+}): TopicalDigestPost[] =>
   posts.map(
     (post) =>
-      new SentimentDigestPost({
+      new TopicalDigestPost({
+        postId: post.id,
         title: post.title || '',
         summary: post.content || post.summary || '',
       }),
   );
+
+const generateItemLinkMarkdown = ({
+  item,
+  postIds,
+}: {
+  item: TopicalDigestItem;
+  postIds: Set<string>;
+}): string => {
+  const itemPostIds = item.postIds
+    .filter((postId) => postIds.has(postId))
+    .slice(0, digestPostIdsMaxItems);
+
+  if (!itemPostIds.length) {
+    return '';
+  }
+
+  const readMoreUrl = new URL(process.env.COMMENTS_PREFIX);
+
+  if (itemPostIds.length === 1) {
+    readMoreUrl.pathname = `/posts/${itemPostIds[0]}`;
+  } else {
+    readMoreUrl.pathname = '/feed-by-ids';
+
+    itemPostIds.forEach((postId) => {
+      readMoreUrl.searchParams.append('id', postId);
+    });
+  }
+
+  return ` [Read more](${readMoreUrl.toString()})`;
+};
+
+const generateMarkdown = ({
+  digest,
+  postIds,
+}: {
+  digest: TopicalDigest;
+  postIds: Set<string>;
+}): string => {
+  const sections: string[] = [`**TLDR:** ${digest.tldr}`];
+
+  if (digest.mainItems.length) {
+    sections.push(
+      digest.mainItems
+        .map(
+          (item) =>
+            `## ${item.title}\n\n${item.body}${generateItemLinkMarkdown({ item, postIds })}`,
+        )
+        .join('\n\n'),
+    );
+  }
+
+  if (digest.alsoNotable.length) {
+    sections.push(
+      [
+        '## Also notable',
+        digest.alsoNotable
+          .map(
+            (item) =>
+              `- **${item.title}:** ${item.body}${generateItemLinkMarkdown({ item, postIds })}`,
+          )
+          .join('\n'),
+      ].join('\n\n'),
+    );
+  }
+
+  return sections.join('\n\n---\n\n').trim();
+};
 
 const createDigestPost = async ({
   con,
@@ -167,10 +253,14 @@ export const generateChannelDigest = async ({
   definition: ChannelDigest;
   now?: Date;
 }): Promise<FreeformPost | null> => {
-  const from = await getDigestWindowStart({
+  const previousDigest = await getPreviousDigestPost({
     con,
+    definition,
+  });
+  const from = getDigestWindowStart({
     now,
     definition,
+    previousDigest,
   });
   const excludedSourceIds = await getChannelDigestSourceIds({
     con,
@@ -187,28 +277,30 @@ export const generateChannelDigest = async ({
   }
 
   const bragiClient = getBragiClient();
-  const request = new SentimentDigestRequest({
+  const request = new TopicalDigestRequest({
     date: toDigestDate(now),
     targetAudience: definition.targetAudience,
     frequency: definition.frequency,
-    sentimentItems: [] as SentimentDigestItem[],
+    previousDigestMd: previousDigest?.content ?? undefined,
     posts: buildDigestPosts({
       posts,
     }),
   });
   const generated = await bragiClient.garmr.execute(() =>
-    bragiClient.instance.generateSentimentDigest(request),
+    bragiClient.instance.generateTopicalDigest(request),
   );
 
-  if (!generated.title || !generated.content) {
-    throw new Error('bragi digest response is missing title or content');
+  if (!generated.title || !generated.tldr) {
+    throw new Error('bragi digest response is missing title or tldr');
   }
+
+  const postIds = new Set(posts.map((post) => post.id));
 
   return createDigestPost({
     con,
     now,
     sourceId: definition.sourceId,
     title: generated.title,
-    content: generated.content,
+    content: generateMarkdown({ digest: generated, postIds }),
   });
 };

--- a/src/integrations/bragi/clients.ts
+++ b/src/integrations/bragi/clients.ts
@@ -29,10 +29,11 @@ import {
   PersonaQuizRevealText,
   ParseFeedbackResponse,
   Pipelines,
-  SentimentDigestResponse,
   RejectionFeedbackClassification,
   RejectionReason,
   RejectionReasonDetail,
+  TopicalDigest,
+  TopicalDigestItem,
   UserFeedbackClassification,
   UserFeedbackSentiment,
   UserFeedbackTeam,
@@ -122,11 +123,24 @@ export const getBragiClient = (
             id: 'mock-id',
             emailBody: '',
           }),
-        generateSentimentDigest: async () =>
-          new SentimentDigestResponse({
-            id: 'mock-id',
-            title: 'Mock sentiment digest',
-            content: 'Mock digest content',
+        generateTopicalDigest: async () =>
+          new TopicalDigest({
+            title: 'Mock topical digest',
+            tldr: 'Mock digest summary',
+            mainItems: [
+              new TopicalDigestItem({
+                title: 'Mock main item',
+                body: 'Mock main item body',
+                postIds: ['post-1'],
+              }),
+            ],
+            alsoNotable: [
+              new TopicalDigestItem({
+                title: 'Mock notable item',
+                body: 'Mock notable item body',
+                postIds: ['post-2'],
+              }),
+            ],
           }),
         evaluateChannelHighlights: async () =>
           new EvaluateChannelHighlightsResponse({


### PR DESCRIPTION
## Summary
- update @dailydotdev/schema to the generated topical digest contract
- call Bragi's generateTopicalDigest with post IDs and previous digest markdown
- render structured topical digest responses back to markdown with read-more links
- validate returned item post IDs against the input posts before linking

## Testing
- NODE_ENV=test pnpm run db:migrate:latest
- NODE_ENV=test npx jest __tests__/common/channelDigestGenerate.ts --testEnvironment=node --runInBand
- pnpm run lint
- pnpm run build