### PR TITLE
feat(posts): notify authors when scheduled posts go live

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -336,6 +336,10 @@ export const workers: Worker[] = [
     subscription: 'api.post-added-user-notification',
   },
   {
+    topic: 'api.v1.post-visible',
+    subscription: 'api.scheduled-post-published-notification',
+  },
+  {
     topic: 'api.v1.source-post-moderation-submitted',
     subscription: 'api.source-post-moderation-submitted-notification',
   },

--- a/__tests__/notifications/index.ts
+++ b/__tests__/notifications/index.ts
@@ -1558,6 +1558,28 @@ describe('storeNotificationBundle', () => {
     ]);
   });
 
+  it('should generate scheduled_post_published notification', () => {
+    const type = NotificationType.ScheduledPostPublished;
+    const ctx: NotificationSourceContext & NotificationPostContext = {
+      userIds: [userId],
+      source: sourcesFixture[0] as Reference<Source>,
+      post: postsFixture[0] as Reference<Post>,
+    };
+    const actual = generateNotificationV2(type, ctx);
+
+    expect(actual.notification.type).toEqual(type);
+    expect(actual.userIds).toEqual([userId]);
+    expect(actual.notification.public).toEqual(true);
+    expect(actual.notification.referenceId).toEqual('p1');
+    expect(actual.notification.referenceType).toEqual('post');
+    expect(actual.notification.title).toEqual(
+      'Your scheduled post is now <span class="text-theme-color-cabbage">live</span>',
+    );
+    expect(actual.notification.targetUrl).toEqual(
+      'http://localhost:5002/posts/p1',
+    );
+  });
+
   it('should generate source_post_submitted notification', async () => {
     const [, ...fixtures] = usersFixture;
     await con.getRepository(Source).save(sourcesFixture);

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1403,6 +1403,41 @@ describe('query post', () => {
     );
   });
 
+  it('should return own scheduled post before it is visible', async () => {
+    loggedUser = '1';
+    const scheduledAt = new Date(Date.now() + 60_000).toISOString();
+
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: loggedUser,
+        visible: false,
+        flags: { scheduledAt, visible: false },
+      },
+    );
+
+    const res = await client.query(QUERY('p1'));
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.post.id).toEqual('p1');
+  });
+
+  it('should not return another user scheduled post before it is visible', async () => {
+    loggedUser = '2';
+    const scheduledAt = new Date(Date.now() + 60_000).toISOString();
+
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        authorId: '1',
+        visible: false,
+        flags: { scheduledAt, visible: false },
+      },
+    );
+
+    return testQueryErrorCode(client, { query: QUERY('p1') }, 'NOT_FOUND');
+  });
+
   it('should throw error when user cannot access the post', async () => {
     loggedUser = '1';
     await con.getRepository(Source).update({ id: 'a' }, { private: true });

--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1409,6 +1409,7 @@ describe('post', () => {
     expect(notifyPostVisible).toHaveBeenCalledTimes(1);
     expect(jest.mocked(notifyPostVisible).mock.calls[0].slice(1)).toEqual([
       after,
+      base,
     ]);
   });
 

--- a/__tests__/workers/notifications.ts
+++ b/__tests__/workers/notifications.ts
@@ -79,6 +79,7 @@ import { SubmissionFailErrorKeys } from '../../src/errors';
 import { devCardUnlocked } from '../../src/workers/notifications/devCardUnlocked';
 import { postAdded } from '../../src/workers/notifications/postAdded';
 import { postMention } from '../../src/workers/notifications/postMention';
+import { scheduledPostPublishedNotification } from '../../src/workers/notifications/scheduledPostPublishedNotification';
 import { sourceMemberRoleChanged } from '../../src/workers/notifications/sourceMemberRoleChanged';
 import { sourceRequest } from '../../src/workers/notifications/sourceRequest';
 import { squadMemberJoined } from '../../src/workers/notifications/squadMemberJoined';
@@ -2794,6 +2795,54 @@ describe('user post added', () => {
         post,
       },
     );
+    expect(actual).toBeUndefined();
+  });
+});
+
+describe('scheduled post published', () => {
+  it('should notify the author when a scheduled post goes live', async () => {
+    const scheduledAt = new Date(Date.now() - 1_000).toISOString();
+    await con.getRepository(Post).update({ id: 'p1' }, { authorId: '1' });
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+    const changedPost = toChangeObject(post);
+
+    const actual = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+      scheduledPostPublishedNotification,
+      {
+        post: changedPost,
+        previousPost: {
+          ...changedPost,
+          flags: JSON.stringify({ scheduledAt, visible: false }),
+        },
+      },
+    );
+
+    expect(actual).toHaveLength(1);
+    if (!actual) {
+      throw new Error('Expected scheduled post notification');
+    }
+    expect(actual[0].type).toEqual(NotificationType.ScheduledPostPublished);
+    expect((actual[0].ctx as NotificationPostContext).post.id).toEqual('p1');
+    expect((actual[0].ctx as NotificationPostContext).source.id).toEqual('a');
+    expect(actual[0].ctx.userIds).toEqual(['1']);
+  });
+
+  it('should skip regular post-visible events', async () => {
+    await con.getRepository(Post).update({ id: 'p1' }, { authorId: '1' });
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+    const changedPost = toChangeObject(post);
+
+    const actual = await invokeTypedNotificationWorker<'api.v1.post-visible'>(
+      scheduledPostPublishedNotification,
+      {
+        post: changedPost,
+        previousPost: {
+          ...changedPost,
+          flags: JSON.stringify({ visible: false }),
+        },
+      },
+    );
+
     expect(actual).toBeUndefined();
   });
 });

--- a/src/common/pubsub.ts
+++ b/src/common/pubsub.ts
@@ -307,7 +307,12 @@ export const notifyFeatureAccess = async (
 export const notifyPostVisible = async (
   log: EventLogger,
   post: ChangeObject<Post>,
-): Promise<void> => publishEvent(log, postVisibleTopic, { post });
+  previousPost?: ChangeObject<Post>,
+): Promise<void> =>
+  publishEvent(log, postVisibleTopic, {
+    post,
+    ...(previousPost ? { previousPost } : {}),
+  });
 
 export const notifyBannerCreated = async (
   log: EventLogger,

--- a/src/common/schema/notificationFlagsSchema.ts
+++ b/src/common/schema/notificationFlagsSchema.ts
@@ -25,6 +25,7 @@ export const notificationFlagsSchema = z.object({
   [NotificationType.UserPostAdded]: notificationPreferenceSchema,
   [NotificationType.CollectionUpdated]: notificationPreferenceSchema,
   [NotificationType.PostBookmarkReminder]: notificationPreferenceSchema,
+  [NotificationType.ScheduledPostPublished]: notificationPreferenceSchema,
   [NotificationType.PromotedToAdmin]: notificationPreferenceSchema,
   [NotificationType.PromotedToModerator]: notificationPreferenceSchema,
   [NotificationType.DemotedToMember]: notificationPreferenceSchema,

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -149,6 +149,7 @@ export type PubSubSchema = {
   };
   'api.v1.post-visible': {
     post: ChangeObject<Post>;
+    previousPost?: ChangeObject<Post>;
   };
   'api.v1.squad-featured-updated': {
     squad: ChangeObject<SquadSource>;

--- a/src/notifications/common.ts
+++ b/src/notifications/common.ts
@@ -57,6 +57,7 @@ export enum NotificationType {
   SquadPublicRejected = 'squad_public_rejected',
   SquadPublicSubmitted = 'squad_public_submitted',
   PostBookmarkReminder = 'post_bookmark_reminder',
+  ScheduledPostPublished = 'scheduled_post_published',
   StreakResetRestore = 'streak_reset_restore',
   UserPostAdded = 'user_post_added',
   UserTopReaderBadge = 'user_given_top_reader',
@@ -203,6 +204,10 @@ export const DEFAULT_NOTIFICATION_SETTINGS: UserNotificationFlags = {
   },
   [NotificationType.PostBookmarkReminder]: {
     email: NotificationPreferenceStatus.Subscribed,
+    inApp: NotificationPreferenceStatus.Subscribed,
+  },
+  [NotificationType.ScheduledPostPublished]: {
+    email: NotificationPreferenceStatus.Muted,
     inApp: NotificationPreferenceStatus.Subscribed,
   },
   [NotificationType.PromotedToAdmin]: {
@@ -536,6 +541,7 @@ export const getUnreadNotificationsCount = async (
 enum UserNotificationUniqueKey {
   PostAdded = 'post_added',
   DigestReady = 'digest_ready',
+  ScheduledPostPublished = 'scheduled_post_published',
 }
 
 const notificationTypeToUniqueKey: Partial<
@@ -545,6 +551,8 @@ const notificationTypeToUniqueKey: Partial<
   [NotificationType.SourcePostAdded]: UserNotificationUniqueKey.PostAdded,
   [NotificationType.UserPostAdded]: UserNotificationUniqueKey.PostAdded,
   [NotificationType.DigestReady]: UserNotificationUniqueKey.DigestReady,
+  [NotificationType.ScheduledPostPublished]:
+    UserNotificationUniqueKey.ScheduledPostPublished,
 };
 
 const fixedUniqueKeyTypes = new Set<NotificationType>([

--- a/src/notifications/generate.ts
+++ b/src/notifications/generate.ts
@@ -134,6 +134,8 @@ export const notificationTitleMap: Record<
   dev_card_unlocked: () => 'Your DevCard is ready to generate',
   post_bookmark_reminder: (ctx: NotificationPostContext) =>
     `Reading reminder! <b>${getPostOrSharedPostTitle(ctx)}</b>`,
+  scheduled_post_published: () =>
+    `Your scheduled post is now <span class="text-theme-color-cabbage">live</span>`,
   source_post_added: (
     ctx: NotificationPostContext & NotificationDoneByContext,
   ) => `New post in <b>${ctx.source.name}</b>`,
@@ -314,6 +316,14 @@ export const generateNotificationMap: Record<
       .avatarSource(ctx.source)
       .uniqueKey(ctx.bookmark.remindAt.toString())
       .objectPost(ctx.post, ctx.source, ctx.sharedPost!),
+  scheduled_post_published: (
+    builder: NotificationBuilder,
+    ctx: NotificationPostContext,
+  ) =>
+    builder
+      .icon(NotificationIcon.Bell)
+      .objectPost(ctx.post, ctx.source, ctx.sharedPost!)
+      .uniqueKey(ctx.post.id),
   streak_reset_restore: (builder, ctx: NotificationStreakRestoreContext) =>
     builder
       .icon(NotificationIcon.Streak)

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -166,6 +166,7 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 import { PollPost } from '../entity/posts/PollPost';
 import type { LiveRoom } from '../entity/LiveRoom';
 import {
+  getPostScheduledAt,
   getScheduledPostFlags,
   validatePostScheduledAt,
 } from '../common/postScheduling';
@@ -2021,14 +2022,21 @@ const getPostById = async (
   ctx: Context,
   info: GraphQLResolveInfo,
   id: string,
+  includeInvisible = false,
 ): Promise<GQLPost> => {
-  const res = await graphorm.query<GQLPost>(ctx, info, (builder) => ({
-    ...builder,
-    queryBuilder: builder.queryBuilder.where(
-      `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false AND "${builder.alias}"."visible" = true`,
-      { id },
-    ),
-  }));
+  const res = await graphorm.query<GQLPost>(ctx, info, (builder) => {
+    const baseCondition = `"${builder.alias}"."id" = :id AND "${builder.alias}"."deleted" = false`;
+
+    return {
+      ...builder,
+      queryBuilder: builder.queryBuilder.where(
+        includeInvisible
+          ? baseCondition
+          : `${baseCondition} AND "${builder.alias}"."visible" = true`,
+        { id },
+      ),
+    };
+  });
   if (res.length) {
     return res[0];
   }
@@ -2113,7 +2121,15 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       info,
     ): Promise<GQLPost> => {
       const partialPost = await ctx.con.getRepository(Post).findOneOrFail({
-        select: ['id', 'sourceId', 'private', 'authorId', 'type'],
+        select: [
+          'id',
+          'sourceId',
+          'private',
+          'authorId',
+          'type',
+          'visible',
+          'flags',
+        ],
         relations: ['source'],
         where: [{ id }, { slug: id }],
       });
@@ -2143,6 +2159,19 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           throw permissionError;
         }
       }
+
+      const isOwnScheduledPost =
+        ctx.userId &&
+        partialPost.authorId === ctx.userId &&
+        !partialPost.visible &&
+        !!getPostScheduledAt(partialPost);
+
+      if (isOwnScheduledPost) {
+        return withInvisiblePosts(ctx as AuthContext, (graphormCtx) =>
+          getPostById(graphormCtx, info, partialPost.id, true),
+        );
+      }
+
       return getPostById(ctx, info, partialPost.id);
     },
     postByUrl: async (

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1193,7 +1193,11 @@ const onPostChange = async (
 
     if (data.payload.after!.visible) {
       if (!data.payload.before!.visible) {
-        await notifyPostVisible(logger, data.payload.after!);
+        await notifyPostVisible(
+          logger,
+          data.payload.after!,
+          data.payload.before!,
+        );
         if (
           data.payload.after!.type === PostType.Freeform &&
           data.payload.after!.authorId

--- a/src/workers/newNotificationV2Mail.ts
+++ b/src/workers/newNotificationV2Mail.ts
@@ -107,6 +107,7 @@ export const notificationToTemplateId: Record<NotificationType, string> = {
   squad_public_rejected: '43',
   squad_public_approved: '41',
   post_bookmark_reminder: '',
+  scheduled_post_published: '',
   streak_reset_restore: '',
   squad_featured: '56',
   user_post_added: '58',
@@ -282,6 +283,7 @@ const notificationToTemplateData: Record<NotificationType, TemplateDataFunc> = {
   },
   source_post_rejected: async () => null,
   post_bookmark_reminder: async () => null,
+  scheduled_post_published: async () => null,
   streak_reset_restore: async () => null,
   community_picks_failed: async (con, user, notification) => {
     const submission = await con

--- a/src/workers/notifications/index.ts
+++ b/src/workers/notifications/index.ts
@@ -45,6 +45,7 @@ import { recruiterExternalPaymentNotification } from './recruiterExternalPayment
 import { reMatchedOpportunityNotification } from './reMatchedOpportunityNotification';
 import { achievementUnlockedNotification } from './achievementUnlockedNotification';
 import { liveRoomStartingSoonNotification } from './liveRoomStartingSoonNotification';
+import { scheduledPostPublishedNotification } from './scheduledPostPublishedNotification';
 
 export function notificationWorkerToWorker(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,6 +137,7 @@ const notificationWorkers: TypedNotificationWorker<any>[] = [
   reMatchedOpportunityNotification,
   achievementUnlockedNotification,
   liveRoomStartingSoonNotification,
+  scheduledPostPublishedNotification,
 ];
 
 export const workers = [...notificationWorkers.map(notificationWorkerToWorker)];

--- a/src/workers/notifications/scheduledPostPublishedNotification.ts
+++ b/src/workers/notifications/scheduledPostPublishedNotification.ts
@@ -1,0 +1,56 @@
+import { getPostScheduledAt } from '../../common/postScheduling';
+import type { PostFlags } from '../../entity/posts/Post';
+import { NotificationType } from '../../notifications/common';
+import type { NotificationPostContext } from '../../notifications/types';
+import { TypedNotificationWorker } from '../worker';
+import { buildPostContext } from './utils';
+
+const getScheduledAtFromFlags = (
+  flags: PostFlags | string | null | undefined,
+): Date | null => {
+  if (!flags) {
+    return null;
+  }
+
+  if (typeof flags !== 'string') {
+    return getPostScheduledAt({ flags });
+  }
+
+  try {
+    return getPostScheduledAt({ flags: JSON.parse(flags) as PostFlags });
+  } catch {
+    return null;
+  }
+};
+
+export const scheduledPostPublishedNotification: TypedNotificationWorker<'api.v1.post-visible'> =
+  {
+    subscription: 'api.scheduled-post-published-notification',
+    handler: async (data, con) => {
+      if (!getScheduledAtFromFlags(data.previousPost?.flags)) {
+        return;
+      }
+
+      const baseCtx = await buildPostContext(con, data.post.id);
+
+      if (!baseCtx) {
+        return;
+      }
+
+      const authorId = data.post.authorId || baseCtx.post.authorId;
+
+      if (!authorId) {
+        return;
+      }
+
+      return [
+        {
+          type: NotificationType.ScheduledPostPublished,
+          ctx: {
+            ...baseCtx,
+            userIds: [authorId],
+          } as NotificationPostContext,
+        },
+      ];
+    },
+  };


### PR DESCRIPTION
## Summary
- include the previous post state on post-visible update events
- notify the author in-app when a scheduled post becomes visible
- allow authors to fetch their own scheduled invisible posts before publish time
- register notification settings, rendering, mail no-op handling, infra subscription, and worker/query coverage

## Tests
- NODE_ENV=test npx jest __tests__/workers/notifications.ts --testEnvironment=node --runInBand -t "scheduled post published"
- NODE_ENV=test npx jest __tests__/notifications/index.ts --testEnvironment=node --runInBand -t "scheduled_post_published"
- NODE_ENV=test npx jest __tests__/workers/cdc/primary.ts --testEnvironment=node --runInBand -t "should notify on post visible"
- NODE_ENV=test npx jest __tests__/posts.ts --testEnvironment=node --runInBand -t "scheduled post before it is visible"
- NODE_ENV=test npx jest __tests__/workers/workers.ts --testEnvironment=node --runInBand
- pnpm run build
- pnpm run lint