### PR TITLE
fix(cdc): re-enrich scheduled freeform posts when they become visible

### DIFF
--- a/__tests__/workers/cdc/primary.ts
+++ b/__tests__/workers/cdc/primary.ts
@@ -1781,6 +1781,61 @@ describe('post', () => {
     expect(notifyContentRequested).toHaveBeenCalledTimes(0);
   });
 
+  it('should re-request enrichment when a scheduled freeform post becomes visible', async () => {
+    const before = {
+      ...base,
+      type: PostType.Freeform,
+      content: '1'.repeat(FREEFORM_POST_MINIMUM_CONTENT_LENGTH),
+      visible: false,
+    };
+    const after = {
+      ...before,
+      visible: true,
+    };
+
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before,
+        op: 'u',
+        table: 'post',
+      }),
+    );
+
+    expect(notifyFreeformContentRequested).toHaveBeenCalledTimes(1);
+    expect(
+      jest.mocked(notifyFreeformContentRequested).mock.calls[0][1].payload
+        .after,
+    ).toEqual(after);
+  });
+
+  it('should not re-request enrichment when a freeform post that becomes visible is too short', async () => {
+    const before = {
+      ...base,
+      type: PostType.Freeform,
+      title: '',
+      content: '',
+      visible: false,
+    };
+    const after = {
+      ...before,
+      visible: true,
+    };
+
+    await expectSuccessfulBackground(
+      worker,
+      mockChangeMessage<ObjectType>({
+        after,
+        before,
+        op: 'u',
+        table: 'post',
+      }),
+    );
+
+    expect(notifyFreeformContentRequested).toHaveBeenCalledTimes(0);
+  });
+
   it('should notify when yggdrasil id is available on creation', async () => {
     const after = {
       ...base,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -1198,6 +1198,17 @@ const onPostChange = async (
           data.payload.after!,
           data.payload.before!,
         );
+        if (data.payload.after!.type === PostType.Freeform) {
+          // A scheduled freeform post just went live. Its tags/contentQuality were
+          // captured once when it was scheduled and are never refreshed at publish,
+          // so a post enriched during a broken window (e.g. empty tags) goes live
+          // broken. Re-request enrichment — same content-requested emit as creation —
+          // so yggdrasil re-enriches against current models before it's shown.
+          const freeform = data as ChangeMessage<FreeformPost>;
+          if (isFreeformPostLongEnough(freeform)) {
+            await notifyFreeformContentRequested(logger, freeform);
+          }
+        }
         if (
           data.payload.after!.type === PostType.Freeform &&
           data.payload.after!.authorId


### PR DESCRIPTION
## Problem

Scheduled freeform posts publish with **stale or empty enrichment**. A post's `tagsStr`/`contentQuality` are populated exactly once — when it's created/scheduled, via the creation-time `content-requested` → yggdrasil round-trip. At `scheduledAt`, `publishScheduledPost` only flips `visible/visibleAt/createdAt/flags`; **nothing re-enriches**. So a post that was enriched during a broken window (e.g. the recent bragi empty-tags bug, or the freeform contentQuality allowlist bug) goes live broken and stays broken.

Correcting the source in yggdrasil afterwards doesn't help either: yggdrasil sends its `content-published` message only once (on `processing → completed`), and a later correction is a `completed → completed` CDC event that's dropped unless `publish_on_update` is set. There is no re-send at publish.

This was surfaced by real scheduled posts (an "Agentic Tips" series) going live with no tags and empty content quality.

## Fix

On the `visible: false → true` transition for a **Freeform** post (op=`u`), emit the same `notifyFreeformContentRequested` event used at creation. yggdrasil resolves it to the **existing** entry (id is a deterministic `NewID(source, url)` hash), flips it back to `processing`, and re-enriches against current models (`canUpdateFreeformContentEntry` → `updateFreeformContentEntry`). The post then publishes with correct `tags`/`contentQuality` via the normal path.

### Why the existing op=`u` re-request didn't already cover this
The existing freeform re-request in `onPostChange` is gated on `isFreeformPostChangeLongEnough` (a **content-length delta**). A scheduled publish changes visibility, not content, so that gate is never satisfied — the publish transition was uncovered.

### Notes
- **Idempotent / no duplicate entry**: the deterministic entry id means a re-request updates the existing entry; verified live end-to-end (published a `content-requested` for a scheduled post → entry went `processing → completed` → post got correct tags/CQ while remaining invisible, then is set to publish normally).
- **No double-fire**: at publish the content is unchanged (existing content-delta path stays quiet); on a normal edit-while-visible, `!before.visible` is false so this path stays quiet.
- **No loop**: the re-enrichment's `updatePost` runs while the post is already visible (`before.visible = true`), so the transition guard prevents re-triggering.
- Bonus: posts scheduled up to 14 days out get current-model enrichment at go-live.

## Test plan
- [x] New unit tests: scheduled freeform becomes visible → re-requests enrichment once; too-short freeform becomes visible → does not.
- [x] All existing freeform CDC tests pass (10/10), `tsc --noEmit` clean, eslint clean.