### PR TITLE
feat: support OneSignal web push migration

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -273,6 +273,10 @@ config:
       secure: AAABAA85JTyvqc0H0ymWJ4UZ+btCk31WpH78pgaNOIiIRKW9jr6p7W1xBMzmCbO6vBfL90LeadptoNV9KQnaPnsmIVlQhTDEERY17PoQ
     emailTrackingOrigin:
       secure: AAABAErY3w6A5DQ0qsRNWLnAJZhLaLnMdqbimt6M5rZSYgAw6yNbtrlUJLeiHW/EQCDUhw==
+    onesignalWebAppId:
+      secure: AAABACoUzLQ6eGNpdjzl7sShD4BDSeSKJPtzdp9Ble0i3Mo3fh49v5dypv2VkcuXF2UH1dgaZlcCE6DhSBTrA/luWKc=
+    onesignalWebApiKey:
+      secure: AAABAPNWKCkjj4VNxfW9pxPksz2srCJuBaOfvxnyIRpnb/e7fBFUBIhTJjiZa8Kf2fAOFEqh1Xpioilpy6UrW//CFVHl5EEDtn+1U2K8Ig398ZbLwCYiJcsqj3m0NVnhs5tH/SUfHyiJBexftNuyAjE9KPW1UmyIeUpB4gTUMJG876JFVYqUY7a2XJFjGJ7a4Q==
   api:k8s:
     host: subs.daily.dev
     namespace: daily

--- a/__mocks__/isomorphic-dompurify.ts
+++ b/__mocks__/isomorphic-dompurify.ts
@@ -1,10 +1,25 @@
-// Mock for isomorphic-dompurify to avoid ESM compatibility issues in Jest
-// When using dynamic import(), the module is accessed directly (not via .default)
-// because Jest's moduleNameMapper resolves to this file which exports these functions directly
+import { parse } from 'node-html-parser';
 
-export const sanitize = (html: string): string => {
-  // Simple mock that returns the input - actual sanitization not needed in tests
-  return html;
+type SanitizeConfig = {
+  ALLOWED_TAGS?: string[];
+};
+
+export const sanitize = (html: string, config?: SanitizeConfig): string => {
+  if (config?.ALLOWED_TAGS?.length !== 0) {
+    return html;
+  }
+
+  const root = parse(html);
+  root.querySelectorAll('script,style').forEach((node) => node.remove());
+  return root.textContent
+    .split('<script')
+    .join('')
+    .split('<style')
+    .join('')
+    .split('<')
+    .join('')
+    .split('>')
+    .join('');
 };
 
 export const addHook = (): void => {

--- a/__tests__/common/notificationUtils.ts
+++ b/__tests__/common/notificationUtils.ts
@@ -1,0 +1,13 @@
+import { basicHtmlStrip } from '../../src/common/notificationUtils';
+
+describe('notificationUtils', () => {
+  describe('basicHtmlStrip', () => {
+    it('should extract plain text without executable HTML', () => {
+      expect(
+        basicHtmlStrip(
+          '<p>Hello <strong>daily.dev</strong></p><script>alert(1)</script><style>body { color: red; }</style><script',
+        ),
+      ).toEqual('Hello daily.dev');
+    });
+  });
+});

--- a/__tests__/webPush.ts
+++ b/__tests__/webPush.ts
@@ -1,0 +1,176 @@
+import {
+  disposeGraphQLTesting,
+  GraphQLTestClient,
+  GraphQLTestingState,
+  initializeGraphQLTesting,
+  MockContext,
+  saveFixtures,
+  testMutationErrorCode,
+} from './helpers';
+import createOrGetConnection from '../src/db';
+import { DataSource } from 'typeorm';
+import { Context } from '../src/Context';
+import { User } from '../src/entity';
+import { usersFixture } from './fixture/user';
+import * as OneSignal from '@onesignal/node-onesignal';
+
+const currentSubscriptionId = '11111111-1111-4111-8111-111111111111';
+const staleChromeSubscriptionId = '22222222-2222-4222-8222-222222222222';
+const staleFirefoxSubscriptionId = '33333333-3333-4333-8333-333333333333';
+const staleSafariLegacySubscriptionId = '55555555-5555-4555-8555-555555555555';
+const iosSubscriptionId = '44444444-4444-4444-8444-444444444444';
+
+const MUTATION = /* GraphQL */ `
+  mutation SyncWebPushSubscription($input: SyncWebPushSubscriptionInput!) {
+    syncWebPushSubscription(input: $input) {
+      cleanedUpSubscriptions
+    }
+  }
+`;
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+let loggedUser: string | undefined;
+let originalOneSignalAppId: string | undefined;
+let originalOneSignalApiKey: string | undefined;
+let originalOneSignalWebAppId: string | undefined;
+let originalOneSignalWebApiKey: string | undefined;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(
+    () => new MockContext(con, loggedUser) as unknown as Context,
+  );
+  client = state.client;
+  originalOneSignalAppId = process.env.ONESIGNAL_APP_ID;
+  originalOneSignalApiKey = process.env.ONESIGNAL_API_KEY;
+  originalOneSignalWebAppId = process.env.ONESIGNAL_WEB_APP_ID;
+  originalOneSignalWebApiKey = process.env.ONESIGNAL_WEB_API_KEY;
+});
+
+beforeEach(async () => {
+  loggedUser = undefined;
+  process.env.ONESIGNAL_APP_ID = '00000000-0000-4000-8000-000000000000';
+  process.env.ONESIGNAL_API_KEY = 'test-key';
+  process.env.ONESIGNAL_WEB_APP_ID = '99999999-9999-4999-8999-999999999999';
+  process.env.ONESIGNAL_WEB_API_KEY = 'test-web-key';
+  jest.restoreAllMocks();
+  await saveFixtures(con, User, usersFixture);
+});
+
+afterAll(async () => {
+  if (originalOneSignalAppId) {
+    process.env.ONESIGNAL_APP_ID = originalOneSignalAppId;
+  } else {
+    Reflect.deleteProperty(process.env, 'ONESIGNAL_APP_ID');
+  }
+
+  if (originalOneSignalApiKey) {
+    process.env.ONESIGNAL_API_KEY = originalOneSignalApiKey;
+  } else {
+    Reflect.deleteProperty(process.env, 'ONESIGNAL_API_KEY');
+  }
+
+  if (originalOneSignalWebAppId) {
+    process.env.ONESIGNAL_WEB_APP_ID = originalOneSignalWebAppId;
+  } else {
+    Reflect.deleteProperty(process.env, 'ONESIGNAL_WEB_APP_ID');
+  }
+
+  if (originalOneSignalWebApiKey) {
+    process.env.ONESIGNAL_WEB_API_KEY = originalOneSignalWebApiKey;
+  } else {
+    Reflect.deleteProperty(process.env, 'ONESIGNAL_WEB_API_KEY');
+  }
+
+  await disposeGraphQLTesting(state);
+});
+
+describe('mutation syncWebPushSubscription', () => {
+  it('should not authorize when not logged in', () =>
+    testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          input: {
+            subscriptionId: currentSubscriptionId,
+            origin: 'https://daily.dev',
+          },
+        },
+      },
+      'UNAUTHENTICATED',
+    ));
+
+  it('should delete stale web subscriptions only', async () => {
+    loggedUser = '1';
+    const fetchUserMock = jest
+      .spyOn(OneSignal.DefaultApi.prototype, 'fetchUser')
+      .mockResolvedValue({
+        subscriptions: [
+          { id: staleChromeSubscriptionId, type: 'ChromePush' },
+          { id: staleFirefoxSubscriptionId, type: 'FirefoxPush' },
+          { id: staleSafariLegacySubscriptionId, type: 'SafariLegacyPush' },
+          { id: iosSubscriptionId, type: 'iOSPush' },
+        ],
+      } as OneSignal.User);
+    const deleteSubscriptionMock = jest
+      .spyOn(OneSignal.DefaultApi.prototype, 'deleteSubscription')
+      .mockResolvedValue(undefined);
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        input: {
+          subscriptionId: currentSubscriptionId,
+          origin: 'daily.dev',
+        },
+      },
+    });
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({
+      syncWebPushSubscription: {
+        cleanedUpSubscriptions: 3,
+      },
+    });
+
+    expect(fetchUserMock).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000000',
+      'external_id',
+      '1',
+    );
+    expect(deleteSubscriptionMock.mock.calls.sort()).toEqual([
+      ['00000000-0000-4000-8000-000000000000', staleChromeSubscriptionId],
+      ['00000000-0000-4000-8000-000000000000', staleFirefoxSubscriptionId],
+      ['00000000-0000-4000-8000-000000000000', staleSafariLegacySubscriptionId],
+    ]);
+  });
+
+  it('should not call OneSignal cleanup when the subscription is opted out', async () => {
+    loggedUser = '1';
+    const fetchUserMock = jest.spyOn(
+      OneSignal.DefaultApi.prototype,
+      'fetchUser',
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        input: {
+          subscriptionId: currentSubscriptionId,
+          origin: 'https://daily.dev',
+          optedIn: false,
+        },
+      },
+    });
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({
+      syncWebPushSubscription: {
+        cleanedUpSubscriptions: 0,
+      },
+    });
+
+    expect(fetchUserMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/mailing.ts
+++ b/src/common/mailing.ts
@@ -30,6 +30,11 @@ import { GetUsersActiveState } from './googleCloud';
 import { logger } from '../logger';
 import { notificationFlagsSchema } from './schema/notificationFlagsSchema';
 import { DEFAULT_NOTIFICATION_SETTINGS } from '../notifications/common';
+export {
+  addNotificationEmailUtm,
+  addNotificationUtm,
+  basicHtmlStrip,
+} from './notificationUtils';
 
 export enum CioTransactionalMessageTemplateId {
   VerifyCompany = '51',
@@ -47,25 +52,6 @@ export enum CioTransactionalMessageTemplateId {
 }
 
 export const cioApi = new APIClient(process.env.CIO_APP_KEY);
-
-export const addNotificationUtm = (
-  url: string,
-  medium: string,
-  notificationType: string,
-): string => {
-  const urlObj = new URL(url);
-  urlObj.searchParams.append('utm_source', 'notification');
-  urlObj.searchParams.append('utm_medium', medium);
-  urlObj.searchParams.append('utm_campaign', notificationType);
-  return urlObj.toString();
-};
-
-export const addNotificationEmailUtm = (
-  url: string,
-  notificationType: string,
-): string => addNotificationUtm(url, 'email', notificationType);
-
-export const basicHtmlStrip = (html: string) => html.replace(/<[^>]*>?/gm, '');
 
 export const getFirstName = (name: string): string =>
   name?.split?.(' ')?.[0] ?? '';

--- a/src/common/notificationUtils.ts
+++ b/src/common/notificationUtils.ts
@@ -1,0 +1,25 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+export const addNotificationUtm = (
+  url: string,
+  medium: string,
+  notificationType: string,
+): string => {
+  const urlObj = new URL(url);
+  urlObj.searchParams.append('utm_source', 'notification');
+  urlObj.searchParams.append('utm_medium', medium);
+  urlObj.searchParams.append('utm_campaign', notificationType);
+  return urlObj.toString();
+};
+
+export const addNotificationEmailUtm = (
+  url: string,
+  notificationType: string,
+): string => addNotificationUtm(url, 'email', notificationType);
+
+export const basicHtmlStrip = (html: string): string => {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: [],
+    ALLOWED_ATTR: [],
+  });
+};

--- a/src/common/schema/webPush.ts
+++ b/src/common/schema/webPush.ts
@@ -1,0 +1,30 @@
+import z from 'zod';
+
+const normalizeOrigin = (origin: string): string => {
+  const normalized = origin.includes('://') ? origin : `https://${origin}`;
+  return new URL(normalized).origin;
+};
+
+export const syncWebPushSubscriptionSchema = z.object({
+  subscriptionId: z.uuid().optional(),
+  origin: z
+    .string()
+    .min(1)
+    .transform((origin, ctx) => {
+      try {
+        return normalizeOrigin(origin);
+      } catch {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Invalid origin',
+        });
+        return z.NEVER;
+      }
+    })
+    .optional(),
+  optedIn: z.boolean().default(true),
+});
+
+export type SyncWebPushSubscriptionInput = z.infer<
+  typeof syncWebPushSubscriptionSchema
+>;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -40,6 +40,7 @@ import * as userHotTake from './schema/userHotTake';
 import * as gear from './schema/gear';
 import * as userWorkspacePhoto from './schema/userWorkspacePhoto';
 import * as personalAccessTokens from './schema/personalAccessTokens';
+import * as webPush from './schema/webPush';
 import * as feedback from './schema/feedback';
 import * as sentiment from './schema/sentiment';
 import * as achievements from './schema/achievements';
@@ -107,6 +108,7 @@ export const schema = urlDirective.transformer(
                 gear.typeDefs,
                 userWorkspacePhoto.typeDefs,
                 personalAccessTokens.typeDefs,
+                webPush.typeDefs,
                 feedback.typeDefs,
                 sentiment.typeDefs,
                 achievements.typeDefs,
@@ -155,6 +157,7 @@ export const schema = urlDirective.transformer(
                   gear.resolvers,
                   userWorkspacePhoto.resolvers,
                   personalAccessTokens.resolvers,
+                  webPush.resolvers,
                   feedback.resolvers,
                   sentiment.resolvers,
                   achievements.resolvers,

--- a/src/onesignal.ts
+++ b/src/onesignal.ts
@@ -1,22 +1,167 @@
 import * as OneSignal from '@onesignal/node-onesignal';
-import { NotificationV2, NotificationAvatarV2 } from './entity';
-import { addNotificationUtm, basicHtmlStrip, mapCloudinaryUrl } from './common';
+import type { NotificationAvatarV2 } from './entity/notifications/NotificationAvatarV2';
+import type { NotificationV2 } from './entity/notifications/NotificationV2';
+import { mapCloudinaryUrl } from './common/cloudinary';
+import { addNotificationUtm, basicHtmlStrip } from './common/notificationUtils';
 import { escapeRegExp } from 'lodash';
 import { NotificationType } from './notifications/common';
 
-const appId = process.env.ONESIGNAL_APP_ID;
-const apiKey = process.env.ONESIGNAL_API_KEY;
 const safeCommentsPrefix = escapeRegExp(process.env.COMMENTS_PREFIX || '');
 
-const configuration = OneSignal.createConfiguration({
-  appKey: apiKey,
-});
-
-const client = new OneSignal.DefaultApi(configuration);
 const chromeWebBadge =
   'https://media.daily.dev/image/upload/v1672745846/public/dailydev.png';
 const chromeWebIcon =
   'https://media.daily.dev/image/upload/s--9vc188bS--/f_auto/v1712221649/1_smcxpz';
+const webPushSubscriptionTypes: ReadonlySet<OneSignal.SubscriptionObjectTypeEnum> =
+  new Set(['ChromePush', 'FirefoxPush', 'SafariLegacyPush', 'SafariPush']);
+
+type OneSignalApp = {
+  appId: string;
+  apiKey: string;
+};
+
+const clientByApiKey = new Map<string, OneSignal.DefaultApi>();
+
+const getOneSignalClient = (apiKey: string): OneSignal.DefaultApi => {
+  const existing = clientByApiKey.get(apiKey);
+  if (existing) return existing;
+
+  const client = new OneSignal.DefaultApi(
+    OneSignal.createConfiguration({ appKey: apiKey }),
+  );
+  clientByApiKey.set(apiKey, client);
+  return client;
+};
+
+const oneSignalApp = (
+  appId: string | undefined,
+  apiKey: string | undefined,
+): OneSignalApp | null => {
+  if (!appId || !apiKey) {
+    return null;
+  }
+
+  return { appId, apiKey };
+};
+
+const getOneSignalDeliveryApps = (): OneSignalApp[] => {
+  const primary = oneSignalApp(
+    process.env.ONESIGNAL_APP_ID,
+    process.env.ONESIGNAL_API_KEY,
+  );
+  if (!primary) {
+    return [];
+  }
+
+  const web = oneSignalApp(
+    process.env.ONESIGNAL_WEB_APP_ID,
+    process.env.ONESIGNAL_WEB_API_KEY,
+  );
+  if (!web || web.appId === primary.appId) {
+    return [primary];
+  }
+
+  return [primary, web];
+};
+
+const isNotFoundError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+
+  return (
+    ('code' in err && err.code === 404) ||
+    ('status' in err && err.status === 404)
+  );
+};
+
+const fetchOneSignalUser = async (
+  app: OneSignalApp,
+  userId: string,
+): Promise<OneSignal.User | null> => {
+  try {
+    return await getOneSignalClient(app.apiKey).fetchUser(
+      app.appId,
+      'external_id',
+      userId,
+    );
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return null;
+    }
+
+    throw err;
+  }
+};
+
+const deleteOneSignalSubscription = async (
+  app: OneSignalApp,
+  subscriptionId: string,
+): Promise<void> => {
+  try {
+    await getOneSignalClient(app.apiKey).deleteSubscription(
+      app.appId,
+      subscriptionId,
+    );
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      return;
+    }
+
+    throw err;
+  }
+};
+
+const sendToOneSignalApps = async (
+  createNotification: (appId: string) => OneSignal.Notification,
+): Promise<OneSignal.CreateNotificationSuccessResponse[]> => {
+  const apps = getOneSignalDeliveryApps();
+  if (!apps.length) {
+    return [];
+  }
+
+  return Promise.all(
+    apps.map((app) =>
+      getOneSignalClient(app.apiKey).createNotification(
+        createNotification(app.appId),
+      ),
+    ),
+  );
+};
+
+export const cleanupStaleOneSignalWebSubscriptions = async (
+  userId: string,
+): Promise<number> => {
+  const legacyApp = oneSignalApp(
+    process.env.ONESIGNAL_APP_ID,
+    process.env.ONESIGNAL_API_KEY,
+  );
+  const webApp = oneSignalApp(
+    process.env.ONESIGNAL_WEB_APP_ID,
+    process.env.ONESIGNAL_WEB_API_KEY,
+  );
+  if (!legacyApp || !webApp || webApp.appId === legacyApp.appId) {
+    return 0;
+  }
+
+  const oneSignalUser = await fetchOneSignalUser(legacyApp, userId);
+
+  if (!oneSignalUser?.subscriptions?.length) {
+    return 0;
+  }
+
+  const staleWebSubscriptions = oneSignalUser.subscriptions.filter(
+    ({ id, type }) => !!id && !!type && webPushSubscriptionTypes.has(type),
+  );
+
+  await Promise.all(
+    staleWebSubscriptions.map(({ id }) =>
+      deleteOneSignalSubscription(legacyApp, id!),
+    ),
+  );
+
+  return staleWebSubscriptions.length;
+};
 
 const pushHeadingMap: Partial<Record<NotificationType, string>> = {
   [NotificationType.ArticleNewComment]: 'New comment',
@@ -115,6 +260,7 @@ const getPushHeading = (type: string, title?: string): string => {
 type PushOpts = { increaseBadge?: boolean };
 
 function createPush(
+  appId: string,
   userIds: string[],
   url: string | undefined,
   notificationType: string,
@@ -123,6 +269,7 @@ function createPush(
   const push = new OneSignal.Notification();
   push.app_id = appId;
   push.include_external_user_ids = userIds;
+  push.channel_for_external_user_ids = 'push';
   push.chrome_web_badge = chromeWebBadge;
   push.chrome_web_icon = chromeWebIcon;
   if (opts?.increaseBadge) {
@@ -152,19 +299,21 @@ export async function sendPushNotification(
   avatar?: Pick<NotificationAvatarV2, 'image'>,
   sendAfter?: Date,
 ): Promise<void> {
-  if (!appId || !apiKey) return;
-
-  const push = createPush(userIds, targetUrl, type, { increaseBadge: true });
-  push.contents = { en: basicHtmlStrip(title) };
-  push.headings = { en: getPushHeading(type, title) };
-  push.data = { notificationId: id };
-  if (avatar) {
-    push.chrome_web_icon = mapCloudinaryUrl(avatar.image);
-  }
-  if (sendAfter) {
-    push.send_after = sendAfter.toISOString();
-  }
-  await client.createNotification(push);
+  await sendToOneSignalApps((appId) => {
+    const push = createPush(appId, userIds, targetUrl, type, {
+      increaseBadge: true,
+    });
+    push.contents = { en: basicHtmlStrip(title) };
+    push.headings = { en: getPushHeading(type, title) };
+    push.data = { notificationId: id };
+    if (avatar) {
+      push.chrome_web_icon = mapCloudinaryUrl(avatar.image);
+    }
+    if (sendAfter) {
+      push.send_after = sendAfter.toISOString();
+    }
+    return push;
+  });
 }
 
 const readingReminderHeadings = [
@@ -194,41 +343,45 @@ export async function sendReadingReminderPush(
   userIds: string[],
   at: Date,
 ): Promise<void> {
-  if (!appId || !apiKey) return;
-
   const seed = Math.floor(new Date().getTime() / 1000);
 
-  const push = createPush(
-    userIds,
-    `${process.env.COMMENTS_PREFIX}`,
-    'reminder',
-  );
-  push.send_after = at.toISOString();
-  push.contents = {
-    en: readingReminderContents[seed % readingReminderContents.length],
-  };
-  push.headings = {
-    en: readingReminderHeadings[seed % readingReminderHeadings.length],
-  };
-  await client.createNotification(push);
+  await sendToOneSignalApps((appId) => {
+    const push = createPush(
+      appId,
+      userIds,
+      `${process.env.COMMENTS_PREFIX}`,
+      'reminder',
+    );
+    push.send_after = at.toISOString();
+    push.contents = {
+      en: readingReminderContents[seed % readingReminderContents.length],
+    };
+    push.headings = {
+      en: readingReminderHeadings[seed % readingReminderHeadings.length],
+    };
+    return push;
+  });
 }
 
 export async function sendStreakReminderPush(
   userIds: string[],
 ): Promise<null | OneSignal.CreateNotificationSuccessResponse> {
-  if (!appId || !apiKey) return null;
-  const push = createPush(
-    userIds,
-    process.env.COMMENTS_PREFIX,
-    'streak_reminder',
-  );
-  push.contents = {
-    en: streakReminderContent,
-  };
-  push.headings = {
-    en: streakReminderHeading,
-  };
-  return await client.createNotification(push);
+  const responses = await sendToOneSignalApps((appId) => {
+    const push = createPush(
+      appId,
+      userIds,
+      process.env.COMMENTS_PREFIX,
+      'streak_reminder',
+    );
+    push.contents = {
+      en: streakReminderContent,
+    };
+    push.headings = {
+      en: streakReminderHeading,
+    };
+    return push;
+  });
+  return responses[0] ?? null;
 }
 
 export type GenericPushPayload = {
@@ -242,17 +395,20 @@ export const sendGenericPush = async (
   userIds: string[],
   notification: GenericPushPayload,
 ) => {
-  if (!appId || !apiKey) return null;
-  const push = createPush(
-    userIds,
-    notification.url,
-    notification.utm_campaign ?? 'generic',
-  );
-  push.contents = {
-    en: notification.body,
-  };
-  push.headings = {
-    en: notification.title,
-  };
-  return client.createNotification(push);
+  const responses = await sendToOneSignalApps((appId) => {
+    const push = createPush(
+      appId,
+      userIds,
+      notification.url,
+      notification.utm_campaign ?? 'generic',
+    );
+    push.contents = {
+      en: notification.body,
+    };
+    push.headings = {
+      en: notification.title,
+    };
+    return push;
+  });
+  return responses[0] ?? null;
 };

--- a/src/schema/webPush.ts
+++ b/src/schema/webPush.ts
@@ -1,0 +1,64 @@
+import { IResolvers } from '@graphql-tools/utils';
+import { AuthContext, BaseContext } from '../Context';
+import {
+  syncWebPushSubscriptionSchema,
+  type SyncWebPushSubscriptionInput,
+} from '../common/schema/webPush';
+import { cleanupStaleOneSignalWebSubscriptions } from '../onesignal';
+
+type GQLSyncWebPushSubscriptionResult = {
+  cleanedUpSubscriptions: number;
+};
+
+export const typeDefs = /* GraphQL */ `
+  input SyncWebPushSubscriptionInput {
+    subscriptionId: ID
+    origin: String
+    optedIn: Boolean = true
+  }
+
+  type SyncWebPushSubscriptionResult {
+    cleanedUpSubscriptions: Int!
+  }
+
+  extend type Mutation {
+    syncWebPushSubscription(
+      input: SyncWebPushSubscriptionInput
+    ): SyncWebPushSubscriptionResult! @auth
+  }
+`;
+
+export const resolvers: IResolvers<unknown, BaseContext> = {
+  Mutation: {
+    syncWebPushSubscription: async (
+      _,
+      args: { input?: SyncWebPushSubscriptionInput },
+      ctx: AuthContext,
+    ): Promise<GQLSyncWebPushSubscriptionResult> => {
+      const input = syncWebPushSubscriptionSchema.parse(args.input ?? {});
+
+      if (!input.optedIn) {
+        return { cleanedUpSubscriptions: 0 };
+      }
+
+      try {
+        const cleanedUpSubscriptions =
+          await cleanupStaleOneSignalWebSubscriptions(ctx.userId);
+
+        return { cleanedUpSubscriptions };
+      } catch (err) {
+        ctx.log.error(
+          {
+            err,
+            userId: ctx.userId,
+            subscriptionId: input.subscriptionId,
+            origin: input.origin,
+          },
+          'failed to clean up stale OneSignal web subscriptions',
+        );
+
+        return { cleanedUpSubscriptions: 0 };
+      }
+    },
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ declare global {
       COOKIES_KEY: string;
       ONESIGNAL_APP_ID: string;
       ONESIGNAL_API_KEY: string;
+      ONESIGNAL_WEB_APP_ID?: string;
+      ONESIGNAL_WEB_API_KEY?: string;
       REDIS_HOST: string;
       REDIS_PORT: string;
       PERSONALIZED_DIGEST_FEED: string;


### PR DESCRIPTION
## Summary
- add authenticated web push sync mutation to clean stale legacy OneSignal web subscriptions
- send push notifications to the legacy app and the new web app when configured
- add encrypted production config entries for the new OneSignal web app
- extract lightweight notification URL/body helpers to avoid importing the full common mailing surface from push code

## Validation
- pnpm exec prettier --write src/common/notificationUtils.ts src/common/mailing.ts src/common/schema/webPush.ts src/schema/webPush.ts src/onesignal.ts src/graphql.ts src/types.ts __tests__/webPush.ts
- pnpm exec eslint src/common/notificationUtils.ts src/common/mailing.ts src/common/schema/webPush.ts src/schema/webPush.ts src/onesignal.ts src/graphql.ts src/types.ts __tests__/webPush.ts --max-warnings 0
- git diff --check

## Notes
- __tests__/webPush.ts requires local Redis on 127.0.0.1:6379 and was not rerun successfully in this environment
- pnpm run build is currently blocked by an unrelated @dailydotdev/schema missing export for HighlightsCanonicalPublishedMessage
