### PR TITLE
feat(contributions): Slack notification on completed action

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -277,8 +277,8 @@ config:
       secure: AAABACoUzLQ6eGNpdjzl7sShD4BDSeSKJPtzdp9Ble0i3Mo3fh49v5dypv2VkcuXF2UH1dgaZlcCE6DhSBTrA/luWKc=
     onesignalWebApiKey:
       secure: AAABAPNWKCkjj4VNxfW9pxPksz2srCJuBaOfvxnyIRpnb/e7fBFUBIhTJjiZa8Kf2fAOFEqh1Xpioilpy6UrW//CFVHl5EEDtn+1U2K8Ig398ZbLwCYiJcsqj3m0NVnhs5tH/SUfHyiJBexftNuyAjE9KPW1UmyIeUpB4gTUMJG876JFVYqUY7a2XJFjGJ7a4Q==
-    SLACK_CONTRIBUTIONS_WEBHOOK:
-      secure: AAABAHV10o4ydqvS52/i2y/eeETUNWxA87FPEpZNp06icxF9ZJb9/YXSsHDXW0ZrKxrgRfUJqsQdf7uEZd+SqL9HH8LYMl4WpDoFQzwziG/xyPylrzjpP+AbXwq8ytMhlbhCdN12bBSMMb/6awihut0=
+    slackContributionsWebhook:
+      secure: AAABAOKNibr2AoUeSHJzmAyyNaOTqhvy/oDYDu1spT6YzFIUpPP32FbJqNJx6Y9AgoYrJksqY+H5PXMCT87RqKYyoqYXcktk4JQpGtWur8XEMAAEfLM55s3bQnF0hfmKgWQ17nk/CuF52K4ozY0rqnw=
   api:k8s:
     host: subs.daily.dev
     namespace: daily

--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -277,6 +277,8 @@ config:
       secure: AAABACoUzLQ6eGNpdjzl7sShD4BDSeSKJPtzdp9Ble0i3Mo3fh49v5dypv2VkcuXF2UH1dgaZlcCE6DhSBTrA/luWKc=
     onesignalWebApiKey:
       secure: AAABAPNWKCkjj4VNxfW9pxPksz2srCJuBaOfvxnyIRpnb/e7fBFUBIhTJjiZa8Kf2fAOFEqh1Xpioilpy6UrW//CFVHl5EEDtn+1U2K8Ig398ZbLwCYiJcsqj3m0NVnhs5tH/SUfHyiJBexftNuyAjE9KPW1UmyIeUpB4gTUMJG876JFVYqUY7a2XJFjGJ7a4Q==
+    SLACK_CONTRIBUTIONS_WEBHOOK:
+      secure: AAABAHV10o4ydqvS52/i2y/eeETUNWxA87FPEpZNp06icxF9ZJb9/YXSsHDXW0ZrKxrgRfUJqsQdf7uEZd+SqL9HH8LYMl4WpDoFQzwziG/xyPylrzjpP+AbXwq8ytMhlbhCdN12bBSMMb/6awihut0=
   api:k8s:
     host: subs.daily.dev
     namespace: daily

--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -260,6 +260,10 @@ export const workers: Worker[] = [
     subscription: 'api.contribution-action-completed-real-time',
   },
   {
+    topic: 'api.v1.contribution-action-completed',
+    subscription: 'api.contribution-action-completed-slack',
+  },
+  {
     topic: 'analytics-api.v1.experiment-allocated',
     subscription: 'api.experiment-allocated',
   },

--- a/__tests__/workers/contributionActionCompletedSlack.ts
+++ b/__tests__/workers/contributionActionCompletedSlack.ts
@@ -1,0 +1,139 @@
+import { DataSource } from 'typeorm';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
+import worker from '../../src/workers/contributionActionCompletedSlack';
+import createOrGetConnection from '../../src/db';
+import { webhooks } from '../../src/common/slack';
+import { ContributionAction } from '../../src/entity/contribution/ContributionAction';
+import { ContributionSubmissionStatus } from '../../src/entity/contribution/ContributionSubmission';
+import { User } from '../../src/entity/user/User';
+
+const mockSend = jest
+  .spyOn(webhooks.contributions, 'send')
+  .mockResolvedValue(undefined);
+
+let con: DataSource;
+
+const actionId = '5c1b1b1e-0000-4000-8000-000000000001';
+
+const baseSubmission = {
+  id: 'ca50b1e0-0000-4000-8000-000000000001',
+  userId: 'sc-user',
+  actionId,
+  paymentId: null,
+  evidence: JSON.stringify({
+    url: 'https://reddit.com/r/programming/x',
+    screenshotUrl: 'https://img.example.com/proof.png',
+    note: 'Shared the post',
+  }),
+  status: ContributionSubmissionStatus.Approved,
+  awardedPoints: 25,
+  flags: '{}',
+  reviewedAt: null,
+  reviewedBy: null,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await saveFixtures(con, User, [
+    { id: 'sc-user', username: 'scuser', name: 'SC User', reputation: 10 },
+  ]);
+  await saveFixtures(con, ContributionAction, [
+    { id: actionId, title: 'Post on Reddit', points: 25 },
+  ]);
+});
+
+afterEach(async () => {
+  await con.getRepository(ContributionAction).delete(actionId);
+  await con.getRepository(User).delete('sc-user');
+});
+
+describe('contributionActionCompletedSlack worker', () => {
+  it('should be registered', async () => {
+    const { typedWorkers } = await import('../../src/workers');
+    expect(
+      typedWorkers.find((item) => item.subscription === worker.subscription),
+    ).toBeDefined();
+  });
+
+  it('should send a notification with user, action and proof', async () => {
+    await expectSuccessfulTypedBackground<'api.v1.contribution-action-completed'>(
+      worker,
+      { submission: baseSubmission },
+    );
+
+    expect(mockSend).toHaveBeenCalledWith({
+      text: 'SC User completed "Post on Reddit"',
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: ':tada: Contribution action completed',
+            emoji: true,
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|SC User>`,
+            },
+            { type: 'mrkdwn', text: '*Action:*\nPost on Reddit' },
+            { type: 'mrkdwn', text: '*Points:*\n25' },
+          ],
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Proof*\n*URL:* <https://reddit.com/r/programming/x|link>\n*Note:* Shared the post',
+          },
+        },
+        {
+          type: 'image',
+          image_url: 'https://img.example.com/proof.png',
+          alt_text: 'Contribution proof screenshot',
+        },
+      ],
+    });
+  });
+
+  it('should omit proof section and image when evidence is empty', async () => {
+    await expectSuccessfulTypedBackground<'api.v1.contribution-action-completed'>(
+      worker,
+      { submission: { ...baseSubmission, evidence: '{}' } },
+    );
+
+    const { blocks } = mockSend.mock.calls[0][0] as {
+      blocks: { type: string }[];
+    };
+    expect(blocks.map((block) => block.type)).toEqual(['header', 'section']);
+  });
+
+  it('should not send when the user or action is missing', async () => {
+    await expectSuccessfulTypedBackground<'api.v1.contribution-action-completed'>(
+      worker,
+      { submission: { ...baseSubmission, userId: 'ghost' } },
+    );
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when the webhook send fails', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Slack error'));
+
+    await expectSuccessfulTypedBackground<'api.v1.contribution-action-completed'>(
+      worker,
+      { submission: baseSubmission },
+    );
+
+    expect(mockSend).toHaveBeenCalled();
+  });
+});

--- a/__tests__/workers/contributionActionCompletedSlack.ts
+++ b/__tests__/workers/contributionActionCompletedSlack.ts
@@ -1,6 +1,7 @@
 import { DataSource } from 'typeorm';
 import { expectSuccessfulTypedBackground, saveFixtures } from '../helpers';
 import worker from '../../src/workers/contributionActionCompletedSlack';
+import { typedWorkers } from '../../src/workers';
 import createOrGetConnection from '../../src/db';
 import { webhooks } from '../../src/common/slack';
 import { ContributionAction } from '../../src/entity/contribution/ContributionAction';
@@ -54,8 +55,7 @@ afterEach(async () => {
 });
 
 describe('contributionActionCompletedSlack worker', () => {
-  it('should be registered', async () => {
-    const { typedWorkers } = await import('../../src/workers');
+  it('should be registered', () => {
     expect(
       typedWorkers.find((item) => item.subscription === worker.subscription),
     ).toBeDefined();
@@ -115,6 +115,28 @@ describe('contributionActionCompletedSlack worker', () => {
       blocks: { type: string }[];
     };
     expect(blocks.map((block) => block.type)).toEqual(['header', 'section']);
+  });
+
+  it('should escape mrkdwn-breaking characters in user and evidence text', async () => {
+    await con.getRepository(User).update('sc-user', { name: 'Tom <& Jerry>' });
+
+    await expectSuccessfulTypedBackground<'api.v1.contribution-action-completed'>(
+      worker,
+      {
+        submission: {
+          ...baseSubmission,
+          evidence: JSON.stringify({ note: 'a <b> & c' }),
+        },
+      },
+    );
+
+    const { blocks } = mockSend.mock.calls[0][0] as {
+      blocks: { fields?: { text: string }[]; text?: { text: string } }[];
+    };
+    expect(blocks[1].fields?.[0].text).toBe(
+      `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|Tom &lt;&amp; Jerry&gt;>`,
+    );
+    expect(blocks[2].text?.text).toBe('*Proof*\n*Note:* a &lt;b&gt; &amp; c');
   });
 
   it('should not send when the user or action is missing', async () => {

--- a/__tests__/workers/contributionActionCompletedSlack.ts
+++ b/__tests__/workers/contributionActionCompletedSlack.ts
@@ -83,10 +83,14 @@ describe('contributionActionCompletedSlack worker', () => {
           fields: [
             {
               type: 'mrkdwn',
-              text: `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|SC User>`,
+              text: `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|SC User>\n\`sc-user\``,
             },
             { type: 'mrkdwn', text: '*Action:*\nPost on Reddit' },
             { type: 'mrkdwn', text: '*Points:*\n25' },
+            {
+              type: 'mrkdwn',
+              text: `*Submission:*\n\`${baseSubmission.id}\``,
+            },
           ],
         },
         {
@@ -134,7 +138,7 @@ describe('contributionActionCompletedSlack worker', () => {
       blocks: { fields?: { text: string }[]; text?: { text: string } }[];
     };
     expect(blocks[1].fields?.[0].text).toBe(
-      `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|Tom &lt;&amp; Jerry&gt;>`,
+      `*User:*\n<${process.env.COMMENTS_PREFIX}/scuser|Tom &lt;&amp; Jerry&gt;>\n\`sc-user\``,
     );
     expect(blocks[2].text?.text).toBe('*Proof*\n*Note:* a &lt;b&gt; &amp; c');
   });

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -52,6 +52,9 @@ export const webhooks = Object.freeze({
   userFeedback: process.env.SLACK_USER_FEEDBACK_WEBHOOK
     ? new IncomingWebhook(process.env.SLACK_USER_FEEDBACK_WEBHOOK)
     : nullWebhook,
+  contributions: process.env.SLACK_CONTRIBUTIONS_WEBHOOK
+    ? new IncomingWebhook(process.env.SLACK_CONTRIBUTIONS_WEBHOOK)
+    : nullWebhook,
 });
 
 export class SlackClient {

--- a/src/workers/contributionActionCompletedSlack.ts
+++ b/src/workers/contributionActionCompletedSlack.ts
@@ -1,20 +1,13 @@
 import type { Block, KnownBlock } from '@slack/web-api';
 import { contributionSubmissionEvidenceSchema } from '../common/schema/contributions';
 import { webhooks } from '../common/slack';
+import { getUserPermalink } from '../common/users';
 import { ContributionAction } from '../entity/contribution/ContributionAction';
 import { User } from '../entity/user/User';
 import { TypedWorker } from './worker';
 
-const parseEvidence = (evidence: string) => {
-  try {
-    const parsed = contributionSubmissionEvidenceSchema.safeParse(
-      JSON.parse(evidence),
-    );
-    return parsed.success ? parsed.data : {};
-  } catch {
-    return {};
-  }
-};
+const escapeSlack = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
 const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
   subscription: 'api.contribution-action-completed-slack',
@@ -45,9 +38,14 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
         return;
       }
 
-      const { url, screenshotUrl, note } = parseEvidence(submission.evidence);
-      const displayName = user.name || user.username || user.id;
-      const profileLink = `${process.env.COMMENTS_PREFIX}/${user.username ?? user.id}`;
+      const parsedEvidence = contributionSubmissionEvidenceSchema.safeParse(
+        JSON.parse(submission.evidence),
+      );
+      const { url, screenshotUrl, note } = parsedEvidence.success
+        ? parsedEvidence.data
+        : {};
+      const displayName = escapeSlack(user.name || user.username || user.id);
+      const title = escapeSlack(action.title);
 
       const blocks: (KnownBlock | Block)[] = [
         {
@@ -63,9 +61,9 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
           fields: [
             {
               type: 'mrkdwn',
-              text: `*User:*\n<${profileLink}|${displayName}>`,
+              text: `*User:*\n<${getUserPermalink(user)}|${displayName}>`,
             },
-            { type: 'mrkdwn', text: `*Action:*\n${action.title}` },
+            { type: 'mrkdwn', text: `*Action:*\n${title}` },
             { type: 'mrkdwn', text: `*Points:*\n${submission.awardedPoints}` },
           ],
         },
@@ -73,7 +71,7 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
 
       const proof = [
         url && `*URL:* <${url}|link>`,
-        note && `*Note:* ${note}`,
+        note && `*Note:* ${escapeSlack(note)}`,
       ].filter(Boolean);
       if (proof.length) {
         blocks.push({
@@ -90,7 +88,7 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
       }
 
       await webhooks.contributions.send({
-        text: `${displayName} completed "${action.title}"`,
+        text: `${displayName} completed "${title}"`,
         blocks,
       });
     } catch (err) {

--- a/src/workers/contributionActionCompletedSlack.ts
+++ b/src/workers/contributionActionCompletedSlack.ts
@@ -61,10 +61,11 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
           fields: [
             {
               type: 'mrkdwn',
-              text: `*User:*\n<${getUserPermalink(user)}|${displayName}>`,
+              text: `*User:*\n<${getUserPermalink(user)}|${displayName}>\n\`${user.id}\``,
             },
             { type: 'mrkdwn', text: `*Action:*\n${title}` },
             { type: 'mrkdwn', text: `*Points:*\n${submission.awardedPoints}` },
+            { type: 'mrkdwn', text: `*Submission:*\n\`${submission.id}\`` },
           ],
         },
       ];

--- a/src/workers/contributionActionCompletedSlack.ts
+++ b/src/workers/contributionActionCompletedSlack.ts
@@ -20,10 +20,14 @@ const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
 
     try {
       const [user, action] = await Promise.all([
-        con.getRepository(User).findOneBy({ id: submission.userId }),
-        con
-          .getRepository(ContributionAction)
-          .findOneBy({ id: submission.actionId }),
+        con.getRepository(User).findOne({
+          where: { id: submission.userId },
+          select: ['id', 'name', 'username'],
+        }),
+        con.getRepository(ContributionAction).findOne({
+          where: { id: submission.actionId },
+          select: ['id', 'title'],
+        }),
       ]);
 
       if (!user || !action) {

--- a/src/workers/contributionActionCompletedSlack.ts
+++ b/src/workers/contributionActionCompletedSlack.ts
@@ -1,0 +1,105 @@
+import type { Block, KnownBlock } from '@slack/web-api';
+import { contributionSubmissionEvidenceSchema } from '../common/schema/contributions';
+import { webhooks } from '../common/slack';
+import { ContributionAction } from '../entity/contribution/ContributionAction';
+import { User } from '../entity/user/User';
+import { TypedWorker } from './worker';
+
+const parseEvidence = (evidence: string) => {
+  try {
+    const parsed = contributionSubmissionEvidenceSchema.safeParse(
+      JSON.parse(evidence),
+    );
+    return parsed.success ? parsed.data : {};
+  } catch {
+    return {};
+  }
+};
+
+const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
+  subscription: 'api.contribution-action-completed-slack',
+  handler: async ({ data }, con, logger): Promise<void> => {
+    if (process.env.NODE_ENV === 'development') {
+      return;
+    }
+
+    const { submission } = data;
+
+    try {
+      const [user, action] = await Promise.all([
+        con.getRepository(User).findOneBy({ id: submission.userId }),
+        con
+          .getRepository(ContributionAction)
+          .findOneBy({ id: submission.actionId }),
+      ]);
+
+      if (!user || !action) {
+        logger.warn(
+          {
+            submissionId: submission.id,
+            userId: submission.userId,
+            actionId: submission.actionId,
+          },
+          'user or action not found for contribution slack notification',
+        );
+        return;
+      }
+
+      const { url, screenshotUrl, note } = parseEvidence(submission.evidence);
+      const displayName = user.name || user.username || user.id;
+      const profileLink = `${process.env.COMMENTS_PREFIX}/${user.username ?? user.id}`;
+
+      const blocks: (KnownBlock | Block)[] = [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: ':tada: Contribution action completed',
+            emoji: true,
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `*User:*\n<${profileLink}|${displayName}>`,
+            },
+            { type: 'mrkdwn', text: `*Action:*\n${action.title}` },
+            { type: 'mrkdwn', text: `*Points:*\n${submission.awardedPoints}` },
+          ],
+        },
+      ];
+
+      const proof = [
+        url && `*URL:* <${url}|link>`,
+        note && `*Note:* ${note}`,
+      ].filter(Boolean);
+      if (proof.length) {
+        blocks.push({
+          type: 'section',
+          text: { type: 'mrkdwn', text: `*Proof*\n${proof.join('\n')}` },
+        });
+      }
+      if (screenshotUrl) {
+        blocks.push({
+          type: 'image',
+          image_url: screenshotUrl,
+          alt_text: 'Contribution proof screenshot',
+        });
+      }
+
+      await webhooks.contributions.send({
+        text: `${displayName} completed "${action.title}"`,
+        blocks,
+      });
+    } catch (err) {
+      logger.error(
+        { submissionId: submission.id, err },
+        'failed to send contribution action completed slack message',
+      );
+    }
+  },
+};
+
+export default worker;

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -19,6 +19,7 @@ import cdcNotifications from './cdc/notifications';
 import newNotificationRealTime from './newNotificationV2RealTime';
 import newHighlightRealTime from './newHighlightRealTime';
 import contributionActionCompletedRealTime from './contributionActionCompletedRealTime';
+import contributionActionCompletedSlack from './contributionActionCompletedSlack';
 import newNotificationMail from './newNotificationV2Mail';
 import newNotificationPush from './newNotificationV2Push';
 import { workers as notificationWorkers } from './notifications';
@@ -179,6 +180,7 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   generateChannelDigest,
   newHighlightRealTime,
   contributionActionCompletedRealTime,
+  contributionActionCompletedSlack,
   userDeletionCleanup,
   liveRoomStartedWorker,
   liveRoomEndedWorker,


### PR DESCRIPTION
## What

Posts a Slack message to a dedicated channel whenever a contribution action is completed, showing the **user**, the **action + points**, and the submitted **proof**.

## How

A **second subscriber** to the existing `api.v1.contribution-action-completed` Pub/Sub topic (the foundation from #3967) — no changes to the CDC dispatcher or the existing real-time worker. The new `contributionActionCompletedSlack` worker fetches the user + action, parses the evidence, and posts via an incoming webhook.

Message: header + a fields section (User profile link, Action, Points), a Proof section (URL link, note), and the screenshot rendered as an image block.

## Changes

- `src/common/slack.ts` — new `webhooks.contributions` incoming webhook, gated on `SLACK_CONTRIBUTIONS_WEBHOOK` (falls back to a no-op webhook when unset, so it's safe before the secret is provisioned).
- `src/workers/contributionActionCompletedSlack.ts` — new `TypedWorker`; skips in development, swallows/logs send failures.
- `.infra/common.ts` — new subscription `api.contribution-action-completed-slack` on the same topic.
- `src/workers/index.ts` — registered in `typedWorkers`.
- Tests — user/action/proof message, empty-evidence (no proof/image blocks), missing user/action (no send), graceful webhook failure.

## Deploy note

Requires the `SLACK_CONTRIBUTIONS_WEBHOOK` secret in the prod stack config before it does anything:

```
pulumi config set --secret --path 'env.SLACK_CONTRIBUTIONS_WEBHOOK' '<webhook-url>' --stack prod
```

Until set, the worker no-ops (nullWebhook) — no errors.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `__tests__/workers/contributionActionCompletedSlack.ts`
- [x] `__tests__/workers/workers.ts` (worker↔infra consistency)