### PR TITLE
fix(highlights): only evaluate candidates that have a summary

### DIFF
--- a/__tests__/cron/channelHighlights.ts
+++ b/__tests__/cron/channelHighlights.ts
@@ -36,7 +36,7 @@ const saveArticle = async ({
   channels = ['vibes'],
   sourceId = 'content-source',
   contentCuration = [] as string[],
-  summary,
+  summary = 'A newsworthy summary describing the story in detail.',
 }: {
   id: string;
   title: string;
@@ -46,7 +46,7 @@ const saveArticle = async ({
   channels?: string[];
   sourceId?: string;
   contentCuration?: string[];
-  summary?: string;
+  summary?: string | null;
 }) =>
   con.getRepository(ArticlePost).save({
     id,
@@ -447,6 +447,75 @@ describe('channel highlight generation cron', () => {
       expect.objectContaining({
         postId: 'pshare-high',
         title: 'Unknown source story',
+      }),
+    ]);
+  });
+
+  it('should not evaluate a candidate until it has a summary', async () => {
+    const now = new Date('2026-03-03T16:00:00.000Z');
+    await saveArticle({
+      id: 'summarized',
+      title: 'Summarized story',
+      summary: 'A concise summary of what happened.',
+      createdAt: new Date('2026-03-03T15:45:00.000Z'),
+    });
+    await saveArticle({
+      id: 'no-summary',
+      title: 'Pending summary story',
+      summary: null,
+      createdAt: new Date('2026-03-03T15:50:00.000Z'),
+    });
+
+    const evaluatorSpy = jest
+      .spyOn(evaluator, 'evaluateHighlights')
+      .mockResolvedValue({ items: [] });
+
+    await runChannelHighlights({ con, now });
+
+    expect(evaluatorSpy).toHaveBeenCalledTimes(1);
+    expect(evaluatorSpy.mock.calls[0][0].newCandidates).toEqual([
+      expect.objectContaining({ postId: 'summarized' }),
+    ]);
+  });
+
+  it('should evaluate a public share using the referred post summary', async () => {
+    const now = new Date('2026-03-03T17:00:00.000Z');
+    await con
+      .getRepository(Source)
+      .save(
+        createSource(
+          UNKNOWN_SOURCE,
+          'Unknown',
+          'https://daily.dev/unknown.png',
+          undefined,
+          true,
+        ),
+      );
+    await saveArticle({
+      id: 'under-summ',
+      sourceId: UNKNOWN_SOURCE,
+      title: 'Referred story',
+      summary: 'The referred post carries the summary.',
+      createdAt: new Date('2026-03-03T16:30:00.000Z'),
+    });
+    await saveShare({
+      id: 'pshare-summ',
+      sharedPostId: 'under-summ',
+      createdAt: new Date('2026-03-03T16:35:00.000Z'),
+      upvotes: 2,
+    });
+
+    const evaluatorSpy = jest
+      .spyOn(evaluator, 'evaluateHighlights')
+      .mockResolvedValue({ items: [] });
+
+    await runChannelHighlights({ con, now });
+
+    expect(evaluatorSpy).toHaveBeenCalledTimes(1);
+    expect(evaluatorSpy.mock.calls[0][0].newCandidates).toEqual([
+      expect.objectContaining({
+        postId: 'pshare-summ',
+        summary: 'The referred post carries the summary.',
       }),
     ]);
   });

--- a/src/common/channelHighlight/stories.ts
+++ b/src/common/channelHighlight/stories.ts
@@ -101,9 +101,11 @@ const getPostSummary = ({
 const buildCandidate = ({
   canonicalPostId,
   memberPosts,
+  postsById,
 }: {
   canonicalPostId: string;
   memberPosts: HighlightPost[];
+  postsById: Map<string, HighlightPost>;
 }): HighlightCandidate => {
   const canonicalPost = selectCanonicalPost({
     posts: memberPosts,
@@ -117,7 +119,7 @@ const buildCandidate = ({
   return {
     postId: canonicalPost.id,
     title: canonicalPost.title || '',
-    summary: canonicalPost.summary || '',
+    summary: getPostSummary({ post: canonicalPost, postsById }) || '',
     createdAt: canonicalPost.createdAt,
     lastActivityAt,
     upvotes: canonicalPost.upvotes,
@@ -160,6 +162,7 @@ export const buildCandidates = ({
   horizonStart: Date;
 }): HighlightCandidate[] => {
   const availablePostIds = new Set(posts.map((post) => post.id));
+  const postsById = new Map(posts.map((post) => [post.id, post]));
   const storyFamilies = buildStoryFamilies({
     relations,
     postIds: availablePostIds,
@@ -169,15 +172,22 @@ export const buildCandidates = ({
     collectionByChildId: storyFamilies.collectionByChild,
   });
 
-  return [...groupedPosts.entries()]
-    .map(([canonicalPostId, memberPosts]) =>
-      buildCandidate({
-        canonicalPostId,
-        memberPosts,
-      }),
-    )
-    .filter((candidate) => candidate.lastActivityAt >= horizonStart)
-    .sort(compareCandidates);
+  return (
+    [...groupedPosts.entries()]
+      .map(([canonicalPostId, memberPosts]) =>
+        buildCandidate({
+          canonicalPostId,
+          memberPosts,
+          postsById,
+        }),
+      )
+      .filter((candidate) => candidate.lastActivityAt >= horizonStart)
+      // Bragi grades significance from title + summary; a post highlighted before
+      // its summary lands gets mis-graded and frozen. Skip until summarized — it
+      // re-enters as a candidate once the summary bumps metadataChangedAt.
+      .filter((candidate) => candidate.summary.trim().length > 0)
+      .sort(compareCandidates)
+  );
 };
 
 export const toHighlightItem = (


### PR DESCRIPTION
## Problem

Level 2+ (Major/Breaking) highlights went stale in production — the top tiers stopped refreshing while Notable stayed current. Investigation traced it to how significance is assigned.

Bragi grades significance from the candidate's **title + summary**. But the highlight cron admits a post ~6 minutes after creation — sometimes before summarization has run — so bragi was handed the raw source title (often vague, e.g. *"GLM5.2 covered by European news channel Euronews"*, *"Researchers Find Backdoor in Thousands of Headphones"*, or an empty title) with **no summary**, and defaulted it to `notable`. Because significance is frozen at admission, that first blind grade never corrects, so Major/Breaking slowly starved.

Reproduced end-to-end against `claude-sonnet-4-6`: with rich title+summary the model grades these stories Major/Breaking correctly; with the raw title and empty summary the same stories collapse to notable or drop entirely.

## Fix

Gate candidate selection on an **effective summary** being present:
- `buildCandidate` now resolves the summary via `getPostSummary` (own summary, or the **referred post's** summary for shares) instead of the raw `post.summary` column — which also fixes a latent bug where a share candidate was sent with its always-empty own summary.
- `buildCandidates` drops candidates with no effective summary.

Un-summarized posts are simply skipped and **re-enter as candidates once the summary lands** (summarization bumps `metadataChangedAt`, which the incremental fetch already keys on). Net effect: highlights still appear instantly, but significance is only decided once the text needed to grade it exists. Posts that never get a summary aren't highlighted (intended — they're too thin to grade).

## Tests

- un-summarized post is not sent to the evaluator; summarized one is
- a public share is evaluated using its referred post's summary

All existing cron tests pass (given a default summary in the fixture helper, reflecting that real posts are summarized by grade time).

## Not included

A separate, milder calibration gap remains on the bragi side (Breaking rarely fires; some non-security majors like landmark rulings / platform expansions under-grade even with full text). That's a follow-up in the bragi repo, tracked separately.