### PR TITLE
feat(contributions): add assist types and action link pool

### DIFF
--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -17,6 +17,7 @@ import { User } from '../src/entity/user/User';
 import * as njordCommon from '../src/common/njord';
 import { SubscriptionCycles } from '../src/paddle';
 import { ContributionAction } from '../src/entity/contribution/ContributionAction';
+import { ContributionActionLink } from '../src/entity/contribution/ContributionActionLink';
 import { ContributionActionCategory } from '../src/entity/contribution/ContributionActionCategory';
 import { ContributionBlockedUser } from '../src/entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../src/entity/contribution/ContributionCause';
@@ -102,6 +103,16 @@ query ContributionActions($categoryId: ID) {
         }
       }
     }
+  }
+}
+`;
+
+const CONTRIBUTION_ACTION_LINKS_QUERY = `
+query ContributionActionLinks($actionId: ID!, $limit: Int) {
+  contributionActionLinks(actionId: $actionId, limit: $limit) {
+    id
+    url
+    label
   }
 }
 `;
@@ -580,6 +591,36 @@ it('returns actions by category and records approved submissions with limits', a
   expect(loveAction.errors?.[0].message).toEqual(
     'Contribution action is not rewardable',
   );
+});
+
+it('returns a randomized handful of active pool links for an action', async () => {
+  await seedActions();
+  await saveFixtures(con, ContributionActionLink, [
+    { actionId, url: 'https://stackoverflow.com/q/1' },
+    { actionId, url: 'https://stackoverflow.com/q/2' },
+    { actionId, url: 'https://stackoverflow.com/q/3' },
+    { actionId, url: 'https://stackoverflow.com/q/4', active: false },
+  ]);
+
+  const limited = await client.query(CONTRIBUTION_ACTION_LINKS_QUERY, {
+    variables: { actionId, limit: 2 },
+  });
+
+  expect(limited.errors).toBeUndefined();
+  expect(limited.data.contributionActionLinks).toHaveLength(2);
+
+  const all = await client.query(CONTRIBUTION_ACTION_LINKS_QUERY, {
+    variables: { actionId },
+  });
+
+  const urls = all.data.contributionActionLinks
+    .map((link: { url: string }) => link.url)
+    .sort();
+  expect(urls).toEqual([
+    'https://stackoverflow.com/q/1',
+    'https://stackoverflow.com/q/2',
+    'https://stackoverflow.com/q/3',
+  ]);
 });
 
 it('updates cause preferences and claims unlocked reward tiers', async () => {

--- a/__tests__/routes/private/contributions.ts
+++ b/__tests__/routes/private/contributions.ts
@@ -325,17 +325,16 @@ describe('private contribution routes', () => {
     ]);
   });
 
-  it('returns 404 when managing links for a missing action or link', async () => {
-    await request(app.server)
-      .post(`/p/contributions/actions/${actionId}/links`)
-      .set(serviceHeaders)
-      .send({ url: 'https://stackoverflow.com/q/1' })
-      .expect(404);
-
+  it('returns 404 when updating or deleting a missing link', async () => {
     await request(app.server)
       .patch(`/p/contributions/links/${actionId}`)
       .set(serviceHeaders)
       .send({ label: 'Updated' })
+      .expect(404);
+
+    await request(app.server)
+      .delete(`/p/contributions/links/${actionId}`)
+      .set(serviceAuthHeaders)
       .expect(404);
   });
 

--- a/__tests__/routes/private/contributions.ts
+++ b/__tests__/routes/private/contributions.ts
@@ -7,6 +7,7 @@ import { saveFixtures } from '../../helpers';
 import { User } from '../../../src/entity/user/User';
 import { ContributionAction } from '../../../src/entity/contribution/ContributionAction';
 import { ContributionActionCategory } from '../../../src/entity/contribution/ContributionActionCategory';
+import { ContributionActionLink } from '../../../src/entity/contribution/ContributionActionLink';
 import { ContributionBlockedUser } from '../../../src/entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../../../src/entity/contribution/ContributionCause';
 import {
@@ -278,6 +279,64 @@ describe('private contribution routes', () => {
     await expect(
       con.getRepository(ContributionSponsor).findOneBy({ id: sponsor.id }),
     ).resolves.toBeNull();
+  });
+
+  it('manages action links individually and in bulk', async () => {
+    await seedContributionConfig();
+
+    const { body: link } = await request(app.server)
+      .post(`/p/contributions/actions/${actionId}/links`)
+      .set(serviceHeaders)
+      .send({ url: 'https://stackoverflow.com/q/1', label: 'Question 1' })
+      .expect(201);
+
+    const { body: bulk } = await request(app.server)
+      .post(`/p/contributions/actions/${actionId}/links/bulk`)
+      .set(serviceHeaders)
+      .send({
+        links: [
+          { url: 'https://stackoverflow.com/q/2' },
+          { url: 'https://stackoverflow.com/q/3', sortOrder: 5 },
+        ],
+      })
+      .expect(201);
+
+    expect(bulk.count).toBe(2);
+
+    await request(app.server)
+      .patch(`/p/contributions/links/${link.id}`)
+      .set(serviceHeaders)
+      .send({ label: 'Updated', active: false })
+      .expect(200);
+
+    await request(app.server)
+      .delete(`/p/contributions/links/${bulk.links[0].id}`)
+      .set(serviceAuthHeaders)
+      .expect(200);
+
+    const links = await con
+      .getRepository(ContributionActionLink)
+      .find({ where: { actionId }, order: { url: 'ASC' } });
+
+    expect(links).toHaveLength(2);
+    expect(links).toMatchObject([
+      { url: 'https://stackoverflow.com/q/1', label: 'Updated', active: false },
+      { url: 'https://stackoverflow.com/q/3', sortOrder: 5 },
+    ]);
+  });
+
+  it('returns 404 when managing links for a missing action or link', async () => {
+    await request(app.server)
+      .post(`/p/contributions/actions/${actionId}/links`)
+      .set(serviceHeaders)
+      .send({ url: 'https://stackoverflow.com/q/1' })
+      .expect(404);
+
+    await request(app.server)
+      .patch(`/p/contributions/links/${actionId}`)
+      .set(serviceHeaders)
+      .send({ label: 'Updated' })
+      .expect(404);
   });
 
   it('reviews submissions, fulfills rewards, and blocks users', async () => {

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import { ContributionAssistType } from '../../entity/contribution/ContributionAction';
 import { ContributionRewardType } from '../../entity/contribution/ContributionRewardTier';
 import { ContributionSubmissionStatus } from '../../entity/contribution/ContributionSubmission';
 import { enumValues } from './utils';
@@ -30,6 +31,7 @@ export const contributionActionMetadataSchema = z
     instructions: z.string().trim().min(1).optional(),
     externalUrl: z.url().optional(),
     isLoveAction: z.boolean().optional(),
+    assistType: z.enum(enumValues(ContributionAssistType)).optional(),
   })
   .strict();
 
@@ -55,6 +57,11 @@ export const contributionSubmissionsArgsSchema =
   contributionConnectionArgsSchema.extend({
     actionId: z.uuid().nullish(),
   });
+
+export const contributionActionLinksArgsSchema = z.object({
+  actionId: z.uuid(),
+  limit: z.number().int().positive().max(20).nullish(),
+});
 
 export const submitContributionActionInputSchema = z.object({
   actionId: z.uuid(),
@@ -222,4 +229,22 @@ export const contributionPrivateBlockUserSchema = z.object({
 export const contributionPrivateFinalizePaymentSchema = z.object({
   amountCents: z.number().int().positive(),
   createdBy: contributionUserIdSchema.nullish(),
+});
+
+export const contributionPrivateCreateActionLinkSchema = z.object({
+  url: z.url(),
+  label: z.string().trim().min(1).nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
+});
+
+export const contributionPrivateBulkCreateActionLinkSchema = z.object({
+  links: z.array(contributionPrivateCreateActionLinkSchema).min(1).max(500),
+});
+
+export const contributionPrivateUpdateActionLinkSchema = z.object({
+  url: z.url().optional(),
+  label: z.string().trim().min(1).nullish(),
+  active: contributionActiveSchema,
+  sortOrder: contributionSortOrderSchema,
 });

--- a/src/entity/contribution/ContributionAction.ts
+++ b/src/entity/contribution/ContributionAction.ts
@@ -22,11 +22,20 @@ export type ContributionEvidenceSchema = {
   };
 };
 
+export enum ContributionAssistType {
+  ExternalLink = 'external_link',
+  ReferralLink = 'referral_link',
+  LinkPool = 'link_pool',
+}
+
 export type ContributionActionMetadata = {
   platform?: string;
   instructions?: string;
   externalUrl?: string;
   isLoveAction?: boolean;
+  // How the UI helps the user complete the action: open a link, surface their
+  // referral link, or pick from a rotating pool (contribution_action_link).
+  assistType?: ContributionAssistType;
 };
 
 @Entity()

--- a/src/entity/contribution/ContributionActionLink.ts
+++ b/src/entity/contribution/ContributionActionLink.ts
@@ -1,0 +1,56 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type { ContributionAction } from './ContributionAction';
+
+// A pool of target links for a single action (e.g. hundreds of community
+// questions to answer). The UI surfaces a randomized handful at a time.
+@Entity()
+@Index('IDX_contribution_action_link_action_active', [
+  'actionId',
+  'active',
+  'sortOrder',
+])
+export class ContributionActionLink {
+  @PrimaryGeneratedColumn('uuid', {
+    primaryKeyConstraintName: 'PK_contribution_action_link_id',
+  })
+  id: string;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @Column({ type: 'uuid' })
+  actionId: string;
+
+  @Column({ type: 'text' })
+  url: string;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  label: string | null;
+
+  @Column({ type: 'boolean', default: true })
+  active: boolean;
+
+  @Column({ type: 'integer', default: 0 })
+  sortOrder: number;
+
+  @ManyToOne('ContributionAction', {
+    lazy: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'actionId',
+    foreignKeyConstraintName: 'FK_contribution_action_link_action_id',
+  })
+  action: Promise<ContributionAction>;
+}

--- a/src/entity/contribution/index.ts
+++ b/src/entity/contribution/index.ts
@@ -1,5 +1,6 @@
 export * from './ContributionAction';
 export * from './ContributionActionCategory';
+export * from './ContributionActionLink';
 export * from './ContributionBlockedUser';
 export * from './ContributionCause';
 export * from './ContributionPayment';

--- a/src/migration/1782100000000-AddContributionActionLink.ts
+++ b/src/migration/1782100000000-AddContributionActionLink.ts
@@ -1,0 +1,53 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddContributionActionLink1782100000000
+  implements MigrationInterface
+{
+  name = 'AddContributionActionLink1782100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE TABLE "contribution_action_link" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" timestamp NOT NULL DEFAULT now(),
+        "updatedAt" timestamp NOT NULL DEFAULT now(),
+        "actionId" uuid NOT NULL,
+        "url" text NOT NULL,
+        "label" text,
+        "active" boolean NOT NULL DEFAULT true,
+        "sortOrder" integer NOT NULL DEFAULT '0',
+        CONSTRAINT "PK_contribution_action_link_id"
+          PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_contribution_action_link_action_active"
+        ON "contribution_action_link" ("actionId", "active", "sortOrder")
+    `);
+
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_action_link"
+        ADD CONSTRAINT "FK_contribution_action_link_action_id"
+        FOREIGN KEY ("actionId")
+        REFERENCES "contribution_action"("id")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "contribution_action_link"
+        DROP CONSTRAINT "FK_contribution_action_link_action_id"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS "IDX_contribution_action_link_action_active"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DROP TABLE "contribution_action_link"
+    `);
+  }
+}

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -211,15 +211,6 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     }
 
     const con = await createOrGetConnection();
-    const action = await con.getRepository(ContributionAction).findOne({
-      select: ['id'],
-      where: { id: params.id },
-    });
-
-    if (!action) {
-      return res.status(404).send({ error: 'Contribution action not found' });
-    }
-
     const link = await con.getRepository(ContributionActionLink).save({
       ...body,
       actionId: params.id,
@@ -247,15 +238,6 @@ export default async (fastify: FastifyInstance): Promise<void> => {
     }
 
     const con = await createOrGetConnection();
-    const action = await con.getRepository(ContributionAction).findOne({
-      select: ['id'],
-      where: { id: params.id },
-    });
-
-    if (!action) {
-      return res.status(404).send({ error: 'Contribution action not found' });
-    }
-
     const links = await con.getRepository(ContributionActionLink).save(
       body.links.map((link) => ({
         ...link,

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -6,7 +6,9 @@ import { parseSchema } from './utils';
 import {
   contributionPrivateBlockUserSchema,
   contributionPrivateBlockedUserParamsSchema,
+  contributionPrivateBulkCreateActionLinkSchema,
   contributionPrivateCreateActionCategorySchema,
+  contributionPrivateCreateActionLinkSchema,
   contributionPrivateCreateActionSchema,
   contributionPrivateCreateCauseSchema,
   contributionPrivateCreateRewardTierSchema,
@@ -17,6 +19,7 @@ import {
   contributionPrivateReviewSubmissionSchema,
   contributionPrivateRewardParamsSchema,
   contributionPrivateUpdateActionCategorySchema,
+  contributionPrivateUpdateActionLinkSchema,
   contributionPrivateUpdateActionSchema,
   contributionPrivateUpdateCauseSchema,
   contributionPrivateUpdateRewardTierSchema,
@@ -28,6 +31,7 @@ import {
 } from '../../common/contribution';
 import { ContributionAction } from '../../entity/contribution/ContributionAction';
 import { ContributionActionCategory } from '../../entity/contribution/ContributionActionCategory';
+import { ContributionActionLink } from '../../entity/contribution/ContributionActionLink';
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../../entity/contribution/ContributionCause';
 import { ContributionRewardTier } from '../../entity/contribution/ContributionRewardTier';
@@ -183,6 +187,139 @@ export default async (fastify: FastifyInstance): Promise<void> => {
 
     if (!result.affected) {
       return res.status(404).send({ error: 'Contribution action not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateCreateActionLinkSchema>;
+  }>('/actions/:id/links', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateCreateActionLinkSchema,
+      value: req.body,
+      res,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const action = await con.getRepository(ContributionAction).findOne({
+      select: ['id'],
+      where: { id: params.id },
+    });
+
+    if (!action) {
+      return res.status(404).send({ error: 'Contribution action not found' });
+    }
+
+    const link = await con.getRepository(ContributionActionLink).save({
+      ...body,
+      actionId: params.id,
+    });
+
+    return res.status(201).send(link);
+  });
+
+  fastify.post<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateBulkCreateActionLinkSchema>;
+  }>('/actions/:id/links/bulk', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateBulkCreateActionLinkSchema,
+      value: req.body,
+      res,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const action = await con.getRepository(ContributionAction).findOne({
+      select: ['id'],
+      where: { id: params.id },
+    });
+
+    if (!action) {
+      return res.status(404).send({ error: 'Contribution action not found' });
+    }
+
+    const links = await con.getRepository(ContributionActionLink).save(
+      body.links.map((link) => ({
+        ...link,
+        actionId: params.id,
+      })),
+    );
+
+    return res.status(201).send({ count: links.length, links });
+  });
+
+  fastify.patch<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+    Body: z.infer<typeof contributionPrivateUpdateActionLinkSchema>;
+  }>('/links/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    const body = parseSchema({
+      schema: contributionPrivateUpdateActionLinkSchema,
+      value: req.body,
+      res,
+      requireNonEmpty: true,
+    });
+    if (!params || !body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionActionLink)
+      .update(params.id, body);
+
+    if (!result.affected) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution action link not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.delete<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+  }>('/links/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    if (!params) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionActionLink)
+      .delete(params.id);
+
+    if (!result.affected) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution action link not found' });
     }
 
     return res.status(200).send({ success: true });

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -542,20 +542,22 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       _,
       args: { actionId: string; limit?: number | null },
       ctx: AuthContext,
+      info: GraphQLResolveInfo,
     ): Promise<ContributionActionLink[]> => {
       const { actionId, limit } = parseContributionArgs(
         contributionActionLinksArgsSchema,
         args,
       );
 
-      return ctx.con
-        .getRepository(ContributionActionLink)
-        .createQueryBuilder('link')
-        .where('link."actionId" = :actionId', { actionId })
-        .andWhere('link.active = true')
-        .orderBy('RANDOM()')
-        .limit(limit ?? DEFAULT_POOL_LINK_LIMIT)
-        .getMany();
+      return graphorm.query<ContributionActionLink>(ctx, info, (builder) => {
+        builder.queryBuilder
+          .where(`"${builder.alias}"."actionId" = :actionId`, { actionId })
+          .andWhere(`"${builder.alias}"."active" = true`)
+          .orderBy('RANDOM()')
+          .limit(limit ?? DEFAULT_POOL_LINK_LIMIT);
+
+        return builder;
+      });
     },
     userContributionSubmissions: async (
       _,

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -18,6 +18,7 @@ import {
 import { fulfillContributionReward } from '../common/contribution/rewards';
 import {
   claimContributionRewardArgsSchema,
+  contributionActionLinksArgsSchema,
   contributionActionsArgsSchema,
   contributionConnectionArgsSchema,
   contributionSubmissionsArgsSchema,
@@ -26,6 +27,7 @@ import {
 } from '../common/schema/contributions';
 import { ContributionAction } from '../entity/contribution/ContributionAction';
 import { ContributionActionCategory } from '../entity/contribution/ContributionActionCategory';
+import { ContributionActionLink } from '../entity/contribution/ContributionActionLink';
 import { ContributionCause } from '../entity/contribution/ContributionCause';
 import {
   ContributionPayment,
@@ -180,6 +182,7 @@ export const typeDefs = /* GraphQL */ `
     instructions: String
     externalUrl: String
     isLoveAction: Boolean!
+    assistType: String
   }
 
   type ContributionActionCategory {
@@ -210,6 +213,12 @@ export const typeDefs = /* GraphQL */ `
     userCooldownEndsAt: DateTime
     userCompletions: Int!
     latestUserSubmission: ContributionSubmission
+  }
+
+  type ContributionActionLink {
+    id: ID!
+    url: String!
+    label: String
   }
 
   type ContributionActionEdge {
@@ -351,6 +360,14 @@ export const typeDefs = /* GraphQL */ `
       first: Int
       after: String
     ): ContributionActionConnection! @auth @contributionEligibility
+    """
+    A randomized handful of pool links for a link_pool action (e.g. community
+    questions to answer). The pool can hold hundreds; we surface a few at a time.
+    """
+    contributionActionLinks(
+      actionId: ID!
+      limit: Int
+    ): [ContributionActionLink!]! @auth @contributionEligibility
     userContributionSubmissions(
       actionId: ID
       first: Int
@@ -397,6 +414,8 @@ export const typeDefs = /* GraphQL */ `
       @contributionEligibility
   }
 `;
+
+const DEFAULT_POOL_LINK_LIMIT = 5;
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
   Query: {
@@ -518,6 +537,25 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           return builder;
         },
       });
+    },
+    contributionActionLinks: async (
+      _,
+      args: { actionId: string; limit?: number | null },
+      ctx: AuthContext,
+    ): Promise<ContributionActionLink[]> => {
+      const { actionId, limit } = parseContributionArgs(
+        contributionActionLinksArgsSchema,
+        args,
+      );
+
+      return ctx.con
+        .getRepository(ContributionActionLink)
+        .createQueryBuilder('link')
+        .where('link."actionId" = :actionId', { actionId })
+        .andWhere('link.active = true')
+        .orderBy('RANDOM()')
+        .limit(limit ?? DEFAULT_POOL_LINK_LIMIT)
+        .getMany();
     },
     userContributionSubmissions: async (
       _,


### PR DESCRIPTION
## What

Backend groundwork for the giveback campaign UX, building on the existing Contribution system.

- **`assistType` on action metadata** — `external_link | referral_link | link_pool`, so the UI knows how to help the user complete each action (open a link, surface their referral link, or pick from a rotating pool). Added to the entity type, the `.strict()` Zod metadata schema (so the private create/update action endpoints accept it), and the GraphQL `ContributionActionMetadata` type.
- **`contribution_action_link` table** — a pool of target links for a single action (can hold hundreds, e.g. community questions to answer). New entity + migration.
- **`contributionActionLinks` query** — returns a randomized handful of active links for an action (default 5, max 20), gated with `@auth @contributionEligibility` like the other contribution queries.
- **Private admin endpoints** — `POST /actions/:id/links`, `POST /actions/:id/links/bulk` (≤500), `PATCH /links/:id`, `DELETE /links/:id` for managing the pool.

## Notes

- Honor-system award flow, caps, cooldowns, evidence, and the `isLoveAction` (for-love) flag already exist and are reused as-is.
- The `referral_link` award hook (auto-create a referrer submission on friend activation) is a separate follow-up.

## Tests

- Resolver test: randomized handful, active-only filtering, `limit` respected.
- Private route tests: single + bulk create, patch, delete, and 404s for missing action/link.
- `tsc` + eslint clean, migration applies to test DB, 16/16 contribution tests pass.