### PR TITLE
fix(markdown): support underscore emphasis near punctuation

### DIFF
--- a/__tests__/common/markdown.ts
+++ b/__tests__/common/markdown.ts
@@ -129,3 +129,49 @@ Some text here
     });
   });
 });
+
+describe('markdown emphasis rendering', () => {
+  it.each([
+    ['WORD_(text)_', 'WORD<em>(text)</em>'],
+    ['word_(text)_', 'word<em>(text)</em>'],
+    ['”_(text)_word', '”<em>(text)</em>word'],
+    ['“WORD”_(text)_', '“WORD”<em>(text)</em>'],
+    [
+      '“SCARRING” _(Oh my goshhh)_ effect',
+      '“SCARRING” <em>(Oh my goshhh)</em> effect',
+    ],
+  ])(
+    'should render underscores around punctuation as emphasis: %s',
+    (content, expected) => {
+      expect(markdown.renderInline(content)).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['some_file_name', 'some_file_name'],
+    ['user_id', 'user_id'],
+    ['a_b_c', 'a_b_c'],
+    ['__init__', '<strong>init</strong>'],
+    ['`some_var`', '<code>some_var</code>'],
+    [
+      'http://x/a_b_c',
+      '<a href="http://x/a_b_c" target="_blank" rel="noopener nofollow">http://x/a_b_c</a>',
+    ],
+  ])(
+    'should preserve existing underscore behavior: %s',
+    (content, expected) => {
+      expect(markdown.renderInline(content)).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['before *(text)* after', 'before <em>(text)</em> after'],
+    ['before **(text)** after', 'before <strong>(text)</strong> after'],
+    ['before __(text)__ after', 'before <strong>(text)</strong> after'],
+  ])(
+    'should preserve non-single-underscore emphasis: %s',
+    (content, expected) => {
+      expect(markdown.renderInline(content)).toBe(expected);
+    },
+  );
+});

--- a/src/common/markdown.ts
+++ b/src/common/markdown.ts
@@ -1,4 +1,5 @@
 import MarkdownIt, { Renderer, Token } from 'markdown-it';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline.mjs';
 import hljs from 'highlight.js';
 import { getUserProfileUrl } from './users';
 import { CommentMention, PostMention, User } from '../entity';
@@ -8,6 +9,10 @@ import { EntityTarget } from 'typeorm/common/EntityTarget';
 import { ghostUser } from './utils';
 import { isValidHttpUrl } from './links';
 import { getProxiedImageUrl } from './imageProxy';
+
+const underscoreMarker = 0x5f;
+const alphaNumericRegex = /[\p{L}\p{N}]/u;
+const adjustedDelimiterStates = new WeakSet<StateInline>();
 
 /**
  * Sanitizes HTML content, allowing only safe tags for rich text content.
@@ -48,6 +53,85 @@ export const markdown: MarkdownIt = MarkdownIt({
     }
   },
 });
+
+const isPunctuationChar = (charCode: number | undefined): boolean =>
+  typeof charCode === 'number' &&
+  (markdown.utils.isMdAsciiPunct(charCode) ||
+    markdown.utils.isPunctChar(String.fromCharCode(charCode)));
+
+const isAlphaNumericChar = (charCode: number | undefined): boolean =>
+  typeof charCode === 'number' &&
+  alphaNumericRegex.test(String.fromCharCode(charCode));
+
+const getCharCode = ({
+  state,
+  pos,
+}: {
+  state: StateInline;
+  pos: number;
+}): number | undefined =>
+  pos >= 0 && pos < state.posMax ? state.src.charCodeAt(pos) : undefined;
+
+const getPunctuationBoundary = ({
+  state,
+  start,
+  length,
+}: {
+  state: StateInline;
+  start: number;
+  length: number;
+}): { canOpen: boolean; canClose: boolean } => {
+  const previousChar = getCharCode({ state, pos: start - 1 });
+  const nextChar = getCharCode({ state, pos: start + length });
+
+  return {
+    canOpen: isAlphaNumericChar(previousChar) && isPunctuationChar(nextChar),
+    canClose: isPunctuationChar(previousChar) && isAlphaNumericChar(nextChar),
+  };
+};
+
+const adjustUnderscoreDelimiterScan = (state: StateInline): void => {
+  const defaultScanDelims = state.scanDelims.bind(state);
+
+  state.scanDelims = (start, canSplitWord) => {
+    const scanned = defaultScanDelims(start, canSplitWord);
+
+    if (
+      canSplitWord ||
+      state.src.charCodeAt(start) !== underscoreMarker ||
+      scanned.length !== 1
+    ) {
+      return scanned;
+    }
+
+    const boundary = getPunctuationBoundary({
+      state,
+      start,
+      length: scanned.length,
+    });
+
+    return {
+      ...scanned,
+      can_open: scanned.can_open || boundary.canOpen,
+      can_close: scanned.can_close || boundary.canClose,
+    };
+  };
+};
+
+markdown.inline.ruler.before(
+  'emphasis',
+  'underscore_punctuation_emphasis',
+  (state: StateInline, silent: boolean) => {
+    if (silent || adjustedDelimiterStates.has(state)) {
+      return false;
+    }
+
+    adjustUnderscoreDelimiterScan(state);
+    adjustedDelimiterStates.add(state);
+
+    return false;
+  },
+);
 
 export const renderMarkdown = (
   content: string,


### PR DESCRIPTION
## Summary
- Adjust markdown-it underscore delimiter scanning so single `_` can open or close emphasis at word-to-punctuation boundaries.
- Preserve intraword underscore protection for snake_case, code spans, linkified URLs, and `__` strong emphasis.
- Add focused markdown renderer coverage for the reported patterns and non-regression cases.

## Verification
- `NODE_ENV=test npx pnpm@10.33.4 exec jest __tests__/common/markdown.ts --testEnvironment=node --runInBand`
- `npx pnpm@10.33.4 exec eslint src/common/markdown.ts __tests__/common/markdown.ts --max-warnings 0`
- `npx pnpm@10.33.4 run build`

Closes ENG-1645

---
Created by Huginn 🐦‍⬛
