### PR TITLE
fix(achievements): sync click and subscription progress

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -127,6 +127,10 @@ export const crons: Cron[] = [
     schedule: '2-59/15 * * * *',
   },
   {
+    name: 'subscription-anniversary-achievements',
+    schedule: '30 3 1 * *',
+  },
+  {
     name: 'post-analytics-history-day-clickhouse',
     schedule: '3-59/5 * * * *',
   },

--- a/__tests__/cron/postAnalyticsAchievements.ts
+++ b/__tests__/cron/postAnalyticsAchievements.ts
@@ -126,7 +126,14 @@ describe('postAnalyticsAchievements cron', () => {
   it('should sync analytics achievements for authors with recent analytics changes', async () => {
     await con.getRepository(PostAnalytics).save([
       { id: 'paa-article', impressions: 700, impressionsAds: 300, clicks: 0 },
-      { id: 'paa-share', impressions: 0, impressionsAds: 0, clicks: 5 },
+      {
+        id: 'paa-share',
+        impressions: 0,
+        impressionsAds: 0,
+        clicks: 0,
+        clicksAds: 2,
+        goToLink: 3,
+      },
     ]);
 
     await expectSuccessfulCron(cron);

--- a/__tests__/cron/subscriptionAnniversaryAchievements.ts
+++ b/__tests__/cron/subscriptionAnniversaryAchievements.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from 'crypto';
+import { addMonths, subMonths } from 'date-fns';
+import type { DataSource } from 'typeorm';
+import { subscriptionAnniversaryAchievementsCron as cron } from '../../src/cron/subscriptionAnniversaryAchievements';
+import { crons } from '../../src/cron/index';
+import createOrGetConnection from '../../src/db';
+import {
+  Achievement,
+  AchievementEventType,
+  AchievementType,
+} from '../../src/entity/Achievement';
+import { User } from '../../src/entity/user/User';
+import { UserAchievement } from '../../src/entity/user/UserAchievement';
+import { SubscriptionStatus } from '../../src/common/plus/subscription';
+import { SubscriptionCycles } from '../../src/paddle';
+import { expectSuccessfulCron, saveFixtures } from '../helpers';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+const achievementId = randomUUID();
+const activeUserId = randomUUID();
+const giftedUserId = randomUUID();
+const hackathonUserId = randomUUID();
+const cancelledUserId = randomUUID();
+const missingCreatedAtUserId = randomUUID();
+
+beforeEach(async () => {
+  await con.getRepository(Achievement).save({
+    id: achievementId,
+    name: 'Subscription Anniversary Achievement',
+    description: 'Stay subscribed to Plus for 12 months',
+    image: '',
+    type: AchievementType.Milestone,
+    eventType: AchievementEventType.SubscriptionAnniversary,
+    criteria: { targetCount: 12 },
+    points: 10,
+  });
+
+  await saveFixtures(con, User, [
+    {
+      id: activeUserId,
+      name: 'Active Plus',
+      email: `active-plus-${activeUserId}@daily.dev`,
+      username: `active${activeUserId.slice(0, 8)}`,
+      infoConfirmed: true,
+      subscriptionFlags: {
+        cycle: SubscriptionCycles.Monthly,
+        createdAt: subMonths(new Date(), 2),
+        status: SubscriptionStatus.Active,
+      },
+    },
+    {
+      id: giftedUserId,
+      name: 'Gifted Plus',
+      email: `gifted-plus-${giftedUserId}@daily.dev`,
+      username: `gifted${giftedUserId.slice(0, 8)}`,
+      infoConfirmed: true,
+      subscriptionFlags: {
+        cycle: SubscriptionCycles.Yearly,
+        createdAt: subMonths(new Date(), 3),
+        giftExpirationDate: addMonths(new Date(), 1),
+        gifterId: activeUserId,
+        status: SubscriptionStatus.Active,
+      },
+    },
+    {
+      id: hackathonUserId,
+      name: 'Hackathon Plus',
+      email: `hackathon-plus-${hackathonUserId}@daily.dev`,
+      username: `hack${hackathonUserId.slice(0, 8)}`,
+      infoConfirmed: true,
+      subscriptionFlags: {
+        cycle: 'hackathon' as SubscriptionCycles,
+        createdAt: subMonths(new Date(), 13),
+        status: SubscriptionStatus.Active,
+      },
+    },
+    {
+      id: cancelledUserId,
+      name: 'Cancelled Plus',
+      email: `cancelled-plus-${cancelledUserId}@daily.dev`,
+      username: `cancel${cancelledUserId.slice(0, 8)}`,
+      infoConfirmed: true,
+      subscriptionFlags: {
+        cycle: SubscriptionCycles.Monthly,
+        createdAt: subMonths(new Date(), 4),
+        status: SubscriptionStatus.Cancelled,
+      },
+    },
+    {
+      id: missingCreatedAtUserId,
+      name: 'Missing Created At Plus',
+      email: `missing-created-at-plus-${missingCreatedAtUserId}@daily.dev`,
+      username: `missing${missingCreatedAtUserId.slice(0, 8)}`,
+      infoConfirmed: true,
+      subscriptionFlags: {
+        cycle: SubscriptionCycles.Monthly,
+        status: SubscriptionStatus.Active,
+      },
+    },
+  ]);
+});
+
+describe('subscriptionAnniversaryAchievements cron', () => {
+  it('should be registered', () => {
+    const registeredCron = crons.find((item) => item.name === cron.name);
+
+    expect(registeredCron).toBeDefined();
+  });
+
+  it('should sync active subscription anniversary progress', async () => {
+    await expectSuccessfulCron(cron);
+
+    const progress = await con.getRepository(UserAchievement).find({
+      where: { achievementId },
+      order: { userId: 'ASC' },
+    });
+
+    expect(progress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: activeUserId,
+          achievementId,
+          progress: 2,
+          unlockedAt: null,
+        }),
+        expect.objectContaining({
+          userId: giftedUserId,
+          achievementId,
+          progress: 3,
+          unlockedAt: null,
+        }),
+        expect.objectContaining({
+          userId: hackathonUserId,
+          achievementId,
+          progress: 13,
+          unlockedAt: expect.any(Date),
+        }),
+      ]),
+    );
+    expect(progress).toHaveLength(3);
+  });
+});

--- a/src/common/achievement/retroactive.ts
+++ b/src/common/achievement/retroactive.ts
@@ -1,13 +1,16 @@
 import { differenceInMonths } from 'date-fns';
 import type { FastifyBaseLogger } from 'fastify';
-import type { DataSource, EntityManager } from 'typeorm';
+import { In, type DataSource, type EntityManager } from 'typeorm';
 import { Achievement, AchievementEventType } from '../../entity/Achievement';
 import { updateUserAchievementProgress } from './index';
+import { SubscriptionStatus } from '../plus/subscription';
 type ProgressMap = Map<string, number>;
 type RetroactiveHandler = (
   con: DataSource | EntityManager,
   userIds: string[],
 ) => Promise<ProgressMap>;
+
+const sharePostClicksExpression = `GREATEST(pa.clicks + pa."clicksAds" + pa."goToLink", 0)`;
 
 interface SyncUsersRetroactiveAchievementsParams {
   con: DataSource | EntityManager;
@@ -219,7 +222,9 @@ const handleShareClick: RetroactiveHandler = async (con, userIds) => {
     `SELECT DISTINCT p."authorId" AS "userId"
      FROM post p
      JOIN post_analytics pa ON pa.id = p.id
-     WHERE p."authorId" = ANY($1) AND p.type = 'share' AND pa.clicks > 0`,
+     WHERE p."authorId" = ANY($1)
+       AND p.type = 'share'
+       AND ${sharePostClicksExpression} > 0`,
     [userIds],
   );
 
@@ -443,8 +448,10 @@ const handleSubscriptionAnniversary: RetroactiveHandler = async (
   const rows: { userId: string; createdAt: string }[] = await con.query(
     `SELECT id AS "userId", "subscriptionFlags"->>'createdAt' AS "createdAt"
      FROM "user"
-     WHERE id = ANY($1) AND "subscriptionFlags"->>'createdAt' IS NOT NULL`,
-    [userIds],
+     WHERE id = ANY($1)
+       AND "subscriptionFlags"->>'createdAt' IS NOT NULL
+       AND "subscriptionFlags"->>'status' = $2`,
+    [userIds, SubscriptionStatus.Active],
   );
 
   const map: ProgressMap = new Map();
@@ -490,7 +497,7 @@ const handlePostImpressions: RetroactiveHandler = async (con, userIds) => {
 
 const handleShareClickMilestone: RetroactiveHandler = async (con, userIds) => {
   const rows = await con.query(
-    `SELECT p."authorId" AS "userId", MAX(pa.clicks)::int AS count
+    `SELECT p."authorId" AS "userId", MAX(${sharePostClicksExpression})::int AS count
      FROM post p
      JOIN post_analytics pa ON pa.id = p.id
      WHERE p."authorId" = ANY($1) AND p.type = 'share'
@@ -506,7 +513,9 @@ const handleSharePostsClicked: RetroactiveHandler = async (con, userIds) => {
     `SELECT p."authorId" AS "userId", COUNT(*)::int AS count
      FROM post p
      JOIN post_analytics pa ON pa.id = p.id
-     WHERE p."authorId" = ANY($1) AND p.type = 'share' AND pa.clicks > 0
+     WHERE p."authorId" = ANY($1)
+       AND p.type = 'share'
+       AND ${sharePostClicksExpression} > 0
      GROUP BY p."authorId"`,
     [userIds],
   );
@@ -590,7 +599,10 @@ export const syncUsersRetroactiveAchievements = async ({
     };
   }
 
-  const allAchievements = await con.getRepository(Achievement).find();
+  const achievementRepo = con.getRepository(Achievement);
+  const allAchievements = eventTypes?.length
+    ? await achievementRepo.find({ where: { eventType: In(eventTypes) } })
+    : await achievementRepo.find();
   const achievementsByEventType = new Map<
     AchievementEventType,
     Achievement[]

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -42,6 +42,7 @@ import updateTagMaterializedViews from './updateTagMaterializedViews';
 import { materializeMonthlyBestPostArchives } from './materializeMonthlyBestPostArchives';
 import { materializeYearlyBestPostArchives } from './materializeYearlyBestPostArchives';
 import cleanOldNotifications from './cleanOldNotifications';
+import { subscriptionAnniversaryAchievementsCron } from './subscriptionAnniversaryAchievements';
 
 export const crons: Cron[] = [
   updateViews,
@@ -87,4 +88,5 @@ export const crons: Cron[] = [
   materializeMonthlyBestPostArchives,
   materializeYearlyBestPostArchives,
   cleanOldNotifications,
+  subscriptionAnniversaryAchievementsCron,
 ];

--- a/src/cron/subscriptionAnniversaryAchievements.ts
+++ b/src/cron/subscriptionAnniversaryAchievements.ts
@@ -1,0 +1,56 @@
+import { Cron } from './cron';
+import { User } from '../entity/user/User';
+import { Achievement, AchievementEventType } from '../entity/Achievement';
+import { syncUsersRetroactiveAchievements } from '../common/achievement/retroactive';
+import { processStreamInBatches } from '../common/streaming';
+import { SubscriptionStatus } from '../common/plus/subscription';
+import { UserAchievement } from '../entity/user/UserAchievement';
+
+const batchSize = 500;
+const concurrency = 3;
+const subscriptionMonthsExpression = `DATE_PART('year', AGE(NOW(), (u."subscriptionFlags"->>'createdAt')::timestamptz)) * 12 + DATE_PART('month', AGE(NOW(), (u."subscriptionFlags"->>'createdAt')::timestamptz))`;
+
+export const subscriptionAnniversaryAchievementsCron: Cron = {
+  name: 'subscription-anniversary-achievements',
+  handler: async (con, logger) => {
+    const stream = await con
+      .getRepository(User)
+      .createQueryBuilder('u')
+      .select('u.id', 'userId')
+      .distinct(true)
+      .innerJoin(Achievement, 'a', 'a."eventType" = :eventType', {
+        eventType: AchievementEventType.SubscriptionAnniversary,
+      })
+      .leftJoin(
+        UserAchievement,
+        'ua',
+        'ua."userId" = u.id AND ua."achievementId" = a.id',
+      )
+      .where(`u."subscriptionFlags"->>'createdAt' IS NOT NULL`)
+      .andWhere(`u."subscriptionFlags"->>'status' = :status`, {
+        status: SubscriptionStatus.Active,
+      })
+      .andWhere(`${subscriptionMonthsExpression} > 0`)
+      .andWhere(`ua."unlockedAt" IS NULL`)
+      .andWhere(
+        `(ua."achievementId" IS NULL OR ua.progress < ${subscriptionMonthsExpression})`,
+      )
+      .stream();
+
+    await processStreamInBatches<{ userId: string }>(
+      stream,
+      async (batch) => {
+        await con.transaction((manager) =>
+          syncUsersRetroactiveAchievements({
+            con: manager,
+            logger,
+            userIds: batch.map((row) => row.userId),
+            eventTypes: [AchievementEventType.SubscriptionAnniversary],
+          }),
+        );
+      },
+      concurrency,
+      batchSize,
+    );
+  },
+};


### PR DESCRIPTION
## What changed

- Align share-click achievement progress with the analytics click definition by counting `clicks + clicksAds + goToLink`.
- Add a monthly `subscription-anniversary-achievements` cron that recomputes anniversary progress for active subscriptions with `subscriptionFlags.createdAt`.
- Scope retroactive achievement sync queries to requested event types when provided.
- Add cron coverage for combined share-click metrics and active subscription anniversary progress, including gifted and hackathon subscriptions.

## Why

Users could see 100+ clicks in analytics while the Hot Topic achievement remained stuck because achievements only read `post_analytics.clicks`. Subscription anniversary progress also did not advance monthly because the existing CDC path only checked the achievement once users reached 12 months.

## Validation

- `NODE_ENV=test npx jest __tests__/cron/postAnalyticsAchievements.ts __tests__/cron/subscriptionAnniversaryAchievements.ts --testEnvironment=node --runInBand`
- `npx eslint src/common/achievement/retroactive.ts src/cron/subscriptionAnniversaryAchievements.ts __tests__/cron/postAnalyticsAchievements.ts __tests__/cron/subscriptionAnniversaryAchievements.ts --ext .ts --max-warnings 0`
- `git diff --check`
