### PR TITLE
fix: notification settings

### DIFF
--- a/__tests__/users.ts
+++ b/__tests__/users.ts
@@ -7694,7 +7694,7 @@ describe('mutation updateNotificationSettings', () => {
     expect(user?.acceptedMarketing).toBeFalsy();
   });
 
-  it('should throw error because of invalid notification flags', async () => {
+  it('should ignore invalid notification flags', async () => {
     loggedUser = '1';
 
     const updatedFlags = {
@@ -7705,14 +7705,16 @@ describe('mutation updateNotificationSettings', () => {
       },
     };
 
-    await testMutationErrorCode(
-      client,
-      {
-        mutation: MUTATION,
-        variables: { notificationFlags: updatedFlags },
-      },
-      'GRAPHQL_VALIDATION_FAILED',
-    );
+    const res = await client.mutate(MUTATION, {
+      variables: { notificationFlags: updatedFlags },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const user = await con.getRepository(User).findOneBy({ id: loggedUser });
+
+    expect(user).not.toBeNull();
+    expect(user?.notificationFlags['new_pokemon']).toBeUndefined();
   });
 });
 

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -14,6 +14,7 @@ import {
   UserPersonalizedDigest,
   UserPersonalizedDigestSendType,
   UserPersonalizedDigestType,
+  type UserNotificationFlags,
 } from '../entity';
 import { blockingBatchRunner, callWithRetryDefault } from './async';
 import {
@@ -149,15 +150,16 @@ export const syncSubscription = async function (
         ...(user?.notificationFlags || {}),
       };
 
-      const mergedNotificationFlags = getCioTopicsToNotificationFlags(
-        subs,
-        existingFlags,
-      );
+      const mergedNotificationFlagsPreValidation =
+        getCioTopicsToNotificationFlags(subs, existingFlags);
 
       const validation = notificationFlagsSchema.safeParse(
-        mergedNotificationFlags,
+        mergedNotificationFlagsPreValidation,
       );
       if (validation.success) {
+        const mergedNotificationFlags =
+          validation.data as UserNotificationFlags;
+
         await manager.getRepository(User).update(
           { id: customer.id },
           {
@@ -171,7 +173,7 @@ export const syncSubscription = async function (
           {
             userId: customer.id,
             errors: validation.error.issues,
-            flags: mergedNotificationFlags,
+            flags: mergedNotificationFlagsPreValidation,
           },
           'Failed to validate merged notification flags from CIO sync, skipping notification flags update',
         );

--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -7,7 +7,7 @@ const notificationPreferenceSchema = z.object({
   inApp: z.enum(['muted', 'subscribed']),
 });
 
-export const notificationFlagsSchema = z.strictObject({
+export const notificationFlagsSchema = z.object({
   [NotificationType.ArticleNewComment]: notificationPreferenceSchema,
   [NotificationType.CommentReply]: notificationPreferenceSchema,
   [NotificationType.ArticleUpvoteMilestone]: notificationPreferenceSchema,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -4227,14 +4227,18 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     },
     updateNotificationSettings: async (
       _,
-      { notificationFlags }: { notificationFlags: UserNotificationFlags },
+      {
+        notificationFlags: notificationFlagsArg,
+      }: { notificationFlags: UserNotificationFlags },
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
-      const validate = notificationFlagsSchema.safeParse(notificationFlags);
+      const validate = notificationFlagsSchema.safeParse(notificationFlagsArg);
 
       if (validate.error) {
         throw new ValidationError(validate.error.issues[0].message);
       }
+
+      const notificationFlags = validate.data as UserNotificationFlags;
 
       const acceptedMarketing =
         notificationFlags[NotificationType.Marketing]?.email ===


### PR DESCRIPTION
`z.strictObject` would break any removed notification types from schema https://github.com/dailydotdev/daily-api/pull/3902

Most likely reason why strictObject was returned in the first place is because it was missed `z.object` also strips and that we can use `validation.data` to prevent any unknown values getting into the system- 