### PR TITLE
feat(contribution): support public giveback UI data

### DIFF
--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -59,6 +59,7 @@ query ContributionStatus {
     currentCycleTargetPoints
     lifetimePoints
     lifetimeAmountCents
+    contributorsCount
     userPoints
   }
 }
@@ -373,6 +374,7 @@ it('returns opaque eligibility status and rejects program lists when ineligible'
     currentCycleTargetPoints: 10000,
     lifetimePoints: 0,
     lifetimeAmountCents: 0,
+    contributorsCount: 0,
     userPoints: 0,
   });
   expect(actions.errors?.[0].message).toEqual(
@@ -394,6 +396,24 @@ it('marks blocked users ineligible without exposing a reason', async () => {
   expect(res.data.contributionStatus).toMatchObject({
     enabled: true,
     eligible: false,
+  });
+});
+
+it('exposes campaign-wide status to anonymous visitors with null user fields', async () => {
+  loggedUser = null;
+
+  const status = await client.query(CONTRIBUTION_STATUS_QUERY);
+
+  expect(status.errors).toBeUndefined();
+  expect(status.data.contributionStatus).toEqual({
+    enabled: true,
+    eligible: null,
+    currentCyclePoints: 0,
+    currentCycleTargetPoints: 10000,
+    lifetimePoints: 0,
+    lifetimeAmountCents: 0,
+    contributorsCount: 0,
+    userPoints: null,
   });
 });
 
@@ -468,6 +488,7 @@ it('returns actions by category and records approved submissions with limits', a
   expect(status.data.contributionStatus).toMatchObject({
     currentCyclePoints: 25,
     lifetimePoints: 25,
+    contributorsCount: 1,
     userPoints: 25,
   });
 
@@ -669,7 +690,36 @@ it('returns finalized cause totals, user cause stats, and sponsors', async () =>
         amountCents: 250000,
         url: 'https://daily.dev',
         logoUrl: 'https://daily.dev/logo.png',
-        tier: 'platinum',
+        tier: 'gold',
+      },
+    },
+  ]);
+});
+
+it('exposes the sponsor wall to anonymous visitors', async () => {
+  loggedUser = null;
+  await saveFixtures(con, ContributionSponsor, [
+    {
+      id: sponsorId,
+      name: 'Daily Corp',
+      amountCents: 250000,
+      url: 'https://daily.dev',
+      logoUrl: 'https://daily.dev/logo.png',
+    },
+  ]);
+
+  const sponsors = await client.query(CONTRIBUTION_SPONSORS_QUERY);
+
+  expect(sponsors.errors).toBeUndefined();
+  expect(sponsors.data.contributionSponsors.edges).toEqual([
+    {
+      node: {
+        id: sponsorId,
+        name: 'Daily Corp',
+        amountCents: 250000,
+        url: 'https://daily.dev',
+        logoUrl: 'https://daily.dev/logo.png',
+        tier: 'gold',
       },
     },
   ]);

--- a/bin/seedEntities.ts
+++ b/bin/seedEntities.ts
@@ -31,4 +31,10 @@ export const seedEntityNames = [
   'UserExperience',
   'UserExperienceSkill',
   'SpotlightAction',
+  'ContributionActionCategory',
+  'ContributionAction',
+  'ContributionCause',
+  'ContributionSponsor',
+  'ContributionPayment',
+  'ContributionSubmission',
 ] as const;

--- a/seeds/ContributionAction.json
+++ b/seeds/ContributionAction.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "a0000000-0000-4000-8000-000000000001",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Post about daily.dev on X",
+    "description": "Share what you love about daily.dev and drop the link.",
+    "points": 25,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "x", "isLoveAction": false },
+    "maxPerUser": 3,
+    "active": true,
+    "sortOrder": 1
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000002",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Star our GitHub repo",
+    "description": "Give the open-source repo a star.",
+    "points": 15,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "github", "isLoveAction": false },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 2
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000003",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Write a blog post",
+    "description": "Publish an article mentioning daily.dev.",
+    "points": 100,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "blog", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 3
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000004",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Leave a store review",
+    "description": "Review the extension on your browser store.",
+    "points": 50,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "chrome_web_store", "isLoveAction": false },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 4
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000005",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Refer a friend",
+    "description": "Invite a fellow developer to daily.dev.",
+    "points": 40,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "daily_dev", "isLoveAction": false },
+    "maxPerUser": 5,
+    "active": true,
+    "sortOrder": 5
+  }
+]

--- a/seeds/ContributionActionCategory.json
+++ b/seeds/ContributionActionCategory.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "c0000000-0000-4000-8000-000000000001",
+    "title": "Spread the word",
+    "active": true,
+    "sortOrder": 1
+  }
+]

--- a/seeds/ContributionCause.json
+++ b/seeds/ContributionCause.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "d0000000-0000-4000-8000-000000000001",
+    "title": "freeCodeCamp",
+    "url": "https://www.freecodecamp.org",
+    "description": "Free coding education for everyone.",
+    "category": "Education",
+    "active": true,
+    "sortOrder": 1
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000002",
+    "title": "Electronic Frontier Foundation",
+    "url": "https://www.eff.org",
+    "description": "Defending digital privacy and free expression.",
+    "category": "Digital rights",
+    "active": true,
+    "sortOrder": 2
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000003",
+    "title": "Python Software Foundation",
+    "url": "https://www.python.org/psf",
+    "description": "Stewarding the Python language and community.",
+    "category": "Open source",
+    "active": true,
+    "sortOrder": 3
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000004",
+    "title": "Open Source Collective",
+    "url": "https://opencollective.com",
+    "description": "Funding the maintainers behind the tools we use.",
+    "category": "Open source",
+    "active": true,
+    "sortOrder": 4
+  }
+]

--- a/seeds/ContributionPayment.json
+++ b/seeds/ContributionPayment.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "b0000000-0000-4000-8000-000000000001",
+    "status": "finalized",
+    "totalPoints": 2500,
+    "amountCents": 250000,
+    "createdBy": "system",
+    "finalizedAt": "2026-05-20T00:00:00.000Z"
+  }
+]

--- a/seeds/ContributionSponsor.json
+++ b/seeds/ContributionSponsor.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "50000000-0000-4000-8000-000000000001",
+    "name": "Vercel",
+    "amountCents": 500000,
+    "url": "https://vercel.com",
+    "logoUrl": "https://svgl.app/library/vercel_wordmark.svg",
+    "active": true,
+    "sortOrder": 1
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000002",
+    "name": "Stripe",
+    "amountCents": 300000,
+    "url": "https://stripe.com",
+    "logoUrl": "https://svgl.app/library/stripe_wordmark.svg",
+    "active": true,
+    "sortOrder": 2
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000003",
+    "name": "GitHub",
+    "amountCents": 150000,
+    "url": "https://github.com",
+    "logoUrl": "https://svgl.app/library/github_wordmark_light.svg",
+    "active": true,
+    "sortOrder": 3
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000004",
+    "name": "Supabase",
+    "amountCents": 120000,
+    "url": "https://supabase.com",
+    "logoUrl": "https://svgl.app/library/supabase_wordmark_light.svg",
+    "active": true,
+    "sortOrder": 4
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000005",
+    "name": "Sentry",
+    "amountCents": 100000,
+    "url": "https://sentry.io",
+    "logoUrl": "https://svgl.app/library/sentry.svg",
+    "active": true,
+    "sortOrder": 5
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000006",
+    "name": "Datadog",
+    "amountCents": 40000,
+    "url": "https://datadoghq.com",
+    "logoUrl": "https://svgl.app/library/datadog.svg",
+    "active": true,
+    "sortOrder": 6
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000007",
+    "name": "Algolia",
+    "amountCents": 30000,
+    "url": "https://algolia.com",
+    "logoUrl": "https://svgl.app/library/algolia.svg",
+    "active": true,
+    "sortOrder": 7
+  },
+  {
+    "id": "50000000-0000-4000-8000-000000000008",
+    "name": "Prisma",
+    "amountCents": 20000,
+    "url": "https://prisma.io",
+    "logoUrl": "https://svgl.app/library/prisma.svg",
+    "active": true,
+    "sortOrder": 8
+  }
+]

--- a/seeds/ContributionSubmission.json
+++ b/seeds/ContributionSubmission.json
@@ -1,0 +1,1652 @@
+[
+  {
+    "id": "f0000000-0000-4000-8000-000000000001",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000002",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000003",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000004",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000005",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000006",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000007",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000008",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000009",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000010",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000011",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000012",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000013",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000014",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000015",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000016",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000017",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000018",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000019",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000020",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000021",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000022",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000023",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000024",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000025",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000026",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000027",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000028",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000029",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000030",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000031",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000032",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000033",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000034",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000035",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000036",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000037",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000038",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000039",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000040",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000041",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000042",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000043",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000044",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000045",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000046",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000047",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000048",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000049",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000050",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000051",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000052",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000053",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000054",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000055",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000056",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000057",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000058",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000059",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000060",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000061",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000062",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000063",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000064",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000065",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000066",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000067",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000068",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000069",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000070",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000071",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000072",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000073",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000074",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000075",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000076",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000077",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000078",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000079",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000080",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000081",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000082",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000083",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000084",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000085",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000086",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000087",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000088",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000089",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000090",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000091",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000092",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000093",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000094",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000095",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000096",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000097",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000098",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000099",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000100",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": null,
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000101",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000102",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000103",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000104",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000105",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000106",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000107",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000108",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000109",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000110",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000111",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000112",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000113",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000114",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000115",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000116",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000117",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000118",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000119",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000120",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000121",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000122",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000123",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000124",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000125",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000126",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000127",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000128",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000129",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000130",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000131",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000132",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000133",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000134",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000135",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000136",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000137",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000138",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000139",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000140",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000141",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000142",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000143",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000144",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000145",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000146",
+    "userId": "testuser1",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000147",
+    "userId": "testuser2",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000148",
+    "userId": "testuser3",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000149",
+    "userId": "testuser4",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  },
+  {
+    "id": "f0000000-0000-4000-8000-000000000150",
+    "userId": "testuser5",
+    "actionId": "a0000000-0000-4000-8000-000000000004",
+    "paymentId": "b0000000-0000-4000-8000-000000000001",
+    "evidence": {
+      "url": "https://chromewebstore.google.com/review"
+    },
+    "status": "approved",
+    "awardedPoints": 50
+  }
+]

--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -384,7 +384,7 @@ export const finalizeContributionPayment = async ({
   return { payment };
 };
 
-const getContributionConfig = (): ContributionConfig => {
+export const getContributionConfig = (): ContributionConfig => {
   const config = remoteConfig.vars.contributionProgram;
 
   return {
@@ -467,6 +467,25 @@ export const getApprovedPointsSum = async ({
   const row = await builder.getRawOne<SumRow>();
 
   return toContributionInt(row?.sum);
+};
+
+// Distinct developers who have contributed at least one approved action — the
+// campaign's "backers" social-proof count.
+export const getApprovedContributorsCount = async ({
+  con,
+}: {
+  con: EntityManager;
+}): Promise<number> => {
+  const row = await con
+    .getRepository(ContributionSubmission)
+    .createQueryBuilder('submission')
+    .select('COUNT(DISTINCT submission."userId")', 'count')
+    .where('submission.status = :status', {
+      status: ContributionSubmissionStatus.Approved,
+    })
+    .getRawOne<{ count: string | number | null }>();
+
+  return toContributionInt(row?.count);
 };
 
 export const getLifetimeAmountCents = async ({

--- a/src/entity/contribution/ContributionSponsor.ts
+++ b/src/entity/contribution/ContributionSponsor.ts
@@ -7,28 +7,23 @@ import {
 } from 'typeorm';
 
 export enum ContributionSponsorTier {
-  Platinum = 'platinum',
   Gold = 'gold',
   Silver = 'silver',
-  Backer = 'backer',
+  Bronze = 'bronze',
 }
 
 export const getContributionSponsorTier = (
   amountCents: number,
 ): ContributionSponsorTier => {
   if (amountCents >= 250000) {
-    return ContributionSponsorTier.Platinum;
-  }
-
-  if (amountCents >= 100000) {
     return ContributionSponsorTier.Gold;
   }
 
-  if (amountCents >= 25000) {
+  if (amountCents >= 75000) {
     return ContributionSponsorTier.Silver;
   }
 
-  return ContributionSponsorTier.Backer;
+  return ContributionSponsorTier.Bronze;
 };
 
 @Entity()

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -95,6 +95,13 @@ class RemoteConfig {
             web_funnel_id: 'paid-v1',
             onboarding_funnel_id: 'organic-v1',
           },
+          // Local dev default so the contribution (Giveback) program is enabled
+          // with a real goal target without a GrowthBook connection.
+          contributionProgram: {
+            enabled: true,
+            allowedCountries: ['US', 'GB', 'CA', 'IL', 'DE', 'FR', 'IN', 'AU'],
+            currentCycleTargetPoints: 10000,
+          },
         }),
       };
     }

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -4,9 +4,11 @@ import type { GraphQLResolveInfo } from 'graphql';
 import type { Connection, ConnectionArguments } from 'graphql-relay';
 import { In } from 'typeorm';
 import type z from 'zod';
-import { AuthContext, BaseContext } from '../Context';
+import { AuthContext, BaseContext, Context } from '../Context';
 import {
+  getApprovedContributorsCount,
   getApprovedPointsSum,
+  getContributionConfig,
   getContributionEligibility,
   getLifetimeAmountCents,
   parseContributionArgs,
@@ -64,7 +66,7 @@ const queryContributionConnection = <
   beforeQuery,
 }: {
   args: TArgs;
-  ctx: AuthContext;
+  ctx: Context;
   info: GraphQLResolveInfo;
   beforeQuery: (builder: GraphORMBuilder, page: OffsetPage) => GraphORMBuilder;
 }): Promise<Connection<TNode>> => {
@@ -88,12 +90,16 @@ const queryContributionConnection = <
 
 type GQLContributionStatus = {
   enabled: boolean;
-  eligible: boolean;
+  // User-specific fields are null for anonymous visitors; the campaign-wide
+  // numbers stay populated so the public hero can render live progress.
+  eligible: boolean | null;
   currentCyclePoints: number;
   currentCycleTargetPoints: number;
   lifetimePoints: number;
   lifetimeAmountCents: number;
-  userPoints: number;
+  // Distinct developers who have contributed at least one approved action.
+  contributorsCount: number;
+  userPoints: number | null;
 };
 
 type GQLUserContributionReward = Pick<
@@ -143,20 +149,29 @@ export const typeDefs = /* GraphQL */ `
   }
 
   enum ContributionSponsorTier {
-    platinum
     gold
     silver
-    backer
+    bronze
   }
 
   type ContributionStatus {
     enabled: Boolean!
-    eligible: Boolean!
+    """
+    User-specific eligibility. Null for anonymous visitors.
+    """
+    eligible: Boolean
     currentCyclePoints: Int!
     currentCycleTargetPoints: Int!
     lifetimePoints: Int!
     lifetimeAmountCents: Int!
-    userPoints: Int!
+    """
+    Distinct developers who have contributed at least one approved action.
+    """
+    contributorsCount: Int!
+    """
+    The visitor's own approved points. Null for anonymous visitors.
+    """
+    userPoints: Int
   }
 
   type ContributionActionMetadata {
@@ -325,7 +340,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   extend type Query {
-    contributionStatus: ContributionStatus! @auth
+    contributionStatus: ContributionStatus!
     contributionActionCategories(
       first: Int
       after: String
@@ -359,10 +374,14 @@ export const typeDefs = /* GraphQL */ `
       first: Int
       after: String
     ): UserContributionCauseStatsConnection! @auth @contributionEligibility
+    """
+    Public campaign social proof: the sponsor wall renders for everyone,
+    including logged-out visitors. No user-specific fields, so no auth gate.
+    """
     contributionSponsors(
       first: Int
       after: String
-    ): ContributionSponsorConnection! @auth @contributionEligibility
+    ): ContributionSponsorConnection!
   }
 
   extend type Mutation {
@@ -383,20 +402,27 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     contributionStatus: async (
       _,
       __,
-      ctx: AuthContext,
+      ctx: Context,
     ): Promise<GQLContributionStatus> => {
+      // Public query: the campaign-wide numbers render for everyone (the hero
+      // shows live progress to logged-out visitors), while eligibility and the
+      // visitor's own points stay null until they sign in.
+      const { userId } = ctx;
       const [
-        { settings, eligible },
+        eligibility,
         currentCyclePoints,
         lifetimePoints,
         userPoints,
         lifetimeAmountCents,
+        contributorsCount,
       ] = await Promise.all([
-        getContributionEligibility({
-          con: ctx.con.manager,
-          userId: ctx.userId,
-          region: ctx.region,
-        }),
+        userId
+          ? getContributionEligibility({
+              con: ctx.con.manager,
+              userId,
+              region: ctx.region,
+            })
+          : null,
         getApprovedPointsSum({
           con: ctx.con.manager,
           unpaidOnly: true,
@@ -404,22 +430,30 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         getApprovedPointsSum({
           con: ctx.con.manager,
         }),
-        getApprovedPointsSum({
-          con: ctx.con.manager,
-          userId: ctx.userId,
-        }),
+        userId
+          ? getApprovedPointsSum({
+              con: ctx.con.manager,
+              userId,
+            })
+          : null,
         getLifetimeAmountCents({
+          con: ctx.con.manager,
+        }),
+        getApprovedContributorsCount({
           con: ctx.con.manager,
         }),
       ]);
 
+      const settings = eligibility?.settings ?? getContributionConfig();
+
       return {
         enabled: settings.enabled,
-        eligible,
+        eligible: eligibility?.eligible ?? null,
         currentCyclePoints,
         currentCycleTargetPoints: settings.currentCycleTargetPoints,
         lifetimePoints,
         lifetimeAmountCents,
+        contributorsCount,
         userPoints,
       };
     },
@@ -675,7 +709,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     contributionSponsors: async (
       _,
       args: ConnectionArguments,
-      ctx: AuthContext,
+      ctx: Context,
       info: GraphQLResolveInfo,
     ): Promise<Connection<ContributionSponsor>> => {
       const parsedArgs = parseContributionArgs(


### PR DESCRIPTION
Backend for the Giveback (contribution) MVP surfaces. Nothing is live yet, so this intentionally breaks the prior sponsor-tier shape.

## What
- **Public read queries**: `contributionStatus` and `contributionSponsors` no longer require auth, so the logged-out hero + sponsor wall can render. User-specific fields (`eligible`, `userPoints`) return `null` for anonymous visitors; campaign-wide numbers always populate.
- **`contributorsCount`** added to `contributionStatus` — distinct developers with at least one approved submission (the "backers" count).
- **Sponsor tiers** changed from `platinum/gold/silver/backer` to **`gold/silver/bronze`** (still derived from `amountCents`).
- **Dev remote-config default** for `contributionProgram` (enabled + goal target) when no GrowthBook key is present, so local dev renders real numbers.
- **Seed data** for categories, actions, causes, sponsors, a finalized payment and submissions.

## Tests
`__tests__/contributions.ts` updated and green (anonymous access for status + sponsors, contributorsCount).

Pairs with dailydotdev/apps PR for the `/giveback` page.