### PR TITLE
feat(contributions): award referral points when invited friend activates

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -31,6 +31,10 @@ export const workers: Worker[] = [
   },
   {
     topic: 'user-updated',
+    subscription: 'api.user-activated-contribution-referral',
+  },
+  {
+    topic: 'user-updated',
     subscription: 'api.user-updated-plus-subscribed-squad',
   },
   {

--- a/__tests__/workers/userActivatedContributionReferral.ts
+++ b/__tests__/workers/userActivatedContributionReferral.ts
@@ -1,0 +1,189 @@
+import { DataSource, In } from 'typeorm';
+import worker from '../../src/workers/userActivatedContributionReferral';
+import { ChangeObject } from '../../src/types';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
+import { User } from '../../src/entity';
+import { PubSubSchema } from '../../src/common';
+import { typedWorkers } from '../../src/workers';
+import createOrGetConnection from '../../src/db';
+import { remoteConfig } from '../../src/remoteConfig';
+import {
+  ContributionAction,
+  ContributionAssistType,
+} from '../../src/entity/contribution/ContributionAction';
+import { ContributionCause } from '../../src/entity/contribution/ContributionCause';
+import { UserContributionCausePreference } from '../../src/entity/contribution/UserContributionCausePreference';
+import { ContributionBlockedUser } from '../../src/entity/contribution/ContributionBlockedUser';
+import {
+  ContributionSubmission,
+  ContributionSubmissionStatus,
+} from '../../src/entity/contribution/ContributionSubmission';
+
+let con: DataSource;
+
+const referrerId = '99999999-9999-4999-8999-999999999990';
+const refereeId = '99999999-9999-4999-8999-999999999991';
+const causeId = '33333333-3333-4333-8333-333333333333';
+const actionId = '22222222-2222-4222-8222-222222222222';
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+const seedReferralAction = async (
+  overrides: Partial<ContributionAction> = {},
+) => {
+  await saveFixtures(con, ContributionAction, [
+    {
+      id: actionId,
+      title: 'Invite a friend to daily.dev',
+      points: 150,
+      evidence: {},
+      metadata: { assistType: ContributionAssistType.ReferralLink },
+      ...overrides,
+    },
+  ]);
+};
+
+beforeEach(async () => {
+  await con
+    .getRepository(ContributionSubmission)
+    .delete({ userId: referrerId });
+  await con
+    .getRepository(UserContributionCausePreference)
+    .delete({ userId: referrerId });
+  await con
+    .getRepository(ContributionBlockedUser)
+    .delete({ userId: referrerId });
+  await con.getRepository(ContributionAction).delete({ id: actionId });
+  await con.getRepository(ContributionCause).delete({ id: causeId });
+  await con.getRepository(User).delete({ id: In([referrerId, refereeId]) });
+
+  remoteConfig.vars.contributionProgram = {
+    enabled: true,
+    allowedCountries: ['US'],
+    currentCycleTargetPoints: 10000,
+  };
+
+  await saveFixtures(con, User, [
+    { id: referrerId, reputation: 10 },
+    { id: refereeId, referralId: referrerId, reputation: 10 },
+  ]);
+  await saveFixtures(con, ContributionCause, [{ id: causeId, title: 'OSS' }]);
+  await saveFixtures(con, UserContributionCausePreference, [
+    { userId: referrerId, causeId },
+  ]);
+});
+
+const inactiveReferee: ChangeObject<User> = {
+  id: refereeId,
+  referralId: referrerId,
+  infoConfirmed: false,
+  emailConfirmed: false,
+} as unknown as ChangeObject<User>;
+
+const activeReferee: ChangeObject<User> = {
+  ...inactiveReferee,
+  infoConfirmed: true,
+  emailConfirmed: true,
+};
+
+const runActivation = (
+  newProfile: ChangeObject<User> = activeReferee,
+  user: ChangeObject<User> = inactiveReferee,
+) =>
+  expectSuccessfulTypedBackground(worker, {
+    newProfile,
+    user,
+  } as unknown as PubSubSchema['user-updated']);
+
+const getReferrerSubmissions = () =>
+  con
+    .getRepository(ContributionSubmission)
+    .find({ where: { userId: referrerId } });
+
+describe('userActivatedContributionReferral', () => {
+  it('should be registered', () => {
+    const registered = typedWorkers.find(
+      (item) => item.subscription === worker.subscription,
+    );
+    expect(registered).toBeDefined();
+  });
+
+  it('awards the referrer when the referee activates', async () => {
+    await seedReferralAction();
+
+    await runActivation();
+
+    const submissions = await getReferrerSubmissions();
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      actionId,
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: 150,
+      flags: { refereeId },
+    });
+  });
+
+  it('does not award when there is no activation transition', async () => {
+    await seedReferralAction();
+
+    await runActivation(activeReferee, activeReferee);
+
+    expect(await getReferrerSubmissions()).toHaveLength(0);
+  });
+
+  it('does not award when the referee has no referrer', async () => {
+    await seedReferralAction();
+
+    const noReferral = { ...activeReferee, referralId: null };
+    await runActivation(
+      noReferral as unknown as ChangeObject<User>,
+      { ...inactiveReferee, referralId: null } as unknown as ChangeObject<User>,
+    );
+
+    expect(await getReferrerSubmissions()).toHaveLength(0);
+  });
+
+  it('does not award when the referrer has not joined the campaign', async () => {
+    await seedReferralAction();
+    await con
+      .getRepository(UserContributionCausePreference)
+      .delete({ userId: referrerId });
+
+    await runActivation();
+
+    expect(await getReferrerSubmissions()).toHaveLength(0);
+  });
+
+  it('does not award when no referral action is configured', async () => {
+    await runActivation();
+
+    expect(await getReferrerSubmissions()).toHaveLength(0);
+  });
+
+  it('is idempotent across redelivered activation events', async () => {
+    await seedReferralAction();
+
+    await runActivation();
+    await runActivation();
+
+    expect(await getReferrerSubmissions()).toHaveLength(1);
+  });
+
+  it('respects the action cap', async () => {
+    await seedReferralAction({ maxPerUser: 1 });
+    await con.getRepository(ContributionSubmission).save({
+      userId: referrerId,
+      actionId,
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: 150,
+      evidence: {},
+      flags: { refereeId: 'some-other-referee' },
+    });
+
+    await runActivation();
+
+    expect(await getReferrerSubmissions()).toHaveLength(1);
+  });
+});

--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -6,10 +6,11 @@ import {
   contributionSubmissionEvidenceSchema,
 } from '../schema/contributions';
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
-import type {
+import {
   ContributionAction,
-  ContributionEvidenceSchema,
+  ContributionAssistType,
 } from '../../entity/contribution/ContributionAction';
+import type { ContributionEvidenceSchema } from '../../entity/contribution/ContributionAction';
 import {
   ContributionPayment,
   ContributionPaymentStatus,
@@ -17,6 +18,7 @@ import {
 import { ContributionPaymentAllocation } from '../../entity/contribution/ContributionPaymentAllocation';
 import { ContributionSubmissionStatus } from '../../entity/contribution/ContributionSubmission';
 import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
+import { UserContributionCausePreference } from '../../entity/contribution/UserContributionCausePreference';
 import { remoteConfig } from '../../remoteConfig';
 
 const ACTIVE_STATUSES_FOR_LIMITS = [
@@ -664,4 +666,90 @@ export const validateContributionActionLimits = async ({
   if (cooldownEndsAt > now) {
     throw new ValidationError('Action is still cooling down');
   }
+};
+
+export const REFERRAL_CONTRIBUTION_REFEREE_FLAG = 'refereeId';
+
+const findReferralContributionAction = (
+  con: EntityManager,
+): Promise<ContributionAction | null> =>
+  con
+    .getRepository(ContributionAction)
+    .createQueryBuilder('action')
+    .where('action.active = true')
+    .andWhere(`action.metadata->>'assistType' = :assistType`, {
+      assistType: ContributionAssistType.ReferralLink,
+    })
+    .orderBy('action."sortOrder"', 'ASC')
+    .addOrderBy('action."createdAt"', 'ASC')
+    .getOne();
+
+// Credits a referrer with contribution points when a friend they invited
+// activates. Gated to referrers who joined the giveback campaign (picked
+// causes). Idempotent per referee via the partial unique index on submission
+// flags, so a redelivered activation event never double-credits.
+export const awardReferralContribution = async ({
+  con,
+  referrerId,
+  refereeId,
+}: {
+  con: EntityManager;
+  referrerId: string;
+  refereeId: string;
+}): Promise<boolean> => {
+  if (!getContributionConfig().enabled) {
+    return false;
+  }
+
+  const [joinedCampaign, blocked] = await Promise.all([
+    con
+      .getRepository(UserContributionCausePreference)
+      .exists({ where: { userId: referrerId } }),
+    con
+      .getRepository(ContributionBlockedUser)
+      .exists({ where: { userId: referrerId } }),
+  ]);
+
+  if (!joinedCampaign || blocked) {
+    return false;
+  }
+
+  const action = await findReferralContributionAction(con);
+
+  // A referral action must be rewardable: skip "for love" (0-point) configs.
+  if (!action || action.points <= 0 || action.metadata?.isLoveAction) {
+    return false;
+  }
+
+  // Best-effort cap: the per-referee unique index guarantees one award per
+  // friend, but the cap is a soft check — concurrent activations from different
+  // referees could each pass it. Acceptable since activation is a rare one-shot.
+  if (action.maxPerUser !== null && action.maxPerUser !== undefined) {
+    const usage = await getContributionActionUsage({
+      con,
+      userId: referrerId,
+      actionId: action.id,
+    });
+
+    if (usage.count >= action.maxPerUser) {
+      return false;
+    }
+  }
+
+  const result = await con
+    .getRepository(ContributionSubmission)
+    .createQueryBuilder()
+    .insert()
+    .values({
+      userId: referrerId,
+      actionId: action.id,
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: action.points,
+      evidence: {},
+      flags: { [REFERRAL_CONTRIBUTION_REFEREE_FLAG]: refereeId },
+    })
+    .orIgnore()
+    .execute();
+
+  return (result.identifiers?.length ?? 0) > 0;
 };

--- a/src/migration/1782200000000-AddContributionReferralIdempotency.ts
+++ b/src/migration/1782200000000-AddContributionReferralIdempotency.ts
@@ -1,0 +1,24 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddContributionReferralIdempotency1782200000000
+  implements MigrationInterface
+{
+  name = 'AddContributionReferralIdempotency1782200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Guarantees a referrer is credited at most once per referee, even if the
+    // activation event is redelivered. Partial so it only applies to
+    // referral-award submissions (those carrying a refereeId flag).
+    await queryRunner.query(/* sql */ `
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_contribution_submission_referee"
+        ON "contribution_submission" ("actionId", (("flags" ->> 'refereeId')))
+        WHERE ("flags" ->> 'refereeId') IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS "UQ_contribution_submission_referee"
+    `);
+  }
+}

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -46,6 +46,7 @@ import userCreatedPersonalizedDigestSendType from './userCreatedPersonalizedDige
 import commentDownvotedRep from './commentDownvotedRep';
 import commentDownvoteCanceledRep from './commentDownvoteCanceledRep';
 import userUpdatedCio from './userUpdatedCio';
+import userActivatedContributionReferral from './userActivatedContributionReferral';
 import userDeletedCio from './userDeletedCio';
 import userStreakUpdatedCio from './userStreakUpdatedCio';
 import { vordrPostCommentPrevented } from './vordrPostCommentPrevented';
@@ -138,6 +139,7 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   postDownvotedRep,
   postDownvoteCanceledRep,
   userUpdatedCio,
+  userActivatedContributionReferral,
   userDeletedCio,
   userStreakUpdatedCio,
   vordrPostCommentPrevented,

--- a/src/workers/userActivatedContributionReferral.ts
+++ b/src/workers/userActivatedContributionReferral.ts
@@ -1,0 +1,48 @@
+import { ghostUser } from '../common';
+import { awardReferralContribution } from '../common/contribution';
+import type { ChangeObject } from '../types';
+import type { User } from '../entity';
+import { TypedWorker } from './worker';
+
+const isActivated = (user: ChangeObject<User>): boolean =>
+  !!user.infoConfirmed && !!user.emailConfirmed;
+
+// Credits the referrer with giveback points the moment an invited friend
+// "gets going" (confirms info + email). Fires once on that transition.
+const worker: TypedWorker<'user-updated'> = {
+  subscription: 'api.user-activated-contribution-referral',
+  handler: async (message, con, log) => {
+    try {
+      const {
+        data: { newProfile: user, user: oldUser },
+      } = message;
+
+      if (user.id === ghostUser.id || !user.referralId) {
+        return;
+      }
+
+      if (!isActivated(user) || isActivated(oldUser)) {
+        return;
+      }
+
+      const awarded = await awardReferralContribution({
+        con: con.manager,
+        referrerId: user.referralId,
+        refereeId: user.id,
+      });
+
+      if (awarded) {
+        log.info(
+          { referrerId: user.referralId, refereeId: user.id },
+          'awarded giveback referral contribution',
+        );
+      }
+    } catch (_err) {
+      const err = _err as Error;
+      log.error({ err }, 'failed to award giveback referral contribution');
+      throw err;
+    }
+  },
+};
+
+export default worker;


### PR DESCRIPTION
## What

Closes the giveback referral loop: when a friend you invited **activates** (confirms info + email), the referrer is automatically credited with the referral action's points.

- New `user-updated` worker `userActivatedContributionReferral` fires once on the inactive→active transition (`infoConfirmed && emailConfirmed`, false→true).
- `awardReferralContribution` helper creates an `Approved` `ContributionSubmission` for the referrer, gated to:
  - referrers who **joined the campaign** (have ≥1 `UserContributionCausePreference`)
  - not in `ContributionBlockedUser`, program enabled
  - the active `ContributionAction` with `metadata.assistType = 'referral_link'`, respecting `maxPerUser`
- **Idempotent** via a new partial unique index `UQ_contribution_submission_referee` on `(actionId, flags->>'refereeId')` + `ON CONFLICT DO NOTHING`, so redelivered events never double-credit.
- Provisions the `api.user-activated-contribution-referral` subscription in `.infra/common.ts`.

## Notes

- Award is deferred by design — points land when the friend "gets going", matching the invite copy.
- The cap is best-effort (the unique index hard-guarantees one award per referee; the `maxPerUser` check is a soft cap given activation is a rare one-shot event). Noted in a code comment.
- Edge case not handled: a user created already-active (no false→true `user-updated` transition). The dominant referred-signup path crosses the boundary via updates.

## Tests

8 worker specs: award on activation; no award on no-transition / no-referrer / not-joined-campaign / no-action-configured; idempotent redelivery; cap respected. `tsc` + eslint clean, migration applies, existing 16 contribution tests still pass.