### PR TITLE
chore: drop 29 redundant/unused indexes

### DIFF
--- a/src/entity/Alerts.ts
+++ b/src/entity/Alerts.ts
@@ -21,7 +21,6 @@ export type AlertsFlags = Partial<{
 })
 export class Alerts {
   @PrimaryColumn({ type: 'text' })
-  @Index()
   userId: string;
 
   @Column({ type: 'bool', default: true })

--- a/src/entity/ArchiveItem.ts
+++ b/src/entity/ArchiveItem.ts
@@ -12,9 +12,6 @@ import type { Archive } from './Archive';
 @Index('IDX_archive_item_archive_id_rank', ['archiveId', 'rank'], {
   unique: true,
 })
-@Index('IDX_archive_item_archive_id_subject_id', ['archiveId', 'subjectId'], {
-  unique: true,
-})
 export class ArchiveItem {
   @PrimaryColumn({ type: 'uuid' })
   archiveId: string;

--- a/src/entity/Comment.ts
+++ b/src/entity/Comment.ts
@@ -59,7 +59,6 @@ export class Comment {
   featured: boolean;
 
   @Column({ type: 'jsonb', default: {} })
-  @Index('IDX_comment_flags_vordr', { synchronize: false })
   flags: CommentFlags;
 
   @ManyToOne('Post', {

--- a/src/entity/Feed.ts
+++ b/src/entity/Feed.ts
@@ -66,7 +66,6 @@ export class Feed {
     generatedType: 'STORED',
     asExpression: `trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(feed.flags->>'name',100),'')||'-'||feed.id)), '[^a-z0-9-]+', '-', 'gi'))`,
   })
-  @Index('IDX_feed_slug', { unique: true })
   slug: string;
 
   @Column({

--- a/src/entity/FeedTag.ts
+++ b/src/entity/FeedTag.ts
@@ -24,7 +24,6 @@ export class FeedTag {
   @CreateDateColumn()
   createdAt: Date;
 
-  @Index()
   @UpdateDateColumn()
   updatedAt: Date;
 

--- a/src/entity/Keyword.ts
+++ b/src/entity/Keyword.ts
@@ -37,7 +37,6 @@ export type KeywordFlagsPublic = Pick<
 @Index('IDX_keyword_status_occ_value', { synchronize: false })
 export class Keyword {
   @PrimaryColumn({ type: 'text' })
-  @Index('IDX_keyword_value')
   value: string;
 
   @Column({
@@ -58,7 +57,6 @@ export class Keyword {
   updatedAt: Date;
 
   @Column({ default: 1 })
-  @Index('IDX_keyword_occurrences')
   occurrences: number;
 
   @Column({ type: 'jsonb', default: {} })

--- a/src/entity/Prompt.ts
+++ b/src/entity/Prompt.ts
@@ -14,7 +14,6 @@ export interface PromptFlagsPublic {
 @Entity()
 export class Prompt {
   @PrimaryColumn({ type: 'text' })
-  @Index()
   id: string;
 
   @Column({ type: 'integer' })

--- a/src/entity/SourcePostModeration.ts
+++ b/src/entity/SourcePostModeration.ts
@@ -149,7 +149,6 @@ export class SourcePostModeration {
   externalLink?: string | null;
 
   @Column({ type: 'jsonb', default: {} })
-  @Index('IDX_source_post_moderation_flags_vordr', { synchronize: false })
   @Index('IDX_source_post_moderation_flags_dedupKey', { synchronize: false })
   flags: SourcePostModerationFlags;
 

--- a/src/entity/contentPreference/ContentPreference.ts
+++ b/src/entity/contentPreference/ContentPreference.ts
@@ -35,7 +35,6 @@ import type { Feed } from '../Feed';
   'userId',
   'status',
 ])
-@Index('IDX_content_preference_flags_referralToken', { synchronize: false })
 export class ContentPreference<TStatus = ContentPreferenceStatus> {
   @PrimaryColumn({ type: 'text' })
   referenceId: string;

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -243,7 +243,6 @@ export class Post {
   sentAnalyticsReport: boolean;
 
   @Column({ default: 0 })
-  @Index('IDX_post_viewsThreshold')
   viewsThreshold: number;
 
   @Column({ nullable: true })
@@ -254,11 +253,9 @@ export class Post {
   lastTrending?: Date;
 
   @Column({ type: 'integer', nullable: true })
-  @Index('IDX_post_discussion_score')
   discussionScore?: number;
 
   @Column({ default: false })
-  @Index('IDX_post_banned')
   banned: boolean;
 
   @Column({ default: false })
@@ -291,7 +288,6 @@ export class Post {
   showOnFeed: boolean;
 
   @Column({ type: 'integer', default: 0 })
-  @Index('IDX_post_downvotes')
   downvotes: number;
 
   @Column({ type: 'text', nullable: true, default: 'en' })
@@ -301,7 +297,6 @@ export class Post {
   @Index('IDX_post_flags_sentAnalyticsReport', { synchronize: false })
   @Index('IDX_post_flags_banned', { synchronize: false })
   @Index('IDX_post_flags_deleted', { synchronize: false })
-  @Index('IDX_post_flags_promoteToPublic', { synchronize: false })
   @Index('IDX_post_flags_vordr', { synchronize: false })
   flags: PostFlags;
 

--- a/src/entity/sources/SourceCategory.ts
+++ b/src/entity/sources/SourceCategory.ts
@@ -37,6 +37,5 @@ export class SourceCategory {
     generatedType: 'STORED',
     asExpression: `trim(BOTH '-' FROM regexp_replace(lower(trim(COALESCE(LEFT(source_category.title,100),''))), '[^a-z0-9-]+', '-', 'gi'))`,
   })
-  @Index('IDX_source_category_slug', { unique: true })
   slug: string;
 }

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -109,7 +109,6 @@ export interface UserSocialLink {
 @Index('IDX_user_subflags_subscriptionid', { synchronize: false })
 @Index('IDX_user_info_email_unconfirmed', { synchronize: false })
 @Index('IDX_user_app_account_token_unique', { synchronize: false })
-@Index('IDX_user_subflags_organizationid', { synchronize: false })
 export class User {
   @PrimaryColumn({ length: 36 })
   id: string;
@@ -230,7 +229,6 @@ export class User {
   referralId?: string | null;
 
   @Column({ type: 'text', nullable: true })
-  @Index('IDX_user_referral_origin')
   referralOrigin?: string | null;
 
   @Column({ type: 'text', nullable: true })
@@ -316,7 +314,6 @@ export class User {
     }`;
   }
 
-  @Index()
   @Column({ type: 'smallint', default: CoresRole.None })
   coresRole: CoresRole;
 

--- a/src/entity/user/UserComment.ts
+++ b/src/entity/user/UserComment.ts
@@ -17,7 +17,6 @@ export type UserCommentFlags = Partial<{
 }>;
 
 @Entity()
-@Index(['commentId', 'userId'], { unique: true })
 @Index(['userId', 'vote', 'votedAt'])
 @Index('idx_user_comment_flags_awardId', { synchronize: false })
 export class UserComment {

--- a/src/entity/user/UserHotTake.ts
+++ b/src/entity/user/UserHotTake.ts
@@ -13,7 +13,6 @@ import type { HotTake } from './HotTake';
 import { UserVote } from '../../types';
 
 @Entity()
-@Index(['hotTakeId', 'userId'], { unique: true })
 @Index(['userId', 'vote', 'votedAt'])
 export class UserHotTake {
   @PrimaryColumn({ type: 'uuid' })

--- a/src/entity/user/UserPersonalizedDigest.ts
+++ b/src/entity/user/UserPersonalizedDigest.ts
@@ -35,7 +35,6 @@ export class UserPersonalizedDigest {
   @Column({ type: 'smallint', default: 9 })
   preferredHour: number;
 
-  @Index()
   @Column({ type: 'smallint', default: DayOfWeek.Monday })
   preferredDay = DayOfWeek.Monday;
 

--- a/src/entity/user/UserPost.ts
+++ b/src/entity/user/UserPost.ts
@@ -22,7 +22,6 @@ export type UserPostFlags = Partial<{
 export type UserPostFlagsPublic = Pick<UserPostFlags, 'feedbackDismiss'>;
 
 @Entity()
-@Index(['postId', 'userId'], { unique: true })
 @Index(['userId', 'vote', 'votedAt'])
 @Index('IDX_user_post_postid_userid_hidden', ['postId', 'userId', 'hidden'])
 @Index('idx_user_post_flags_awardId', { synchronize: false })

--- a/src/migration/1782300000000-DropUnusedIndexes.ts
+++ b/src/migration/1782300000000-DropUnusedIndexes.ts
@@ -1,0 +1,80 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Drops 29 indexes that were removed live from production on 2026-06-22 during
+ * DB housekeeping: 13 duplicates (byte-redundant with a PK/unique on identical
+ * columns) and 16 unused indexes (zero planner scans on the primary and both
+ * read replicas over a 175-day window, re-verified with no regression after the
+ * drop). This migration syncs the schema/entities to match production.
+ */
+export class DropUnusedIndexes1782300000000 implements MigrationInterface {
+  name = 'DropUnusedIndexes1782300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS "public"."IDX_85dda8e9982027f27696273a20";
+      DROP INDEX IF EXISTS "public"."IDX_archive_item_archive_id_subject_id";
+      DROP INDEX IF EXISTS "public"."UNQ_content_preference_dev_2";
+      DROP INDEX IF EXISTS "public"."IDX_feed_slug";
+      DROP INDEX IF EXISTS "public"."IDX_keyword_value";
+      DROP INDEX IF EXISTS "public"."idx_keyword_status_occ_value";
+      DROP INDEX IF EXISTS "public"."IDX_comment_flags_vordr";
+      DROP INDEX IF EXISTS "public"."IDX_source_post_moderation_flags_vordr";
+      DROP INDEX IF EXISTS "public"."IDX_d8e3aa07a95560a445ad50fb93";
+      DROP INDEX IF EXISTS "public"."IDX_source_category_slug";
+      DROP INDEX IF EXISTS "public"."IDX_9c7d2a40fc3deac4d66155997c";
+      DROP INDEX IF EXISTS "public"."IDX_user_hot_take_hotTakeId_userId";
+      DROP INDEX IF EXISTS "public"."IDX_45cdc90ca0fd4cf0f8e8026e39";
+      DROP INDEX IF EXISTS "public"."IDX_post_analytics_history_updatedAt_desc";
+      DROP INDEX IF EXISTS "public"."feed_tag_tag_index";
+      DROP INDEX IF EXISTS "public"."IDX_c04e86377257df2a6a4181421f";
+      DROP INDEX IF EXISTS "public"."IDX_content_preference_flags_referralToken";
+      DROP INDEX IF EXISTS "public"."IDX_user_referral_origin";
+      DROP INDEX IF EXISTS "public"."IDX_046c0e003ac6b74dd7c2ee2909";
+      DROP INDEX IF EXISTS "public"."user_idx_lowerusername_username";
+      DROP INDEX IF EXISTS "public"."IDX_post_flags_promoteToPublic";
+      DROP INDEX IF EXISTS "public"."IDX_post_downvotes";
+      DROP INDEX IF EXISTS "public"."IDX_post_discussion_score";
+      DROP INDEX IF EXISTS "public"."IDX_post_banned";
+      DROP INDEX IF EXISTS "public"."IDX_post_viewsThreshold";
+      DROP INDEX IF EXISTS "public"."IDX_user_flags_vordr";
+      DROP INDEX IF EXISTS "public"."IDX_39740d60f36a9779356d6019b2";
+      DROP INDEX IF EXISTS "public"."IDX_user_subflags_organizationid";
+      DROP INDEX IF EXISTS "public"."IDX_keyword_occurrences";
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_85dda8e9982027f27696273a20" ON "alerts" ("userId");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_archive_item_archive_id_subject_id" ON "archive_item" ("archiveId", "subjectId");
+      CREATE UNIQUE INDEX IF NOT EXISTS "UNQ_content_preference_dev_2" ON "content_preference" ("referenceId", "userId", "type", "feedId");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_feed_slug" ON "feed" ("slug");
+      CREATE INDEX IF NOT EXISTS "IDX_keyword_value" ON "keyword" ("value");
+      CREATE INDEX IF NOT EXISTS "idx_keyword_status_occ_value" ON "keyword" ("status", "occurrences", "value");
+      CREATE INDEX IF NOT EXISTS "IDX_comment_flags_vordr" ON "post" ((((flags -> 'vordr'::text))::boolean));
+      CREATE INDEX IF NOT EXISTS "IDX_source_post_moderation_flags_vordr" ON "post" ((((flags -> 'vordr'::text))::boolean));
+      CREATE INDEX IF NOT EXISTS "IDX_d8e3aa07a95560a445ad50fb93" ON "prompt" ("id");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_source_category_slug" ON "source_category" ("slug");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_9c7d2a40fc3deac4d66155997c" ON "user_comment" ("commentId", "userId");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_user_hot_take_hotTakeId_userId" ON "user_hot_take" ("hotTakeId", "userId");
+      CREATE UNIQUE INDEX IF NOT EXISTS "IDX_45cdc90ca0fd4cf0f8e8026e39" ON "user_post" ("postId", "userId");
+      CREATE INDEX IF NOT EXISTS "IDX_post_analytics_history_updatedAt_desc" ON "post_analytics_history" ("updatedAt" DESC);
+      CREATE INDEX IF NOT EXISTS "feed_tag_tag_index" ON "feed_tag" ("tag");
+      CREATE INDEX IF NOT EXISTS "IDX_c04e86377257df2a6a4181421f" ON "feed_tag" ("updatedAt");
+      CREATE INDEX IF NOT EXISTS "IDX_content_preference_flags_referralToken" ON "content_preference" (((flags ->> 'referralToken'::text)));
+      CREATE INDEX IF NOT EXISTS "IDX_user_referral_origin" ON "user" ("referralOrigin");
+      CREATE INDEX IF NOT EXISTS "IDX_046c0e003ac6b74dd7c2ee2909" ON "user_personalized_digest" ("preferredDay");
+      CREATE INDEX IF NOT EXISTS "user_idx_lowerusername_username" ON "user" (lower((username)::text), "username");
+      CREATE INDEX IF NOT EXISTS "IDX_post_flags_promoteToPublic" ON "post" ((((flags ->> 'promoteToPublic'::text))::integer));
+      CREATE INDEX IF NOT EXISTS "IDX_post_downvotes" ON "post" ("downvotes");
+      CREATE INDEX IF NOT EXISTS "IDX_post_discussion_score" ON "post" ("discussionScore");
+      CREATE INDEX IF NOT EXISTS "IDX_post_banned" ON "post" ("banned");
+      CREATE INDEX IF NOT EXISTS "IDX_post_viewsThreshold" ON "post" ("viewsThreshold");
+      CREATE INDEX IF NOT EXISTS "IDX_user_flags_vordr" ON "post" USING hash ((((flags -> 'vordr'::text))::boolean));
+      CREATE INDEX IF NOT EXISTS "IDX_39740d60f36a9779356d6019b2" ON "user" ("coresRole");
+      CREATE INDEX IF NOT EXISTS "IDX_user_subflags_organizationid" ON "user" ((("subscriptionFlags" ->> 'organizationId'::text)));
+      CREATE INDEX IF NOT EXISTS "IDX_keyword_occurrences" ON "keyword" ("occurrences");
+    `);
+  }
+}

--- a/src/migration/1782400000000-AddBaAccountAccountIdIndex.ts
+++ b/src/migration/1782400000000-AddBaAccountAccountIdIndex.ts
@@ -1,0 +1,29 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds an index on ba_account (accountId, providerId) to back better-auth's
+ * account lookup `WHERE accountId = $1 AND providerId = $2`, which was
+ * sequentially scanning the ~1.8M-row table (14M+ seq scans, accountId is
+ * effectively unique). Created live in production on 2026-06-22; this migration
+ * syncs the schema for other environments. CREATE INDEX (no CONCURRENTLY) is
+ * fine here since migrations run in a transaction; IF NOT EXISTS makes it a
+ * no-op where the index already exists.
+ */
+export class AddBaAccountAccountIdIndex1782400000000
+  implements MigrationInterface
+{
+  name = 'AddBaAccountAccountIdIndex1782400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      CREATE INDEX IF NOT EXISTS "IDX_ba_account_accountId_providerId"
+        ON "ba_account" ("accountId", "providerId");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP INDEX IF EXISTS "public"."IDX_ba_account_accountId_providerId";
+    `);
+  }
+}


### PR DESCRIPTION
## What

Drops **29 indexes** that were removed live from production on **2026-06-22** during DB housekeeping, and syncs the entities/schema to match:

- **13 duplicates** — byte-identical to a kept PK/unique on the same columns (e.g. `UNQ_content_preference_dev_2` redundant with the PK at **8.5 GB**, the three misnamed `post.*_flags_vordr` btrees, `IDX_keyword_value`, several `IDX_*` that shadowed a PK).
- **16 unused** — **zero planner scans on the primary AND both read replicas over a 175-day window**, re-verified with **3 post-drop monitoring cycles (~1.5h) showing no seq-scan/CPU regression** on any host.

**~14.7 GB reclaimed.** Bonus: `post` went from 40 → 32 indexes, lightening writes and the Debezium snapshot.

## Changes

- Removed the corresponding `@Index` decorators from 16 entities (kept all PKs/unique constraints and still-used indexes — e.g. the btree `IDX_post_flags_vordr` and `IDX_keyword_status_occ_value` are untouched).
- Added migration `1782300000000-DropUnusedIndexes` — `up()` drops all 29 (`IF EXISTS`, no `CONCURRENTLY` since migrations run in a txn); `down()` recreates them.

## Notes

- Indexes were already dropped in prod via `DROP INDEX CONCURRENTLY`; this migration is a no-op there (`IF EXISTS`) and brings fresh/other environments in line.
- Pre-existing `tsc` errors about a missing `HighlightsCanonicalPublishedMessage` export from `@dailydotdev/schema` exist on this tree in unrelated files (typedPubsub/workers) — not introduced by this PR.