### PR TITLE
fix: remap unknown-source posts in channel digest to public shares

### DIFF
--- a/__tests__/common/channelDigestGenerate.ts
+++ b/__tests__/common/channelDigestGenerate.ts
@@ -7,8 +7,14 @@ import {
 } from '@dailydotdev/schema';
 import createOrGetConnection from '../../src/db';
 import { ChannelDigest } from '../../src/entity/ChannelDigest';
-import { AGENTS_DIGEST_SOURCE, Source } from '../../src/entity/Source';
+import {
+  AGENTS_DIGEST_SOURCE,
+  Source,
+  UNKNOWN_SOURCE,
+} from '../../src/entity/Source';
 import { FreeformPost } from '../../src/entity/posts/FreeformPost';
+import { PostType } from '../../src/entity/posts/Post';
+import { SharePost } from '../../src/entity/posts/SharePost';
 import { generateChannelDigest } from '../../src/common/channelDigest/generate';
 import { createSource } from '../fixture/source';
 import * as bragiClients from '../../src/integrations/bragi/clients';
@@ -290,6 +296,152 @@ describe('generateChannelDigest', () => {
           },
         ],
       }),
+    );
+  });
+
+  it('should remap unknown-source posts to their public SharePost counterpart', async () => {
+    const now = new Date('2026-03-03T10:00:00.000Z');
+    let request: TopicalDigestRequest | undefined;
+
+    jest.spyOn(bragiClients, 'getBragiClient').mockImplementation(
+      (): ServiceClient<typeof Pipelines> => ({
+        instance: {
+          generateTopicalDigest: async (data: TopicalDigestRequest) => {
+            request = data;
+
+            return new TopicalDigest({
+              title: 'Remap digest',
+              tldr: 'Remap summary',
+              mainItems: [
+                new TopicalDigestItem({
+                  title: 'Remap item',
+                  body: 'Remap body',
+                  postIds: ['sh-pub'],
+                }),
+              ],
+            });
+          },
+        } as ServiceClient<typeof Pipelines>['instance'],
+        garmr: createGarmrMock(),
+      }),
+    );
+
+    await con
+      .getRepository(Source)
+      .save([
+        createSource(
+          UNKNOWN_SOURCE,
+          'Unknown',
+          'https://daily.dev/unknown.png',
+        ),
+        createSource(
+          'squad-public',
+          'Public Squad',
+          'https://daily.dev/sq.png',
+        ),
+        createSource(
+          'remap-digest-source',
+          'Digest',
+          'https://daily.dev/d.png',
+        ),
+      ]);
+    const definition = await saveDefinition({
+      key: 'remap-test',
+      sourceId: 'remap-digest-source',
+      channel: 'remap',
+      frequency: 'daily',
+    });
+    await savePost({
+      id: 'unk-art',
+      sourceId: UNKNOWN_SOURCE,
+      title: 'Unknown article',
+      content: 'Article content',
+      createdAt: new Date('2026-03-03T09:00:00.000Z'),
+      channel: 'remap',
+    });
+    await con.getRepository(SharePost).save({
+      id: 'sh-pub',
+      shortId: 'sh-pub',
+      sourceId: 'squad-public',
+      type: PostType.Share,
+      sharedPostId: 'unk-art',
+      visible: true,
+      private: false,
+      showOnFeed: true,
+      deleted: false,
+      banned: false,
+      createdAt: new Date('2026-03-03T09:30:00.000Z'),
+    });
+
+    const result = await generateChannelDigest({ con, definition, now });
+
+    expect(request?.posts.map((post) => post.postId)).toEqual(['sh-pub']);
+    expect(request?.posts[0]).toMatchObject({
+      title: 'Unknown article',
+      summary: 'Article content',
+    });
+    expect(result?.content).toContain(
+      '[Read more](http://localhost:5002/posts/sh-pub)',
+    );
+  });
+
+  it('should keep the unknown-source post id when no public SharePost exists', async () => {
+    const now = new Date('2026-03-03T10:00:00.000Z');
+    let request: TopicalDigestRequest | undefined;
+
+    jest.spyOn(bragiClients, 'getBragiClient').mockImplementation(
+      (): ServiceClient<typeof Pipelines> => ({
+        instance: {
+          generateTopicalDigest: async (data: TopicalDigestRequest) => {
+            request = data;
+
+            return new TopicalDigest({
+              title: 'Keep digest',
+              tldr: 'Keep summary',
+              mainItems: [
+                new TopicalDigestItem({
+                  title: 'Keep item',
+                  body: 'Keep body',
+                  postIds: ['orph-art'],
+                }),
+              ],
+            });
+          },
+        } as ServiceClient<typeof Pipelines>['instance'],
+        garmr: createGarmrMock(),
+      }),
+    );
+
+    await con
+      .getRepository(Source)
+      .save([
+        createSource(
+          UNKNOWN_SOURCE,
+          'Unknown',
+          'https://daily.dev/unknown.png',
+        ),
+        createSource('keep-digest-source', 'Digest', 'https://daily.dev/d.png'),
+      ]);
+    const definition = await saveDefinition({
+      key: 'keep-test',
+      sourceId: 'keep-digest-source',
+      channel: 'keep',
+      frequency: 'daily',
+    });
+    await savePost({
+      id: 'orph-art',
+      sourceId: UNKNOWN_SOURCE,
+      title: 'Orphan article',
+      content: 'Orphan content',
+      createdAt: new Date('2026-03-03T09:00:00.000Z'),
+      channel: 'keep',
+    });
+
+    const result = await generateChannelDigest({ con, definition, now });
+
+    expect(request?.posts.map((post) => post.postId)).toEqual(['orph-art']);
+    expect(result?.content).toContain(
+      '[Read more](http://localhost:5002/posts/orph-art)',
     );
   });
 });

--- a/src/common/channelDigest/generate.ts
+++ b/src/common/channelDigest/generate.ts
@@ -15,6 +15,8 @@ import {
   PostRelation,
   PostRelationType,
 } from '../../entity/posts/PostRelation';
+import { UNKNOWN_SOURCE } from '../../entity/Source';
+import { fetchPublicShareFallbackPostIds } from '../channelHighlight/queries';
 import {
   getChannelDigestLookbackSeconds,
   getChannelDigestSourceIds,
@@ -22,6 +24,7 @@ import {
 
 type DigestPostRow = {
   id: string;
+  sourceId: string;
   title: string | null;
   summary: string | null;
   content: string | null;
@@ -104,6 +107,7 @@ const findDigestPosts = async ({
       },
     )
     .select('post.id', 'id')
+    .addSelect('post."sourceId"', 'sourceId')
     .addSelect('post.title', 'title')
     .addSelect('post.summary', 'summary')
     .addSelect('post.content', 'content')
@@ -121,6 +125,48 @@ const findDigestPosts = async ({
     .andWhere('relation."relatedPostId" IS NULL')
     .orderBy('post.createdAt', 'DESC')
     .getRawMany<DigestPostRow>();
+};
+
+const remapUnknownSourcePostIds = async ({
+  con,
+  posts,
+  excludedSourceIds,
+}: {
+  con: DataSource;
+  posts: DigestPostRow[];
+  excludedSourceIds: string[];
+}): Promise<DigestPostRow[]> => {
+  const unknownPostIds = posts
+    .filter((post) => post.sourceId === UNKNOWN_SOURCE)
+    .map((post) => post.id);
+
+  if (!unknownPostIds.length) {
+    return posts;
+  }
+
+  const fallbacks = await fetchPublicShareFallbackPostIds({
+    con,
+    sharedPostIds: unknownPostIds,
+    excludedSourceIds,
+  });
+
+  const seen = new Set<string>();
+  const remapped: DigestPostRow[] = [];
+
+  for (const post of posts) {
+    const fallbackId =
+      post.sourceId === UNKNOWN_SOURCE ? fallbacks.get(post.id) : undefined;
+    const id = fallbackId ?? post.id;
+
+    if (seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    remapped.push(fallbackId ? { ...post, id } : post);
+  }
+
+  return remapped;
 };
 
 const buildDigestPosts = ({
@@ -265,10 +311,15 @@ export const generateChannelDigest = async ({
   const excludedSourceIds = await getChannelDigestSourceIds({
     con,
   });
-  const posts = await findDigestPosts({
+  const rawPosts = await findDigestPosts({
     con,
     from,
     channel: definition.channel,
+    excludedSourceIds,
+  });
+  const posts = await remapUnknownSourcePostIds({
+    con,
+    posts: rawPosts,
     excludedSourceIds,
   });
 

--- a/src/common/channelHighlight/queries.ts
+++ b/src/common/channelHighlight/queries.ts
@@ -190,6 +190,7 @@ export const fetchPublicShareFallbackPostIds = async ({
   const shares = await con
     .getRepository(SharePost)
     .createQueryBuilder('post')
+    .select(['post.id', 'post.sharedPostId'])
     .where('post."sharedPostId" IN (:...sharedPostIds)', {
       sharedPostIds,
     })


### PR DESCRIPTION
## Summary
- Articles created via squad shares of external links have `sourceId='unknown'` and don't render as standalone pages. After #3914 added `[Read more]` links to topical digests, any unknown-source article that Bragi picked surfaced as a broken `/posts/<id>` link.
- Mirrors the `channelHighlight` pattern: for each unknown-source candidate, swap to the best public `SharePost` counterpart via the existing `fetchPublicShareFallbackPostIds` helper. Falls back to the original id when no public share exists, so editorial coverage isn't lost on rare orphans.
- Tightened `fetchPublicShareFallbackPostIds` to select only `id` + `sharedPostId`.

## Verified
- 6 generator tests pass (4 existing + 2 new: remap-when-share-exists, keep-when-no-share)
- All 8 worker tests + 31 channel-highlight tests still pass
- Dry-ran against the agentic digest on prod data (no post written): 6/27 candidates were unknown-sourced, all 6 successfully remapped to their public shares. Before the fix, one of those would have linked to `/posts/tl2aTyPEZ` (broken); after, it links to `/posts/eC0jdjIYx` (the public share).

## Test plan
- [ ] Wait for next agentic digest cron run and confirm no unknown-source links in the generated post