### PR TITLE
feat(achievements): add 67 and 666 reading streak achievements

### DIFF
--- a/bin/syncReadingStreakAchievements.ts
+++ b/bin/syncReadingStreakAchievements.ts
@@ -1,0 +1,86 @@
+import '../src/config';
+import { In } from 'typeorm';
+import createOrGetConnection from '../src/db';
+import { Achievement, AchievementEventType, UserStreak } from '../src/entity';
+import { updateUserAchievementProgress } from '../src/common/achievement';
+import { logger } from '../src/logger';
+
+/**
+ * One-off backfill to retroactively unlock the newly added reading streak
+ * achievements for users whose max streak already qualifies.
+ * Idempotent: updateUserAchievementProgress skips already-unlocked achievements.
+ */
+
+const NEW_ACHIEVEMENT_NAMES = ['What time is it?', 'Devil is impressed'];
+
+const start = async (): Promise<void> => {
+  const con = await createOrGetConnection();
+
+  try {
+    const achievements = await con.getRepository(Achievement).find({
+      where: {
+        eventType: AchievementEventType.ReadingStreak,
+        name: In(NEW_ACHIEVEMENT_NAMES),
+      },
+    });
+
+    const foundNames = new Set(achievements.map(({ name }) => name));
+    const missing = NEW_ACHIEVEMENT_NAMES.filter(
+      (name) => !foundNames.has(name),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `Missing reading streak achievements: ${missing.join(', ')}. Run migrations first.`,
+      );
+    }
+
+    const minTarget = Math.min(
+      ...achievements.map(({ criteria }) => criteria.targetCount ?? 1),
+    );
+
+    const streaks = await con
+      .getRepository(UserStreak)
+      .createQueryBuilder('us')
+      .select(['us.userId', 'us.maxStreak'])
+      .where('us.maxStreak >= :minTarget', { minTarget })
+      .getMany();
+
+    console.log(
+      `Found ${streaks.length} users with maxStreak >= ${minTarget} and ${achievements.length} target achievements.`,
+    );
+
+    let totalUnlocked = 0;
+
+    for (const { userId, maxStreak } of streaks) {
+      for (const achievement of achievements) {
+        const wasUnlocked = await updateUserAchievementProgress(
+          con,
+          logger,
+          userId,
+          achievement.id,
+          maxStreak,
+          achievement.criteria.targetCount ?? 1,
+        );
+
+        if (wasUnlocked) {
+          totalUnlocked++;
+        }
+      }
+    }
+
+    console.log(
+      `Finished reading streak achievements backfill. Unlocked ${totalUnlocked} achievements.`,
+    );
+  } finally {
+    await con.destroy();
+  }
+};
+
+start()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/migration/1783416206466-AddMoreReadingStreakAchievements.ts
+++ b/src/migration/1783416206466-AddMoreReadingStreakAchievements.ts
@@ -1,0 +1,46 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMoreReadingStreakAchievements1783416206466 implements MigrationInterface {
+  name = 'AddMoreReadingStreakAchievements1783416206466';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "achievement" (
+        "name",
+        "description",
+        "image",
+        "type",
+        "eventType",
+        "criteria",
+        "points"
+      )
+      VALUES
+        (
+          'What time is it?',
+          'Reach a 67-day reading streak',
+          'https://media.daily.dev/image/upload/s--2bqSyiqr--/v1783416166/achievements/What_time_is_it',
+          'milestone',
+          'reading_streak',
+          '{"targetCount": 67}',
+          35
+        ),
+        (
+          'Devil is impressed',
+          'Reach a 666-day reading streak',
+          'https://media.daily.dev/image/upload/s--W0-BqBQd--/v1783416167/achievements/Devil_is_impressed',
+          'milestone',
+          'reading_streak',
+          '{"targetCount": 666}',
+          50
+        )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "achievement"
+      WHERE "eventType" = 'reading_streak'
+        AND "name" IN ('What time is it?', 'Devil is impressed')
+    `);
+  }
+}


### PR DESCRIPTION
## What

Adds two new `reading_streak` milestone achievements:

| Streak | Name | Points |
|---|---|---|
| 67 | What time is it? | 35 |
| 666 | Devil is impressed | 50 |

Full reading-streak set is now 10, 50, 67, 365, 512, 666, 1024.

## Changes

- **Migration** `AddMoreReadingStreakAchievements` — inserts the two achievement rows (badges already uploaded to Cloudinary `achievements/` folder).
- **Backfill** `bin/syncReadingStreakAchievements.ts` — one-off script to retroactively unlock the new milestones for users whose `maxStreak` already qualifies. Idempotent (reuses `updateUserAchievementProgress`), scoped to the two new achievements and `maxStreak >= 67`.

## Post-deploy

Run the backfill **after** this migration deploys (the rows must exist first):
`npx ts-node bin/syncReadingStreakAchievements.ts`

## Notes

No new unit test: the CDC worker already covers the generic reading-streak unlock path; 67/666 exercise the identical `evaluateAbsoluteValueAchievement` code path. Migration verified by applying locally; existing streak tests pass.