### PR TITLE
chore(giveback): seed MVP campaign data

### DIFF
--- a/bin/seedEntities.ts
+++ b/bin/seedEntities.ts
@@ -33,6 +33,7 @@ export const seedEntityNames = [
   'SpotlightAction',
   'ContributionActionCategory',
   'ContributionAction',
+  'ContributionRewardTier',
   'ContributionCause',
   'ContributionSponsor',
   'ContributionPayment',

--- a/seeds/ContributionAction.json
+++ b/seeds/ContributionAction.json
@@ -1,5 +1,40 @@
 [
   {
+    "id": "a0000000-0000-4000-8000-000000000022",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Share a screenshot of your daily.dev feed",
+    "description": "Show off your setup — just upload a screenshot, no link needed.",
+    "points": 20,
+    "evidence": { "screenshot": { "required": true } },
+    "metadata": {
+      "platform": "daily_dev",
+      "isLoveAction": false,
+      "instructions": "Upload a screenshot of your daily.dev feed or new tab."
+    },
+    "maxPerUser": 3,
+    "active": true,
+    "sortOrder": 0
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000023",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Share daily.dev on X with a screenshot",
+    "description": "Post about daily.dev, then drop the link and a screenshot of it.",
+    "points": 35,
+    "evidence": {
+      "url": { "required": true },
+      "screenshot": { "required": true }
+    },
+    "metadata": {
+      "platform": "x",
+      "isLoveAction": false,
+      "instructions": "Add the link to your post and a screenshot showing it's live."
+    },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 0
+  },
+  {
     "id": "a0000000-0000-4000-8000-000000000001",
     "categoryId": "c0000000-0000-4000-8000-000000000001",
     "title": "Post about daily.dev on X",
@@ -8,24 +43,29 @@
     "evidence": { "url": { "required": true } },
     "metadata": { "platform": "x", "isLoveAction": false },
     "maxPerUser": 3,
+    "cooldownSeconds": 86400,
     "active": true,
     "sortOrder": 1
   },
   {
     "id": "a0000000-0000-4000-8000-000000000002",
-    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
     "title": "Star our GitHub repo",
     "description": "Give the open-source repo a star.",
     "points": 15,
-    "evidence": { "url": { "required": true } },
-    "metadata": { "platform": "github", "isLoveAction": false },
+    "evidence": { "url": { "required": true, "allowedDomains": ["github.com"] } },
+    "metadata": {
+      "platform": "github",
+      "isLoveAction": false,
+      "externalUrl": "https://github.com/dailydotdev/daily"
+    },
     "maxPerUser": 1,
     "active": true,
     "sortOrder": 2
   },
   {
     "id": "a0000000-0000-4000-8000-000000000003",
-    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "categoryId": "c0000000-0000-4000-8000-000000000002",
     "title": "Write a blog post",
     "description": "Publish an article mentioning daily.dev.",
     "points": 100,
@@ -37,11 +77,16 @@
   },
   {
     "id": "a0000000-0000-4000-8000-000000000004",
-    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "categoryId": "c0000000-0000-4000-8000-000000000003",
     "title": "Leave a store review",
     "description": "Review the extension on your browser store.",
     "points": 50,
-    "evidence": { "url": { "required": true } },
+    "evidence": {
+      "url": {
+        "required": true,
+        "allowedDomains": ["chromewebstore.google.com", "chrome.google.com"]
+      }
+    },
     "metadata": { "platform": "chrome_web_store", "isLoveAction": false },
     "maxPerUser": 1,
     "active": true,
@@ -56,7 +101,244 @@
     "evidence": { "url": { "required": true } },
     "metadata": { "platform": "daily_dev", "isLoveAction": false },
     "maxPerUser": 5,
+    "cooldownSeconds": 43200,
     "active": true,
     "sortOrder": 5
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000006",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Share daily.dev on LinkedIn",
+    "description": "Tell your network why daily.dev is part of your routine.",
+    "points": 30,
+    "evidence": { "url": { "required": true } },
+    "metadata": {
+      "platform": "linkedin",
+      "isLoveAction": false,
+      "instructions": "Make sure the post is public so we can verify it."
+    },
+    "maxPerUser": 3,
+    "cooldownSeconds": 86400,
+    "active": true,
+    "sortOrder": 6
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000007",
+    "categoryId": "c0000000-0000-4000-8000-000000000001",
+    "title": "Post in a Reddit community",
+    "description": "Recommend daily.dev where developers hang out.",
+    "points": 35,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "reddit", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 7
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000008",
+    "categoryId": "c0000000-0000-4000-8000-000000000002",
+    "title": "Publish a YouTube video",
+    "description": "Record a walkthrough or review of daily.dev.",
+    "points": 150,
+    "evidence": { "url": { "required": true }, "note": {} },
+    "metadata": { "platform": "youtube", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 8
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000009",
+    "categoryId": "c0000000-0000-4000-8000-000000000002",
+    "title": "Write a tutorial on DEV",
+    "description": "Show how you use daily.dev in your workflow.",
+    "points": 90,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "dev", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 9
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000010",
+    "categoryId": "c0000000-0000-4000-8000-000000000002",
+    "title": "Publish an article on Hashnode",
+    "description": "Share a guide or story that mentions daily.dev.",
+    "points": 90,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "hashnode", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 10
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000011",
+    "categoryId": "c0000000-0000-4000-8000-000000000002",
+    "title": "Feature us in your newsletter",
+    "description": "Give daily.dev a shout-out to your subscribers.",
+    "points": 80,
+    "evidence": { "url": {}, "note": { "required": true } },
+    "metadata": {
+      "platform": "newsletter",
+      "isLoveAction": false,
+      "instructions": "Add a note with the issue title and audience size. A public link is optional."
+    },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 11
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000012",
+    "categoryId": "c0000000-0000-4000-8000-000000000003",
+    "title": "Review us on Product Hunt",
+    "description": "Leave an honest review on our Product Hunt page.",
+    "points": 60,
+    "evidence": {
+      "url": { "required": true, "allowedDomains": ["producthunt.com"] }
+    },
+    "metadata": {
+      "platform": "product_hunt",
+      "isLoveAction": false,
+      "externalUrl": "https://www.producthunt.com/products/daily-dev"
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 12
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000013",
+    "categoryId": "c0000000-0000-4000-8000-000000000003",
+    "title": "Leave a G2 review",
+    "description": "Tell other teams what daily.dev does for you.",
+    "points": 70,
+    "evidence": { "screenshot": { "required": true } },
+    "metadata": {
+      "platform": "g2",
+      "isLoveAction": false,
+      "instructions": "Upload a screenshot of your published review."
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 13
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000014",
+    "categoryId": "c0000000-0000-4000-8000-000000000003",
+    "title": "Review the Edge add-on",
+    "description": "Rate the extension on the Edge Add-ons store.",
+    "points": 50,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "edge_addons", "isLoveAction": false },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 14
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000015",
+    "categoryId": "c0000000-0000-4000-8000-000000000003",
+    "title": "Rate the mobile app",
+    "description": "Leave a rating on the App Store or Google Play.",
+    "points": 40,
+    "evidence": { "screenshot": { "required": true } },
+    "metadata": {
+      "platform": "app_store",
+      "isLoveAction": false,
+      "instructions": "A screenshot of your rating is enough."
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 15
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000016",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Answer a question on Stack Overflow",
+    "description": "Help a developer and link daily.dev where it fits.",
+    "points": 35,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "stack_overflow", "isLoveAction": false },
+    "maxPerUser": 5,
+    "cooldownSeconds": 43200,
+    "active": true,
+    "sortOrder": 16
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000017",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Help someone in our Discord",
+    "description": "Answer a question or welcome a new member.",
+    "points": 20,
+    "evidence": {
+      "screenshot": { "required": true },
+      "note": { "required": true }
+    },
+    "metadata": {
+      "platform": "discord",
+      "isLoveAction": false,
+      "instructions": "Share a screenshot of the conversation and a short note on how you helped."
+    },
+    "maxPerUser": 10,
+    "cooldownSeconds": 3600,
+    "active": true,
+    "sortOrder": 17
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000018",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Share daily.dev on Hacker News",
+    "description": "Post a thoughtful submission or comment.",
+    "points": 40,
+    "evidence": { "url": { "required": true } },
+    "metadata": { "platform": "hacker_news", "isLoveAction": false },
+    "maxPerUser": 2,
+    "active": true,
+    "sortOrder": 18
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000019",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Follow daily.dev on X",
+    "description": "No proof needed, we just appreciate it.",
+    "points": 0,
+    "evidence": {},
+    "metadata": {
+      "platform": "x",
+      "isLoveAction": true,
+      "externalUrl": "https://x.com/dailydotdev"
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 19
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000020",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Join our Discord community",
+    "description": "Come say hi and hang out with other developers.",
+    "points": 0,
+    "evidence": {},
+    "metadata": {
+      "platform": "discord",
+      "isLoveAction": true,
+      "externalUrl": "https://discord.gg/dailydotdev"
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 20
+  },
+  {
+    "id": "a0000000-0000-4000-8000-000000000021",
+    "categoryId": "c0000000-0000-4000-8000-000000000004",
+    "title": "Subscribe on YouTube",
+    "description": "Follow along with our latest videos.",
+    "points": 0,
+    "evidence": {},
+    "metadata": {
+      "platform": "youtube",
+      "isLoveAction": true,
+      "externalUrl": "https://www.youtube.com/@dailydotdev"
+    },
+    "maxPerUser": 1,
+    "active": true,
+    "sortOrder": 21
   }
 ]

--- a/seeds/ContributionActionCategory.json
+++ b/seeds/ContributionActionCategory.json
@@ -4,5 +4,23 @@
     "title": "Spread the word",
     "active": true,
     "sortOrder": 1
+  },
+  {
+    "id": "c0000000-0000-4000-8000-000000000002",
+    "title": "Create content",
+    "active": true,
+    "sortOrder": 2
+  },
+  {
+    "id": "c0000000-0000-4000-8000-000000000003",
+    "title": "Reviews & ratings",
+    "active": true,
+    "sortOrder": 3
+  },
+  {
+    "id": "c0000000-0000-4000-8000-000000000004",
+    "title": "Community",
+    "active": true,
+    "sortOrder": 4
   }
 ]

--- a/seeds/ContributionCause.json
+++ b/seeds/ContributionCause.json
@@ -1,38 +1,132 @@
 [
   {
     "id": "d0000000-0000-4000-8000-000000000001",
-    "title": "freeCodeCamp",
-    "url": "https://www.freecodecamp.org",
-    "description": "Free coding education for everyone.",
-    "category": "Education",
+    "title": "Software Freedom Conservancy",
+    "url": "https://sfconservancy.org",
+    "description": "The nonprofit backbone of free and open source software: legal support, fiscal sponsorship, and governance for the projects developers depend on.",
+    "category": "Open source",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=sfconservancy.org&sz=128",
     "active": true,
     "sortOrder": 1
   },
   {
     "id": "d0000000-0000-4000-8000-000000000002",
-    "title": "Electronic Frontier Foundation",
-    "url": "https://www.eff.org",
-    "description": "Defending digital privacy and free expression.",
-    "category": "Digital rights",
+    "title": "Python Software Foundation",
+    "url": "https://www.python.org/psf/",
+    "description": "The nonprofit behind Python, maintaining the language, PyPI, python.org, and a global grants program that keeps Python alive.",
+    "category": "Open source",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=python.org&sz=128",
     "active": true,
     "sortOrder": 2
   },
   {
     "id": "d0000000-0000-4000-8000-000000000003",
-    "title": "Python Software Foundation",
-    "url": "https://www.python.org/psf",
-    "description": "Stewarding the Python language and community.",
+    "title": "NumFOCUS",
+    "url": "https://numfocus.org",
+    "description": "Keeps the open source scientific computing stack (NumPy, pandas, Jupyter, Matplotlib, and more) funded, governed, and growing.",
     "category": "Open source",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=numfocus.org&sz=128",
     "active": true,
     "sortOrder": 3
   },
   {
     "id": "d0000000-0000-4000-8000-000000000004",
-    "title": "Open Source Collective",
-    "url": "https://opencollective.com",
-    "description": "Funding the maintainers behind the tools we use.",
-    "category": "Open source",
+    "title": "OWASP Foundation",
+    "url": "https://owasp.org",
+    "description": "Makes software security visible and actionable through open source projects, the OWASP Top 10, and free security education for every developer.",
+    "category": "Open source security",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=owasp.org&sz=128",
     "active": true,
     "sortOrder": 4
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000005",
+    "title": "freeCodeCamp",
+    "url": "https://www.freecodecamp.org",
+    "description": "Free, self-paced coding education at global scale, from HTML basics to data science and machine learning, for anyone with internet access.",
+    "category": "Developer education",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=freecodecamp.org&sz=128",
+    "active": true,
+    "sortOrder": 5
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000006",
+    "title": "CodePath",
+    "url": "https://www.codepath.org",
+    "description": "Embeds industry-grade software engineering education directly into universities, free for students from underrepresented backgrounds.",
+    "category": "Developer education",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=codepath.org&sz=128",
+    "active": true,
+    "sortOrder": 6
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000007",
+    "title": "Raspberry Pi Foundation",
+    "url": "https://www.raspberrypi.org",
+    "description": "Global charity putting computing education in the hands of young people everywhere, through free curricula, Code Club, CoderDojo, and Raspberry Pi hardware.",
+    "category": "Developer education",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=raspberrypi.org&sz=128",
+    "active": true,
+    "sortOrder": 7
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000008",
+    "title": "CodeYourFuture",
+    "url": "https://codeyourfuture.io",
+    "description": "Free coding school for refugees and people from disadvantaged backgrounds, with full support from learning through to employment in tech.",
+    "category": "Inclusion & access",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=codeyourfuture.io&sz=128",
+    "active": true,
+    "sortOrder": 8
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000009",
+    "title": "Open Sourcing Mental Health",
+    "url": "https://osmihelp.org",
+    "description": "Raises awareness and provides practical resources to support mental wellness in the tech and open source communities.",
+    "category": "Mental health",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=osmihelp.org&sz=128",
+    "active": true,
+    "sortOrder": 9
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000010",
+    "title": "NV Access",
+    "url": "https://www.nvaccess.org",
+    "description": "Builds and maintains NVDA, the free open source screen reader that gives blind and vision-impaired people full access to the digital world.",
+    "category": "Accessibility",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=nvaccess.org&sz=128",
+    "active": true,
+    "sortOrder": 10
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000011",
+    "title": "Human-I-T",
+    "url": "https://www.human-i-t.org",
+    "description": "Turns donated tech into refurbished devices, low-cost internet, digital training, and e-waste diversion, making computing accessible and less wasteful.",
+    "category": "Device access",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=human-i-t.org&sz=128",
+    "active": true,
+    "sortOrder": 11
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000012",
+    "title": "GiveWell Top Charities Fund",
+    "url": "https://www.givewell.org",
+    "description": "Rigorously researches and directs donations to the most cost-effective charities in the world, where each dollar saves the most lives.",
+    "category": "Global good",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=givewell.org&sz=128",
+    "active": true,
+    "sortOrder": 12
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000013",
+    "title": "HackYourFuture",
+    "url": "https://www.hackyourfuture.net",
+    "description": "Free 9-month coding school in Amsterdam for refugees and people from disadvantaged backgrounds, with full career coaching and job placement support.",
+    "category": "Developer education",
+    "logoUrl": "https://www.google.com/s2/favicons?domain=hackyourfuture.net&sz=128",
+    "active": true,
+    "sortOrder": 13
   }
 ]

--- a/seeds/ContributionRewardTier.json
+++ b/seeds/ContributionRewardTier.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "d0000000-0000-4000-8000-000000000001",
+    "title": "100 Cores",
+    "description": "A pile of Cores to spend across daily.dev.",
+    "thresholdPoints": 25,
+    "rewardType": "cores",
+    "metadata": { "cores": 100 },
+    "active": true,
+    "sortOrder": 1
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000002",
+    "title": "1 week of daily.dev Plus",
+    "description": "Seven days of Plus, on us.",
+    "thresholdPoints": 100,
+    "rewardType": "plus_days",
+    "metadata": { "days": 7 },
+    "active": true,
+    "sortOrder": 2
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000003",
+    "title": "Contributor badge",
+    "description": "A profile badge that shows you back the cause.",
+    "thresholdPoints": 250,
+    "rewardType": "privilege",
+    "metadata": { "badge": "contributor" },
+    "active": true,
+    "sortOrder": 3
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000004",
+    "title": "1:1 with the team",
+    "description": "A 30-minute call with the daily.dev team.",
+    "thresholdPoints": 500,
+    "rewardType": "call",
+    "metadata": { "minutes": 30 },
+    "active": true,
+    "sortOrder": 4
+  },
+  {
+    "id": "d0000000-0000-4000-8000-000000000005",
+    "title": "Limited-edition swag",
+    "description": "A swag pack reserved for our top contributors.",
+    "thresholdPoints": 1000,
+    "rewardType": "custom",
+    "metadata": { "swag": "founders_pack" },
+    "active": true,
+    "sortOrder": 5
+  }
+]


### PR DESCRIPTION
Seeds the data backing the Giveback campaign UI (causes, actions, reward tiers) so the onboarded experience renders end to end in local/preview environments.

## Seeds
- **Causes** — vetted nonprofits across categories (cause picker + "Your causes").
- **Action categories** (4) — Spread the word, Create content, Reviews & ratings, Community.
- **Actions** (23) — diverse across categories, evidence types (url / screenshot / url+screenshot / love), points, `maxPerUser`, and cooldowns. Powers the Take action catalog and its card states.
- **Reward tiers** (5) — 25 → 1000 points, one per `rewardType` (cores, plus_days, privilege, call, custom) with `metadata`. Powers the Impact-tab reward ladder (icons by type) and the contribution summary's "next reward".

Sponsors already seeded on `main` carry `amountCents`, so the Impact-tab funding meter and sponsor budget bar render too.

## Other
- `bin/seedEntities.ts`: register `ContributionRewardTier` so it imports with the other contribution entities.

No schema or resolver changes — data only.