### PR TITLE
feat(contribution): add suggestContributionCause mutation

### DIFF
--- a/__tests__/contributions.ts
+++ b/__tests__/contributions.ts
@@ -331,6 +331,14 @@ mutation ClaimContributionReward($tierId: ID!) {
 }
 `;
 
+const SUGGEST_CONTRIBUTION_CAUSE_MUTATION = `
+mutation SuggestContributionCause($url: String!, $note: String) {
+  suggestContributionCause(url: $url, note: $note) {
+    _
+  }
+}
+`;
+
 beforeAll(async () => {
   con = await createOrGetConnection();
   const app = await appFunc();
@@ -965,6 +973,57 @@ it('notifies Slack when claiming a store_discount reward', async () => {
     variables: { tierId: discountTierId },
   });
   expect(sendSpy).toHaveBeenCalledTimes(1);
+});
+
+it('posts a suggested cause to Slack for a contributor who unlocked the reward', async () => {
+  const sendSpy = jest
+    .spyOn(webhooks.contributions, 'send')
+    .mockResolvedValue(undefined);
+  await con.getRepository(Feature).save({
+    userId,
+    feature: FeatureType.ContributionSuggestCauses,
+    value: FeatureValue.Allow,
+  });
+
+  const res = await client.mutate(SUGGEST_CONTRIBUTION_CAUSE_MUTATION, {
+    variables: { url: 'https://example.org', note: 'they do great work' },
+  });
+
+  expect(res.errors).toBeUndefined();
+  expect(res.data.suggestContributionCause).toEqual({ _: true });
+  expect(sendSpy).toHaveBeenCalledTimes(1);
+  expect(sendSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      text: expect.stringContaining('https://example.org'),
+    }),
+  );
+});
+
+it('rejects a cause suggestion when the reward is not unlocked', async () => {
+  const sendSpy = jest
+    .spyOn(webhooks.contributions, 'send')
+    .mockResolvedValue(undefined);
+
+  const res = await client.mutate(SUGGEST_CONTRIBUTION_CAUSE_MUTATION, {
+    variables: { url: 'https://example.org' },
+  });
+
+  expect(res.errors?.[0].extensions?.code).toBe('FORBIDDEN');
+  expect(sendSpy).not.toHaveBeenCalled();
+});
+
+it('rejects a malformed cause url', async () => {
+  await con.getRepository(Feature).save({
+    userId,
+    feature: FeatureType.ContributionSuggestCauses,
+    value: FeatureValue.Allow,
+  });
+
+  const res = await client.mutate(SUGGEST_CONTRIBUTION_CAUSE_MUTATION, {
+    variables: { url: 'not-a-url' },
+  });
+
+  expect(res.errors).toBeTruthy();
 });
 
 it('returns finalized cause totals, user cause stats, and sponsors', async () => {

--- a/src/common/schema/contributions.ts
+++ b/src/common/schema/contributions.ts
@@ -72,6 +72,11 @@ export const updateContributionCausePreferencesArgsSchema = z.object({
   causeIds: z.array(z.uuid()).max(50),
 });
 
+export const suggestContributionCauseArgsSchema = z.object({
+  url: z.url(),
+  note: z.string().trim().min(1).max(1000).nullish(),
+});
+
 export const claimContributionRewardArgsSchema = z.object({
   tierId: z.uuid(),
 });

--- a/src/common/slack.ts
+++ b/src/common/slack.ts
@@ -321,6 +321,54 @@ export const notifyContributionRewardClaimedSlack = async ({
   });
 };
 
+// A contributor who unlocked the "suggest a cause" reward nominated a nonprofit
+// or open-source fund. We don't store it — the team reviews the link here and
+// decides whether to add it to the vetted causes.
+export const notifyContributionCauseSuggestedSlack = async ({
+  user,
+  url,
+  note,
+}: {
+  user: Pick<User, 'id' | 'username' | 'name' | 'email'>;
+  url: string;
+  note?: string | null;
+}): Promise<void> => {
+  const displayName = user.name || user.username || user.id;
+
+  await webhooks.contributions.send({
+    text: `${displayName} suggested a cause: ${url}`,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: '💡 New cause suggestion to review',
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*From:*\n<${getUserPermalink(user)}|${displayName}>\n\`${user.id}\``,
+          },
+          { type: 'mrkdwn', text: `*Email:*\n${user.email ?? '—'}` },
+          { type: 'mrkdwn', text: `*Cause:*\n<${url}|${url}>` },
+        ],
+      },
+      ...(note
+        ? [
+            {
+              type: 'section' as const,
+              text: { type: 'mrkdwn' as const, text: `*Note:*\n${note}` },
+            },
+          ]
+        : []),
+    ],
+  });
+};
+
 export const notifyNewComment = async (
   post: Post,
   userId: string,

--- a/src/schema/contributions.ts
+++ b/src/schema/contributions.ts
@@ -20,9 +20,13 @@ import {
   validateContributionEvidence,
 } from '../common/contribution';
 import { fulfillContributionReward } from '../common/contribution/rewards';
-import { notifyContributionRewardClaimedSlack } from '../common/slack';
+import {
+  notifyContributionCauseSuggestedSlack,
+  notifyContributionRewardClaimedSlack,
+} from '../common/slack';
 import { logger } from '../logger';
 import { User } from '../entity/user/User';
+import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import {
   claimContributionRewardArgsSchema,
   contributionActionLinksArgsSchema,
@@ -30,6 +34,7 @@ import {
   contributionConnectionArgsSchema,
   contributionSubmissionsArgsSchema,
   submitContributionActionInputSchema,
+  suggestContributionCauseArgsSchema,
   updateContributionCausePreferencesArgsSchema,
 } from '../common/schema/contributions';
 import { ContributionAction } from '../entity/contribution/ContributionAction';
@@ -565,6 +570,13 @@ export const typeDefs = /* GraphQL */ `
       input: SubmitContributionActionInput!
     ): ContributionSubmission! @auth @contributionEligibility
     updateContributionCausePreferences(causeIds: [ID!]!): EmptyResponse!
+      @auth
+      @contributionEligibility
+    """
+    Nominates a cause (by URL, with an optional note) for the team to review.
+    Not stored — the suggestion is posted to Slack for a human decision.
+    """
+    suggestContributionCause(url: String!, note: String): EmptyResponse!
       @auth
       @contributionEligibility
     claimContributionReward(tierId: ID!): UserContributionReward!
@@ -1240,6 +1252,49 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       }
 
       return state;
+    },
+    suggestContributionCause: async (
+      _,
+      args: z.infer<typeof suggestContributionCauseArgsSchema>,
+      ctx: AuthContext,
+    ): Promise<GQLEmptyResponse> => {
+      const { url, note } = parseContributionArgs(
+        suggestContributionCauseArgsSchema,
+        args,
+      );
+
+      // Nominating a cause is a reward: only contributors who claimed the
+      // `suggest_causes` tier hold the feature access it grants (see
+      // fulfillContributionSuggestCausesReward).
+      const canSuggest = await ctx.con.getRepository(Feature).exists({
+        where: {
+          userId: ctx.userId,
+          feature: FeatureType.ContributionSuggestCauses,
+          value: FeatureValue.Allow,
+        },
+      });
+
+      if (!canSuggest) {
+        throw new ForbiddenError(
+          'Unlock the suggest-a-cause reward to nominate a cause',
+        );
+      }
+
+      const user = await ctx.con.getRepository(User).findOne({
+        select: ['id', 'username', 'name', 'email'],
+        where: { id: ctx.userId },
+      });
+
+      if (!user) {
+        throw new NotFoundError('User not found');
+      }
+
+      // The Slack post is the only place the suggestion lands (no DB row), so a
+      // failed send must surface as an error the caller can retry — don't
+      // swallow it the way reward-claim notifications do.
+      await notifyContributionCauseSuggestedSlack({ user, url, note });
+
+      return { _: true };
     },
   },
   Subscription: {


### PR DESCRIPTION
## What

Adds `suggestContributionCause(url, note): EmptyResponse! @auth @contributionEligibility`.

Contributors who unlocked the `suggest_causes` reward can nominate a cause by URL (with an optional note). The suggestion isn't stored — it's posted to the contributions Slack channel for the team to review.

- Resolver enforces the reward's feature access (`contribution_suggest_causes`); returns `FORBIDDEN` without it.
- `notifyContributionCauseSuggestedSlack` posts to the existing `webhooks.contributions` channel (`SLACK_CONTRIBUTIONS_WEBHOOK`).
- The Slack send is **not** swallowed — a failure surfaces as an error to retry, since it's the only place the suggestion lands.

Frontend: dailydotdev/apps#6293.

## Notes

- Needs `SLACK_CONTRIBUTIONS_WEBHOOK` set in the deploy env (no-ops safely if unset).

## Test plan

- [x] Posts a suggested cause to Slack for a contributor who unlocked the reward
- [x] Rejects the suggestion (FORBIDDEN) when the reward is not unlocked
- [x] Rejects a malformed URL