### PR TITLE
fix(achievements): exclude tag-chip seeded feeds from FeedCreate

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1209,7 +1209,7 @@ describe('feed', () => {
     feedAchievementId = randomUUID();
     await con.getRepository(Achievement).save({
       id: feedAchievementId,
-      name: 'Power user',
+      name: 'Power user (cdc feed test)',
       description: 'Create a custom feed',
       image: '',
       type: AchievementType.Instant,

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1202,7 +1202,7 @@ describe('feed', () => {
     id: 'custom-feed-1',
     userId: feedUserId,
     createdAt: 0,
-    flags: {},
+    flags: '{}',
   } as unknown as ChangeObject<ObjectType>;
 
   beforeEach(async () => {
@@ -1255,7 +1255,10 @@ describe('feed', () => {
     await expectSuccessfulBackground(
       worker,
       mockChangeMessage<ObjectType>({
-        after: { ...baseFeed, flags: { origin: FeedOrigin.TagChip } },
+        after: {
+          ...baseFeed,
+          flags: JSON.stringify({ origin: FeedOrigin.TagChip }),
+        },
         table: 'feed',
         op: 'c',
       }),

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -27,6 +27,7 @@ import {
   Feature,
   FeatureType,
   Feed,
+  FeedOrigin,
   FREEFORM_POST_MINIMUM_CHANGE_LENGTH,
   FREEFORM_POST_MINIMUM_CONTENT_LENGTH,
   FreeformPost,
@@ -1189,6 +1190,99 @@ describe('user', () => {
         await con.getRepository(SourceUser).countBy({ userId: '2' }),
       ).toEqual(0);
     });
+  });
+});
+
+describe('feed', () => {
+  type ObjectType = Feed;
+  const feedUserId = 'feed-achievement-user';
+  let feedAchievementId: string;
+
+  const baseFeed = {
+    id: 'custom-feed-1',
+    userId: feedUserId,
+    createdAt: 0,
+    flags: {},
+  } as unknown as ChangeObject<ObjectType>;
+
+  beforeEach(async () => {
+    feedAchievementId = randomUUID();
+    await con.getRepository(Achievement).save({
+      id: feedAchievementId,
+      name: 'Power user',
+      description: 'Create a custom feed',
+      image: '',
+      type: AchievementType.Instant,
+      eventType: AchievementEventType.FeedCreate,
+      criteria: { targetCount: 1 },
+      points: 10,
+    });
+
+    await saveFixtures(con, User, [
+      {
+        id: feedUserId,
+        bio: null,
+        name: 'Feed User',
+        image: 'https://daily.dev/feed-user.jpg',
+        email: `${feedUserId}@daily.dev`,
+        createdAt: new Date(),
+        username: 'feeduser',
+        infoConfirmed: true,
+      },
+    ]);
+  });
+
+  it('should unlock the create-custom-feed achievement on custom feed creation', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: { ...baseFeed },
+        table: 'feed',
+        op: 'c',
+      }),
+    );
+
+    const userAchievement = await con
+      .getRepository(UserAchievement)
+      .findOneBy({ achievementId: feedAchievementId, userId: feedUserId });
+
+    expect(userAchievement).not.toBeNull();
+    expect(userAchievement!.progress).toEqual(1);
+    expect(userAchievement!.unlockedAt).not.toBeNull();
+  });
+
+  it('should not progress the achievement for tag-chip seeded feeds', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: { ...baseFeed, flags: { origin: FeedOrigin.TagChip } },
+        table: 'feed',
+        op: 'c',
+      }),
+    );
+
+    const userAchievement = await con
+      .getRepository(UserAchievement)
+      .findOneBy({ achievementId: feedAchievementId, userId: feedUserId });
+
+    expect(userAchievement).toBeNull();
+  });
+
+  it('should not progress the achievement for the main feed', async () => {
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after: { ...baseFeed, id: feedUserId },
+        table: 'feed',
+        op: 'c',
+      }),
+    );
+
+    const userAchievement = await con
+      .getRepository(UserAchievement)
+      .findOneBy({ achievementId: feedAchievementId, userId: feedUserId });
+
+    expect(userAchievement).toBeNull();
   });
 });
 

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -2117,7 +2117,7 @@ describe('feed', () => {
     userId: '1',
     id: '1',
     slug: '1',
-    flags: {},
+    flags: '{}',
     createdAt: Date.now(),
   };
 

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -15,6 +15,7 @@ import {
   ContentImage,
   Feature,
   Feed,
+  FeedOrigin,
   FREEFORM_POST_MINIMUM_CHANGE_LENGTH,
   FREEFORM_POST_MINIMUM_CONTENT_LENGTH,
   FreeformPost,
@@ -1463,7 +1464,9 @@ const onFeedChange = async (
 
     // feed id differs from userId means custom feed
     const feed = data.payload.after!;
-    if (feed.id !== feed.userId) {
+    // skip tag-chip feeds seeded during onboarding so they don't auto-complete
+    // the "Create a custom feed" achievement on signup
+    if (feed.id !== feed.userId && feed.flags?.origin !== FeedOrigin.TagChip) {
       await checkAchievementProgress(
         con,
         logger,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1466,7 +1466,9 @@ const onFeedChange = async (
     // feed id differs from userId means custom feed
     const feed = data.payload.after!;
     // flags arrive as a JSON string from CDC
-    const feedFlags = JSON.parse(feed.flags || '{}') as FeedFlags;
+    const feedFlags = JSON.parse(
+      (feed.flags as unknown as string) || '{}',
+    ) as FeedFlags;
     // skip tag-chip feeds seeded during onboarding so they don't auto-complete
     // the "Create a custom feed" achievement on signup
     if (feed.id !== feed.userId && feedFlags.origin !== FeedOrigin.TagChip) {

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1465,12 +1465,8 @@ const onFeedChange = async (
 
     // feed id differs from userId means custom feed
     const feed = data.payload.after!;
-    const rawFlags = feed.flags;
-    const feedFlags = (
-      typeof rawFlags === 'string'
-        ? JSON.parse(rawFlags || '{}')
-        : rawFlags || {}
-    ) as FeedFlags;
+    // flags arrive as a JSON string from CDC
+    const feedFlags = JSON.parse(feed.flags || '{}') as FeedFlags;
     // skip tag-chip feeds seeded during onboarding so they don't auto-complete
     // the "Create a custom feed" achievement on signup
     if (feed.id !== feed.userId && feedFlags.origin !== FeedOrigin.TagChip) {

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -15,6 +15,7 @@ import {
   ContentImage,
   Feature,
   Feed,
+  type FeedFlags,
   FeedOrigin,
   FREEFORM_POST_MINIMUM_CHANGE_LENGTH,
   FREEFORM_POST_MINIMUM_CONTENT_LENGTH,
@@ -1464,9 +1465,15 @@ const onFeedChange = async (
 
     // feed id differs from userId means custom feed
     const feed = data.payload.after!;
+    const rawFlags = feed.flags;
+    const feedFlags = (
+      typeof rawFlags === 'string'
+        ? JSON.parse(rawFlags || '{}')
+        : rawFlags || {}
+    ) as FeedFlags;
     // skip tag-chip feeds seeded during onboarding so they don't auto-complete
     // the "Create a custom feed" achievement on signup
-    if (feed.id !== feed.userId && feed.flags?.origin !== FeedOrigin.TagChip) {
+    if (feed.id !== feed.userId && feedFlags.origin !== FeedOrigin.TagChip) {
       await checkAchievementProgress(
         con,
         logger,


### PR DESCRIPTION
## Problem
On signup, `seedTagChipFeedsIfNeeded` auto-creates up to 5 **custom** feeds from the user's tag chips, each tagged `flags.origin = 'TAG_CHIP'`. The CDC `onFeedChange` handler fires the `FeedCreate` achievement event for any custom feed (`feed.id !== feed.userId`), and the "Power user / Create a custom feed" achievement is `instant` with `targetCount: 1`. Result: the quest auto-completes immediately at signup, before the user ever manually creates a feed.

Reported in #user-feedback: a fresh local signup instantly gets the "Power user / create custom feed" quest.

## Change
In `src/workers/cdc/primary.ts` `onFeedChange`, skip feeds with `flags.origin === FeedOrigin.TagChip` when triggering `checkAchievementProgress(FeedCreate)`. The quest now only progresses on a real, user-created custom feed.

## Scope / notes
- Trigger-side only, as requested. **No retroactive backfill change** — `handleFeedCreate` in `retroactive.ts` still counts all custom feeds.
- Users who already had the achievement auto-completed are **not** reverted by this change.
- No schema/migration changes.