### PR TITLE
fix(posts): persist content quality for freeform on update

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -2127,6 +2127,44 @@ describe('on post update', () => {
     });
   });
 
+  it('should replace content quality for freeform', async () => {
+    const postId = 'ff-cq-p1';
+
+    const existingPost = await con.getRepository(FreeformPost).save({
+      id: postId,
+      shortId: postId,
+      type: PostType.Freeform,
+      yggdrasilId: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+      sourceId: 'a',
+    });
+
+    expect(existingPost).not.toBeNull();
+
+    await expectSuccessfulBackground(worker, {
+      id: 'f99a445f-e2fb-48e8-959c-e02a17f5e816',
+      post_id: postId,
+      content_type: PostType.Freeform,
+      content_quality: {
+        is_ai_probability: 0,
+        is_clickbait_probability: 0.8,
+        specificity: 'focused',
+        intent: 'learning',
+      },
+    });
+
+    const updatedPost = await con.getRepository(FreeformPost).findOneBy({
+      id: postId,
+    });
+
+    expect(updatedPost).not.toBeNull();
+    expect(updatedPost?.contentQuality).toMatchObject({
+      is_ai_probability: 0,
+      is_clickbait_probability: 0.8,
+      specificity: 'focused',
+      intent: 'learning',
+    });
+  });
+
   it('should replace content quality', async () => {
     const postId = 'p1';
 

--- a/src/workers/postUpdated/freeform/processing.ts
+++ b/src/workers/postUpdated/freeform/processing.ts
@@ -10,6 +10,7 @@ export const freeformAllowedFields = [
   'summary',
   'tagsStr',
   'contentMeta',
+  'contentQuality',
 ];
 
 export const processFreeform = async ({


### PR DESCRIPTION
## Problem

Content quality (AI/clickbait probability, specificity, intent, substance depth, etc.) was being **dropped** for user-generated **freeform** posts, so they landed on the platform with no content-quality signals.

### Root cause

User-generated freeform posts are created in daily-api first (by the user), then yggdrasil enriches them and emits `content-published`. Because the post already exists, the `postUpdated` worker takes the **update** path, which filters the incoming payload down to an allowlist (`freeformAllowedFields`). That list included `contentMeta` but **not `contentQuality`**, so `updatePost` deleted the field (`shared.ts`) before the DB write.

`buildCommonPostFields` maps `content_quality` → `contentQuality` correctly and the `Post.contentQuality` column exists, so the data was arriving and being discarded purely by the allowlist. This is asymmetric with:
- **socialTwitter**, whose allowlist already includes `contentQuality`
- **article/collection/youtube**, which pass no restricting allowlist (so the field is kept)

Freeform simply forgot the field when `contentMeta` was added.

### Example

Post `1As9RA7f4` (freeform, `user_generated`): yggdrasil sent `content_quality` with clickbait 0.8, is_ai 0, specificity `focused`, intent `learning`. None of it persisted.

## Fix

Add `'contentQuality'` to `freeformAllowedFields`, mirroring `twitterAllowedFields`. No migration or entity change needed — the column and mapping already exist.

## Test

Added `should replace content quality for freeform` covering the update path. Verified it **fails** without the fix (`contentQuality` stays `{}`) and **passes** with it.