### PR TITLE
feat: add contribution private api

### DIFF
--- a/__tests__/routes/private/contributions.ts
+++ b/__tests__/routes/private/contributions.ts
@@ -1,0 +1,407 @@
+import type { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import type { DataSource } from 'typeorm';
+import appFunc from '../../../src';
+import createOrGetConnection from '../../../src/db';
+import { saveFixtures } from '../../helpers';
+import { User } from '../../../src/entity/user/User';
+import { ContributionAction } from '../../../src/entity/contribution/ContributionAction';
+import { ContributionActionCategory } from '../../../src/entity/contribution/ContributionActionCategory';
+import { ContributionBlockedUser } from '../../../src/entity/contribution/ContributionBlockedUser';
+import { ContributionCause } from '../../../src/entity/contribution/ContributionCause';
+import {
+  ContributionPayment,
+  ContributionPaymentStatus,
+} from '../../../src/entity/contribution/ContributionPayment';
+import { ContributionPaymentAllocation } from '../../../src/entity/contribution/ContributionPaymentAllocation';
+import {
+  ContributionRewardTier,
+  ContributionRewardType,
+} from '../../../src/entity/contribution/ContributionRewardTier';
+import {
+  ContributionSubmission,
+  ContributionSubmissionStatus,
+} from '../../../src/entity/contribution/ContributionSubmission';
+import { UserContributionCausePreference } from '../../../src/entity/contribution/UserContributionCausePreference';
+import {
+  UserContributionReward,
+  UserContributionRewardStatus,
+} from '../../../src/entity/contribution/UserContributionReward';
+
+let app: FastifyInstance;
+let con: DataSource;
+
+const serviceHeaders = {
+  authorization: `Service ${process.env.ACCESS_SECRET}`,
+  'content-type': 'application/json',
+};
+const serviceAuthHeaders = {
+  authorization: `Service ${process.env.ACCESS_SECRET}`,
+};
+const userId = '99999999-9999-4999-8999-999999999998';
+const secondUserId = '99999999-9999-4999-8999-999999999997';
+const categoryId = '11111111-1111-4111-8111-111111111111';
+const actionId = '22222222-2222-4222-8222-222222222222';
+const causeId = '33333333-3333-4333-8333-333333333333';
+const secondCauseId = '33333333-3333-4333-8333-333333333334';
+const inactiveCauseId = '33333333-3333-4333-8333-333333333335';
+const tierId = '44444444-4444-4444-8444-444444444444';
+const submissionId = '55555555-5555-4555-8555-555555555555';
+const secondSubmissionId = '55555555-5555-4555-8555-555555555556';
+const paidSubmissionId = '55555555-5555-4555-8555-555555555557';
+const paymentId = '66666666-6666-4666-8666-666666666666';
+
+beforeAll(async () => {
+  app = await appFunc();
+  con = await createOrGetConnection();
+  return app.ready();
+});
+
+beforeEach(async () => {
+  await saveFixtures(con, User, [
+    { id: userId, reputation: 10 },
+    { id: secondUserId, reputation: 10 },
+  ]);
+});
+
+afterAll(() => app.close());
+
+const seedContributionConfig = async () => {
+  await saveFixtures(con, ContributionActionCategory, [
+    {
+      id: categoryId,
+      title: 'Social',
+    },
+  ]);
+  await saveFixtures(con, ContributionAction, [
+    {
+      id: actionId,
+      categoryId,
+      title: 'Post on X',
+      points: 10,
+      evidence: {},
+    },
+  ]);
+  await saveFixtures(con, ContributionCause, [
+    {
+      id: causeId,
+      title: 'Open source',
+      sortOrder: 1,
+    },
+    {
+      id: secondCauseId,
+      title: 'Education',
+      sortOrder: 2,
+    },
+    {
+      id: inactiveCauseId,
+      title: 'Inactive',
+      active: false,
+      sortOrder: 3,
+    },
+  ]);
+  await saveFixtures(con, ContributionRewardTier, [
+    {
+      id: tierId,
+      title: 'Call',
+      thresholdPoints: 100,
+      rewardType: ContributionRewardType.Call,
+      metadata: {},
+    },
+  ]);
+};
+
+describe('private contribution routes', () => {
+  it('requires service authorization', () => {
+    return request(app.server)
+      .post('/p/contributions/action-categories')
+      .send({ title: 'Social' })
+      .expect(404);
+  });
+
+  it('creates, updates, and deletes action categories', async () => {
+    const { body } = await request(app.server)
+      .post('/p/contributions/action-categories')
+      .set(serviceHeaders)
+      .send({ title: 'Social', sortOrder: 2 })
+      .expect(201);
+
+    await request(app.server)
+      .patch(`/p/contributions/action-categories/${body.id}`)
+      .set(serviceHeaders)
+      .send({ title: 'Community', active: false, sortOrder: 3 })
+      .expect(200);
+
+    await con.getRepository(ContributionAction).save({
+      id: actionId,
+      categoryId: body.id,
+      title: 'Post on Reddit',
+      points: 20,
+      evidence: {},
+    });
+
+    await request(app.server)
+      .delete(`/p/contributions/action-categories/${body.id}`)
+      .set(serviceAuthHeaders)
+      .expect(200);
+
+    const [category, action] = await Promise.all([
+      con.getRepository(ContributionActionCategory).findOneBy({ id: body.id }),
+      con.getRepository(ContributionAction).findOneByOrFail({ id: actionId }),
+    ]);
+
+    expect(category).toBeNull();
+    expect(action.categoryId).toBeNull();
+  });
+
+  it('creates and updates actions, causes, and reward tiers', async () => {
+    const { body: category } = await request(app.server)
+      .post('/p/contributions/action-categories')
+      .set(serviceHeaders)
+      .send({ title: 'Social' })
+      .expect(201);
+
+    const { body: action } = await request(app.server)
+      .post('/p/contributions/actions')
+      .set(serviceHeaders)
+      .send({
+        categoryId: category.id,
+        title: 'Post on Reddit',
+        points: 20,
+        evidence: { url: { required: true } },
+        cooldownSeconds: 3600,
+        maxPerUser: 3,
+      })
+      .expect(201);
+
+    await request(app.server)
+      .patch(`/p/contributions/actions/${action.id}`)
+      .set(serviceHeaders)
+      .send({ points: 25, active: false })
+      .expect(200);
+
+    const { body: cause } = await request(app.server)
+      .post('/p/contributions/causes')
+      .set(serviceHeaders)
+      .send({ title: 'Open source', url: 'https://daily.dev' })
+      .expect(201);
+
+    await request(app.server)
+      .patch(`/p/contributions/causes/${cause.id}`)
+      .set(serviceHeaders)
+      .send({ title: 'Education', active: false })
+      .expect(200);
+
+    const { body: tier } = await request(app.server)
+      .post('/p/contributions/reward-tiers')
+      .set(serviceHeaders)
+      .send({
+        title: 'Call',
+        thresholdPoints: 100,
+        rewardType: ContributionRewardType.Call,
+        metadata: { calendly: 'https://daily.dev' },
+      })
+      .expect(201);
+
+    await request(app.server)
+      .patch(`/p/contributions/reward-tiers/${tier.id}`)
+      .set(serviceHeaders)
+      .send({ thresholdPoints: 150, active: false })
+      .expect(200);
+
+    await expect(
+      con.getRepository(ContributionAction).findOneByOrFail({ id: action.id }),
+    ).resolves.toMatchObject({ points: 25, active: false });
+    await expect(
+      con.getRepository(ContributionCause).findOneByOrFail({ id: cause.id }),
+    ).resolves.toMatchObject({ title: 'Education', active: false });
+    await expect(
+      con
+        .getRepository(ContributionRewardTier)
+        .findOneByOrFail({ id: tier.id }),
+    ).resolves.toMatchObject({ thresholdPoints: 150, active: false });
+  });
+
+  it('reviews submissions, fulfills rewards, and blocks users', async () => {
+    await seedContributionConfig();
+    await saveFixtures(con, ContributionPayment, [
+      {
+        id: paymentId,
+        status: ContributionPaymentStatus.Finalized,
+        totalPoints: 10,
+        amountCents: 1000,
+      },
+    ]);
+    await saveFixtures(con, ContributionSubmission, [
+      {
+        id: submissionId,
+        userId,
+        actionId,
+        status: ContributionSubmissionStatus.Flagged,
+        awardedPoints: 10,
+        evidence: {},
+      },
+      {
+        id: paidSubmissionId,
+        userId,
+        actionId,
+        paymentId,
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 10,
+        evidence: {},
+      },
+    ]);
+    await saveFixtures(con, UserContributionReward, [
+      {
+        userId,
+        tierId,
+        status: UserContributionRewardStatus.Claimed,
+        claimedAt: new Date(),
+      },
+    ]);
+
+    await request(app.server)
+      .patch(`/p/contributions/submissions/${submissionId}/review`)
+      .set(serviceHeaders)
+      .send({
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 15,
+        flags: { reviewed: true },
+        reviewedBy: secondUserId,
+      })
+      .expect(200);
+
+    await request(app.server)
+      .patch(`/p/contributions/submissions/${paidSubmissionId}/review`)
+      .set(serviceHeaders)
+      .send({ status: ContributionSubmissionStatus.Rejected })
+      .expect(400);
+
+    await request(app.server)
+      .patch(`/p/contributions/rewards/${userId}/${tierId}/fulfill`)
+      .set(serviceHeaders)
+      .send({})
+      .expect(200);
+
+    await request(app.server)
+      .post('/p/contributions/blocked-users')
+      .set(serviceHeaders)
+      .send({ userId, reason: 'abuse' })
+      .expect(201);
+
+    await request(app.server)
+      .delete(`/p/contributions/blocked-users/${userId}`)
+      .set(serviceAuthHeaders)
+      .expect(200);
+
+    await expect(
+      con
+        .getRepository(ContributionSubmission)
+        .findOneByOrFail({ id: submissionId }),
+    ).resolves.toMatchObject({
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: 15,
+      flags: { reviewed: true },
+      reviewedBy: secondUserId,
+    });
+    await expect(
+      con.getRepository(UserContributionReward).findOneByOrFail({
+        userId,
+        tierId,
+      }),
+    ).resolves.toMatchObject({
+      status: UserContributionRewardStatus.Fulfilled,
+    });
+    await expect(
+      con.getRepository(ContributionBlockedUser).findOneBy({ userId }),
+    ).resolves.toBeNull();
+  });
+
+  it('finalizes a payment cycle using cause preferences at payment time', async () => {
+    await seedContributionConfig();
+    await saveFixtures(con, UserContributionCausePreference, [
+      {
+        userId,
+        causeId,
+      },
+      {
+        userId,
+        causeId: inactiveCauseId,
+      },
+    ]);
+    await saveFixtures(con, ContributionSubmission, [
+      {
+        id: submissionId,
+        userId,
+        actionId,
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 30,
+        evidence: {},
+      },
+      {
+        id: secondSubmissionId,
+        userId: secondUserId,
+        actionId,
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 10,
+        evidence: {},
+      },
+    ]);
+
+    const { body } = await request(app.server)
+      .post('/p/contributions/payments/finalize')
+      .set(serviceHeaders)
+      .send({ amountCents: 1000, createdBy: secondUserId })
+      .expect(201);
+
+    expect(body).toMatchObject({
+      status: ContributionPaymentStatus.Finalized,
+      totalPoints: 40,
+      amountCents: 1000,
+      createdBy: secondUserId,
+    });
+
+    const [submissions, allocations] = await Promise.all([
+      con.getRepository(ContributionSubmission).find({
+        select: ['id', 'paymentId'],
+        order: { id: 'ASC' },
+      }),
+      con.getRepository(ContributionPaymentAllocation).find({
+        select: ['userId', 'causeId', 'points', 'amountCents'],
+        order: { userId: 'ASC', causeId: 'ASC' },
+      }),
+    ]);
+
+    expect(submissions).toEqual([
+      { id: submissionId, paymentId: body.id },
+      { id: secondSubmissionId, paymentId: body.id },
+    ]);
+    expect(
+      allocations.map(({ userId, causeId, points, amountCents }) => ({
+        userId,
+        causeId,
+        points,
+        amountCents,
+      })),
+    ).toEqual([
+      {
+        userId: secondUserId,
+        causeId,
+        points: 5,
+        amountCents: 125,
+      },
+      {
+        userId: secondUserId,
+        causeId: secondCauseId,
+        points: 5,
+        amountCents: 125,
+      },
+      {
+        userId,
+        causeId,
+        points: 30,
+        amountCents: 750,
+      },
+    ]);
+  });
+});

--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -1,5 +1,5 @@
 import { ForbiddenError, ValidationError } from 'apollo-server-errors';
-import type { EntityManager } from 'typeorm';
+import { In, type EntityManager } from 'typeorm';
 import type z from 'zod';
 import {
   contributionActionEvidenceSchema,
@@ -14,6 +14,7 @@ import {
   ContributionPayment,
   ContributionPaymentStatus,
 } from '../../entity/contribution/ContributionPayment';
+import { ContributionPaymentAllocation } from '../../entity/contribution/ContributionPaymentAllocation';
 import { ContributionSubmissionStatus } from '../../entity/contribution/ContributionSubmission';
 import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
 import { remoteConfig } from '../../remoteConfig';
@@ -43,6 +44,47 @@ type ContributionActionUsage = {
   latestCreatedAt: Date | null;
 };
 
+type ContributionActionEvidenceInput = z.infer<
+  typeof contributionActionEvidenceSchema
+>;
+
+type ContributionPointAllocation = {
+  userId: string;
+  points: number;
+  amountCents: number;
+};
+
+type ContributionPaymentAllocationInput = Pick<
+  ContributionPaymentAllocation,
+  'paymentId' | 'userId' | 'causeId' | 'points' | 'amountCents'
+>;
+
+type ContributionPaymentUserAllocation = {
+  userId: string;
+  points: number;
+  causeIds: string[];
+};
+
+type ContributionPaymentFinalizationError =
+  | 'noSubmissions'
+  | 'noActiveCauses'
+  | 'noPoints';
+
+type ContributionPaymentFinalizationResult =
+  | {
+      payment: ContributionPayment;
+    }
+  | {
+      error: ContributionPaymentFinalizationError;
+    };
+
+type ContributionPaymentSnapshotRow = {
+  submissionIds: string[] | null;
+  totalPoints: string | number | null;
+  activeCauseIds: string[] | null;
+  userAllocations: ContributionPaymentUserAllocation[] | string | null;
+};
+
 export const parseContributionArgs = <TSchema extends z.ZodType>(
   schema: TSchema,
   args: unknown,
@@ -59,6 +101,288 @@ export const parseContributionArgs = <TSchema extends z.ZodType>(
 
 const toContributionInt = (value: string | number | null | undefined): number =>
   Number(value ?? 0);
+
+const splitContributionInteger = ({
+  total,
+  parts,
+}: {
+  total: number;
+  parts: number;
+}): number[] => {
+  const base = Math.floor(total / parts);
+  const remainder = total % parts;
+
+  return Array.from(
+    { length: parts },
+    (_, index) => base + (index < remainder ? 1 : 0),
+  );
+};
+
+const allocateContributionAmountByPoints = ({
+  userPoints,
+  amountCents,
+  totalPoints,
+}: {
+  userPoints: Map<string, number>;
+  amountCents: number;
+  totalPoints: number;
+}): ContributionPointAllocation[] => {
+  const allocations = [...userPoints.entries()]
+    .sort(([firstUserId], [secondUserId]) =>
+      firstUserId.localeCompare(secondUserId),
+    )
+    .map(([userId, points]) => ({
+      userId,
+      points,
+      amountCents: Math.floor((amountCents * points) / totalPoints),
+      remainder: (amountCents * points) % totalPoints,
+    }));
+
+  const allocatedAmountCents = allocations.reduce(
+    (total, allocation) => total + allocation.amountCents,
+    0,
+  );
+  const remainderCents = amountCents - allocatedAmountCents;
+  const remainderOrder = [...allocations].sort((first, second) => {
+    if (second.remainder !== first.remainder) {
+      return second.remainder - first.remainder;
+    }
+
+    return first.userId.localeCompare(second.userId);
+  });
+
+  for (let index = 0; index < remainderCents; index += 1) {
+    remainderOrder[index].amountCents += 1;
+  }
+
+  return allocations.map(({ userId, points, amountCents }) => ({
+    userId,
+    points,
+    amountCents,
+  }));
+};
+
+const getContributionPaymentAllocations = ({
+  paymentId,
+  userAllocations,
+  amountCents,
+  totalPoints,
+}: {
+  paymentId: string;
+  userAllocations: ContributionPaymentUserAllocation[];
+  amountCents: number;
+  totalPoints: number;
+}): ContributionPaymentAllocationInput[] => {
+  const userAllocationById = new Map(
+    userAllocations.map((allocation) => [allocation.userId, allocation]),
+  );
+
+  return allocateContributionAmountByPoints({
+    userPoints: new Map(
+      userAllocations.map((allocation) => [
+        allocation.userId,
+        allocation.points,
+      ]),
+    ),
+    amountCents,
+    totalPoints,
+  })
+    .flatMap((weightedAllocation) => {
+      const allocation = userAllocationById.get(weightedAllocation.userId);
+      const causeIds = allocation?.causeIds ?? [];
+      const pointParts = splitContributionInteger({
+        total: weightedAllocation.points,
+        parts: causeIds.length,
+      });
+      const amountParts = splitContributionInteger({
+        total: weightedAllocation.amountCents,
+        parts: causeIds.length,
+      });
+
+      return causeIds.map((causeId, index) => ({
+        paymentId,
+        userId: weightedAllocation.userId,
+        causeId,
+        points: pointParts[index],
+        amountCents: amountParts[index],
+      }));
+    })
+    .filter(
+      (allocation) => allocation.points > 0 || allocation.amountCents > 0,
+    );
+};
+
+const parseContributionUserAllocations = (
+  value: ContributionPaymentSnapshotRow['userAllocations'],
+): ContributionPaymentUserAllocation[] => {
+  if (!value) {
+    return [];
+  }
+
+  const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+
+  return parsed.map(
+    ({
+      userId,
+      points,
+      causeIds,
+    }: {
+      userId: string;
+      points: string | number;
+      causeIds: string[] | null;
+    }) => ({
+      userId,
+      points: toContributionInt(points),
+      causeIds: causeIds ?? [],
+    }),
+  );
+};
+
+export const finalizeContributionPayment = async ({
+  con,
+  amountCents,
+  createdBy,
+}: {
+  con: EntityManager;
+  amountCents: number;
+  createdBy?: string | null;
+}): Promise<ContributionPaymentFinalizationResult> => {
+  const snapshot = await con
+    .createQueryBuilder()
+    .addCommonTableExpression(
+      `
+        SELECT
+          submission.id,
+          submission."userId",
+          submission."awardedPoints"
+        FROM "contribution_submission" submission
+        WHERE submission.status = :status
+          AND submission."paymentId" IS NULL
+        ORDER BY submission."createdAt" ASC, submission.id ASC
+        FOR UPDATE
+      `,
+      'locked_submission',
+    )
+    .addCommonTableExpression(
+      `
+        SELECT
+          cause.id
+        FROM "contribution_cause" cause
+        WHERE cause.active = true
+      `,
+      'active_cause',
+    )
+    .addCommonTableExpression(
+      `
+        SELECT
+          locked_submission."userId",
+          SUM(locked_submission."awardedPoints")::int AS points
+        FROM locked_submission
+        GROUP BY locked_submission."userId"
+      `,
+      'user_points',
+    )
+    .addCommonTableExpression(
+      `
+        SELECT
+          preference."userId",
+          array_agg(preference."causeId" ORDER BY preference."causeId") AS "causeIds"
+        FROM "user_contribution_cause_preference" preference
+        INNER JOIN active_cause
+          ON active_cause.id = preference."causeId"
+        GROUP BY preference."userId"
+      `,
+      'preferred_cause',
+    )
+    .select(
+      'COALESCE((SELECT array_agg(id) FROM locked_submission), ARRAY[]::uuid[])',
+      'submissionIds',
+    )
+    .addSelect(
+      'COALESCE((SELECT SUM("awardedPoints") FROM locked_submission), 0)::int',
+      'totalPoints',
+    )
+    .addSelect(
+      'COALESCE((SELECT array_agg(id ORDER BY id) FROM active_cause), ARRAY[]::uuid[])',
+      'activeCauseIds',
+    )
+    .addSelect(
+      `
+        COALESCE((
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'userId', user_points."userId",
+              'points', user_points.points,
+              'causeIds', COALESCE(
+                preferred_cause."causeIds",
+                (SELECT array_agg(id ORDER BY id) FROM active_cause)
+              )
+            )
+            ORDER BY user_points."userId"
+          )
+          FROM user_points
+          LEFT JOIN preferred_cause
+            ON preferred_cause."userId" = user_points."userId"
+        ), '[]'::jsonb)
+      `,
+      'userAllocations',
+    )
+    .from('(SELECT 1)', 'snapshot')
+    .setParameter('status', ContributionSubmissionStatus.Approved)
+    .getRawOne<ContributionPaymentSnapshotRow>();
+  const submissionIds = snapshot?.submissionIds ?? [];
+
+  if (!submissionIds.length) {
+    return { error: 'noSubmissions' };
+  }
+
+  const totalPoints = toContributionInt(snapshot?.totalPoints);
+
+  if (totalPoints <= 0) {
+    return { error: 'noPoints' };
+  }
+
+  if (!snapshot?.activeCauseIds?.length) {
+    return { error: 'noActiveCauses' };
+  }
+
+  const userAllocations = parseContributionUserAllocations(
+    snapshot.userAllocations,
+  );
+  const payment = await con.getRepository(ContributionPayment).save({
+    status: ContributionPaymentStatus.Finalized,
+    totalPoints,
+    amountCents,
+    createdBy,
+    finalizedAt: new Date(),
+  });
+  const paymentAllocations = getContributionPaymentAllocations({
+    paymentId: payment.id,
+    userAllocations,
+    amountCents,
+    totalPoints,
+  });
+
+  await con.getRepository(ContributionPaymentAllocation).insert(
+    paymentAllocations.map((allocation) => ({
+      paymentId: allocation.paymentId,
+      userId: allocation.userId,
+      causeId: allocation.causeId,
+      points: allocation.points,
+      amountCents: allocation.amountCents,
+    })),
+  );
+  await con.getRepository(ContributionSubmission).update(
+    {
+      id: In(submissionIds),
+    },
+    {
+      paymentId: payment.id,
+    },
+  );
+
+  return { payment };
+};
 
 const getContributionConfig = (): ContributionConfig => {
   const config = remoteConfig.vars.contributionProgram;
@@ -199,10 +523,51 @@ const getContributionActionUsage = async ({
   };
 };
 
-const normalizeEvidenceSchema = (
-  evidence: ContributionEvidenceSchema,
-): z.infer<typeof contributionActionEvidenceSchema> =>
-  contributionActionEvidenceSchema.parse(evidence ?? {});
+export const normalizeContributionActionEvidence = (
+  evidence:
+    | ContributionActionEvidenceInput
+    | ContributionEvidenceSchema
+    | null
+    | undefined,
+): ContributionEvidenceSchema => {
+  const parsed = contributionActionEvidenceSchema.parse(evidence ?? {});
+
+  return {
+    ...(parsed.url
+      ? {
+          url: {
+            ...(parsed.url.required !== undefined &&
+            parsed.url.required !== null
+              ? { required: parsed.url.required }
+              : {}),
+            ...(parsed.url.allowedDomains
+              ? { allowedDomains: parsed.url.allowedDomains }
+              : {}),
+          },
+        }
+      : {}),
+    ...(parsed.screenshot
+      ? {
+          screenshot: {
+            ...(parsed.screenshot.required !== undefined &&
+            parsed.screenshot.required !== null
+              ? { required: parsed.screenshot.required }
+              : {}),
+          },
+        }
+      : {}),
+    ...(parsed.note
+      ? {
+          note: {
+            ...(parsed.note.required !== undefined &&
+            parsed.note.required !== null
+              ? { required: parsed.note.required }
+              : {}),
+          },
+        }
+      : {}),
+  };
+};
 
 export const validateContributionEvidence = ({
   input,
@@ -211,7 +576,7 @@ export const validateContributionEvidence = ({
   input: z.infer<typeof contributionSubmissionEvidenceSchema>;
   action: ContributionAction;
 }): void => {
-  const requiredEvidence = normalizeEvidenceSchema(action.evidence);
+  const requiredEvidence = normalizeContributionActionEvidence(action.evidence);
 
   if (requiredEvidence.url?.required && !input.url) {
     throw new ValidationError('URL evidence is required');

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -1,4 +1,7 @@
 import z from 'zod';
+import { ContributionRewardType } from '../../entity/contribution/ContributionRewardTier';
+import { ContributionSubmissionStatus } from '../../entity/contribution/ContributionSubmission';
+import { enumValues } from './utils';
 
 export const contributionActionEvidenceSchema = z
   .object({
@@ -50,4 +53,121 @@ export const updateContributionCausePreferencesArgsSchema = z.object({
 
 export const claimContributionRewardArgsSchema = z.object({
   tierId: z.uuid(),
+});
+
+const contributionMetadataSchema = z
+  .object({})
+  .catchall(z.unknown())
+  .optional();
+
+const contributionFlagsSchema = z.object({}).catchall(z.unknown()).optional();
+
+const contributionSortOrderSchema = z.number().int().optional();
+
+const contributionActiveSchema = z.boolean().optional();
+
+const contributionUserIdSchema = z.string().trim().min(1).max(36);
+
+export const contributionPrivateIdParamsSchema = z.object({
+  id: z.uuid(),
+});
+
+export const contributionPrivateRewardParamsSchema = z.object({
+  userId: contributionUserIdSchema,
+  tierId: z.uuid(),
+});
+
+export const contributionPrivateBlockedUserParamsSchema = z.object({
+  userId: contributionUserIdSchema,
+});
+
+export const contributionPrivateCreateActionCategorySchema = z.object({
+  title: z.string().trim().min(1),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateUpdateActionCategorySchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateCreateActionSchema = z.object({
+  categoryId: z.uuid().nullish(),
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1).nullish(),
+  points: z.number().int().positive(),
+  evidence: contributionActionEvidenceSchema.optional(),
+  cooldownSeconds: z.number().int().positive().nullish(),
+  maxPerUser: z.number().int().positive().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateUpdateActionSchema = z.object({
+  categoryId: z.uuid().nullish(),
+  title: z.string().trim().min(1).optional(),
+  description: z.string().trim().min(1).nullish(),
+  points: z.number().int().positive().optional(),
+  evidence: contributionActionEvidenceSchema.optional(),
+  cooldownSeconds: z.number().int().positive().nullish(),
+  maxPerUser: z.number().int().positive().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateCreateCauseSchema = z.object({
+  title: z.string().trim().min(1),
+  url: z.url().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateUpdateCauseSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  url: z.url().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateCreateRewardTierSchema = z.object({
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1).nullish(),
+  thresholdPoints: z.number().int().positive(),
+  rewardType: z.enum(enumValues(ContributionRewardType)),
+  metadata: contributionMetadataSchema,
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateUpdateRewardTierSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  description: z.string().trim().min(1).nullish(),
+  thresholdPoints: z.number().int().positive().optional(),
+  rewardType: z.enum(enumValues(ContributionRewardType)).optional(),
+  metadata: contributionMetadataSchema,
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateReviewSubmissionSchema = z.object({
+  status: z.enum(enumValues(ContributionSubmissionStatus)),
+  awardedPoints: z.number().int().min(0).optional(),
+  flags: contributionFlagsSchema,
+  reviewedBy: contributionUserIdSchema.nullish(),
+});
+
+export const contributionPrivateFulfillRewardSchema = z.object({
+  fulfilledAt: z.coerce.date().nullish(),
+});
+
+export const contributionPrivateBlockUserSchema = z.object({
+  userId: contributionUserIdSchema,
+  reason: z.string().trim().min(1).nullish(),
+});
+
+export const contributionPrivateFinalizePaymentSchema = z.object({
+  amountCents: z.number().int().positive(),
+  createdBy: contributionUserIdSchema.nullish(),
 });

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -16,6 +16,7 @@ import {
 } from '../entity/user/utils';
 import { queryReadReplica } from '../common/queryReadReplica';
 import { kvasir } from './private/kvasir';
+import contributions from './private/contributions';
 import rpc from './private/rpc';
 import { createWorkerJobRpc } from './private/workerJobRpc';
 import { connectRpcPlugin, baseRpcContext } from '../common/connectRpc';
@@ -57,6 +58,8 @@ const vordrUsersSchema = z.object({
 });
 
 export default async function (fastify: FastifyInstance): Promise<void> {
+  fastify.register(contributions, { prefix: '/contributions' });
+
   fastify.post<{ Body: AddUserDataPost }>('/newUser', async (req, res) => {
     if (!req.service) {
       return res.status(404).send();

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -1,0 +1,504 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import type z from 'zod';
+import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import createOrGetConnection from '../../db';
+import {
+  contributionPrivateBlockUserSchema,
+  contributionPrivateBlockedUserParamsSchema,
+  contributionPrivateCreateActionCategorySchema,
+  contributionPrivateCreateActionSchema,
+  contributionPrivateCreateCauseSchema,
+  contributionPrivateCreateRewardTierSchema,
+  contributionPrivateFinalizePaymentSchema,
+  contributionPrivateFulfillRewardSchema,
+  contributionPrivateIdParamsSchema,
+  contributionPrivateReviewSubmissionSchema,
+  contributionPrivateRewardParamsSchema,
+  contributionPrivateUpdateActionCategorySchema,
+  contributionPrivateUpdateActionSchema,
+  contributionPrivateUpdateCauseSchema,
+  contributionPrivateUpdateRewardTierSchema,
+} from '../../common/schema/contributions';
+import {
+  finalizeContributionPayment,
+  normalizeContributionActionEvidence,
+} from '../../common/contribution';
+import { ContributionAction } from '../../entity/contribution/ContributionAction';
+import { ContributionActionCategory } from '../../entity/contribution/ContributionActionCategory';
+import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
+import { ContributionCause } from '../../entity/contribution/ContributionCause';
+import { ContributionRewardTier } from '../../entity/contribution/ContributionRewardTier';
+import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
+import {
+  UserContributionReward,
+  UserContributionRewardStatus,
+} from '../../entity/contribution/UserContributionReward';
+
+const parseSchema = <TSchema extends z.ZodType>({
+  schema,
+  value,
+  res,
+  requireNonEmpty = false,
+}: {
+  schema: TSchema;
+  value: unknown;
+  res: FastifyReply;
+  requireNonEmpty?: boolean;
+}): z.infer<TSchema> | undefined => {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    res.status(400).send({
+      error: {
+        name: parsed.error.name,
+        issues: parsed.error.issues,
+      },
+    });
+    return undefined;
+  }
+
+  if (
+    requireNonEmpty &&
+    parsed.data &&
+    typeof parsed.data === 'object' &&
+    !Array.isArray(parsed.data) &&
+    Object.keys(parsed.data).length === 0
+  ) {
+    res.status(400).send({
+      error: {
+        name: 'ZodError',
+        issues: [{ message: 'At least one field is required' }],
+      },
+    });
+    return undefined;
+  }
+
+  return parsed.data;
+};
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.addHook('preHandler', async (req, res) => {
+    if (!req.service) {
+      return res.status(404).send();
+    }
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateActionCategorySchema>;
+  }>('/action-categories', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateActionCategorySchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const category = await con
+      .getRepository(ContributionActionCategory)
+      .save(body);
+
+    return res.status(201).send(category);
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateActionCategorySchema>;
+  }>('/action-categories/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateActionCategorySchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionActionCategory)
+      .update(params.id, body);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution category not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.delete<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+  }>('/action-categories/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    if (!params) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionActionCategory)
+      .delete(params.id);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution category not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateActionSchema>;
+  }>('/actions', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateActionSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const action = await con.getRepository(ContributionAction).save({
+      ...body,
+      evidence: normalizeContributionActionEvidence(body.evidence),
+    });
+
+    return res.status(201).send(action);
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateActionSchema>;
+  }>('/actions/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateActionSchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const { evidence, ...actionUpdate } = body;
+    const updatePayload: QueryDeepPartialEntity<ContributionAction> = {
+      ...actionUpdate,
+    };
+
+    if (evidence !== undefined) {
+      updatePayload.evidence = normalizeContributionActionEvidence(evidence);
+    }
+
+    const result = await con
+      .getRepository(ContributionAction)
+      .update(params.id, updatePayload);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution action not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateCauseSchema>;
+  }>('/causes', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateCauseSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const cause = await con.getRepository(ContributionCause).save(body);
+
+    return res.status(201).send(cause);
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateCauseSchema>;
+  }>('/causes/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateCauseSchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionCause)
+      .update(params.id, body);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution cause not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateRewardTierSchema>;
+  }>('/reward-tiers', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateRewardTierSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const tier = await con.getRepository(ContributionRewardTier).save(body);
+
+    return res.status(201).send(tier);
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateRewardTierSchema>;
+  }>('/reward-tiers/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateRewardTierSchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const updatePayload: QueryDeepPartialEntity<ContributionRewardTier> = {
+      ...body,
+      metadata: body.metadata as
+        | QueryDeepPartialEntity<ContributionRewardTier['metadata']>
+        | undefined,
+    };
+    const result = await con
+      .getRepository(ContributionRewardTier)
+      .update(params.id, updatePayload);
+
+    if (!result.affected) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution reward tier not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateReviewSubmissionSchema>;
+  }>('/submissions/:id/review', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateReviewSubmissionSchema,
+      value: req.body,
+      res,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const submission = await con.getRepository(ContributionSubmission).findOne({
+      select: ['id', 'paymentId'],
+      where: { id: params.id },
+    });
+
+    if (!submission) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution submission not found' });
+    }
+
+    if (submission.paymentId) {
+      return res
+        .status(400)
+        .send({ error: 'Paid submissions cannot be reviewed' });
+    }
+
+    const updatePayload: QueryDeepPartialEntity<ContributionSubmission> = {
+      status: body.status,
+      reviewedAt: new Date(),
+    };
+
+    if (body.awardedPoints !== undefined) {
+      updatePayload.awardedPoints = body.awardedPoints;
+    }
+
+    if (body.flags !== undefined) {
+      updatePayload.flags = body.flags as QueryDeepPartialEntity<
+        ContributionSubmission['flags']
+      >;
+    }
+
+    if (body.reviewedBy !== undefined) {
+      updatePayload.reviewedBy = body.reviewedBy;
+    }
+
+    await con
+      .getRepository(ContributionSubmission)
+      .update(params.id, updatePayload);
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateRewardParamsSchema>;
+    Body: z.infer<typeof contributionPrivateFulfillRewardSchema>;
+  }>('/rewards/:userId/:tierId/fulfill', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateRewardParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateFulfillRewardSchema,
+      value: req.body,
+      res,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con.getRepository(UserContributionReward).update(
+      {
+        userId: params.userId,
+        tierId: params.tierId,
+      },
+      {
+        status: UserContributionRewardStatus.Fulfilled,
+        fulfilledAt: body.fulfilledAt ?? new Date(),
+      },
+    );
+
+    if (!result.affected) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution reward claim not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateBlockUserSchema>;
+  }>('/blocked-users', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateBlockUserSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const blockedUser = await con.getRepository(ContributionBlockedUser).save({
+      userId: body.userId,
+      reason: body.reason,
+    });
+
+    return res.status(201).send(blockedUser);
+  });
+
+  fastify.delete<{
+    Params: z.infer<typeof contributionPrivateBlockedUserParamsSchema>;
+  }>('/blocked-users/:userId', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateBlockedUserParamsSchema,
+      value: req.params,
+      res,
+    });
+    if (!params) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    await con.getRepository(ContributionBlockedUser).delete({
+      userId: params.userId,
+    });
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateFinalizePaymentSchema>;
+  }>('/payments/finalize', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateFinalizePaymentSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con.transaction((manager) =>
+      finalizeContributionPayment({
+        con: manager,
+        amountCents: body.amountCents,
+        createdBy: body.createdBy,
+      }),
+    );
+
+    if ('error' in result) {
+      if (result.error === 'noActiveCauses') {
+        return res
+          .status(400)
+          .send({ error: 'No active contribution causes found' });
+      }
+
+      return res
+        .status(400)
+        .send({ error: 'No approved unpaid contribution submissions found' });
+    }
+
+    return res.status(201).send(result.payment);
+  });
+};


### PR DESCRIPTION
## Summary
- add private service-auth contribution write routes under `/p/contributions`
- add Zod validation schemas for contribution admin operations
- implement payment finalization with locked unpaid submissions and deterministic cause allocation
- cover category/action/cause/tier writes, review, fulfillment, blocking, and payment finalization with route tests

## Validation
- `pnpm run build`
- `pnpm run lint`
- `NODE_ENV=test npx jest __tests__/routes/private/contributions.ts __tests__/contributions.ts --testEnvironment=node --runInBand`