### PR TITLE
fix(feed): default allowed_post_types for for_you_by_date

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -21,6 +21,7 @@ import {
   PostKeyword,
   PostTag,
   PostType,
+  postTypes,
   SharePost,
   Source,
   SourceMember,
@@ -1107,6 +1108,7 @@ describe('query feed', () => {
         expect(body.feed_config_name).toBe('for_you_by_date');
         expect(body.order_by).toBe(FeedOrderBy.Date);
         expect(body.disable_engagement_filter).toBe(true);
+        expect(body.allowed_post_types).toEqual(postTypes);
         return true;
       })
       .reply(200, {

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -19,6 +19,18 @@ import {
 import { LofnClient } from '../lofn';
 import { GarmrService } from '../garmr';
 import { FeedOrderBy } from '../../entity/Feed';
+import { postTypes } from '../../entity/posts/Post';
+
+// for_you_by_date skips Lofn, so default allowed_post_types to all types to
+// mirror For You; client supportedTypes and user exclusions still take priority.
+const ensureAllowedPostTypes = (
+  result: FeedConfigGeneratorResult,
+): FeedConfigGeneratorResult => {
+  if (result.config.allowed_post_types == null) {
+    result.config.allowed_post_types = postTypes;
+  }
+  return result;
+};
 
 /**
  * Utility class for easily generating feeds using provided config and client
@@ -169,7 +181,7 @@ export const feedGenerators: Partial<Record<FeedVersion, FeedGenerator>> =
         },
       ),
       'time',
-    ),
+    ).withConfigTransform(ensureAllowedPostTypes),
     onboarding: new FeedGenerator(
       feedClient,
       new FeedPreferencesConfigGenerator(
@@ -213,5 +225,5 @@ export const versionToTimeFeedGenerator = (_version: number): FeedGenerator => {
       },
       opts,
     ),
-  );
+  ).withConfigTransform(ensureAllowedPostTypes);
 };


### PR DESCRIPTION
## What

The `for_you_by_date` feed config skips Lofn, so it had no post-type config to fall back on. When the client sent no `supportedTypes` and the user had no post-type exclusions, `allowed_post_types` stayed `undefined` and was dropped from the feed-service request body by `JSON.stringify` — arriving empty.

The regular For You feed isn't affected because it runs through Lofn, which supplies post-type config.

## Fix

Added an `ensureAllowedPostTypes` config transform that defaults `allowed_post_types` to the full `postTypes` set when unresolved, applied to both `for_you_by_date` generators (`feedGenerators.time` and `versionToTimeFeedGenerator`). It only fills the missing case — client `supportedTypes` and user exclusions still take priority.

## Test

Extended the existing TIME-ranking chronological-config test to assert `allowed_post_types` equals the full `postTypes` set.