### PR TITLE
feat: add private endpoint to batch set post briefWorthy flag

### DIFF
--- a/__tests__/private.ts
+++ b/__tests__/private.ts
@@ -13,7 +13,8 @@ import {
   UserPersonalizedDigest,
 } from '../src/entity';
 import { FreeformPost } from '../src/entity/posts/FreeformPost';
-import { PostType } from '../src/entity/posts/Post';
+import { Post, PostType } from '../src/entity/posts/Post';
+import { updateFlagsStatement } from '../src/common/utils';
 import { sourcesFixture } from './fixture/source';
 import request from 'supertest';
 import { usersFixture } from './fixture/user';
@@ -1708,5 +1709,86 @@ describe('POST /p/updatePostContent', () => {
       .findOneByOrFail({ id: post.id });
     expect(updated.title).toBe('Updated title');
     expect(updated.content).toBe('New content');
+  });
+});
+
+describe('POST /p/updatePostsBriefWorthy', () => {
+  const path = '/p/updatePostsBriefWorthy';
+
+  beforeEach(async () => {
+    await saveFixtures(con, ArticlePost, postsFixture);
+  });
+
+  it('should return 404 when not authorized', async () => {
+    return request(app.server)
+      .post(path)
+      .send({ postIds: ['p1'], briefWorthy: true })
+      .expect(404);
+  });
+
+  it('should return 400 when postIds is empty', async () => {
+    return request(app.server)
+      .post(path)
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({ postIds: [], briefWorthy: true })
+      .expect(400);
+  });
+
+  it('should return 400 when briefWorthy is missing', async () => {
+    return request(app.server)
+      .post(path)
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({ postIds: ['p1'] })
+      .expect(400);
+  });
+
+  it('should set briefWorthy flag and bump metadataChangedAt', async () => {
+    const repo = con.getRepository(ArticlePost);
+    const before = await repo.findOneByOrFail({ id: 'p1' });
+
+    const res = await request(app.server)
+      .post(path)
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({ postIds: ['p1', 'p2'], briefWorthy: true })
+      .expect(200);
+
+    expect(res.body).toEqual({ updated: 2 });
+
+    const [p1, p2] = await Promise.all([
+      repo.findOneByOrFail({ id: 'p1' }),
+      repo.findOneByOrFail({ id: 'p2' }),
+    ]);
+    expect(p1.flags.briefWorthy).toBe(true);
+    expect(p2.flags.briefWorthy).toBe(true);
+    expect(p1.metadataChangedAt.getTime()).toBeGreaterThan(
+      before.metadataChangedAt.getTime(),
+    );
+  });
+
+  it('should unset briefWorthy flag when value is false', async () => {
+    const repo = con.getRepository(ArticlePost);
+    await repo.update(
+      { id: 'p1' },
+      { flags: updateFlagsStatement<Post>({ briefWorthy: true }) },
+    );
+
+    await request(app.server)
+      .post(path)
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({ postIds: ['p1'], briefWorthy: false })
+      .expect(200);
+
+    const updated = await repo.findOneByOrFail({ id: 'p1' });
+    expect(updated.flags.briefWorthy).toBe(false);
+  });
+
+  it('should only count existing posts as updated', async () => {
+    const res = await request(app.server)
+      .post(path)
+      .set('authorization', `Service ${process.env.ACCESS_SECRET}`)
+      .send({ postIds: ['p1', 'nonexistent'], briefWorthy: true })
+      .expect(200);
+
+    expect(res.body).toEqual({ updated: 1 });
   });
 });

--- a/src/common/schema/posts.ts
+++ b/src/common/schema/posts.ts
@@ -6,3 +6,15 @@ export const updatePostContentSchema = z.object({
   mode: z.enum(['append', 'prepend', 'replace']).default('replace'),
   title: z.string().min(1).optional(),
 });
+
+const MAX_BRIEF_WORTHY_BATCH_SIZE = 500;
+
+export const updatePostsBriefWorthySchema = z.object({
+  postIds: z
+    .array(z.string().trim().min(1))
+    .min(1, { error: 'At least one post ID is required' })
+    .max(MAX_BRIEF_WORTHY_BATCH_SIZE, {
+      error: `Maximum of ${MAX_BRIEF_WORTHY_BATCH_SIZE} post IDs can be processed at once`,
+    }),
+  briefWorthy: z.boolean(),
+});

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -45,6 +45,7 @@ export type PostFlags = Partial<{
   private: boolean;
   visible: boolean;
   showOnFeed: boolean;
+  briefWorthy: boolean;
   promoteToPublic: number | null;
   deletedBy: string;
   vordr: boolean;

--- a/src/routes/private.ts
+++ b/src/routes/private.ts
@@ -39,7 +39,12 @@ import { addOpportunityDefaultQuestionFeedback } from '../common/opportunity/que
 import { z } from 'zod';
 import { counters } from '../telemetry';
 import { applyVordrToUsers } from '../common/vordr';
-import { updatePostContentSchema } from '../common/schema/posts';
+import {
+  updatePostContentSchema,
+  updatePostsBriefWorthySchema,
+} from '../common/schema/posts';
+import { updateFlagsStatement } from '../common/utils';
+import { In } from 'typeorm';
 
 interface SearchUsername {
   search: string;
@@ -419,6 +424,38 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     await con.getRepository(FreeformPost).update({ id: postId }, updatePayload);
 
     return res.status(200).send({ id: postId });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof updatePostsBriefWorthySchema>;
+  }>('/updatePostsBriefWorthy', async (req, res) => {
+    if (!req.service) {
+      return res.status(404).send();
+    }
+
+    const body = updatePostsBriefWorthySchema.safeParse(req.body);
+
+    if (body.error) {
+      return res.status(400).send({
+        error: {
+          name: body.error.name,
+          issues: body.error.issues,
+        },
+      });
+    }
+
+    const { briefWorthy, postIds } = body.data;
+    const con = await createOrGetConnection();
+
+    const { affected } = await con.getRepository(Post).update(
+      { id: In(postIds) },
+      {
+        flags: updateFlagsStatement<Post>({ briefWorthy }),
+        metadataChangedAt: new Date(),
+      },
+    );
+
+    return res.status(200).send({ updated: affected ?? 0 });
   });
 
   fastify.register(kvasir, { prefix: '/kvasir' });


### PR DESCRIPTION
## What

Adds a private (service-to-service) endpoint **`POST /p/updatePostsBriefWorthy`** that batch-sets the `briefWorthy` flag on posts. It accepts an array of post ids and a boolean value, updates the flag, and bumps `metadataChangedAt` so the change propagates downstream (CDC).

## Key decisions

- **Flag lives in `Post.flags` JSONB** (alongside `vordr`, `promoteToPublic`, etc.) rather than a dedicated column — matches the codebase's "flag" pattern and the AGENTS.md "Updating JSONB Flag Fields" guidance (`updateFlagsStatement`), so no migration is needed.
- **Single atomic SQL update** via `In(postIds)` — duplicate ids are harmless, so no dedup overhead.
- **Validation** with a Zod schema (`updatePostsBriefWorthySchema`) in `src/common/schema/posts.ts`: non-empty `postIds` (capped at 500, matching the existing batch convention) and a required boolean `briefWorthy`.
- Follows existing private-route conventions: `req.service` guard returning 404, `{ error: { name, issues } }` on validation failure; returns `{ updated: <affected count> }`.

## Tests

Integration tests in `__tests__/private.ts` cover the auth guard, validation (empty `postIds`, missing `briefWorthy`), setting/unsetting the flag with `metadataChangedAt` bump, and the affected-count for non-existent ids.

Closes ENG-1631

---
Created by Huginn 🐦‍⬛