### PR TITLE
feat(highlights): add postHighlightsFeed query with channel and significance filters

### DIFF
--- a/__tests__/highlights.ts
+++ b/__tests__/highlights.ts
@@ -138,6 +138,41 @@ const MAJOR_HEADLINES_QUERY = `
   }
 `;
 
+const POST_HIGHLIGHTS_FEED_QUERY = `
+  query PostHighlightsFeed(
+    $channel: String
+    $significance: [String!]
+    $first: Int
+    $after: String
+  ) {
+    postHighlightsFeed(
+      channel: $channel
+      significance: $significance
+      first: $first
+      after: $after
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          id
+          channel
+          highlightedAt
+          headline
+          significance
+          post {
+            id
+            title
+          }
+        }
+      }
+    }
+  }
+`;
+
 const CHANNEL_CONFIGURATIONS_QUERY = `
   query ChannelConfigurations {
     channelConfigurations {
@@ -489,6 +524,304 @@ describe('query majorHeadlines', () => {
     expect(res.data.majorHeadlines.edges[0].node).toMatchObject({
       channel: 'vibes',
       headline: 'Live breaking headline',
+      post: { id: 'h1' },
+    });
+  });
+});
+
+describe('query postHighlightsFeed', () => {
+  it('should return all highlights deduplicated by post and ordered desc when no filters are provided', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Older agentic',
+        significance: PostHighlightSignificance.Major,
+      },
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Newer vibes',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Notable headline',
+        significance: PostHighlightSignificance.Notable,
+      },
+      {
+        postId: 'h3',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:20:00.000Z'),
+        headline: 'Routine headline',
+        significance: PostHighlightSignificance.Routine,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.pageInfo.hasNextPage).toBe(false);
+    expect(res.data.postHighlightsFeed.edges.map(({ node }) => node)).toEqual([
+      expect.objectContaining({
+        channel: 'vibes',
+        headline: 'Newer vibes',
+        significance: 'breaking',
+        post: { id: 'h1', title: 'Test Post 1' },
+      }),
+      expect.objectContaining({
+        channel: 'vibes',
+        headline: 'Notable headline',
+        significance: 'notable',
+        post: { id: 'h2', title: 'Test Post 2' },
+      }),
+      expect.objectContaining({
+        channel: 'agentic',
+        headline: 'Routine headline',
+        significance: 'routine',
+        post: { id: 'h3', title: 'Test Post 3' },
+      }),
+    ]);
+  });
+
+  it('should filter by channel', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Vibes headline',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Agentic headline',
+        significance: PostHighlightSignificance.Major,
+      },
+      {
+        postId: 'h3',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Another agentic headline',
+        significance: PostHighlightSignificance.Notable,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { channel: 'agentic', first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.edges).toHaveLength(2);
+    expect(
+      res.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
+    ).toEqual(['h2', 'h3']);
+  });
+
+  it('should filter by significance', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Breaking headline',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Major headline',
+        significance: PostHighlightSignificance.Major,
+      },
+      {
+        postId: 'h3',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Notable headline',
+        significance: PostHighlightSignificance.Notable,
+      },
+      {
+        postId: 'h4',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:25:00.000Z'),
+        headline: 'Routine headline',
+        significance: PostHighlightSignificance.Routine,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { significance: ['breaking', 'major'], first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.edges).toHaveLength(2);
+    expect(
+      res.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
+    ).toEqual(['h1', 'h2']);
+  });
+
+  it('should combine channel and significance filters', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Vibes breaking',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Agentic breaking',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h3',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Agentic notable',
+        significance: PostHighlightSignificance.Notable,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: {
+        channel: 'agentic',
+        significance: ['breaking'],
+        first: 10,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.edges).toHaveLength(1);
+    expect(res.data.postHighlightsFeed.edges[0].node).toMatchObject({
+      channel: 'agentic',
+      headline: 'Agentic breaking',
+      post: { id: 'h2' },
+    });
+  });
+
+  it('should ignore unknown significance values', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Breaking headline',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Routine headline',
+        significance: PostHighlightSignificance.Routine,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { significance: ['nonsense'], first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.edges).toHaveLength(2);
+  });
+
+  it('should paginate ordered by highlightedAt desc', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Headline 1',
+        significance: PostHighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Headline 2',
+        significance: PostHighlightSignificance.Notable,
+      },
+      {
+        postId: 'h3',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Headline 3',
+        significance: PostHighlightSignificance.Routine,
+      },
+    ]);
+
+    const firstPage = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { first: 2 },
+    });
+
+    expect(firstPage.errors).toBeFalsy();
+    expect(firstPage.data.postHighlightsFeed.pageInfo.hasNextPage).toBe(true);
+    expect(
+      firstPage.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
+    ).toEqual(['h1', 'h2']);
+
+    const secondPage = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: {
+        first: 2,
+        after: firstPage.data.postHighlightsFeed.pageInfo.endCursor,
+      },
+    });
+
+    expect(secondPage.errors).toBeFalsy();
+    expect(secondPage.data.postHighlightsFeed.pageInfo.hasNextPage).toBe(false);
+    expect(
+      secondPage.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
+    ).toEqual(['h3']);
+  });
+
+  it('should exclude retired highlights', async () => {
+    await createTestPosts();
+    await con.getRepository(PostHighlight).save([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Live headline',
+        significance: PostHighlightSignificance.Breaking,
+        retiredAt: null,
+      },
+      {
+        postId: 'h2',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Retired headline',
+        significance: PostHighlightSignificance.Major,
+        retiredAt: new Date('2026-03-19T10:45:00.000Z'),
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.postHighlightsFeed.edges).toHaveLength(1);
+    expect(res.data.postHighlightsFeed.edges[0].node).toMatchObject({
+      channel: 'vibes',
+      headline: 'Live headline',
       post: { id: 'h1' },
     });
   });

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -13,6 +13,7 @@ import type { OffsetPage } from './common';
 import {
   PostHighlight,
   PostHighlightSignificance,
+  toPostHighlightSignificance,
 } from '../entity/PostHighlight';
 import type { GQLSource } from './sources';
 
@@ -87,6 +88,18 @@ export const typeDefs = /* GraphQL */ `
     Get major headlines across all channels, deduplicated by post and ordered by recency
     """
     majorHeadlines(first: Int, after: String): PostHighlightConnection!
+
+    """
+    Get highlights deduplicated by post and ordered by recency.
+    Accepts optional channel and significance filters so it can power per-channel,
+    major-headlines and global feeds from a single endpoint.
+    """
+    postHighlightsFeed(
+      channel: String
+      significance: [String!]
+      first: Int
+      after: String
+    ): PostHighlightConnection!
   }
 
   extend type Subscription {
@@ -99,38 +112,109 @@ const majorHeadlineSignificances = [
   PostHighlightSignificance.Major,
 ];
 
-const defaultMajorHeadlinesLimit = 10;
-const maxMajorHeadlinesLimit = 50;
+const defaultHighlightsLimit = 10;
+const maxHighlightsLimit = 50;
 
-const getMajorHeadlinesPage = (args: ConnectionArguments): OffsetPage => ({
-  limit:
-    Math.min(args.first || defaultMajorHeadlinesLimit, maxMajorHeadlinesLimit) +
-    1,
+const getHighlightsPage = (args: ConnectionArguments): OffsetPage => ({
+  limit: Math.min(args.first || defaultHighlightsLimit, maxHighlightsLimit) + 1,
   offset: getOffsetWithDefault(args.after, -1) + 1,
 });
 
-const addMajorHeadlineFilter = <T extends PostHighlight>(
-  builder: SelectQueryBuilder<T>,
-): SelectQueryBuilder<T> =>
-  builder
-    .where('highlight.significance IN (:...significances)', {
-      significances: majorHeadlineSignificances,
-    })
-    .andWhere('highlight."retiredAt" IS NULL');
+type HighlightsFilters = {
+  channel?: string | null;
+  significances?: PostHighlightSignificance[];
+};
 
-const getDedupedMajorHeadlinesQuery = (
+const applyHighlightsFilters = <T extends PostHighlight>(
+  builder: SelectQueryBuilder<T>,
+  { channel, significances }: HighlightsFilters,
+): SelectQueryBuilder<T> => {
+  let qb = builder.where('highlight."retiredAt" IS NULL');
+
+  if (significances && significances.length > 0) {
+    qb = qb.andWhere('highlight.significance IN (:...significances)', {
+      significances,
+    });
+  }
+
+  if (channel) {
+    qb = qb.andWhere('highlight.channel = :channel', { channel });
+  }
+
+  return qb;
+};
+
+const getDedupedHighlightsQuery = (
   queryBuilder: SelectQueryBuilder<PostHighlight>,
+  filters: HighlightsFilters,
 ) =>
-  addMajorHeadlineFilter(
+  applyHighlightsFilters(
     queryBuilder
       .subQuery()
       .select('highlight.id', 'id')
       .from(PostHighlight, 'highlight'),
+    filters,
   )
     .distinctOn(['highlight.postId'])
     .orderBy('highlight.postId', 'ASC')
     .addOrderBy('highlight.highlightedAt', 'DESC')
     .addOrderBy('highlight.id', 'DESC');
+
+const resolveDedupedHighlightsFeed = (
+  ctx: Context,
+  info: Parameters<typeof graphorm.queryPaginated>[1],
+  args: ConnectionArguments,
+  filters: HighlightsFilters,
+) => {
+  const page = getHighlightsPage(args);
+
+  return graphorm.queryPaginated(
+    ctx,
+    info,
+    () => page.offset > 0,
+    (nodeSize) => nodeSize >= page.limit,
+    (_, index) => offsetToCursor(page.offset + index),
+    (builder) => {
+      const dedupedIdsQuery = getDedupedHighlightsQuery(
+        builder.queryBuilder as SelectQueryBuilder<PostHighlight>,
+        filters,
+      );
+
+      builder.queryBuilder
+        .innerJoin(
+          `(${dedupedIdsQuery.getQuery()})`,
+          'deduped',
+          `deduped.id = ${builder.alias}.id`,
+        )
+        .setParameters(dedupedIdsQuery.getParameters())
+        .orderBy(`${builder.alias}."highlightedAt"`, 'DESC')
+        .addOrderBy(`${builder.alias}."id"`, 'DESC')
+        .offset(page.offset)
+        .limit(page.limit);
+
+      return builder;
+    },
+    (nodes) => nodes.slice(0, page.limit - 1),
+    true,
+  );
+};
+
+type PostHighlightsFeedArgs = ConnectionArguments & {
+  channel?: string | null;
+  significance?: string[] | null;
+};
+
+const parseSignificanceFilters = (
+  values: string[] | null | undefined,
+): PostHighlightSignificance[] => {
+  if (!values?.length) {
+    return [];
+  }
+
+  return values
+    .map(toPostHighlightSignificance)
+    .filter((value) => value !== PostHighlightSignificance.Unspecified);
+};
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
   Query: {
@@ -164,43 +248,20 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         },
         true,
       ),
-    majorHeadlines: async (
+    majorHeadlines: async (_, args: ConnectionArguments, ctx: Context, info) =>
+      resolveDedupedHighlightsFeed(ctx, info, args, {
+        significances: majorHeadlineSignificances,
+      }),
+    postHighlightsFeed: async (
       _,
-      args: ConnectionArguments,
+      args: PostHighlightsFeedArgs,
       ctx: Context,
       info,
-    ) => {
-      const page = getMajorHeadlinesPage(args);
-
-      return graphorm.queryPaginated(
-        ctx,
-        info,
-        () => page.offset > 0,
-        (nodeSize) => nodeSize >= page.limit,
-        (_, index) => offsetToCursor(page.offset + index),
-        (builder) => {
-          const dedupedIdsQuery = getDedupedMajorHeadlinesQuery(
-            builder.queryBuilder as SelectQueryBuilder<PostHighlight>,
-          );
-
-          builder.queryBuilder
-            .innerJoin(
-              `(${dedupedIdsQuery.getQuery()})`,
-              'deduped',
-              `deduped.id = ${builder.alias}.id`,
-            )
-            .setParameters(dedupedIdsQuery.getParameters())
-            .orderBy(`${builder.alias}."highlightedAt"`, 'DESC')
-            .addOrderBy(`${builder.alias}."id"`, 'DESC')
-            .offset(page.offset)
-            .limit(page.limit);
-
-          return builder;
-        },
-        (nodes) => nodes.slice(0, page.limit - 1),
-        true,
-      );
-    },
+    ) =>
+      resolveDedupedHighlightsFeed(ctx, info, args, {
+        channel: args.channel,
+        significances: parseSignificanceFilters(args.significance),
+      }),
   },
   Subscription: {
     newHighlight: {

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -1,4 +1,5 @@
 import { IResolvers } from '@graphql-tools/utils';
+import type { GraphQLResolveInfo } from 'graphql';
 import {
   ConnectionArguments,
   getOffsetWithDefault,
@@ -162,7 +163,7 @@ const getDedupedHighlightsQuery = (
 
 const resolveDedupedHighlightsFeed = (
   ctx: Context,
-  info: Parameters<typeof graphorm.queryPaginated>[1],
+  info: GraphQLResolveInfo,
   args: ConnectionArguments,
   filters: HighlightsFilters,
 ) => {
@@ -206,15 +207,10 @@ type PostHighlightsFeedArgs = ConnectionArguments & {
 
 const parseSignificanceFilters = (
   values: string[] | null | undefined,
-): PostHighlightSignificance[] => {
-  if (!values?.length) {
-    return [];
-  }
-
-  return values
+): PostHighlightSignificance[] =>
+  (values ?? [])
     .map(toPostHighlightSignificance)
     .filter((value) => value !== PostHighlightSignificance.Unspecified);
-};
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
   Query: {


### PR DESCRIPTION
## Summary

Introduces a single paginated highlights endpoint that can power the new "All" tab on `/highlights`, and is designed to eventually replace `majorHeadlines` and the per-channel `postHighlights` query.

- New query: `postHighlightsFeed(channel: String, significance: [String!], first: Int, after: String): PostHighlightConnection!`
- Always deduplicates by `postId` (most recent highlight per post). For per-channel reads this is a no-op thanks to the existing `(channel, postId)` unique constraint.
- Significance filter parses string labels (`breaking`, `major`, `notable`, `routine`) and silently drops unknown values, so the client never errors on a stale filter list.
- Extracted `resolveDedupedHighlightsFeed` and `getDedupedHighlightsQuery` helpers; `majorHeadlines` now delegates to them so both endpoints share the same dedup/pagination implementation.

## Key decisions

- Kept `majorHeadlines` and `postHighlights(channel)` in place to avoid coupling this change to a client migration. They can be deleted once all callers move to `postHighlightsFeed`.
- Reused the existing offset-cursor pagination pattern (`getOffsetWithDefault` / `offsetToCursor`) with overfetch-by-one to avoid an extra `COUNT(*)`, matching `majorHeadlines`.
- Reused the read replica (`true` flag to `graphorm.queryPaginated`) since highlights are read-heavy and eventually consistent.

## Test plan

- [x] `pnpm exec eslint src/schema/highlights.ts __tests__/highlights.ts --max-warnings 0`
- [x] `pnpm run build`
- [x] `NODE_ENV=test pnpm exec jest __tests__/highlights.ts --testEnvironment=node --runInBand` — 15/15 pass (7 new `postHighlightsFeed` cases covering no filters, channel filter, significance filter, combined filters, unknown values, pagination, and retired exclusion)

Closes ENG-1590

---
Created by Huginn 🐦‍⬛