### PR TITLE
feat: read highlights from canonical

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -13,10 +13,10 @@ import {
   FeedAdvancedSettings,
   FeedOrderBy,
   FreeformPost,
+  HighlightsCanonical,
   Keyword,
   MachineSource,
   Post,
-  PostHighlight,
   PostKeyword,
   PostTag,
   PostType,
@@ -1227,18 +1227,18 @@ describe('query feedV2', () => {
   it('should return mixed post and highlight items', async () => {
     loggedUser = '1';
     await saveFeedFixtures();
-    await con.getRepository(PostHighlight).save([
+    await con.getRepository(HighlightsCanonical).save([
       {
         id: '3c75fab6-e28b-431d-ab54-a927708de085',
         postId: 'p1',
-        channel: 'happening-now',
+        channels: ['happening-now'],
         highlightedAt: new Date('2026-03-19T10:10:00.000Z'),
         headline: 'First highlight',
       },
       {
         id: 'c2e332bf-83ac-4651-8a05-8e19fbefc5ac',
         postId: 'p4',
-        channel: 'happening-now',
+        channels: ['happening-now'],
         highlightedAt: new Date('2026-03-19T10:20:00.000Z'),
         headline: 'Second highlight',
       },

--- a/__tests__/highlights.ts
+++ b/__tests__/highlights.ts
@@ -11,11 +11,9 @@ import createOrGetConnection from '../src/db';
 import { ArticlePost } from '../src/entity/posts/ArticlePost';
 import { ChannelDigest } from '../src/entity/ChannelDigest';
 import { ChannelHighlightDefinition } from '../src/entity/ChannelHighlightDefinition';
+import { HighlightsCanonical } from '../src/entity/HighlightsCanonical';
 import { Source, SourceType } from '../src/entity/Source';
-import {
-  PostHighlight,
-  PostHighlightSignificance,
-} from '../src/entity/PostHighlight';
+import { PostHighlightSignificance } from '../src/entity/PostHighlight';
 import { PostType } from '../src/entity/posts/Post';
 import { sourcesFixture } from './fixture/source';
 
@@ -91,12 +89,26 @@ beforeEach(async () => {
   jest.resetAllMocks();
   await con.getRepository(ChannelDigest).clear();
   await con.getRepository(ChannelHighlightDefinition).clear();
-  await con.getRepository(PostHighlight).clear();
+  await con.getRepository(HighlightsCanonical).clear();
   await con.getRepository(ArticlePost).delete(['h1', 'h2', 'h3', 'h4']);
   await con
     .getRepository(Source)
     .delete(['a', 'b', 'c', 'backend_digest', 'career_digest']);
 });
+
+const saveCanonicalHighlights = (
+  highlights: Array<
+    Partial<HighlightsCanonical> & {
+      channel?: string;
+    }
+  >,
+): Promise<HighlightsCanonical[]> =>
+  con.getRepository(HighlightsCanonical).save(
+    highlights.map(({ channel, channels, ...highlight }) => ({
+      ...highlight,
+      channels: channels ?? (channel ? [channel] : []),
+    })),
+  );
 
 const QUERY = `
   query PostHighlights($channel: String!) {
@@ -269,7 +281,7 @@ describe('query postHighlights', () => {
 
   it('should return highlights ordered by highlightedAt desc', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h2',
         channel: 'happening-now',
@@ -313,7 +325,7 @@ describe('query postHighlights', () => {
 
   it('should filter by channel', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'happening-now',
@@ -340,54 +352,15 @@ describe('query postHighlights', () => {
       post: { id: 'h2' },
     });
   });
-
-  it('should hide retired highlights', async () => {
-    await createTestPosts();
-    await con.getRepository(PostHighlight).save([
-      {
-        postId: 'h1',
-        channel: 'happening-now',
-        highlightedAt: new Date('2026-03-19T10:00:00.000Z'),
-        headline: 'Still live',
-        retiredAt: null,
-      },
-      {
-        postId: 'h2',
-        channel: 'happening-now',
-        highlightedAt: new Date('2026-03-19T10:05:00.000Z'),
-        headline: 'Retired headline',
-        retiredAt: new Date('2026-03-19T10:10:00.000Z'),
-      },
-    ]);
-
-    const res = await client.query(QUERY, {
-      variables: { channel: 'happening-now' },
-    });
-
-    expect(res.errors).toBeFalsy();
-    expect(res.data.postHighlights).toHaveLength(1);
-    expect(res.data.postHighlights[0]).toMatchObject({
-      channel: 'happening-now',
-      headline: 'Still live',
-      post: { id: 'h1' },
-    });
-  });
 });
 
 describe('query majorHeadlines', () => {
-  it('should return only breaking and major headlines deduplicated by postId', async () => {
+  it('should return only breaking and major headlines ordered by highlightedAt desc', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
-        channel: 'agentic',
-        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
-        headline: 'Major agentic headline',
-        significance: PostHighlightSignificance.Major,
-      },
-      {
-        postId: 'h1',
-        channel: 'vibes',
+        channels: ['vibes', 'agentic'],
         highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
         headline: 'Newer breaking headline',
         significance: PostHighlightSignificance.Breaking,
@@ -446,7 +419,7 @@ describe('query majorHeadlines', () => {
 
   it('should paginate major headlines ordered by highlightedAt desc', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -493,56 +466,15 @@ describe('query majorHeadlines', () => {
       secondPage.data.majorHeadlines.edges.map(({ node }) => node.post.id),
     ).toEqual(['h3']);
   });
-
-  it('should exclude retired major headlines', async () => {
-    await createTestPosts();
-    await con.getRepository(PostHighlight).save([
-      {
-        postId: 'h1',
-        channel: 'vibes',
-        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
-        headline: 'Live breaking headline',
-        significance: PostHighlightSignificance.Breaking,
-        retiredAt: null,
-      },
-      {
-        postId: 'h2',
-        channel: 'agentic',
-        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
-        headline: 'Retired major headline',
-        significance: PostHighlightSignificance.Major,
-        retiredAt: new Date('2026-03-19T10:45:00.000Z'),
-      },
-    ]);
-
-    const res = await client.query(MAJOR_HEADLINES_QUERY, {
-      variables: { first: 10 },
-    });
-
-    expect(res.errors).toBeFalsy();
-    expect(res.data.majorHeadlines.edges).toHaveLength(1);
-    expect(res.data.majorHeadlines.edges[0].node).toMatchObject({
-      channel: 'vibes',
-      headline: 'Live breaking headline',
-      post: { id: 'h1' },
-    });
-  });
 });
 
 describe('query postHighlightsFeed', () => {
-  it('should return all highlights deduplicated by post and ordered desc when no filters are provided', async () => {
+  it('should return all highlights ordered desc when no filters are provided', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
-        channel: 'agentic',
-        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
-        headline: 'Older agentic',
-        significance: PostHighlightSignificance.Major,
-      },
-      {
-        postId: 'h1',
-        channel: 'vibes',
+        channels: ['vibes', 'agentic'],
         highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
         headline: 'Newer vibes',
         significance: PostHighlightSignificance.Breaking,
@@ -593,7 +525,7 @@ describe('query postHighlightsFeed', () => {
 
   it('should filter by channel', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -630,7 +562,7 @@ describe('query postHighlightsFeed', () => {
 
   it('should filter by significance', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -674,7 +606,7 @@ describe('query postHighlightsFeed', () => {
 
   it('should combine channel and significance filters', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -717,7 +649,7 @@ describe('query postHighlightsFeed', () => {
 
   it('should ignore unknown significance values', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -744,7 +676,7 @@ describe('query postHighlightsFeed', () => {
 
   it('should paginate ordered by highlightedAt desc', async () => {
     await createTestPosts();
-    await con.getRepository(PostHighlight).save([
+    await saveCanonicalHighlights([
       {
         postId: 'h1',
         channel: 'vibes',
@@ -790,39 +722,5 @@ describe('query postHighlightsFeed', () => {
     expect(
       secondPage.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
     ).toEqual(['h3']);
-  });
-
-  it('should exclude retired highlights', async () => {
-    await createTestPosts();
-    await con.getRepository(PostHighlight).save([
-      {
-        postId: 'h1',
-        channel: 'vibes',
-        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
-        headline: 'Live headline',
-        significance: PostHighlightSignificance.Breaking,
-        retiredAt: null,
-      },
-      {
-        postId: 'h2',
-        channel: 'agentic',
-        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
-        headline: 'Retired headline',
-        significance: PostHighlightSignificance.Major,
-        retiredAt: new Date('2026-03-19T10:45:00.000Z'),
-      },
-    ]);
-
-    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
-      variables: { first: 10 },
-    });
-
-    expect(res.errors).toBeFalsy();
-    expect(res.data.postHighlightsFeed.edges).toHaveLength(1);
-    expect(res.data.postHighlightsFeed.edges[0].node).toMatchObject({
-      channel: 'vibes',
-      headline: 'Live headline',
-      post: { id: 'h1' },
-    });
   });
 });

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -23,6 +23,7 @@ import {
   Feed,
   FeedType,
   FreeformPost,
+  HighlightsCanonical,
   Post,
   PostMention,
   PostOrigin,
@@ -42,10 +43,7 @@ import {
   WelcomePost,
   YouTubePost,
 } from '../src/entity';
-import {
-  PostHighlight,
-  PostHighlightSignificance,
-} from '../src/entity/PostHighlight';
+import { PostHighlightSignificance } from '../src/entity/PostHighlight';
 import { Roles, SourceMemberRoles, sourceRoleRank } from '../src/roles';
 import { sourcesFixture } from './fixture/source';
 import {
@@ -925,6 +923,10 @@ describe('postHighlight field', () => {
     }
   }`;
 
+  beforeEach(async () => {
+    await con.getRepository(HighlightsCanonical).clear();
+  });
+
   it('returns null when the post has no active highlight', async () => {
     const res = await client.query(QUERY);
     expect(res.errors).toBeFalsy();
@@ -932,9 +934,9 @@ describe('postHighlight field', () => {
   });
 
   it('returns the active highlight when one exists', async () => {
-    await con.getRepository(PostHighlight).save({
+    await con.getRepository(HighlightsCanonical).save({
       postId: 'p1',
-      channel: 'vibes',
+      channels: ['vibes'],
       highlightedAt: new Date(),
       headline: 'Breaking headline',
       significance: PostHighlightSignificance.Breaking,
@@ -952,9 +954,9 @@ describe('postHighlight field', () => {
   });
 
   it('returns null when the highlight significance is unspecified', async () => {
-    await con.getRepository(PostHighlight).save({
+    await con.getRepository(HighlightsCanonical).save({
       postId: 'p1',
-      channel: 'vibes',
+      channels: ['vibes'],
       highlightedAt: new Date(),
       headline: 'Unspecified headline',
       significance: PostHighlightSignificance.Unspecified,
@@ -965,25 +967,10 @@ describe('postHighlight field', () => {
     expect(res.data.post.postHighlight).toBeNull();
   });
 
-  it('returns null when the highlight is retired', async () => {
-    await con.getRepository(PostHighlight).save({
-      postId: 'p1',
-      channel: 'vibes',
-      highlightedAt: new Date(),
-      headline: 'Retired headline',
-      significance: PostHighlightSignificance.Breaking,
-      retiredAt: new Date(),
-    });
-
-    const res = await client.query(QUERY);
-    expect(res.errors).toBeFalsy();
-    expect(res.data.post.postHighlight).toBeNull();
-  });
-
   it('returns null when the highlight is older than the TTL', async () => {
-    await con.getRepository(PostHighlight).save({
+    await con.getRepository(HighlightsCanonical).save({
       postId: 'p1',
-      channel: 'vibes',
+      channels: ['vibes'],
       highlightedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
       headline: 'Stale headline',
       significance: PostHighlightSignificance.Breaking,

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -749,7 +749,6 @@ const obj = new GraphORM({
               .andWhere(`${childAlias}."significance" != :unspecified`, {
                 unspecified: PostHighlightSignificance.Unspecified,
               })
-              .andWhere(`${childAlias}."retiredAt" IS NULL`)
               .andWhere(
                 `${childAlias}."highlightedAt" > now() - (:ttlSeconds || ' seconds')::interval`,
                 { ttlSeconds: getPostHighlightTtlSeconds() },
@@ -2773,7 +2772,15 @@ const obj = new GraphORM({
     },
   },
   PostHighlight: {
+    from: 'HighlightsCanonical',
+    requiredColumns: ['postId'],
+    additionalQuery: (_ctx, _alias, qb): QueryBuilder =>
+      qb.setParameter('highlightChannel', null),
     fields: {
+      channel: {
+        select: (_ctx, alias) =>
+          `coalesce(:highlightChannel, "${alias}"."channels"[1], '')`,
+      },
       significance: {
         transform: (value: PostHighlightSignificance) =>
           toPostHighlightSignificanceLabel(value),

--- a/src/schema/feedV2.ts
+++ b/src/schema/feedV2.ts
@@ -18,7 +18,7 @@ import {
   fixedIdsFeedBuilder,
   Ranking,
 } from '../common';
-import { type PostHighlight } from '../entity';
+import { HighlightsCanonical } from '../entity';
 
 export type FeedV2Args = FeedArgs & {
   unreadOnly: boolean;
@@ -35,12 +35,13 @@ type GQLFeedPostItem = {
 
 type GQLFeedHighlightsItem = {
   itemType: 'highlight';
-  highlightIds: string[];
-  highlights?: PostHighlight[];
+  highlights?: GQLPostHighlight[];
   feedMeta: string | null;
 };
 
 type GQLFeedItem = GQLFeedPostItem | GQLFeedHighlightsItem;
+
+type GQLPostHighlight = HighlightsCanonical & { channel: string };
 
 export const feedV2TypeDefs = /* GraphQL */ `
   type FeedItemConnection {
@@ -175,7 +176,7 @@ const toFeedV2Items = ({
 }: {
   response: FeedResponse;
   postsById: Map<string, GQLPost>;
-  highlightsById: Map<string, PostHighlight>;
+  highlightsById: Map<string, GQLPostHighlight>;
 }): GQLFeedItem[] =>
   response.data.reduce<GQLFeedItem[]>((acc, item) => {
     if (isFeedResponseHighlightItem(item)) {
@@ -183,16 +184,14 @@ const toFeedV2Items = ({
         return acc;
       }
 
+      const highlights = item.highlightIds.flatMap((id) => {
+        const highlight = highlightsById.get(id);
+        return highlight ? [highlight] : [];
+      });
+
       acc.push({
         itemType: 'highlight',
-        highlightIds: item.highlightIds,
-        highlights: item.highlightIds.reduce<PostHighlight[]>((items, id) => {
-          const highlight = highlightsById.get(id);
-          if (highlight) {
-            items.push(highlight);
-          }
-          return items;
-        }, []),
+        highlights,
         feedMeta: item.feedMeta,
       });
       return acc;
@@ -307,13 +306,13 @@ export const feedV2QueryResolver: IFieldResolver<
         )
       : Promise.resolve([]),
     highlightIds.length && highlightsFieldTree
-      ? graphorm.queryResolveTree<PostHighlight>(
+      ? graphorm.queryResolveTree<GQLPostHighlight>(
           ctx,
           highlightsFieldTree,
           (builder) => {
-            builder.queryBuilder
-              .where(`${builder.alias}.id IN (:...ids)`, {
-                ids: highlightIds,
+            builder.queryBuilder = builder.queryBuilder
+              .where(`"${builder.alias}"."id" IN (:...highlightIds)`, {
+                highlightIds,
               })
               .limit(highlightIds.length);
             return builder;
@@ -350,7 +349,7 @@ export const feedV2Resolvers: IResolvers<unknown, BaseContext> = {
       encodeFeedMeta(item.feedMeta),
   },
   FeedHighlightsItem: {
-    highlights: (item: GQLFeedHighlightsItem): PostHighlight[] =>
+    highlights: (item: GQLFeedHighlightsItem): GQLPostHighlight[] =>
       item.highlights ?? [],
     feedMeta: (item: GQLFeedHighlightsItem): string | null =>
       encodeFeedMeta(item.feedMeta),

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -11,8 +11,8 @@ import { NEW_HIGHLIGHT_CHANNEL } from '../common/highlights';
 import graphorm from '../graphorm';
 import { redisPubSub } from '../redis';
 import type { OffsetPage } from './common';
+import { HighlightsCanonical } from '../entity/HighlightsCanonical';
 import {
-  PostHighlight,
   PostHighlightSignificance,
   toPostHighlightSignificance,
 } from '../entity/PostHighlight';
@@ -30,16 +30,15 @@ type GQLChannelConfiguration = {
 };
 
 type GQLSubscribedPostHighlight = Pick<
-  PostHighlight,
+  HighlightsCanonical,
   | 'id'
   | 'post'
   | 'postId'
-  | 'channel'
   | 'highlightedAt'
   | 'headline'
   | 'createdAt'
   | 'updatedAt'
->;
+> & { channel: string };
 
 export const typeDefs = /* GraphQL */ `
   type ChannelDigestConfiguration {
@@ -86,14 +85,14 @@ export const typeDefs = /* GraphQL */ `
     postHighlights(channel: String!): [PostHighlight!]!
 
     """
-    Get major headlines across all channels, deduplicated by post and ordered by recency
+    Get major canonical headlines across all channels, ordered by recency
     """
     majorHeadlines(first: Int, after: String): PostHighlightConnection!
 
     """
-    Get highlights deduplicated by post and ordered by recency.
-    Accepts optional channel and significance filters so it can power per-channel,
-    major-headlines and global feeds from a single endpoint.
+    Get canonical highlights ordered by recency.
+    Accepts optional channel and significance filters for channel-specific and
+    global feeds from a single endpoint.
     """
     postHighlightsFeed(
       channel: String
@@ -126,42 +125,27 @@ type HighlightsFilters = {
   significances?: PostHighlightSignificance[];
 };
 
-const applyHighlightsFilters = <T extends PostHighlight>(
+const applyHighlightsFilters = <T extends HighlightsCanonical>(
   builder: SelectQueryBuilder<T>,
+  alias: string,
   { channel, significances }: HighlightsFilters,
 ): SelectQueryBuilder<T> => {
-  let qb = builder.where('highlight."retiredAt" IS NULL');
+  builder.setParameter('highlightChannel', channel ?? null);
 
   if (significances && significances.length > 0) {
-    qb = qb.andWhere('highlight.significance IN (:...significances)', {
+    builder.andWhere(`"${alias}"."significance" IN (:...significances)`, {
       significances,
     });
   }
 
   if (channel) {
-    qb = qb.andWhere('highlight.channel = :channel', { channel });
+    builder.andWhere(`:highlightChannel = ANY("${alias}"."channels")`);
   }
 
-  return qb;
+  return builder;
 };
 
-const getDedupedHighlightsQuery = (
-  queryBuilder: SelectQueryBuilder<PostHighlight>,
-  filters: HighlightsFilters,
-) =>
-  applyHighlightsFilters(
-    queryBuilder
-      .subQuery()
-      .select('highlight.id', 'id')
-      .from(PostHighlight, 'highlight'),
-    filters,
-  )
-    .distinctOn(['highlight.postId'])
-    .orderBy('highlight.postId', 'ASC')
-    .addOrderBy('highlight.highlightedAt', 'DESC')
-    .addOrderBy('highlight.id', 'DESC');
-
-const resolveDedupedHighlightsFeed = (
+const resolveCanonicalHighlightsFeed = (
   ctx: Context,
   info: GraphQLResolveInfo,
   args: ConnectionArguments,
@@ -176,20 +160,13 @@ const resolveDedupedHighlightsFeed = (
     (nodeSize) => nodeSize >= page.limit,
     (_, index) => offsetToCursor(page.offset + index),
     (builder) => {
-      const dedupedIdsQuery = getDedupedHighlightsQuery(
-        builder.queryBuilder as SelectQueryBuilder<PostHighlight>,
+      builder.queryBuilder = applyHighlightsFilters(
+        builder.queryBuilder as SelectQueryBuilder<HighlightsCanonical>,
+        builder.alias,
         filters,
-      );
-
-      builder.queryBuilder
-        .innerJoin(
-          `(${dedupedIdsQuery.getQuery()})`,
-          'deduped',
-          `deduped.id = ${builder.alias}.id`,
-        )
-        .setParameters(dedupedIdsQuery.getParameters())
-        .orderBy(`${builder.alias}."highlightedAt"`, 'DESC')
-        .addOrderBy(`${builder.alias}."id"`, 'DESC')
+      )
+        .orderBy(`"${builder.alias}"."highlightedAt"`, 'DESC')
+        .addOrderBy(`"${builder.alias}"."id"`, 'DESC')
         .offset(page.offset)
         .limit(page.limit);
 
@@ -235,17 +212,17 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         info,
         (builder) => {
           builder.queryBuilder
-            .where(`"${builder.alias}"."channel" = :channel`, {
-              channel: args.channel,
+            .where(`:highlightChannel = ANY("${builder.alias}"."channels")`, {
+              highlightChannel: args.channel,
             })
-            .andWhere(`"${builder.alias}"."retiredAt" IS NULL`)
-            .orderBy(`"${builder.alias}"."highlightedAt"`, 'DESC');
+            .orderBy(`"${builder.alias}"."highlightedAt"`, 'DESC')
+            .addOrderBy(`"${builder.alias}"."id"`, 'DESC');
           return builder;
         },
         true,
       ),
     majorHeadlines: async (_, args: ConnectionArguments, ctx: Context, info) =>
-      resolveDedupedHighlightsFeed(ctx, info, args, {
+      resolveCanonicalHighlightsFeed(ctx, info, args, {
         significances: majorHeadlineSignificances,
       }),
     postHighlightsFeed: async (
@@ -254,7 +231,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       ctx: Context,
       info,
     ) =>
-      resolveDedupedHighlightsFeed(ctx, info, args, {
+      resolveCanonicalHighlightsFeed(ctx, info, args, {
         channel: args.channel,
         significances: parseSignificanceFilters(args.significance),
       }),


### PR DESCRIPTION
## What changed

- Read GraphQL `PostHighlight` data from `highlights_canonical` via GraphORM.
- Switch `postHighlights`, `majorHeadlines`, `postHighlightsFeed`, and feedV2 highlight hydration to canonical IDs and canonical channel membership.
- Remove the leftover legacy `post_highlight` read bridge from feedV2.
- Remove retired-row test plumbing from read-side highlight tests because canonical highlights do not carry `retiredAt`.
- Simplify read-side filtering and feedV2 hydrated highlight item shape now that the read path no longer dedupes or bridges legacy IDs.

## Why

Canonical highlights are now the source of truth. The read side should query canonical rows directly and should not keep post-level dedupe or legacy-table compatibility logic in the main path.

## Validation

- `NODE_ENV=test npx jest __tests__/highlights.ts --testEnvironment=node --runInBand`
- `NODE_ENV=test npx jest __tests__/posts.ts --testEnvironment=node --runInBand -t "postHighlight field"`
- `NODE_ENV=test npx jest __tests__/feeds.ts --testEnvironment=node --runInBand -t "should return mixed post and highlight items"`
- `npx eslint src/schema/highlights.ts src/schema/feedV2.ts src/graphorm/index.ts __tests__/highlights.ts __tests__/posts.ts __tests__/feeds.ts --max-warnings 0`
- `pnpm run build`
