### PR TITLE
feat: support contribution giveback UI data

### DIFF
--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -26,6 +26,7 @@ import {
   ContributionSubmissionStatus,
 } from '../src/entity/contribution/ContributionSubmission';
 import { ContributionRewardType } from '../src/entity/contribution/ContributionRewardTier';
+import { ContributionSponsor } from '../src/entity/contribution/ContributionSponsor';
 import { UserContributionCausePreference } from '../src/entity/contribution/UserContributionCausePreference';
 import { UserContributionReward } from '../src/entity/contribution/UserContributionReward';
 import { remoteConfig } from '../src/remoteConfig';
@@ -42,8 +43,10 @@ const categoryId = '11111111-1111-4111-8111-111111111111';
 const secondCategoryId = '11111111-1111-4111-8111-111111111112';
 const actionId = '22222222-2222-4222-8222-222222222222';
 const secondActionId = '22222222-2222-4222-8222-222222222223';
+const loveActionId = '22222222-2222-4222-8222-222222222224';
 const causeId = '33333333-3333-4333-8333-333333333333';
 const secondCauseId = '33333333-3333-4333-8333-333333333334';
+const sponsorId = '33333333-3333-4333-8333-333333333335';
 const tierId = '44444444-4444-4444-8444-444444444444';
 const paymentId = '55555555-5555-4555-8555-555555555555';
 
@@ -71,8 +74,39 @@ query ContributionActions($categoryId: ID) {
         title
         points
         evidence
+        metadata {
+          platform
+          instructions
+          externalUrl
+          isLoveAction
+        }
         maxPerUser
         userCompletions
+        latestUserSubmission {
+          status
+          awardedPoints
+          evidence
+        }
+      }
+    }
+  }
+}
+`;
+
+const USER_CONTRIBUTION_SUBMISSIONS_QUERY = `
+query UserContributionSubmissions($actionId: ID) {
+  userContributionSubmissions(actionId: $actionId, first: 10) {
+    edges {
+      node {
+        actionId
+        status
+        awardedPoints
+        evidence
+        reviewedAt
+        action {
+          id
+          title
+        }
       }
     }
   }
@@ -86,8 +120,28 @@ query ContributionCauses {
       node {
         id
         title
+        description
+        category
+        logoUrl
         totalPoints
         totalAmountCents
+      }
+    }
+  }
+}
+`;
+
+const CONTRIBUTION_SPONSORS_QUERY = `
+query ContributionSponsors {
+  contributionSponsors(first: 10) {
+    edges {
+      node {
+        id
+        name
+        amountCents
+        url
+        logoUrl
+        tier
       }
     }
   }
@@ -117,6 +171,9 @@ query UserContributionCauseStats {
         cause {
           id
           title
+          description
+          category
+          logoUrl
           totalPoints
           totalAmountCents
         }
@@ -270,6 +327,11 @@ const seedActions = async () => {
       title: 'Post on Reddit',
       points: 25,
       evidence: { url: { required: true, allowedDomains: ['Reddit.com'] } },
+      metadata: {
+        platform: 'reddit',
+        instructions: 'Submit the public Reddit URL.',
+        externalUrl: 'https://reddit.com/r/programming',
+      },
       maxPerUser: 1,
       sortOrder: 1,
     },
@@ -281,11 +343,17 @@ const seedCauses = async () => {
     {
       id: secondCauseId,
       title: 'Open Source Grants',
+      description: 'Funding maintainers and tools.',
+      category: 'Open source',
+      logoUrl: 'https://daily.dev/oss.png',
       sortOrder: 2,
     },
     {
       id: causeId,
       title: 'Developer Education',
+      description: 'Helping developers learn.',
+      category: 'Education',
+      logoUrl: 'https://daily.dev/education.png',
       sortOrder: 1,
     },
   ]);
@@ -344,8 +412,15 @@ it('returns actions by category and records approved submissions with limits', a
         title: 'Post on Reddit',
         points: 25,
         evidence: { url: { required: true, allowedDomains: ['Reddit.com'] } },
+        metadata: {
+          platform: 'reddit',
+          instructions: 'Submit the public Reddit URL.',
+          externalUrl: 'https://reddit.com/r/programming',
+          isLoveAction: false,
+        },
         maxPerUser: 1,
         userCompletions: 0,
+        latestUserSubmission: null,
       },
     },
   ]);
@@ -396,6 +471,42 @@ it('returns actions by category and records approved submissions with limits', a
     userPoints: 25,
   });
 
+  const [submissions, updatedActions] = await Promise.all([
+    client.query(USER_CONTRIBUTION_SUBMISSIONS_QUERY, {
+      variables: { actionId },
+    }),
+    client.query(CONTRIBUTION_ACTIONS_QUERY, {
+      variables: { categoryId },
+    }),
+  ]);
+
+  expect(submissions.data.userContributionSubmissions.edges).toEqual([
+    {
+      node: {
+        actionId,
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 25,
+        evidence: {
+          url: 'https://www.reddit.com/r/programming/comments/123',
+        },
+        reviewedAt: null,
+        action: {
+          id: actionId,
+          title: 'Post on Reddit',
+        },
+      },
+    },
+  ]);
+  expect(
+    updatedActions.data.contributionActions.edges[0].node.latestUserSubmission,
+  ).toMatchObject({
+    status: ContributionSubmissionStatus.Approved,
+    awardedPoints: 25,
+    evidence: {
+      url: 'https://www.reddit.com/r/programming/comments/123',
+    },
+  });
+
   const duplicate = await client.mutate(SUBMIT_CONTRIBUTION_ACTION_MUTATION, {
     variables: {
       input: {
@@ -408,6 +519,29 @@ it('returns actions by category and records approved submissions with limits', a
   });
 
   expect(duplicate.errors?.[0].message).toEqual('Action limit reached');
+
+  await saveFixtures(con, ContributionAction, [
+    {
+      id: loveActionId,
+      title: 'Leave an honest review',
+      points: 0,
+      evidence: {},
+      metadata: { isLoveAction: true },
+    },
+  ]);
+
+  const loveAction = await client.mutate(SUBMIT_CONTRIBUTION_ACTION_MUTATION, {
+    variables: {
+      input: {
+        actionId: loveActionId,
+        evidence: {},
+      },
+    },
+  });
+
+  expect(loveAction.errors?.[0].message).toEqual(
+    'Contribution action is not rewardable',
+  );
 });
 
 it('updates cause preferences and claims unlocked reward tiers', async () => {
@@ -465,7 +599,7 @@ it('updates cause preferences and claims unlocked reward tiers', async () => {
   expect(claimed.data.claimContributionReward.claimedAt).toBeTruthy();
 });
 
-it('returns finalized cause totals and user cause stats', async () => {
+it('returns finalized cause totals, user cause stats, and sponsors', async () => {
   await seedCauses();
   await saveFixtures(con, ContributionPayment, [
     {
@@ -485,14 +619,27 @@ it('returns finalized cause totals and user cause stats', async () => {
       amountCents: 10000,
     },
   ]);
+  await saveFixtures(con, ContributionSponsor, [
+    {
+      id: sponsorId,
+      name: 'Daily Corp',
+      amountCents: 250000,
+      url: 'https://daily.dev',
+      logoUrl: 'https://daily.dev/logo.png',
+    },
+  ]);
 
   const causes = await client.query(CONTRIBUTION_CAUSES_QUERY);
   const stats = await client.query(USER_CAUSE_STATS_QUERY);
+  const sponsors = await client.query(CONTRIBUTION_SPONSORS_QUERY);
 
   expect(causes.data.contributionCauses.edges[0]).toEqual({
     node: {
       id: causeId,
       title: 'Developer Education',
+      description: 'Helping developers learn.',
+      category: 'Education',
+      logoUrl: 'https://daily.dev/education.png',
       totalPoints: 100,
       totalAmountCents: 10000,
     },
@@ -505,9 +652,24 @@ it('returns finalized cause totals and user cause stats', async () => {
         cause: {
           id: causeId,
           title: 'Developer Education',
+          description: 'Helping developers learn.',
+          category: 'Education',
+          logoUrl: 'https://daily.dev/education.png',
           totalPoints: 100,
           totalAmountCents: 10000,
         },
+      },
+    },
+  ]);
+  expect(sponsors.data.contributionSponsors.edges).toEqual([
+    {
+      node: {
+        id: sponsorId,
+        name: 'Daily Corp',
+        amountCents: 250000,
+        url: 'https://daily.dev',
+        logoUrl: 'https://daily.dev/logo.png',
+        tier: 'platinum',
       },
     },
   ]);

--- a/__tests__/routes/private/contributions.ts
+++ b/__tests__/routes/private/contributions.ts
@@ -18,6 +18,7 @@ import {
   ContributionRewardTier,
   ContributionRewardType,
 } from '../../../src/entity/contribution/ContributionRewardTier';
+import { ContributionSponsor } from '../../../src/entity/contribution/ContributionSponsor';
 import {
   ContributionSubmission,
   ContributionSubmissionStatus,
@@ -169,6 +170,11 @@ describe('private contribution routes', () => {
         title: 'Post on Reddit',
         points: 20,
         evidence: { url: { required: true } },
+        metadata: {
+          platform: 'reddit',
+          instructions: 'Submit the public post URL.',
+          externalUrl: 'https://reddit.com/r/programming',
+        },
         cooldownSeconds: 3600,
         maxPerUser: 3,
       })
@@ -183,13 +189,37 @@ describe('private contribution routes', () => {
     const { body: cause } = await request(app.server)
       .post('/p/contributions/causes')
       .set(serviceHeaders)
-      .send({ title: 'Open source', url: 'https://daily.dev' })
+      .send({
+        title: 'Open source',
+        url: 'https://daily.dev',
+        description: 'Funds open source projects.',
+        category: 'Open source',
+        logoUrl: 'https://daily.dev/logo.png',
+      })
       .expect(201);
 
     await request(app.server)
       .patch(`/p/contributions/causes/${cause.id}`)
       .set(serviceHeaders)
-      .send({ title: 'Education', active: false })
+      .send({ title: 'Education', category: 'Education', active: false })
+      .expect(200);
+
+    const { body: sponsor } = await request(app.server)
+      .post('/p/contributions/sponsors')
+      .set(serviceHeaders)
+      .send({
+        name: 'Daily Corp',
+        amountCents: 250000,
+        url: 'https://daily.dev',
+        logoUrl: 'https://daily.dev/logo.png',
+        sortOrder: 1,
+      })
+      .expect(201);
+
+    await request(app.server)
+      .patch(`/p/contributions/sponsors/${sponsor.id}`)
+      .set(serviceHeaders)
+      .send({ amountCents: 100000, active: false })
       .expect(200);
 
     const { body: tier } = await request(app.server)
@@ -211,15 +241,43 @@ describe('private contribution routes', () => {
 
     await expect(
       con.getRepository(ContributionAction).findOneByOrFail({ id: action.id }),
-    ).resolves.toMatchObject({ points: 25, active: false });
+    ).resolves.toMatchObject({
+      points: 25,
+      active: false,
+      metadata: {
+        platform: 'reddit',
+        instructions: 'Submit the public post URL.',
+        externalUrl: 'https://reddit.com/r/programming',
+      },
+    });
     await expect(
       con.getRepository(ContributionCause).findOneByOrFail({ id: cause.id }),
-    ).resolves.toMatchObject({ title: 'Education', active: false });
+    ).resolves.toMatchObject({
+      title: 'Education',
+      description: 'Funds open source projects.',
+      category: 'Education',
+      logoUrl: 'https://daily.dev/logo.png',
+      active: false,
+    });
+    await expect(
+      con
+        .getRepository(ContributionSponsor)
+        .findOneByOrFail({ id: sponsor.id }),
+    ).resolves.toMatchObject({ amountCents: 100000, active: false });
     await expect(
       con
         .getRepository(ContributionRewardTier)
         .findOneByOrFail({ id: tier.id }),
     ).resolves.toMatchObject({ thresholdPoints: 150, active: false });
+
+    await request(app.server)
+      .delete(`/p/contributions/sponsors/${sponsor.id}`)
+      .set(serviceAuthHeaders)
+      .expect(200);
+
+    await expect(
+      con.getRepository(ContributionSponsor).findOneBy({ id: sponsor.id }),
+    ).resolves.toBeNull();
   });
 
   it('reviews submissions, fulfills rewards, and blocks users', async () => {

--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -2,12 +2,14 @@ import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { In, type EntityManager } from 'typeorm';
 import type z from 'zod';
 import {
+  contributionActionMetadataSchema,
   contributionActionEvidenceSchema,
   contributionSubmissionEvidenceSchema,
 } from '../schema/contributions';
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
 import type {
   ContributionAction,
+  ContributionActionMetadata,
   ContributionEvidenceSchema,
 } from '../../entity/contribution/ContributionAction';
 import {
@@ -46,6 +48,10 @@ type ContributionActionUsage = {
 
 type ContributionActionEvidenceInput = z.infer<
   typeof contributionActionEvidenceSchema
+>;
+
+type ContributionActionMetadataInput = z.infer<
+  typeof contributionActionMetadataSchema
 >;
 
 type ContributionPointAllocation = {
@@ -565,6 +571,25 @@ export const normalizeContributionActionEvidence = (
               : {}),
           },
         }
+      : {}),
+  };
+};
+
+export const normalizeContributionActionMetadata = (
+  metadata:
+    | ContributionActionMetadataInput
+    | ContributionActionMetadata
+    | null
+    | undefined,
+): ContributionActionMetadata => {
+  const parsed = contributionActionMetadataSchema.parse(metadata ?? {});
+
+  return {
+    ...(parsed.platform ? { platform: parsed.platform } : {}),
+    ...(parsed.instructions ? { instructions: parsed.instructions } : {}),
+    ...(parsed.externalUrl ? { externalUrl: parsed.externalUrl } : {}),
+    ...(parsed.isLoveAction !== undefined && parsed.isLoveAction !== null
+      ? { isLoveAction: parsed.isLoveAction }
       : {}),
   };
 };

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -24,6 +24,15 @@ export const contributionActionEvidenceSchema = z
   })
   .strict();
 
+export const contributionActionMetadataSchema = z
+  .object({
+    platform: z.string().trim().min(1).nullish(),
+    instructions: z.string().trim().min(1).nullish(),
+    externalUrl: z.url().nullish(),
+    isLoveAction: z.boolean().nullish(),
+  })
+  .strict();
+
 export const contributionSubmissionEvidenceSchema = z
   .object({
     url: z.url().nullish(),
@@ -40,6 +49,11 @@ export const contributionConnectionArgsSchema = z.object({
 export const contributionActionsArgsSchema =
   contributionConnectionArgsSchema.extend({
     categoryId: z.uuid().nullish(),
+  });
+
+export const contributionSubmissionsArgsSchema =
+  contributionConnectionArgsSchema.extend({
+    actionId: z.uuid().nullish(),
   });
 
 export const submitContributionActionInputSchema = z.object({
@@ -97,8 +111,9 @@ export const contributionPrivateCreateActionSchema = z.object({
   categoryId: z.uuid().nullish(),
   title: z.string().trim().min(1),
   description: z.string().trim().min(1).nullish(),
-  points: z.number().int().positive(),
+  points: z.number().int().min(0),
   evidence: contributionActionEvidenceSchema.optional(),
+  metadata: contributionActionMetadataSchema.optional(),
   cooldownSeconds: z.number().int().positive().nullish(),
   maxPerUser: z.number().int().positive().nullish(),
   active: contributionActiveSchema,
@@ -109,8 +124,9 @@ export const contributionPrivateUpdateActionSchema = z.object({
   categoryId: z.uuid().nullish(),
   title: z.string().trim().min(1).optional(),
   description: z.string().trim().min(1).nullish(),
-  points: z.number().int().positive().optional(),
+  points: z.number().int().min(0).optional(),
   evidence: contributionActionEvidenceSchema.optional(),
+  metadata: contributionActionMetadataSchema.optional(),
   cooldownSeconds: z.number().int().positive().nullish(),
   maxPerUser: z.number().int().positive().nullish(),
   active: contributionActiveSchema,
@@ -120,6 +136,9 @@ export const contributionPrivateUpdateActionSchema = z.object({
 export const contributionPrivateCreateCauseSchema = z.object({
   title: z.string().trim().min(1),
   url: z.url().nullish(),
+  description: z.string().trim().min(1).nullish(),
+  category: z.string().trim().min(1).nullish(),
+  logoUrl: z.url().nullish(),
   active: contributionActiveSchema,
   sortOrder: contributionSortOrderSchema,
 });
@@ -127,6 +146,27 @@ export const contributionPrivateCreateCauseSchema = z.object({
 export const contributionPrivateUpdateCauseSchema = z.object({
   title: z.string().trim().min(1).optional(),
   url: z.url().nullish(),
+  description: z.string().trim().min(1).nullish(),
+  category: z.string().trim().min(1).nullish(),
+  logoUrl: z.url().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateCreateSponsorSchema = z.object({
+  name: z.string().trim().min(1),
+  amountCents: z.number().int().positive(),
+  url: z.url().nullish(),
+  logoUrl: z.url().nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateUpdateSponsorSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  amountCents: z.number().int().positive().optional(),
+  url: z.url().nullish(),
+  logoUrl: z.url().nullish(),
   active: contributionActiveSchema,
   sortOrder: contributionSortOrderSchema,
 });

--- a/src/entity/contribution/ContributionAction.ts
+++ b/src/entity/contribution/ContributionAction.ts
@@ -22,6 +22,13 @@ export type ContributionEvidenceSchema = {
   };
 };
 
+export type ContributionActionMetadata = {
+  platform?: string;
+  instructions?: string;
+  externalUrl?: string;
+  isLoveAction?: boolean;
+};
+
 @Entity()
 @Index('IDX_contribution_action_active_sort', [
   'active',
@@ -55,6 +62,9 @@ export class ContributionAction {
 
   @Column({ type: 'jsonb', default: {} })
   evidence: ContributionEvidenceSchema;
+
+  @Column({ type: 'jsonb', default: {} })
+  metadata: ContributionActionMetadata;
 
   @Column({ type: 'integer', nullable: true, default: null })
   cooldownSeconds: number | null;

--- a/src/entity/contribution/ContributionCause.ts
+++ b/src/entity/contribution/ContributionCause.ts
@@ -30,6 +30,15 @@ export class ContributionCause {
   @Column({ type: 'text', nullable: true, default: null })
   url: string | null;
 
+  @Column({ type: 'text', nullable: true, default: null })
+  description: string | null;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  category: string | null;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  logoUrl: string | null;
+
   @Column({ type: 'boolean', default: true })
   active: boolean;
 

--- a/src/entity/contribution/ContributionSponsor.ts
+++ b/src/entity/contribution/ContributionSponsor.ts
@@ -1,0 +1,69 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum ContributionSponsorTier {
+  Platinum = 'platinum',
+  Gold = 'gold',
+  Silver = 'silver',
+  Backer = 'backer',
+}
+
+export const getContributionSponsorTier = (
+  amountCents: number,
+): ContributionSponsorTier => {
+  if (amountCents >= 250000) {
+    return ContributionSponsorTier.Platinum;
+  }
+
+  if (amountCents >= 100000) {
+    return ContributionSponsorTier.Gold;
+  }
+
+  if (amountCents >= 25000) {
+    return ContributionSponsorTier.Silver;
+  }
+
+  return ContributionSponsorTier.Backer;
+};
+
+@Entity()
+@Index('IDX_contribution_sponsor_active_sort', [
+  'active',
+  'sortOrder',
+  'createdAt',
+])
+export class ContributionSponsor {
+  @PrimaryGeneratedColumn('uuid', {
+    primaryKeyConstraintName: 'PK_contribution_sponsor_id',
+  })
+  id: string;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ type: 'integer' })
+  amountCents: number;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  url: string | null;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  logoUrl: string | null;
+
+  @Column({ type: 'boolean', default: true })
+  active: boolean;
+
+  @Column({ type: 'integer', default: 0 })
+  sortOrder: number;
+}

--- a/src/entity/contribution/index.ts
+++ b/src/entity/contribution/index.ts
@@ -6,5 +6,6 @@ export * from './ContributionPayment';
 export * from './ContributionPaymentAllocation';
 export * from './ContributionRewardTier';
 export * from './ContributionSubmission';
+export * from './ContributionSponsor';
 export * from './UserContributionCausePreference';
 export * from './UserContributionReward';

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -88,10 +88,12 @@ import {
   ContributionPaymentStatus,
 } from '../entity/contribution/ContributionPayment';
 import { ContributionPaymentAllocation } from '../entity/contribution/ContributionPaymentAllocation';
+import { getContributionSponsorTier } from '../entity/contribution/ContributionSponsor';
 import {
   ContributionSubmission,
   ContributionSubmissionStatus,
 } from '../entity/contribution/ContributionSubmission';
+import { normalizeContributionActionMetadata } from '../common/contribution';
 import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
@@ -382,6 +384,13 @@ const obj = new GraphORM({
       evidence: {
         jsonType: true,
       },
+      metadata: {
+        jsonType: true,
+        transform: (value) => ({
+          isLoveAction: false,
+          ...normalizeContributionActionMetadata(value),
+        }),
+      },
       userCompletions: {
         select: (ctx, alias, qb) =>
           `COALESCE(${contributionActionSubmissions({
@@ -397,6 +406,19 @@ const obj = new GraphORM({
         select: selectContributionActionCooldownEndsAt,
         transform: (value: Date | string | null): Date | null =>
           value ? new Date(value) : null,
+      },
+      latestUserSubmission: {
+        relation: {
+          isMany: false,
+          customRelation: (ctx, parentAlias, childAlias, qb): QueryBuilder =>
+            qb
+              .where(`"${childAlias}"."actionId" = "${parentAlias}"."id"`)
+              .andWhere(`"${childAlias}"."userId" = :latestSubmissionUserId`, {
+                latestSubmissionUserId: ctx.userId,
+              })
+              .orderBy(`"${childAlias}"."createdAt"`, 'DESC')
+              .addOrderBy(`"${childAlias}"."id"`, 'DESC'),
+        },
       },
     },
   },
@@ -418,6 +440,15 @@ const obj = new GraphORM({
     fields: {
       metadata: {
         jsonType: true,
+      },
+    },
+  },
+  ContributionSponsor: {
+    fields: {
+      tier: {
+        select: 'amountCents',
+        transform: (value: string | number) =>
+          getContributionSponsorTier(toContributionNumber(value)),
       },
     },
   },

--- a/src/migration/1780987130989-AddContributionUiSupport.ts
+++ b/src/migration/1780987130989-AddContributionUiSupport.ts
@@ -1,0 +1,74 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddContributionUiSupport1780987130989 implements MigrationInterface {
+  name = 'AddContributionUiSupport1780987130989';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "contribution_sponsor" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" timestamp NOT NULL DEFAULT now(),
+        "updatedAt" timestamp NOT NULL DEFAULT now(),
+        "name" text NOT NULL,
+        "amountCents" integer NOT NULL,
+        "url" text,
+        "logoUrl" text,
+        "active" boolean NOT NULL DEFAULT true,
+        "sortOrder" integer NOT NULL DEFAULT 0,
+        CONSTRAINT "PK_contribution_sponsor_id"
+          PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_contribution_sponsor_active_sort"
+        ON "contribution_sponsor" ("active", "sortOrder", "createdAt")
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_action"
+        ADD "metadata" jsonb NOT NULL DEFAULT '{}'
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        ADD "description" text
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        ADD "category" text
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        ADD "logoUrl" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        DROP COLUMN "logoUrl"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        DROP COLUMN "category"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_cause"
+        DROP COLUMN "description"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_action"
+        DROP COLUMN "metadata"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP TABLE "contribution_sponsor"
+    `);
+  }
+}

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -10,6 +10,7 @@ import {
   contributionPrivateCreateActionSchema,
   contributionPrivateCreateCauseSchema,
   contributionPrivateCreateRewardTierSchema,
+  contributionPrivateCreateSponsorSchema,
   contributionPrivateFinalizePaymentSchema,
   contributionPrivateFulfillRewardSchema,
   contributionPrivateIdParamsSchema,
@@ -19,9 +20,11 @@ import {
   contributionPrivateUpdateActionSchema,
   contributionPrivateUpdateCauseSchema,
   contributionPrivateUpdateRewardTierSchema,
+  contributionPrivateUpdateSponsorSchema,
 } from '../../common/schema/contributions';
 import {
   finalizeContributionPayment,
+  normalizeContributionActionMetadata,
   normalizeContributionActionEvidence,
 } from '../../common/contribution';
 import { ContributionAction } from '../../entity/contribution/ContributionAction';
@@ -29,6 +32,7 @@ import { ContributionActionCategory } from '../../entity/contribution/Contributi
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../../entity/contribution/ContributionCause';
 import { ContributionRewardTier } from '../../entity/contribution/ContributionRewardTier';
+import { ContributionSponsor } from '../../entity/contribution/ContributionSponsor';
 import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
 import {
   UserContributionReward,
@@ -133,6 +137,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     const action = await con.getRepository(ContributionAction).save({
       ...body,
       evidence: normalizeContributionActionEvidence(body.evidence),
+      metadata: normalizeContributionActionMetadata(body.metadata),
     });
 
     return res.status(201).send(action);
@@ -158,13 +163,19 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     }
 
     const con = await createOrGetConnection();
-    const { evidence, ...actionUpdate } = body;
+    const { evidence, metadata, ...actionUpdate } = body;
     const updatePayload: QueryDeepPartialEntity<ContributionAction> = {
       ...actionUpdate,
     };
 
     if (evidence !== undefined) {
       updatePayload.evidence = normalizeContributionActionEvidence(evidence);
+    }
+
+    if (metadata !== undefined) {
+      updatePayload.metadata = normalizeContributionActionMetadata(
+        metadata,
+      ) as QueryDeepPartialEntity<ContributionAction['metadata']>;
     }
 
     const result = await con
@@ -222,6 +233,79 @@ export default async (fastify: FastifyInstance): Promise<void> => {
 
     if (!result.affected) {
       return res.status(404).send({ error: 'Contribution cause not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateSponsorSchema>;
+  }>('/sponsors', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateSponsorSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const sponsor = await con.getRepository(ContributionSponsor).save(body);
+
+    return res.status(201).send(sponsor);
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateSponsorSchema>;
+  }>('/sponsors/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateSponsorSchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionSponsor)
+      .update(params.id, body);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution sponsor not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.delete<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+  }>('/sponsors/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    if (!params) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionSponsor)
+      .delete(params.id);
+
+    if (!result.affected) {
+      return res.status(404).send({ error: 'Contribution sponsor not found' });
     }
 
     return res.status(200).send({ success: true });

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -9,6 +9,7 @@ import {
   getApprovedPointsSum,
   getContributionEligibility,
   getLifetimeAmountCents,
+  normalizeContributionActionMetadata,
   parseContributionArgs,
   validateContributionActionLimits,
   validateContributionEvidence,
@@ -17,6 +18,7 @@ import {
   claimContributionRewardArgsSchema,
   contributionActionsArgsSchema,
   contributionConnectionArgsSchema,
+  contributionSubmissionsArgsSchema,
   submitContributionActionInputSchema,
   updateContributionCausePreferencesArgsSchema,
 } from '../common/schema/contributions';
@@ -35,6 +37,7 @@ import {
   ContributionSubmission,
   ContributionSubmissionStatus,
 } from '../entity/contribution/ContributionSubmission';
+import { ContributionSponsor } from '../entity/contribution/ContributionSponsor';
 import { UserContributionCausePreference } from '../entity/contribution/UserContributionCausePreference';
 import {
   UserContributionReward,
@@ -140,6 +143,13 @@ export const typeDefs = /* GraphQL */ `
     fulfilled
   }
 
+  enum ContributionSponsorTier {
+    platinum
+    gold
+    silver
+    backer
+  }
+
   type ContributionStatus {
     enabled: Boolean!
     eligible: Boolean!
@@ -148,6 +158,13 @@ export const typeDefs = /* GraphQL */ `
     lifetimePoints: Int!
     lifetimeAmountCents: Int!
     userPoints: Int!
+  }
+
+  type ContributionActionMetadata {
+    platform: String
+    instructions: String
+    externalUrl: String
+    isLoveAction: Boolean!
   }
 
   type ContributionActionCategory {
@@ -172,10 +189,12 @@ export const typeDefs = /* GraphQL */ `
     description: String
     points: Int!
     evidence: JSON!
+    metadata: ContributionActionMetadata!
     cooldownSeconds: Int
     maxPerUser: Int
     userCooldownEndsAt: DateTime
     userCompletions: Int!
+    latestUserSubmission: ContributionSubmission
   }
 
   type ContributionActionEdge {
@@ -192,6 +211,9 @@ export const typeDefs = /* GraphQL */ `
     id: ID!
     title: String!
     url: String
+    description: String
+    category: String
+    logoUrl: String
     totalPoints: Int!
     totalAmountCents: Int!
   }
@@ -265,6 +287,37 @@ export const typeDefs = /* GraphQL */ `
     status: ContributionSubmissionStatus!
     awardedPoints: Int!
     createdAt: DateTime!
+    reviewedAt: DateTime
+    action: ContributionAction!
+  }
+
+  type ContributionSubmissionEdge {
+    node: ContributionSubmission!
+    cursor: String!
+  }
+
+  type ContributionSubmissionConnection {
+    pageInfo: PageInfo!
+    edges: [ContributionSubmissionEdge!]!
+  }
+
+  type ContributionSponsor {
+    id: ID!
+    name: String!
+    amountCents: Int!
+    url: String
+    logoUrl: String
+    tier: ContributionSponsorTier!
+  }
+
+  type ContributionSponsorEdge {
+    node: ContributionSponsor!
+    cursor: String!
+  }
+
+  type ContributionSponsorConnection {
+    pageInfo: PageInfo!
+    edges: [ContributionSponsorEdge!]!
   }
 
   input SubmitContributionActionInput {
@@ -283,6 +336,11 @@ export const typeDefs = /* GraphQL */ `
       first: Int
       after: String
     ): ContributionActionConnection! @auth @contributionEligibility
+    userContributionSubmissions(
+      actionId: ID
+      first: Int
+      after: String
+    ): ContributionSubmissionConnection! @auth @contributionEligibility
     contributionCauses(first: Int, after: String): ContributionCauseConnection!
       @auth
       @contributionEligibility
@@ -302,6 +360,10 @@ export const typeDefs = /* GraphQL */ `
       first: Int
       after: String
     ): UserContributionCauseStatsConnection! @auth @contributionEligibility
+    contributionSponsors(
+      first: Int
+      after: String
+    ): ContributionSponsorConnection! @auth @contributionEligibility
   }
 
   extend type Mutation {
@@ -416,6 +478,42 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             builder.queryBuilder.andWhere(
               `${builder.alias}."categoryId" = :categoryId`,
               { categoryId: parsedArgs.categoryId },
+            );
+          }
+
+          return builder;
+        },
+      });
+    },
+    userContributionSubmissions: async (
+      _,
+      args: ConnectionArguments & { actionId?: string | null },
+      ctx: AuthContext,
+      info: GraphQLResolveInfo,
+    ): Promise<Connection<ContributionSubmission>> => {
+      const parsedArgs = parseContributionArgs(
+        contributionSubmissionsArgsSchema,
+        args,
+      );
+
+      return queryContributionConnection<ContributionSubmission>({
+        args: parsedArgs,
+        ctx,
+        info,
+        beforeQuery: (builder, page) => {
+          builder.queryBuilder
+            .where(`${builder.alias}."userId" = :userId`, {
+              userId: ctx.userId,
+            })
+            .orderBy(`${builder.alias}."createdAt"`, 'DESC')
+            .addOrderBy(`${builder.alias}."id"`, 'DESC')
+            .limit(page.limit)
+            .offset(page.offset);
+
+          if (parsedArgs.actionId) {
+            builder.queryBuilder.andWhere(
+              `${builder.alias}."actionId" = :actionId`,
+              { actionId: parsedArgs.actionId },
             );
           }
 
@@ -575,6 +673,33 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         },
       });
     },
+    contributionSponsors: async (
+      _,
+      args: ConnectionArguments,
+      ctx: AuthContext,
+      info: GraphQLResolveInfo,
+    ): Promise<Connection<ContributionSponsor>> => {
+      const parsedArgs = parseContributionArgs(
+        contributionConnectionArgsSchema,
+        args,
+      );
+
+      return queryContributionConnection<ContributionSponsor>({
+        args: parsedArgs,
+        ctx,
+        info,
+        beforeQuery: (builder, page) => {
+          builder.queryBuilder
+            .where(`${builder.alias}.active = true`)
+            .orderBy(`${builder.alias}."sortOrder"`, 'ASC')
+            .addOrderBy(`${builder.alias}."createdAt"`, 'ASC')
+            .limit(page.limit)
+            .offset(page.offset);
+
+          return builder;
+        },
+      });
+    },
   },
   Mutation: {
     submitContributionAction: async (
@@ -598,6 +723,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
 
         if (!action) {
           throw new NotFoundError('Contribution action not found');
+        }
+
+        const actionMetadata = normalizeContributionActionMetadata(
+          action.metadata,
+        );
+        if (action.points <= 0 || actionMetadata.isLoveAction) {
+          throw new ValidationError('Contribution action is not rewardable');
         }
 
         validateContributionEvidence({


### PR DESCRIPTION
## Summary
- add lean contribution action metadata and cause display fields for the giveback UI
- add contribution sponsors with derived public tiers and private management endpoints
- expose user contribution submission state and sponsor data through public GraphQL

## Validation
- NODE_ENV=test npx jest __tests__/contributions.ts __tests__/routes/private/contributions.ts --testEnvironment=node --runInBand
- pnpm run build
- pnpm run lint
- git diff --check