### PR TITLE
refactor: simplify contribution action metadata

### DIFF
--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -2,14 +2,12 @@ import { ForbiddenError, ValidationError } from 'apollo-server-errors';
 import { In, type EntityManager } from 'typeorm';
 import type z from 'zod';
 import {
-  contributionActionMetadataSchema,
   contributionActionEvidenceSchema,
   contributionSubmissionEvidenceSchema,
 } from '../schema/contributions';
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
 import type {
   ContributionAction,
-  ContributionActionMetadata,
   ContributionEvidenceSchema,
 } from '../../entity/contribution/ContributionAction';
 import {
@@ -48,10 +46,6 @@ type ContributionActionUsage = {
 
 type ContributionActionEvidenceInput = z.infer<
   typeof contributionActionEvidenceSchema
->;
-
-type ContributionActionMetadataInput = z.infer<
-  typeof contributionActionMetadataSchema
 >;
 
 type ContributionPointAllocation = {
@@ -571,25 +565,6 @@ export const normalizeContributionActionEvidence = (
               : {}),
           },
         }
-      : {}),
-  };
-};
-
-export const normalizeContributionActionMetadata = (
-  metadata:
-    | ContributionActionMetadataInput
-    | ContributionActionMetadata
-    | null
-    | undefined,
-): ContributionActionMetadata => {
-  const parsed = contributionActionMetadataSchema.parse(metadata ?? {});
-
-  return {
-    ...(parsed.platform ? { platform: parsed.platform } : {}),
-    ...(parsed.instructions ? { instructions: parsed.instructions } : {}),
-    ...(parsed.externalUrl ? { externalUrl: parsed.externalUrl } : {}),
-    ...(parsed.isLoveAction !== undefined && parsed.isLoveAction !== null
-      ? { isLoveAction: parsed.isLoveAction }
       : {}),
   };
 };

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -26,10 +26,10 @@ export const contributionActionEvidenceSchema = z
 
 export const contributionActionMetadataSchema = z
   .object({
-    platform: z.string().trim().min(1).nullish(),
-    instructions: z.string().trim().min(1).nullish(),
-    externalUrl: z.url().nullish(),
-    isLoveAction: z.boolean().nullish(),
+    platform: z.string().trim().min(1).optional(),
+    instructions: z.string().trim().min(1).optional(),
+    externalUrl: z.url().optional(),
+    isLoveAction: z.boolean().optional(),
   })
   .strict();
 

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -93,7 +93,6 @@ import {
   ContributionSubmission,
   ContributionSubmissionStatus,
 } from '../entity/contribution/ContributionSubmission';
-import { normalizeContributionActionMetadata } from '../common/contribution';
 import { LiveRoomSubscription } from '../entity/LiveRoomSubscription';
 import { OpportunityUserRecruiter } from '../entity/opportunities/user';
 import { OpportunityUserType } from '../entity/opportunities/types';
@@ -388,7 +387,7 @@ const obj = new GraphORM({
         jsonType: true,
         transform: (value) => ({
           isLoveAction: false,
-          ...normalizeContributionActionMetadata(value),
+          ...((value ?? {}) as Record<string, unknown>),
         }),
       },
       userCompletions: {

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -24,7 +24,6 @@ import {
 } from '../../common/schema/contributions';
 import {
   finalizeContributionPayment,
-  normalizeContributionActionMetadata,
   normalizeContributionActionEvidence,
 } from '../../common/contribution';
 import { ContributionAction } from '../../entity/contribution/ContributionAction';
@@ -137,7 +136,7 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     const action = await con.getRepository(ContributionAction).save({
       ...body,
       evidence: normalizeContributionActionEvidence(body.evidence),
-      metadata: normalizeContributionActionMetadata(body.metadata),
+      metadata: body.metadata ?? {},
     });
 
     return res.status(201).send(action);
@@ -173,9 +172,9 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     }
 
     if (metadata !== undefined) {
-      updatePayload.metadata = normalizeContributionActionMetadata(
-        metadata,
-      ) as QueryDeepPartialEntity<ContributionAction['metadata']>;
+      updatePayload.metadata = metadata as QueryDeepPartialEntity<
+        ContributionAction['metadata']
+      >;
     }
 
     const result = await con

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -9,7 +9,6 @@ import {
   getApprovedPointsSum,
   getContributionEligibility,
   getLifetimeAmountCents,
-  normalizeContributionActionMetadata,
   parseContributionArgs,
   validateContributionActionLimits,
   validateContributionEvidence,
@@ -725,10 +724,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           throw new NotFoundError('Contribution action not found');
         }
 
-        const actionMetadata = normalizeContributionActionMetadata(
-          action.metadata,
-        );
-        if (action.points <= 0 || actionMetadata.isLoveAction) {
+        if (action.points <= 0 || action.metadata?.isLoveAction) {
           throw new ValidationError('Contribution action is not rewardable');
         }
 


### PR DESCRIPTION
## Summary
- remove the unnecessary contribution action metadata normalizer
- persist strict private API metadata directly and default `isLoveAction` only at GraphQL read time
- read `action.metadata?.isLoveAction` directly in submission validation

## Validation
- NODE_ENV=test npx jest __tests__/contributions.ts __tests__/routes/private/contributions.ts --testEnvironment=node --runInBand
- pnpm run build
- pnpm run lint
