### PR TITLE
feat(posts): cancel scheduling and publish now via editPost

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1594,6 +1594,68 @@ describe('query post', () => {
     });
   });
 
+  describe('scheduled post', () => {
+    const LOCAL_QUERY = /* GraphQL */ `
+      query Post($id: ID!) {
+        post(id: $id) {
+          id
+          flags {
+            scheduledAt
+          }
+        }
+      }
+    `;
+
+    const scheduleP1 = async () => {
+      const scheduledAt = new Date(Date.now() + 60_000).toISOString();
+      await con.getRepository(Post).update(
+        { id: 'p1' },
+        {
+          type: PostType.Freeform,
+          authorId: '1',
+          visible: false,
+          visibleAt: null,
+          flags: { visible: false, scheduledAt },
+        },
+      );
+
+      return scheduledAt;
+    };
+
+    it('should return the scheduled post to its author', async () => {
+      loggedUser = '1';
+      const scheduledAt = await scheduleP1();
+
+      const res = await client.query(LOCAL_QUERY, { variables: { id: 'p1' } });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.post.id).toEqual('p1');
+      expect(res.data.post.flags.scheduledAt).toEqual(scheduledAt);
+    });
+
+    it('should not return the scheduled post to a non-author', async () => {
+      loggedUser = '2';
+      await scheduleP1();
+
+      return testQueryErrorCode(
+        client,
+        { query: LOCAL_QUERY, variables: { id: 'p1' } },
+        'NOT_FOUND',
+      );
+    });
+
+    it('should not return the scheduled post to anonymous users', async () => {
+      loggedUser = null;
+      await scheduleP1();
+
+      return testQueryErrorCode(
+        client,
+        { query: LOCAL_QUERY, variables: { id: 'p1' } },
+        'NOT_FOUND',
+      );
+    });
+  });
+
   describe('analytics field', () => {
     const LOCAL_QUERY = /* GraphQL */ `
       query Post($id: ID!) {
@@ -7429,6 +7491,64 @@ describe('mutation editPost', () => {
       },
       'GRAPHQL_VALIDATION_FAILED',
       'Cannot update scheduled time after post is published',
+    );
+  });
+
+  it('should cancel scheduling and publish immediately when scheduledAt is null', async () => {
+    loggedUser = '1';
+    const scheduledAt = new Date(Date.now() + 60_000).toISOString();
+
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        type: PostType.Freeform,
+        authorId: loggedUser,
+        visible: false,
+        visibleAt: null,
+        flags: {
+          visible: false,
+          scheduledAt,
+        },
+      },
+    );
+
+    const res = await client.mutate(MUTATION, {
+      variables: { id: 'p1', title: 'Published now', scheduledAt: null },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.editPost.title).toEqual('Published now');
+    expect(res.data.editPost.flags.scheduledAt).toBeNull();
+
+    const post = await con.getRepository(Post).findOneByOrFail({ id: 'p1' });
+    expect(post.visible).toBe(true);
+    expect(post.visibleAt).not.toBeNull();
+    expect(post.flags.scheduledAt).toBeNull();
+  });
+
+  it('should not publish a post that is not scheduled', async () => {
+    loggedUser = '1';
+    await con.getRepository(Post).update(
+      { id: 'p1' },
+      {
+        type: PostType.Freeform,
+        authorId: loggedUser,
+        visible: false,
+        visibleAt: null,
+        flags: {
+          visible: false,
+        },
+      },
+    );
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { id: 'p1', scheduledAt: null },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+      'Post is not scheduled',
     );
   });
 

--- a/src/entity/posts/Post.ts
+++ b/src/entity/posts/Post.ts
@@ -56,7 +56,7 @@ export type PostFlags = Partial<{
   sources: number;
   savedTime: number;
   generatedAt: Date;
-  scheduledAt: string;
+  scheduledAt: string | null;
   dedupKey: string;
   digestPostIds: string[];
   collectionSources: string[];

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1004,7 +1004,9 @@ const obj = new GraphORM({
           return {
             ...value,
             generatedAt: transformDate(value.generatedAt),
-            scheduledAt: transformDate(value.scheduledAt),
+            scheduledAt: value.scheduledAt
+              ? transformDate(value.scheduledAt)
+              : null,
             digestPostIds: value?.digestPostIds ?? null,
             ad: ad
               ? {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1637,7 +1637,8 @@ export const typeDefs = /* GraphQL */ `
       """
       content: String
       """
-      Time the post should go live
+      Time the post should go live. Pass null to cancel the schedule and
+      publish the post immediately together with any edits.
       """
       scheduledAt: DateTime
     ): Post! @auth
@@ -2956,7 +2957,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         }
 
         let updated: Partial<
-          EditablePost & Pick<Post, 'visible' | 'visibleAt'>
+          EditablePost & Pick<Post, 'visible' | 'visibleAt' | 'createdAt'>
         > = {};
 
         if (args.scheduledAt !== undefined) {
@@ -2966,18 +2967,34 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             );
           }
 
-          const scheduledAt = validatePostScheduledAt(args.scheduledAt);
-
-          if (!scheduledAt) {
-            throw new ValidationError('Scheduled time is required');
+          // Guard both reschedule and publish-now to posts that are actually
+          // scheduled, so an unrelated invisible post can't be force-published.
+          if (!getPostScheduledAt(post)) {
+            throw new ValidationError('Post is not scheduled');
           }
 
-          updated.visible = false;
-          updated.visibleAt = null;
-          updated.flags = {
-            ...updated.flags,
-            ...getScheduledPostFlags(scheduledAt),
-          };
+          const scheduledAt = validatePostScheduledAt(args.scheduledAt);
+
+          if (scheduledAt) {
+            updated.visible = false;
+            updated.visibleAt = null;
+            updated.flags = {
+              ...updated.flags,
+              ...getScheduledPostFlags(scheduledAt),
+            };
+          } else {
+            // scheduledAt was explicitly null: cancel the schedule and publish
+            // now. The pending publish workflow no-ops once the post is visible.
+            const now = new Date();
+            updated.visible = true;
+            updated.visibleAt = now;
+            updated.createdAt = now;
+            updated.flags = {
+              ...updated.flags,
+              scheduledAt: null,
+              visible: true,
+            };
+          }
         }
 
         if (title && title !== post.title) {


### PR DESCRIPTION
## What

Lets a post author **cancel a scheduled post's schedule and publish it immediately** (together with any edits) by passing `scheduledAt: null` to `editPost`.

- `editPost` now treats an explicit `scheduledAt: null` as "publish now": sets `visible=true, visibleAt=now, createdAt=now` and clears the `scheduledAt` flag. A valid future date still reschedules; `undefined` still leaves the schedule untouched.
- Guards the whole schedule branch on the post actually being scheduled (`getPostScheduledAt`), so an unrelated invisible post can't be force-published.
- The pending Temporal publish workflow no-ops once the post is visible, so no cancellation is needed.
- `PostFlags.scheduledAt` is now `string | null` (needed to null the flag on publish).

The author-read path for own scheduled posts is already on main; this PR only adds the publish-now transition.

## Tests
- publish-now on null (visible flip + flag cleared)
- rejects publishing a non-scheduled post
- author can read own scheduled post; non-author / anonymous get NOT_FOUND

## Notes
Pairs with the apps-side "view & edit scheduled posts" PR.