### PR TITLE
feat: migrate company verification from Retool to private APIs

### DIFF
--- a/__tests__/routes/private/companyVerification.ts
+++ b/__tests__/routes/private/companyVerification.ts
@@ -144,6 +144,26 @@ describe('private company verification routes', () => {
       expect(body.id).toEqual('mycompany');
     });
 
+    it('returns 409 when a provided id already exists', async () => {
+      await seedUserCompanies();
+
+      await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({
+          id: existingCompanyId,
+          name: 'Acme',
+          domains: ['acme.com'],
+          image: 'https://cdn.example.com/logo.png',
+        })
+        .expect(409);
+
+      const company = await con
+        .getRepository(Company)
+        .findOneByOrFail({ id: existingCompanyId });
+      expect(company.name).toEqual('Existing Co');
+    });
+
     it('rejects missing required fields', async () => {
       await request(app.server)
         .post('/p/company-verification/companies')

--- a/__tests__/routes/private/companyVerification.ts
+++ b/__tests__/routes/private/companyVerification.ts
@@ -1,0 +1,228 @@
+import type { FastifyInstance } from 'fastify';
+import request from 'supertest';
+import type { DataSource } from 'typeorm';
+import appFunc from '../../../src';
+import createOrGetConnection from '../../../src/db';
+import { saveFixtures } from '../../helpers';
+import { User } from '../../../src/entity/user/User';
+import { Company } from '../../../src/entity/Company';
+import { UserCompany } from '../../../src/entity/UserCompany';
+import * as cloudinary from '../../../src/common/cloudinary';
+
+let app: FastifyInstance;
+let con: DataSource;
+
+const serviceHeaders = {
+  authorization: `Service ${process.env.ACCESS_SECRET}`,
+  'content-type': 'application/json',
+};
+
+const hostedImage = 'https://media.daily.dev/company-logo';
+
+const userId = '99999999-9999-4999-8999-999999999991';
+const secondUserId = '99999999-9999-4999-8999-999999999992';
+const thirdUserId = '99999999-9999-4999-8999-999999999993';
+const otherUserId = '99999999-9999-4999-8999-999999999994';
+const existingCompanyId = 'existingco';
+
+beforeAll(async () => {
+  app = await appFunc();
+  con = await createOrGetConnection();
+  return app.ready();
+});
+
+beforeEach(async () => {
+  jest.restoreAllMocks();
+  jest.spyOn(cloudinary, 'uploadLogoFromUrl').mockResolvedValue(hostedImage);
+  await saveFixtures(con, User, [
+    { id: userId, reputation: 10 },
+    { id: secondUserId, reputation: 10 },
+    { id: thirdUserId, reputation: 10 },
+    { id: otherUserId, reputation: 10 },
+  ]);
+});
+
+afterAll(() => app.close());
+
+const seedUserCompanies = async () => {
+  await saveFixtures(con, Company, [
+    {
+      id: existingCompanyId,
+      name: 'Existing Co',
+      image: hostedImage,
+      domains: ['example.com'],
+    },
+  ]);
+  await con.getRepository(UserCompany).save([
+    {
+      userId,
+      email: 'alice@example.com',
+      code: '111111',
+      verified: true,
+    },
+    {
+      userId: secondUserId,
+      email: 'Bob@Example.com',
+      code: '222222',
+      verified: true,
+    },
+    {
+      userId: thirdUserId,
+      email: 'carol@other.com',
+      code: '333333',
+      verified: true,
+    },
+  ]);
+};
+
+describe('private company verification routes', () => {
+  describe('service guard', () => {
+    it('returns 404 for POST /companies without service auth', () =>
+      request(app.server)
+        .post('/p/company-verification/companies')
+        .send({
+          name: 'Acme',
+          domains: ['acme.com'],
+          image: 'https://x.com/a.png',
+        })
+        .expect(404));
+
+    it('returns 404 for POST /link-domain without service auth', () =>
+      request(app.server)
+        .post('/p/company-verification/link-domain')
+        .send({ companyId: existingCompanyId, domain: 'example.com' })
+        .expect(404));
+
+    it('returns 404 for POST /reject-domain without service auth', () =>
+      request(app.server)
+        .post('/p/company-verification/reject-domain')
+        .send({ domain: 'example.com' })
+        .expect(404));
+  });
+
+  describe('POST /companies', () => {
+    it('creates a company with a generated id and hosted image', async () => {
+      const uploadLogoFromUrl = jest.spyOn(cloudinary, 'uploadLogoFromUrl');
+      const { body } = await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({
+          name: 'Acme',
+          domains: [' Acme.com ', 'ACME.IO'],
+          image: 'https://cdn.example.com/logo.png',
+        })
+        .expect(201);
+
+      expect(body.id).toEqual(expect.any(String));
+      expect(uploadLogoFromUrl).toHaveBeenCalledWith(
+        body.id,
+        'https://cdn.example.com/logo.png',
+      );
+
+      const company = await con
+        .getRepository(Company)
+        .findOneByOrFail({ id: body.id });
+      expect(company).toMatchObject({
+        name: 'Acme',
+        image: hostedImage,
+        domains: ['acme.com', 'acme.io'],
+      });
+    });
+
+    it('respects a provided id', async () => {
+      const { body } = await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({
+          id: 'mycompany',
+          name: 'Acme',
+          domains: ['acme.com'],
+          image: 'https://cdn.example.com/logo.png',
+        })
+        .expect(201);
+
+      expect(body.id).toEqual('mycompany');
+    });
+
+    it('rejects missing required fields', async () => {
+      await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({ domains: ['acme.com'], image: 'https://cdn.example.com/a.png' })
+        .expect(400);
+      await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({ name: 'Acme', image: 'https://cdn.example.com/a.png' })
+        .expect(400);
+      await request(app.server)
+        .post('/p/company-verification/companies')
+        .set(serviceHeaders)
+        .send({ name: 'Acme', domains: ['acme.com'] })
+        .expect(400);
+    });
+  });
+
+  describe('POST /link-domain', () => {
+    it('links all matching rows regardless of email casing', async () => {
+      await seedUserCompanies();
+
+      const { body } = await request(app.server)
+        .post('/p/company-verification/link-domain')
+        .set(serviceHeaders)
+        .send({ companyId: existingCompanyId, domain: 'Example.com' })
+        .expect(200);
+
+      expect(body).toEqual({ affected: 2 });
+
+      const linked = await con
+        .getRepository(UserCompany)
+        .findBy({ companyId: existingCompanyId });
+      expect(linked.map((uc) => uc.email).sort()).toEqual([
+        'Bob@Example.com',
+        'alice@example.com',
+      ]);
+
+      const other = await con
+        .getRepository(UserCompany)
+        .findOneByOrFail({ email: 'carol@other.com' });
+      expect(other.companyId).toBeNull();
+    });
+
+    it('returns 404 when the company does not exist', async () => {
+      await seedUserCompanies();
+
+      await request(app.server)
+        .post('/p/company-verification/link-domain')
+        .set(serviceHeaders)
+        .send({ companyId: 'missing', domain: 'example.com' })
+        .expect(404);
+    });
+  });
+
+  describe('POST /reject-domain', () => {
+    it('rejects matching rows and is idempotent', async () => {
+      await seedUserCompanies();
+
+      const first = await request(app.server)
+        .post('/p/company-verification/reject-domain')
+        .set(serviceHeaders)
+        .send({ domain: 'example.com' })
+        .expect(200);
+      expect(first.body).toEqual({ affected: 2 });
+
+      const rejected = await con.getRepository(UserCompany).find();
+      const byEmail = new Map(rejected.map((uc) => [uc.email, uc.flags]));
+      expect(byEmail.get('alice@example.com')).toEqual({ rejected: true });
+      expect(byEmail.get('Bob@Example.com')).toEqual({ rejected: true });
+      expect(byEmail.get('carol@other.com')).toEqual({});
+
+      const second = await request(app.server)
+        .post('/p/company-verification/reject-domain')
+        .set(serviceHeaders)
+        .send({ domain: 'example.com' })
+        .expect(200);
+      expect(second.body).toEqual({ affected: 2 });
+    });
+  });
+});

--- a/src/common/schema/companyVerification.ts
+++ b/src/common/schema/companyVerification.ts
@@ -1,0 +1,23 @@
+import z from 'zod';
+import { CompanyType } from '../../entity/Company';
+import { enumValues } from './utils';
+
+const normalizedDomainSchema = z.string().trim().toLowerCase().min(1);
+
+export const companyVerificationCreateCompanySchema = z.object({
+  id: z.string().trim().min(1).optional(),
+  name: z.string().trim().min(1),
+  altName: z.string().trim().min(1).nullish(),
+  domains: z.array(normalizedDomainSchema).min(1),
+  image: z.url(),
+  type: z.enum(enumValues(CompanyType)).optional(),
+});
+
+export const companyVerificationLinkDomainSchema = z.object({
+  companyId: z.string().trim().min(1),
+  domain: normalizedDomainSchema,
+});
+
+export const companyVerificationRejectDomainSchema = z.object({
+  domain: normalizedDomainSchema,
+});

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -17,6 +17,7 @@ import {
 import { queryReadReplica } from '../common/queryReadReplica';
 import { kvasir } from './private/kvasir';
 import contributions from './private/contributions';
+import companyVerification from './private/companyVerification';
 import rpc from './private/rpc';
 import { createWorkerJobRpc } from './private/workerJobRpc';
 import { connectRpcPlugin, baseRpcContext } from '../common/connectRpc';
@@ -59,6 +60,7 @@ const vordrUsersSchema = z.object({
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.register(contributions, { prefix: '/contributions' });
+  fastify.register(companyVerification, { prefix: '/company-verification' });
 
   fastify.post<{ Body: AddUserDataPost }>('/newUser', async (req, res) => {
     if (!req.service) {

--- a/src/routes/private/companyVerification.ts
+++ b/src/routes/private/companyVerification.ts
@@ -1,0 +1,130 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import type z from 'zod';
+import createOrGetConnection from '../../db';
+import {
+  companyVerificationCreateCompanySchema,
+  companyVerificationLinkDomainSchema,
+  companyVerificationRejectDomainSchema,
+} from '../../common/schema/companyVerification';
+import { Company } from '../../entity/Company';
+import { UserCompany } from '../../entity/UserCompany';
+import { generateShortId } from '../../ids';
+import { uploadLogoFromUrl } from '../../common/cloudinary';
+import { updateFlagsStatement } from '../../common/utils';
+
+const parseSchema = <TSchema extends z.ZodType>({
+  schema,
+  value,
+  res,
+}: {
+  schema: TSchema;
+  value: unknown;
+  res: FastifyReply;
+}): z.infer<TSchema> | undefined => {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    res.status(400).send({
+      error: {
+        name: parsed.error.name,
+        issues: parsed.error.issues,
+      },
+    });
+    return undefined;
+  }
+
+  return parsed.data;
+};
+
+const domainWhere = `split_part(lower(email), '@', 2) = :domain`;
+
+export default async (fastify: FastifyInstance): Promise<void> => {
+  fastify.addHook('preHandler', async (req, res) => {
+    if (!req.service) {
+      return res.status(404).send();
+    }
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof companyVerificationCreateCompanySchema>;
+  }>('/companies', async (req, res) => {
+    const body = parseSchema({
+      schema: companyVerificationCreateCompanySchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const id = body.id ?? (await generateShortId());
+    const image = await uploadLogoFromUrl(id, body.image);
+
+    const company = await con.getRepository(Company).save({
+      id,
+      name: body.name,
+      altName: body.altName ?? null,
+      domains: body.domains,
+      image,
+      ...(body.type ? { type: body.type } : {}),
+    });
+
+    return res.status(201).send(company);
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof companyVerificationLinkDomainSchema>;
+  }>('/link-domain', async (req, res) => {
+    const body = parseSchema({
+      schema: companyVerificationLinkDomainSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const company = await con
+      .getRepository(Company)
+      .findOneBy({ id: body.companyId });
+
+    if (!company) {
+      return res.status(404).send({ error: 'Company not found' });
+    }
+
+    const result = await con
+      .getRepository(UserCompany)
+      .createQueryBuilder()
+      .update()
+      .set({ companyId: body.companyId })
+      .where(domainWhere, { domain: body.domain })
+      .execute();
+
+    return res.status(200).send({ affected: result.affected ?? 0 });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof companyVerificationRejectDomainSchema>;
+  }>('/reject-domain', async (req, res) => {
+    const body = parseSchema({
+      schema: companyVerificationRejectDomainSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(UserCompany)
+      .createQueryBuilder()
+      .update()
+      .set({ flags: updateFlagsStatement<UserCompany>({ rejected: true }) })
+      .where(domainWhere, { domain: body.domain })
+      .execute();
+
+    return res.status(200).send({ affected: result.affected ?? 0 });
+  });
+};

--- a/src/routes/private/companyVerification.ts
+++ b/src/routes/private/companyVerification.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import type z from 'zod';
 import createOrGetConnection from '../../db';
 import {
@@ -11,29 +11,7 @@ import { UserCompany } from '../../entity/UserCompany';
 import { generateShortId } from '../../ids';
 import { uploadLogoFromUrl } from '../../common/cloudinary';
 import { updateFlagsStatement } from '../../common/utils';
-
-const parseSchema = <TSchema extends z.ZodType>({
-  schema,
-  value,
-  res,
-}: {
-  schema: TSchema;
-  value: unknown;
-  res: FastifyReply;
-}): z.infer<TSchema> | undefined => {
-  const parsed = schema.safeParse(value);
-  if (!parsed.success) {
-    res.status(400).send({
-      error: {
-        name: parsed.error.name,
-        issues: parsed.error.issues,
-      },
-    });
-    return undefined;
-  }
-
-  return parsed.data;
-};
+import { parseSchema } from './utils';
 
 const domainWhere = `split_part(lower(email), '@', 2) = :domain`;
 
@@ -57,10 +35,15 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     }
 
     const con = await createOrGetConnection();
+    const repo = con.getRepository(Company);
     const id = body.id ?? (await generateShortId());
-    const image = await uploadLogoFromUrl(id, body.image);
 
-    const company = await con.getRepository(Company).save({
+    if (body.id && (await repo.findOneBy({ id: body.id }))) {
+      return res.status(409).send({ error: 'Company already exists' });
+    }
+
+    const image = await uploadLogoFromUrl(id, body.image);
+    const company = await repo.save({
       id,
       name: body.name,
       altName: body.altName ?? null,

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -1,7 +1,8 @@
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import type z from 'zod';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import createOrGetConnection from '../../db';
+import { parseSchema } from './utils';
 import {
   contributionPrivateBlockUserSchema,
   contributionPrivateBlockedUserParamsSchema,
@@ -33,47 +34,6 @@ import {
   UserContributionReward,
   UserContributionRewardStatus,
 } from '../../entity/contribution/UserContributionReward';
-
-const parseSchema = <TSchema extends z.ZodType>({
-  schema,
-  value,
-  res,
-  requireNonEmpty = false,
-}: {
-  schema: TSchema;
-  value: unknown;
-  res: FastifyReply;
-  requireNonEmpty?: boolean;
-}): z.infer<TSchema> | undefined => {
-  const parsed = schema.safeParse(value);
-  if (!parsed.success) {
-    res.status(400).send({
-      error: {
-        name: parsed.error.name,
-        issues: parsed.error.issues,
-      },
-    });
-    return undefined;
-  }
-
-  if (
-    requireNonEmpty &&
-    parsed.data &&
-    typeof parsed.data === 'object' &&
-    !Array.isArray(parsed.data) &&
-    Object.keys(parsed.data).length === 0
-  ) {
-    res.status(400).send({
-      error: {
-        name: 'ZodError',
-        issues: [{ message: 'At least one field is required' }],
-      },
-    });
-    return undefined;
-  }
-
-  return parsed.data;
-};
 
 export default async (fastify: FastifyInstance): Promise<void> => {
   fastify.addHook('preHandler', async (req, res) => {

--- a/src/routes/private/utils.ts
+++ b/src/routes/private/utils.ts
@@ -1,0 +1,43 @@
+import type { FastifyReply } from 'fastify';
+import type z from 'zod';
+
+export const parseSchema = <TSchema extends z.ZodType>({
+  schema,
+  value,
+  res,
+  requireNonEmpty = false,
+}: {
+  schema: TSchema;
+  value: unknown;
+  res: FastifyReply;
+  requireNonEmpty?: boolean;
+}): z.infer<TSchema> | undefined => {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    res.status(400).send({
+      error: {
+        name: parsed.error.name,
+        issues: parsed.error.issues,
+      },
+    });
+    return undefined;
+  }
+
+  if (
+    requireNonEmpty &&
+    parsed.data &&
+    typeof parsed.data === 'object' &&
+    !Array.isArray(parsed.data) &&
+    Object.keys(parsed.data).length === 0
+  ) {
+    res.status(400).send({
+      error: {
+        name: 'ZodError',
+        issues: [{ message: 'At least one field is required' }],
+      },
+    });
+    return undefined;
+  }
+
+  return parsed.data;
+};


### PR DESCRIPTION
Replaces the Retool company-verification **write** actions with service-only private REST endpoints in daily-api, so the review workflow can be driven by AI agents (and humans) through a stable, validated API instead of raw SQL. Read/listing queries are out of scope.

## Endpoints (under `/p/company-verification`)

- `POST /companies` — create a company. Generates the `id` via `generateShortId()` when not supplied; uploads the provided `image` URL to Cloudinary (`uploadLogoFromUrl`) and stores the hosted URL; normalizes domains. Returns `201`.
- `POST /link-domain` — link `user_company` rows to a company by email domain (`404` if the company doesn't exist). Returns affected-row count.
- `POST /reject-domain` — set `flags.rejected = true` for matching rows via `updateFlagsStatement`. Idempotent. Returns affected-row count.

## Key decisions

- **REST, mirroring `contributions.ts`** — the closest existing private-router pattern: `preHandler` service guard (404 when `!req.service`), Zod-validated bodies, query-builder access, handlers that always `return res.send(...)`.
- **Domain normalization** — inputs are `.trim().toLowerCase()`'d in Zod and matched against `split_part(lower(email), '@', 2)` (parameterized, no raw `con.query`), so stored-email casing can't cause missed matches — a deliberate improvement over Retool's exact match.
- **Logos always re-hosted on Cloudinary** rather than storing arbitrary external URLs; upload happens before persist so a failed upload aborts creation (no partial company).
- **Create-only semantics** — supplying an existing `id` returns `409` instead of silently upserting, since company ids are referenced by `user_company.companyId`.
- **Additive only** — the enrichment worker and cron are left untouched; these endpoints are the manual/agent review fallback.

Shared `parseSchema` helper extracted to `src/routes/private/utils.ts` and reused by both `contributions` and `companyVerification`.

## Tests

Integration tests in `__tests__/routes/private/companyVerification.ts` (Cloudinary mocked): service guards, create (generated/provided id, hosted image, domain normalization, validation, 409 conflict), link (mixed-case matching, 404), reject (mixed-case, idempotency).

Closes ENG-1630

---
Created by Huginn 🐦‍⬛