### PR TITLE
feat(quests): restrict brief_read quests to plus slots

### DIFF
--- a/__tests__/questRotation.ts
+++ b/__tests__/questRotation.ts
@@ -356,6 +356,140 @@ describe('rotateQuestPeriod', () => {
     expect(existingUserQuest.claimedAt).toBeNull();
   });
 
+  it('should only rotate brief_read quests into the plus slot', async () => {
+    const now = new Date('2026-03-12T12:00:00.000Z');
+    const logger = createMockLogger();
+    const { periodStart } = getQuestWindow(QuestType.Daily, now);
+
+    await saveFixtures(con, Quest, [
+      {
+        id: questIds[0],
+        name: 'Rotation regular quest 1',
+        description: 'Upvote 5 posts',
+        type: QuestType.Daily,
+        eventType: QuestEventType.PostUpvote,
+        criteria: { targetCount: 5 },
+        active: true,
+        createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      },
+      {
+        id: questIds[1],
+        name: 'Rotation regular quest 2',
+        description: 'Write 2 comments',
+        type: QuestType.Daily,
+        eventType: QuestEventType.CommentCreate,
+        criteria: { targetCount: 2 },
+        active: true,
+        createdAt: new Date('2026-03-02T00:00:00.000Z'),
+      },
+      {
+        id: questIds[2],
+        name: 'Rotation brief read quest',
+        description: 'Read 1 brief',
+        type: QuestType.Daily,
+        eventType: QuestEventType.BriefRead,
+        criteria: { targetCount: 1 },
+        active: true,
+        createdAt: new Date('2026-03-03T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await rotateQuestPeriod({
+      con,
+      logger,
+      type: QuestType.Daily,
+      now,
+    });
+
+    const rotations = await con.getRepository(QuestRotation).find({
+      where: {
+        type: QuestType.Daily,
+        periodStart,
+      },
+      order: {
+        plusOnly: 'ASC',
+        slot: 'ASC',
+      },
+    });
+
+    expect(result.created).toBe(3);
+    expect(
+      rotations.map(({ questId, plusOnly, slot }) => ({
+        questId,
+        plusOnly,
+        slot,
+      })),
+    ).toEqual([
+      { questId: questIds[0], plusOnly: false, slot: 1 },
+      { questId: questIds[1], plusOnly: false, slot: 2 },
+      { questId: questIds[2], plusOnly: true, slot: 1 },
+    ]);
+  });
+
+  it('should never rotate a brief_read quest into a regular slot', async () => {
+    const now = new Date('2026-03-12T12:00:00.000Z');
+    const logger = createMockLogger();
+    const { periodStart } = getQuestWindow(QuestType.Daily, now);
+
+    await saveFixtures(con, Quest, [
+      {
+        id: questIds[0],
+        name: 'Rotation regular quest 1',
+        description: 'Upvote 5 posts',
+        type: QuestType.Daily,
+        eventType: QuestEventType.PostUpvote,
+        criteria: { targetCount: 5 },
+        active: true,
+        createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      },
+      {
+        id: questIds[1],
+        name: 'Rotation brief read quest 1',
+        description: 'Read 1 brief',
+        type: QuestType.Daily,
+        eventType: QuestEventType.BriefRead,
+        criteria: { targetCount: 1 },
+        active: true,
+        createdAt: new Date('2026-03-02T00:00:00.000Z'),
+      },
+      {
+        id: questIds[2],
+        name: 'Rotation brief read quest 2',
+        description: 'Read 2 briefs',
+        type: QuestType.Daily,
+        eventType: QuestEventType.BriefRead,
+        criteria: { targetCount: 2 },
+        active: true,
+        createdAt: new Date('2026-03-03T00:00:00.000Z'),
+      },
+    ]);
+
+    await rotateQuestPeriod({
+      con,
+      logger,
+      type: QuestType.Daily,
+      now,
+    });
+
+    const rotations = await con.getRepository(QuestRotation).find({
+      where: {
+        type: QuestType.Daily,
+        periodStart,
+      },
+      relations: {
+        quest: true,
+      },
+    });
+
+    const regularEventTypes = await Promise.all(
+      rotations
+        .filter((rotation) => !rotation.plusOnly)
+        .map(async (rotation) => (await rotation.quest).eventType),
+    );
+
+    expect(regularEventTypes).not.toContain(QuestEventType.BriefRead);
+  });
+
   it('should only reuse previous quests when there are not enough fresh quests left', async () => {
     const previousNow = new Date('2026-03-11T12:00:00.000Z');
     const now = new Date('2026-03-12T12:00:00.000Z');

--- a/src/common/quest/rotation.ts
+++ b/src/common/quest/rotation.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'typeorm';
 import { FastifyBaseLogger } from 'fastify';
-import { Quest, QuestType } from '../../entity/Quest';
+import { Quest, QuestEventType, QuestType } from '../../entity/Quest';
 import { QuestRotation } from '../../entity/QuestRotation';
 import { getQuestWindow } from './window';
 
@@ -12,6 +12,9 @@ const REQUIRED_REGULAR_QUESTS: Record<QuestType, number> = {
 };
 
 const REQUIRED_PLUS_QUESTS = 1;
+
+const isPlusOnlyQuest = (quest: Quest): boolean =>
+  quest.eventType === QuestEventType.BriefRead;
 
 const compareQuestOrder = (left: Quest, right: Quest): number => {
   const createdAtDiff = left.createdAt.getTime() - right.createdAt.getTime();
@@ -113,23 +116,35 @@ export const rotateQuestPeriod = async ({
   const freshQuests = allQuests.filter(
     (quest) => !previousQuestIds.has(quest.id),
   );
+  const allRegularQuests = allQuests.filter((quest) => !isPlusOnlyQuest(quest));
+  const freshRegularQuests = freshQuests.filter(
+    (quest) => !isPlusOnlyQuest(quest),
+  );
   let regularQuests: Quest[] = [];
   let plusQuests: Quest[] = [];
 
-  if (freshQuests.length >= totalLimit) {
+  if (
+    freshQuests.length === totalLimit &&
+    freshRegularQuests.length >= regularLimit
+  ) {
     const selectedFreshQuests = pickQuests({
       pool: freshQuests,
       count: totalLimit,
       selectedIds: new Set<string>(),
     }).sort(compareQuestOrder);
 
-    regularQuests = selectedFreshQuests.slice(0, regularLimit);
-    plusQuests = selectedFreshQuests.slice(regularLimit);
+    regularQuests = selectedFreshQuests
+      .filter((quest) => !isPlusOnlyQuest(quest))
+      .slice(0, regularLimit);
+    const regularQuestIds = new Set(regularQuests.map((quest) => quest.id));
+    plusQuests = selectedFreshQuests
+      .filter((quest) => !regularQuestIds.has(quest.id))
+      .slice(0, REQUIRED_PLUS_QUESTS);
   } else {
     const selectedQuestIds = new Set<string>();
 
     regularQuests = pickQuests({
-      pool: freshQuests,
+      pool: freshRegularQuests,
       count: regularLimit,
       selectedIds: selectedQuestIds,
     });
@@ -137,7 +152,7 @@ export const rotateQuestPeriod = async ({
     if (regularQuests.length < regularLimit) {
       regularQuests.push(
         ...pickQuests({
-          pool: allQuests,
+          pool: allRegularQuests,
           count: regularLimit - regularQuests.length,
           selectedIds: selectedQuestIds,
         }),


### PR DESCRIPTION
## What

`brief_read` quests require Plus, so they should only be rotated into **plus-only** slots and never the regular rotation.

## Changes

- `rotateQuestPeriod` regular slot pools now exclude `brief_read` quests (both the fresh-first pick and the reuse fallback).
- Plus slots remain open to any quest — the constraint is that `brief_read` is *restricted to* plus, not that plus must be `brief_read`.
- The deterministic all-fresh fast path is scoped to the exactly-tight case and its split is eligibility-aware, so a `brief_read` quest there lands in the plus slot.

Plus-subscription gating itself is unchanged — `plusOnly` rotations are already blocked at claim time (`claimQuestReward` / `locked`), so restricting `brief_read` to plus slots is sufficient.

## Tests

Added two integration tests: `brief_read` lands in the plus slot alongside regular quests, and `brief_read` never lands in a regular slot even when regular quests are scarce. Existing rotation/determinism tests preserved.

Closes ENG-1691