### PR TITLE
feat(awards): add restricted Giveback Founding Member award

### DIFF
--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -1092,17 +1092,10 @@ it('stops granting once the cap is reached', async () => {
   ).resolves.toBeNull();
 });
 
-it('is a no-op when the award product is unset or missing', async () => {
+it('is a no-op when the award product is missing', async () => {
   mockNjord();
 
   expect(await grantFoundingContributorAward({ con, userId })).toBe(false);
-  expect(
-    await grantFoundingContributorAward({
-      con,
-      userId,
-      productId: foundingProductId,
-    }),
-  ).toBe(false);
 
   expect(await con.getRepository(ContributionFoundingContributor).count()).toBe(
     0,

--- a/__tests__/njord.ts
+++ b/__tests__/njord.ts
@@ -110,7 +110,34 @@ describe('award user mutation', () => {
         type: ProductType.Award,
         value: 20,
       },
+      {
+        id: 'e1c2b3a4-5d6e-4f70-8a91-b2c3d4e5f607',
+        name: 'Restricted Award',
+        image: 'https://daily.dev/award.jpg',
+        type: ProductType.Award,
+        value: 20,
+        flags: {
+          restricted: true,
+        },
+      },
     ]);
+  });
+
+  it('should throw when awarding a restricted product', async () => {
+    loggedUser = 't-awum-1';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          productId: 'e1c2b3a4-5d6e-4f70-8a91-b2c3d4e5f607',
+          entityId: 't-awum-2',
+          note: 'Test test!',
+        },
+      },
+      'FORBIDDEN',
+    );
   });
 
   it('should not authorize when not logged in', async () => {
@@ -777,7 +804,30 @@ describe('query products', () => {
         type: ProductType.Award,
         value: 20,
       },
+      {
+        id: 'b3d9d8b1-1f2e-4c3a-9d6f-2a5e7c1b0f4d',
+        name: 'Restricted Award',
+        image: 'https://daily.dev/award.jpg',
+        type: ProductType.Award,
+        value: 5,
+        flags: {
+          restricted: true,
+        },
+      },
     ]);
+  });
+
+  it('should exclude restricted products from the catalog', async () => {
+    loggedUser = 't-awpm-1';
+
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(
+      res.data.products.edges.map(
+        ({ node }: { node: { id: string } }) => node.id,
+      ),
+    ).not.toContain('b3d9d8b1-1f2e-4c3a-9d6f-2a5e7c1b0f4d');
   });
 
   it('should return products sorted by value', async () => {

--- a/seeds/Product.json
+++ b/seeds/Product.json
@@ -142,5 +142,18 @@
     "flags": {
       "imageGlow": "https://media.daily.dev/image/upload/s--NZ-1Is9I--/f_auto/v1743664360/public/fineDogGlow"
     }
+  },
+  {
+    "id": "3bbe8325-ceb9-411b-be83-ffba2703ce82",
+    "type": "award",
+    "image": "https:\/\/media.daily.dev\/image\/upload\/s--BxFWArbd--\/f_auto,q_auto\/v1783344577\/public\/Color%3DDefault",
+    "name": "Giveback Founding Member",
+    "createdAt": "2025-04-02T13:41:27.981Z",
+    "updatedAt": "2025-04-02T13:41:27.981Z",
+    "value": 1000,
+    "flags": {
+      "imageGlow": "https://media.daily.dev/image/upload/s--9SAk6IKY--/f_auto,q_auto/v1783344582/public/Color%3Dglow",
+      "restricted": true
+    }
   }
 ]

--- a/src/common/contribution/founding.ts
+++ b/src/common/contribution/founding.ts
@@ -13,6 +13,9 @@ import { systemUser } from '../utils';
 
 export const CONTRIBUTION_FOUNDING_LIMIT = 1000;
 
+export const CONTRIBUTION_FOUNDING_AWARD_PRODUCT_ID =
+  '3bbe8325-ceb9-411b-be83-ffba2703ce82';
+
 // Grants the founding-contributor award (a Product award paid by the system) the
 // first time a user contributes, while the campaign is under the cap. Idempotent
 // per user via the founding-contributor PK; the whole grant is transactional, so
@@ -22,19 +25,13 @@ export const grantFoundingContributorAward = async ({
   con,
   userId,
   limit = CONTRIBUTION_FOUNDING_LIMIT,
-  // Award (Product) granted to the first contributors. Unset until the dedicated
-  // product exists, in which case the grant is a no-op.
-  productId = process.env.CONTRIBUTION_FOUNDING_AWARD_PRODUCT_ID,
+  productId = CONTRIBUTION_FOUNDING_AWARD_PRODUCT_ID,
 }: {
   con: DataSource;
   userId: string;
   limit?: number;
   productId?: string;
 }): Promise<boolean> => {
-  if (!productId) {
-    return false;
-  }
-
   return con.transaction(async (manager) => {
     const foundingRepo = manager.getRepository(ContributionFoundingContributor);
 

--- a/src/common/njord.ts
+++ b/src/common/njord.ts
@@ -535,6 +535,14 @@ export type TransactionCreated = {
   referenceId?: string;
 };
 
+const assertGiftableProduct = (
+  product: Pick<Product, 'type' | 'flags'>,
+): void => {
+  if (product.type !== ProductType.Award || product.flags?.restricted) {
+    throw new ForbiddenError('Can not award this product');
+  }
+};
+
 const canAward = async ({
   ctx,
   receiverId,
@@ -628,18 +636,15 @@ export const awardUser = async (
   try {
     await canAward({ ctx, receiverId: props.entityId });
 
-    const product: Pick<Product, 'id' | 'type'> = await ctx.con.manager
-      .getRepository(Product)
-      .findOneOrFail({
-        select: ['id', 'type'],
+    const product: Pick<Product, 'id' | 'type' | 'flags'> =
+      await ctx.con.manager.getRepository(Product).findOneOrFail({
+        select: ['id', 'type', 'flags'],
         where: {
           id: props.productId,
         },
       });
 
-    if (product.type !== ProductType.Award) {
-      throw new ForbiddenError('Can not award this product');
-    }
+    assertGiftableProduct(product);
 
     const { transaction, transfer } = await ctx.con.transaction(
       async (entityManager) => {
@@ -712,12 +717,12 @@ export const awardPost = async (
 
   try {
     const [product, post, userPost]: [
-      Pick<Product, 'id' | 'type'>,
+      Pick<Product, 'id' | 'type' | 'flags'>,
       Pick<Post, 'id' | 'authorId' | 'sourceId'>,
       Pick<UserPost, 'awardTransactionId'> | null,
     ] = await Promise.all([
       ctx.con.manager.getRepository(Product).findOneOrFail({
-        select: ['id', 'type'],
+        select: ['id', 'type', 'flags'],
         where: {
           id: props.productId,
         },
@@ -739,9 +744,7 @@ export const awardPost = async (
 
     await canAward({ ctx, receiverId: post.authorId });
 
-    if (product.type !== ProductType.Award) {
-      throw new ForbiddenError('Can not award this product');
-    }
+    assertGiftableProduct(product);
 
     if (userPost?.awardTransactionId) {
       throw new ConflictError('Post already awarded');
@@ -873,12 +876,12 @@ export const awardComment = async (
 
   try {
     const [product, comment, userComment]: [
-      Pick<Product, 'id' | 'type'>,
+      Pick<Product, 'id' | 'type' | 'flags'>,
       Pick<Comment, 'id' | 'userId' | 'postId' | 'post' | 'parentId'>,
       Pick<UserComment, 'awardTransactionId'> | null,
     ] = await Promise.all([
       ctx.con.manager.getRepository(Product).findOneOrFail({
-        select: ['id', 'type'],
+        select: ['id', 'type', 'flags'],
         where: {
           id: props.productId,
         },
@@ -903,9 +906,7 @@ export const awardComment = async (
 
     await canAward({ ctx, receiverId: comment.userId });
 
-    if (product.type !== ProductType.Award) {
-      throw new ForbiddenError('Can not award this product');
-    }
+    assertGiftableProduct(product);
 
     if (userComment?.awardTransactionId) {
       throw new ConflictError('Comment already awarded');

--- a/src/entity/Product.ts
+++ b/src/entity/Product.ts
@@ -10,6 +10,7 @@ import {
 export type ProductFlags = Partial<{
   description: string;
   imageGlow: string;
+  restricted: boolean;
 }>;
 
 export type ProductFlagsPublic = Pick<

--- a/src/schema/njord.ts
+++ b/src/schema/njord.ts
@@ -307,6 +307,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         (node, index) => pageGenerator.nodeToCursor(page, args, node, index),
         (builder) => {
           builder.queryBuilder
+            .andWhere(
+              `(${builder.alias}.flags->>'restricted') IS DISTINCT FROM 'true'`,
+            )
             .limit(page.limit)
             .offset(page.offset)
             .addOrderBy(`${builder.alias}."value"`, 'ASC');


### PR DESCRIPTION
## What

Adds the **Giveback Founding Member** award — a limited-edition award that is **system-granted only**: it can't be bought from the catalog and users can't gift it to each other. It's granted by the existing founding-contributor flow and shows on the profile like any other received award.

## How

- **`flags.restricted`** — new optional key on `ProductFlags` (jsonb, no migration; kept out of `ProductFlagsPublic` so it never leaks via GraphQL).
- **Catalog** — `products` query now excludes `flags->>'restricted' = 'true'`.
- **Gifting** — new `assertGiftableProduct` helper rejects restricted products; replaces the three duplicated `type !== Award` checks in `awardUser`/`awardPost`/`awardComment` (`awardSquad` delegates to `awardUser`).
- **Grant** — the founding award product id is now hardcoded in `founding.ts` (`CONTRIBUTION_FOUNDING_AWARD_PRODUCT_ID`) instead of an env var; the existing `grantFoundingContributorAward` path is otherwise unchanged (system-paid, 1000 cores to the recipient).
- **Seed** — added the award to `seeds/Product.json` (dev only).

## Ops

Insert the product row in prod (`daily` namespace) — no env var needed:

\`\`\`sql
INSERT INTO product (id, type, name, image, value, flags)
VALUES (
  '3bbe8325-ceb9-411b-be83-ffba2703ce82',
  'award',
  'Giveback Founding Member',
  'https://media.daily.dev/image/upload/s--BxFWArbd--/f_auto,q_auto/v1783344577/public/Color%3DDefault',
  1000,
  '{"imageGlow":"https://media.daily.dev/image/upload/s--9SAk6IKY--/f_auto,q_auto/v1783344582/public/Color%3Dglow","restricted":true}'::jsonb
)
ON CONFLICT (id) DO NOTHING;
\`\`\`

## Tests

- Catalog excludes restricted products; gifting a restricted product throws `FORBIDDEN`.
- `__tests__/njord.ts` 38/38, `__tests__/contributions.ts` 19/19, tsc + lint green.