### PR TITLE
feat(contributions): global milestones

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -264,6 +264,10 @@ export const workers: Worker[] = [
     subscription: 'api.contribution-action-completed-slack',
   },
   {
+    topic: 'api.v1.contribution-action-completed',
+    subscription: 'api.contribution-action-completed-milestone',
+  },
+  {
     topic: 'analytics-api.v1.experiment-allocated',
     subscription: 'api.experiment-allocated',
   },

--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -42,6 +42,12 @@ import {
   UserTransactionType,
 } from '../src/entity/user/UserTransaction';
 import { remoteConfig } from '../src/remoteConfig';
+import { ContributionMilestone } from '../src/entity/contribution/ContributionMilestone';
+import {
+  CONTRIBUTION_LAST_MILESTONE_REDIS_KEY,
+  detectContributionMilestones,
+} from '../src/common/contribution';
+import { deleteRedisKey } from '../src/redis';
 
 let con: DataSource;
 let client: GraphQLTestClient;
@@ -168,6 +174,17 @@ query ContributionSponsors {
         tier
       }
     }
+  }
+}
+`;
+
+const CONTRIBUTION_LAST_MILESTONE_QUERY = `
+query ContributionLastReachedMilestone {
+  contributionLastReachedMilestone {
+    id
+    value
+    title
+    reachedAt
   }
 }
 `;
@@ -309,6 +326,8 @@ beforeEach(async () => {
     .delete()
     .from(ContributionActionCategory)
     .execute();
+  await con.createQueryBuilder().delete().from(ContributionMilestone).execute();
+  await deleteRedisKey(CONTRIBUTION_LAST_MILESTONE_REDIS_KEY);
   await con.getRepository(User).delete({ id: userId });
   await con.getRepository(User).delete({ id: blockedUserId });
 
@@ -852,4 +871,66 @@ it('exposes the sponsor wall to anonymous visitors', async () => {
       },
     },
   ]);
+});
+
+const firstMilestoneId = '66666666-6666-4666-8666-666666666661';
+const secondMilestoneId = '66666666-6666-4666-8666-666666666662';
+const thirdMilestoneId = '66666666-6666-4666-8666-666666666663';
+
+it('returns null for the last reached milestone when none crossed', async () => {
+  await saveFixtures(con, ContributionMilestone, [
+    { id: firstMilestoneId, value: 100, title: '100' },
+  ]);
+
+  const res = await client.query(CONTRIBUTION_LAST_MILESTONE_QUERY);
+
+  expect(res.errors).toBeUndefined();
+  expect(res.data.contributionLastReachedMilestone).toBeNull();
+});
+
+it('stamps crossed milestones once and exposes the highest reached', async () => {
+  await seedActions();
+  await saveFixtures(con, ContributionMilestone, [
+    { id: firstMilestoneId, value: 100, title: '100' },
+    { id: secondMilestoneId, value: 500, title: '500' },
+    { id: thirdMilestoneId, value: 1000, title: '1000' },
+  ]);
+  await saveFixtures(con, ContributionSubmission, [
+    {
+      userId,
+      actionId,
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: 300,
+    },
+    {
+      userId,
+      actionId,
+      status: ContributionSubmissionStatus.Approved,
+      awardedPoints: 300,
+    },
+  ]);
+
+  await detectContributionMilestones({ con: con.manager });
+
+  const stamped = await con
+    .getRepository(ContributionMilestone)
+    .find({ order: { value: 'ASC' } });
+  expect(
+    stamped.filter((m) => m.reachedAt !== null).map((m) => m.value),
+  ).toEqual([100, 500]);
+
+  const reachedAt = stamped.find((m) => m.value === 500)?.reachedAt;
+
+  // Re-running must not re-stamp an already-reached milestone.
+  await detectContributionMilestones({ con: con.manager });
+  const rerun = await con
+    .getRepository(ContributionMilestone)
+    .findOneByOrFail({ value: 500 });
+  expect(rerun.reachedAt).toEqual(reachedAt);
+
+  const last = await client.query(CONTRIBUTION_LAST_MILESTONE_QUERY);
+  expect(last.data.contributionLastReachedMilestone).toMatchObject({
+    value: 500,
+    title: '500',
+  });
 });

--- a/__tests__/routes/private/contributions.ts
+++ b/__tests__/routes/private/contributions.ts
@@ -10,6 +10,7 @@ import { ContributionActionCategory } from '../../../src/entity/contribution/Con
 import { ContributionActionLink } from '../../../src/entity/contribution/ContributionActionLink';
 import { ContributionBlockedUser } from '../../../src/entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../../../src/entity/contribution/ContributionCause';
+import { ContributionMilestone } from '../../../src/entity/contribution/ContributionMilestone';
 import {
   ContributionPayment,
   ContributionPaymentStatus,
@@ -334,6 +335,34 @@ describe('private contribution routes', () => {
 
     await request(app.server)
       .delete(`/p/contributions/links/${actionId}`)
+      .set(serviceAuthHeaders)
+      .expect(404);
+  });
+
+  it('creates and deletes milestones', async () => {
+    const { body: milestone } = await request(app.server)
+      .post('/p/contributions/milestones')
+      .set(serviceHeaders)
+      .send({ value: 500, title: '500 points' })
+      .expect(201);
+
+    expect(milestone).toMatchObject({
+      value: 500,
+      title: '500 points',
+      reachedAt: null,
+    });
+
+    await request(app.server)
+      .delete(`/p/contributions/milestones/${milestone.id}`)
+      .set(serviceAuthHeaders)
+      .expect(200);
+
+    await expect(
+      con.getRepository(ContributionMilestone).findOneBy({ id: milestone.id }),
+    ).resolves.toBeNull();
+
+    await request(app.server)
+      .delete(`/p/contributions/milestones/${milestone.id}`)
       .set(serviceAuthHeaders)
       .expect(404);
   });

--- a/src/common/contribution/index.ts
+++ b/src/common/contribution/index.ts
@@ -18,11 +18,29 @@ import {
 import { ContributionPaymentAllocation } from '../../entity/contribution/ContributionPaymentAllocation';
 import { ContributionSubmissionStatus } from '../../entity/contribution/ContributionSubmission';
 import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
+import { ContributionMilestone } from '../../entity/contribution/ContributionMilestone';
 import { UserContributionCausePreference } from '../../entity/contribution/UserContributionCausePreference';
 import { remoteConfig } from '../../remoteConfig';
+import { ONE_HOUR_IN_SECONDS } from '../constants';
+import { getRedisObject, setRedisObjectWithExpiry } from '../../redis';
 
 export const CONTRIBUTION_ACTION_COMPLETED_CHANNEL =
   'events.contributions.completed';
+
+// Cache for the single high-frequency polled endpoint (header gift icon). The
+// value only changes when detection stamps a new milestone, so the poll never
+// touches the DB. A short TTL bounds DB load if the cache is cold.
+export const CONTRIBUTION_LAST_MILESTONE_REDIS_KEY =
+  'contribution:last-milestone';
+// The cache is refreshed on every milestone write, so a long TTL is safe; it
+// only guards against a cold cache re-querying the DB on each poll.
+const CONTRIBUTION_LAST_MILESTONE_TTL_SECONDS = ONE_HOUR_IN_SECONDS;
+const CONTRIBUTION_LAST_MILESTONE_NONE = 'none';
+
+type CachedContributionMilestone = Pick<
+  ContributionMilestone,
+  'id' | 'value' | 'title' | 'reachedAt'
+>;
 
 const ACTIVE_STATUSES_FOR_LIMITS = [
   ContributionSubmissionStatus.Approved,
@@ -508,6 +526,76 @@ export const getLifetimeAmountCents = async ({
     .getRawOne<SumRow>();
 
   return toContributionInt(row?.sum);
+};
+
+const cacheLastReachedMilestone = (
+  milestone: CachedContributionMilestone | null,
+): Promise<unknown> =>
+  setRedisObjectWithExpiry(
+    CONTRIBUTION_LAST_MILESTONE_REDIS_KEY,
+    milestone ? JSON.stringify(milestone) : CONTRIBUTION_LAST_MILESTONE_NONE,
+    CONTRIBUTION_LAST_MILESTONE_TTL_SECONDS,
+  );
+
+const queryLastReachedMilestone = (
+  con: EntityManager,
+): Promise<CachedContributionMilestone | null> =>
+  con
+    .getRepository(ContributionMilestone)
+    .createQueryBuilder('milestone')
+    .select([
+      'milestone.id',
+      'milestone.value',
+      'milestone.title',
+      'milestone.reachedAt',
+    ])
+    .where('milestone."reachedAt" IS NOT NULL')
+    .orderBy('milestone.value', 'DESC')
+    .getOne();
+
+// The highest milestone the campaign has crossed, served from cache for the
+// high-frequency header poll. Falls back to the DB on a cold cache.
+export const getLastReachedMilestone = async ({
+  con,
+}: {
+  con: EntityManager;
+}): Promise<CachedContributionMilestone | null> => {
+  const cached = await getRedisObject(CONTRIBUTION_LAST_MILESTONE_REDIS_KEY);
+  if (cached === CONTRIBUTION_LAST_MILESTONE_NONE) {
+    return null;
+  }
+  if (cached) {
+    return JSON.parse(cached);
+  }
+
+  const milestone = await queryLastReachedMilestone(con);
+  await cacheLastReachedMilestone(milestone);
+
+  return milestone;
+};
+
+// Runs on each approved-submission event (low frequency). Sums lifetime
+// approved points, stamps any newly-crossed milestones exactly once, and
+// refreshes the polled cache when the last-reached milestone advances.
+export const detectContributionMilestones = async ({
+  con,
+}: {
+  con: EntityManager;
+}): Promise<void> => {
+  const total = await getApprovedPointsSum({ con });
+
+  const result = await con
+    .getRepository(ContributionMilestone)
+    .createQueryBuilder()
+    .update()
+    .set({ reachedAt: () => 'now()' })
+    .where('"reachedAt" IS NULL')
+    .andWhere('value <= :total', { total })
+    .execute();
+
+  if (result.affected) {
+    await cacheLastReachedMilestone(await queryLastReachedMilestone(con));
+  }
 };
 
 const getContributionActionUsage = async ({

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -190,6 +190,11 @@ export const contributionPrivateUpdateSponsorSchema = z.object({
   sortOrder: contributionSortOrderSchema,
 });
 
+export const contributionPrivateCreateMilestoneSchema = z.object({
+  value: z.number().int().positive(),
+  title: z.string().trim().min(1).nullish(),
+});
+
 export const contributionPrivateCreateRewardTierSchema = z.object({
   title: z.string().trim().min(1),
   description: z.string().trim().min(1).nullish(),

--- a/src/entity/contribution/ContributionMilestone.ts
+++ b/src/entity/contribution/ContributionMilestone.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+@Index('IDX_contribution_milestone_value', ['value'], { unique: true })
+export class ContributionMilestone {
+  @PrimaryGeneratedColumn('uuid', {
+    primaryKeyConstraintName: 'PK_contribution_milestone_id',
+  })
+  id: string;
+
+  @Column({ default: () => 'now()' })
+  createdAt: Date;
+
+  // The lifetime approved-points threshold this milestone represents.
+  @Column({ type: 'integer' })
+  value: number;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  title: string | null;
+
+  // Stamped once when the global lifetime points cross this threshold.
+  @Column({ type: 'timestamptz', nullable: true, default: null })
+  reachedAt: Date | null;
+}

--- a/src/entity/contribution/index.ts
+++ b/src/entity/contribution/index.ts
@@ -3,6 +3,7 @@ export * from './ContributionActionCategory';
 export * from './ContributionActionLink';
 export * from './ContributionBlockedUser';
 export * from './ContributionCause';
+export * from './ContributionMilestone';
 export * from './ContributionPayment';
 export * from './ContributionPaymentAllocation';
 export * from './ContributionRewardTier';

--- a/src/migration/1782982387878-AddContributionMilestone.ts
+++ b/src/migration/1782982387878-AddContributionMilestone.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddContributionMilestone1782982387878
+  implements MigrationInterface
+{
+  name = 'AddContributionMilestone1782982387878';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "contribution_milestone" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "value" integer NOT NULL,
+        "title" text,
+        "reachedAt" TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT "PK_contribution_milestone_id" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "IDX_contribution_milestone_value"
+        ON "contribution_milestone" ("value")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_contribution_milestone_value"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "contribution_milestone"`);
+  }
+}

--- a/src/routes/private/contributions.ts
+++ b/src/routes/private/contributions.ts
@@ -11,6 +11,7 @@ import {
   contributionPrivateCreateActionLinkSchema,
   contributionPrivateCreateActionSchema,
   contributionPrivateCreateCauseSchema,
+  contributionPrivateCreateMilestoneSchema,
   contributionPrivateCreateRewardTierSchema,
   contributionPrivateCreateSponsorSchema,
   contributionPrivateFinalizePaymentSchema,
@@ -34,6 +35,7 @@ import { ContributionActionCategory } from '../../entity/contribution/Contributi
 import { ContributionActionLink } from '../../entity/contribution/ContributionActionLink';
 import { ContributionBlockedUser } from '../../entity/contribution/ContributionBlockedUser';
 import { ContributionCause } from '../../entity/contribution/ContributionCause';
+import { ContributionMilestone } from '../../entity/contribution/ContributionMilestone';
 import { ContributionRewardTier } from '../../entity/contribution/ContributionRewardTier';
 import { ContributionSponsor } from '../../entity/contribution/ContributionSponsor';
 import { ContributionSubmission } from '../../entity/contribution/ContributionSubmission';
@@ -424,6 +426,50 @@ export default async (fastify: FastifyInstance): Promise<void> => {
 
     if (!result.affected) {
       return res.status(404).send({ error: 'Contribution sponsor not found' });
+    }
+
+    return res.status(200).send({ success: true });
+  });
+
+  fastify.post<{
+    Body: z.infer<typeof contributionPrivateCreateMilestoneSchema>;
+  }>('/milestones', async (req, res) => {
+    const body = parseSchema({
+      schema: contributionPrivateCreateMilestoneSchema,
+      value: req.body,
+      res,
+    });
+    if (!body) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const milestone = await con.getRepository(ContributionMilestone).save(body);
+
+    return res.status(201).send(milestone);
+  });
+
+  fastify.delete<{
+    Params: z.infer<typeof contributionPrivateIdParamsSchema>;
+  }>('/milestones/:id', async (req, res) => {
+    const params = parseSchema({
+      schema: contributionPrivateIdParamsSchema,
+      value: req.params,
+      res,
+    });
+    if (!params) {
+      return;
+    }
+
+    const con = await createOrGetConnection();
+    const result = await con
+      .getRepository(ContributionMilestone)
+      .delete(params.id);
+
+    if (!result.affected) {
+      return res
+        .status(404)
+        .send({ error: 'Contribution milestone not found' });
     }
 
     return res.status(200).send({ success: true });

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -11,6 +11,7 @@ import {
   getApprovedPointsSum,
   getContributionConfig,
   getContributionEligibility,
+  getLastReachedMilestone,
   getLifetimeAmountCents,
   parseContributionArgs,
   validateContributionActionLimits,
@@ -30,6 +31,7 @@ import { ContributionAction } from '../entity/contribution/ContributionAction';
 import { ContributionActionCategory } from '../entity/contribution/ContributionActionCategory';
 import { ContributionActionLink } from '../entity/contribution/ContributionActionLink';
 import { ContributionCause } from '../entity/contribution/ContributionCause';
+import { ContributionMilestone } from '../entity/contribution/ContributionMilestone';
 import {
   ContributionPayment,
   ContributionPaymentStatus,
@@ -334,6 +336,13 @@ export const typeDefs = /* GraphQL */ `
     edges: [ContributionSubmissionEdge!]!
   }
 
+  type ContributionMilestone {
+    id: ID!
+    value: Int!
+    title: String
+    reachedAt: DateTime
+  }
+
   type ContributionSponsor {
     id: ID!
     name: String!
@@ -409,6 +418,11 @@ export const typeDefs = /* GraphQL */ `
       first: Int
       after: String
     ): ContributionSponsorConnection!
+    """
+    The highest global milestone reached, served from cache for the header
+    gift-icon poll. Null until the first milestone is crossed.
+    """
+    contributionLastReachedMilestone: ContributionMilestone
   }
 
   extend type Mutation {
@@ -794,6 +808,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         },
       });
     },
+    contributionLastReachedMilestone: (
+      _,
+      __,
+      ctx: Context,
+    ): Promise<Pick<
+      ContributionMilestone,
+      'id' | 'value' | 'title' | 'reachedAt'
+    > | null> => getLastReachedMilestone({ con: ctx.con.manager }),
   },
   Mutation: {
     submitContributionAction: async (

--- a/src/workers/contributionMilestoneReached.ts
+++ b/src/workers/contributionMilestoneReached.ts
@@ -1,0 +1,11 @@
+import { detectContributionMilestones } from '../common/contribution';
+import { TypedWorker } from './worker';
+
+const worker: TypedWorker<'api.v1.contribution-action-completed'> = {
+  subscription: 'api.contribution-action-completed-milestone',
+  handler: async (_, con): Promise<void> => {
+    await detectContributionMilestones({ con: con.manager });
+  },
+};
+
+export default worker;

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -20,6 +20,7 @@ import newNotificationRealTime from './newNotificationV2RealTime';
 import newHighlightRealTime from './newHighlightRealTime';
 import contributionActionCompletedRealTime from './contributionActionCompletedRealTime';
 import contributionActionCompletedSlack from './contributionActionCompletedSlack';
+import contributionMilestoneReached from './contributionMilestoneReached';
 import newNotificationMail from './newNotificationV2Mail';
 import newNotificationPush from './newNotificationV2Push';
 import { workers as notificationWorkers } from './notifications';
@@ -181,6 +182,7 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   newHighlightRealTime,
   contributionActionCompletedRealTime,
   contributionActionCompletedSlack,
+  contributionMilestoneReached,
   userDeletionCleanup,
   liveRoomStartedWorker,
   liveRoomEndedWorker,


### PR DESCRIPTION
Adds DB-driven global milestones for the giveback launch. Pull-only (no broadcast) — the client polls the last reached milestone for the header gift-icon animation.

## What's included
- **`ContributionMilestone`** entity (`value` unique / `title` / `active` / `sortOrder` / `reachedAt`) + migration.
- **Detection** on the approved-submission event (`api.v1.contribution-action-completed`): sum lifetime approved points, idempotently stamp any crossed milestones (`UPDATE ... WHERE value <= :total AND reachedAt IS NULL`), refresh the poll cache. Low-frequency event, so no counter/cron and no drift.
- **`contributionLastReachedMilestone`** query — the single high-frequency poll, served from a tiny Redis cache (`contribution:last-milestone`, 60s TTL), deliberately kept out of the heavy `contributionStatus` aggregates.
- **Private admin CRUD** for milestones (`POST/PATCH/DELETE /contributions/milestones`).

## Notes
- Milestone metric = total approved points, lifetime. Thresholds are admin-managed, not hardcoded.
- Generated migration was cleaned to only the table + 2 indexes (`IF NOT EXISTS`, no `CONCURRENTLY`).

First of 3 PRs for the giveback launch (next: first-1k founding award; leaderboard + causes breakdown).