### PR TITLE
fix: don't mark headline backfill done when no sources resolve

### DIFF
--- a/__tests__/highlights.ts
+++ b/__tests__/highlights.ts
@@ -715,7 +715,7 @@ describe('query dailyHeadlines', () => {
       expect(action).not.toBeNull();
     });
 
-    it('should mark backfilled without seeding when no channel clears the minimum post count', async () => {
+    it('should not seed and not mark backfilled when no channel clears the minimum post count', async () => {
       loggedUser = '1';
 
       await saveDigestSource('backend_digest');
@@ -735,7 +735,7 @@ describe('query dailyHeadlines', () => {
         userId: '1',
         type: UserActionType.DailyHeadlinesBackfilled,
       });
-      expect(action).not.toBeNull();
+      expect(action).toBeNull();
     });
 
     it('should not seed when the user was already backfilled', async () => {
@@ -788,7 +788,7 @@ describe('query dailyHeadlines', () => {
       expect(action).not.toBeNull();
     });
 
-    it('should mark backfilled without seeding when the user has no onboarding tags', async () => {
+    it('should not seed and not mark backfilled when the user has no onboarding tags', async () => {
       loggedUser = '1';
 
       await saveDigestSource('backend_digest');
@@ -806,7 +806,45 @@ describe('query dailyHeadlines', () => {
         userId: '1',
         type: UserActionType.DailyHeadlinesBackfilled,
       });
-      expect(action).not.toBeNull();
+      expect(action).toBeNull();
+    });
+
+    it('should seed on a later call once onboarding tags exist', async () => {
+      loggedUser = '1';
+
+      await saveDigestSource('backend_digest');
+      await saveChannelDigest('backend', 'backend_digest', 'backend');
+      await saveChannelPosts('mh', ['backend'], 'nodejs', 3);
+      await saveDigestPost('bd-new', 'backend_digest', hoursAgo(2));
+      await refreshKeywordChannel();
+
+      const first = await client.query(DAILY_HEADLINES_BACKFILL_QUERY);
+      expect(first.errors).toBeFalsy();
+      expect(
+        await con.getRepository(UserAction).findOneBy({
+          userId: '1',
+          type: UserActionType.DailyHeadlinesBackfilled,
+        }),
+      ).toBeNull();
+
+      await followKeyword('nodejs');
+
+      const second = await client.query(DAILY_HEADLINES_BACKFILL_QUERY);
+      expect(second.errors).toBeFalsy();
+      const follows = await con
+        .getRepository(ContentPreferenceSource)
+        .find({ where: { userId: '1', feedId: '1' } });
+      expect(follows).toHaveLength(1);
+      expect(follows[0]).toMatchObject({
+        referenceId: 'backend_digest',
+        status: ContentPreferenceStatus.Follow,
+      });
+      expect(
+        await con.getRepository(UserAction).findOneBy({
+          userId: '1',
+          type: UserActionType.DailyHeadlinesBackfilled,
+        }),
+      ).not.toBeNull();
     });
   });
 });

--- a/src/common/channelDigest/headlineFollows.ts
+++ b/src/common/channelDigest/headlineFollows.ts
@@ -138,7 +138,6 @@ export const seedHeadlineChannelsForUser = async ({
   });
 
   if (!sourceIds.length) {
-    await markBackfilled({ manager: con, userId });
     return { seeded: false, sourceIds: [] };
   }
 


### PR DESCRIPTION
## Problem

`dailyHeadlines` can race onboarding. We observed a production case where the query resolved before the user's onboarding tag preferences were persisted (the backfill mark landed under a second before the first tag write).

So `resolveHeadlineChannelSourcesForUser` saw zero tags, returned `[]`, and `seedHeadlineChannelsForUser` hit the `!sourceIds.length` branch which called `markBackfilled`. Every subsequent call short-circuits on `alreadyBackfilled`, so the user never gets their channel digest follows — even though their tags resolve to matching digest sources afterwards.

## Fix

Don't mark the user as backfilled when the resolved source list is empty (no tags yet, or no channel clears the min-posts threshold). The resolve query is cheap, so retrying on later calls is fine. The user still gets marked once seeding actually happens (or when they already have a digest preference).

## Tests

- Updated the two existing "mark backfilled without seeding" tests to assert no `user_action` row is written.
- Added a regression test for the race: first call with no tags doesn't lock the user; a second call after tags exist seeds the follows and marks backfilled.

A companion apps PR gates the `dailyHeadlines` fetch behind `isOnboardingComplete` so the query doesn't fire mid-onboarding in the first place.