### PR TITLE
fix(highlights): exclude deleted/invisible posts from highlight feeds

### DIFF
--- a/__tests__/highlights.ts
+++ b/__tests__/highlights.ts
@@ -1156,6 +1156,44 @@ describe('query postHighlightsFeed', () => {
     ]);
   });
 
+  it('should exclude highlights whose post is deleted or not visible', async () => {
+    await createTestPosts();
+    await con.getRepository(ArticlePost).update('h2', { deleted: true });
+    await con.getRepository(ArticlePost).update('h3', { visible: false });
+    await saveCanonicalHighlights([
+      {
+        postId: 'h1',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Visible headline',
+        significance: HighlightSignificance.Breaking,
+      },
+      {
+        postId: 'h2',
+        channel: 'vibes',
+        highlightedAt: new Date('2026-03-19T10:35:00.000Z'),
+        headline: 'Deleted post headline',
+        significance: HighlightSignificance.Notable,
+      },
+      {
+        postId: 'h3',
+        channel: 'agentic',
+        highlightedAt: new Date('2026-03-19T10:30:00.000Z'),
+        headline: 'Invisible post headline',
+        significance: HighlightSignificance.Routine,
+      },
+    ]);
+
+    const res = await client.query(POST_HIGHLIGHTS_FEED_QUERY, {
+      variables: { first: 10 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(
+      res.data.postHighlightsFeed.edges.map(({ node }) => node.post.id),
+    ).toEqual(['h1']);
+  });
+
   it('should filter by channel', async () => {
     await createTestPosts();
     await saveCanonicalHighlights([

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -171,6 +171,20 @@ type HighlightsFilters = {
   significances?: HighlightSignificance[];
 };
 
+const applyVisiblePostFilter = <T extends HighlightsCanonical>(
+  builder: SelectQueryBuilder<T>,
+  alias: string,
+): SelectQueryBuilder<T> =>
+  builder.andWhere(
+    `EXISTS (
+      SELECT 1
+      FROM "post" p
+      WHERE p."id" = "${alias}"."postId"
+        AND p."deleted" = false
+        AND p."visible" = true
+    )`,
+  );
+
 const applyHighlightsFilters = <T extends HighlightsCanonical>(
   builder: SelectQueryBuilder<T>,
   alias: string,
@@ -188,7 +202,7 @@ const applyHighlightsFilters = <T extends HighlightsCanonical>(
     builder.andWhere(`:highlightChannel = ANY("${alias}"."channels")`);
   }
 
-  return builder;
+  return applyVisiblePostFilter(builder, alias);
 };
 
 const resolveCanonicalHighlightsFeed = (
@@ -276,6 +290,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             })
             .orderBy(`"${builder.alias}"."highlightedAt"`, 'DESC')
             .addOrderBy(`"${builder.alias}"."id"`, 'DESC');
+          applyVisiblePostFilter(
+            builder.queryBuilder as SelectQueryBuilder<HighlightsCanonical>,
+            builder.alias,
+          );
           return builder;
         },
         true,


### PR DESCRIPTION
## Problem

`postHighlightsFeed` throws `Unexpected error` at `…node.post` in production when a highlighted post has been deleted.

Root cause: posts are **soft-deleted** (`deleted=true`, row kept), so the `highlights_canonical` FK `ON DELETE CASCADE` never fires and the highlight survives. GraphORM resolves the non-nullable `post: Post!` field with a `deleted=false AND visible=true` filter, so the correlated post subquery returns null → non-null violation → masked as `Unexpected error`.

Verified in prod: 2/1784 highlights were orphaned (both soft-deleted `share` posts). Those rows have been cleaned up separately.

## Fix

Add `applyVisiblePostFilter` — a correlated `EXISTS` requiring the highlight's post to exist, be `visible` and not `deleted`. Applied to `postHighlightsFeed`, `majorHeadlines`, and `postHighlights`.

GraphORM emits the nested `post` as a correlated subquery in the same SQL statement, so filtering the outer rows on the same predicate is **race-free** — the non-null `post` can never resolve to null.

## Test

Added a case marking one post `deleted` and another `visible=false`, asserting only the visible post's highlight is returned.

Build + lint clean; highlight query suites pass.