### PR TITLE
fix: resolve daily personalise state via snotra user API

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -36,7 +36,7 @@ import {
 } from '../src/entity';
 import { PollOption } from '../src/entity/polls/PollOption';
 import { SourceMemberRoles } from '../src/roles';
-import { snotraClient } from '../src/integrations/snotra/clients';
+import { snotraUserApiClient } from '../src/integrations/snotra/clients';
 import { PersonaliseState } from '../src/integrations/snotra/types';
 import { Category } from '../src/entity/Category';
 import { Persona } from '../src/entity/Persona';
@@ -1578,7 +1578,7 @@ describe('query dailyFeed', () => {
     loggedUser = '1';
     await saveFeedFixtures();
 
-    jest.spyOn(snotraClient, 'getUserProfile').mockResolvedValue({
+    jest.spyOn(snotraUserApiClient, 'getUserProfile').mockResolvedValue({
       personalise: { state: PersonaliseState.Personalised },
     });
     nock('http://localhost:6000')
@@ -1605,7 +1605,7 @@ describe('query dailyFeed', () => {
     loggedUser = '1';
     await saveFeedFixtures();
 
-    jest.spyOn(snotraClient, 'getUserProfile').mockResolvedValue({
+    jest.spyOn(snotraUserApiClient, 'getUserProfile').mockResolvedValue({
       personalise: { state: PersonaliseState.NonPersonalised },
     });
     nock('http://localhost:6000')
@@ -1630,7 +1630,7 @@ describe('query dailyFeed', () => {
     loggedUser = '1';
     await saveFeedFixtures();
 
-    jest.spyOn(snotraClient, 'getUserProfile').mockResolvedValue({
+    jest.spyOn(snotraUserApiClient, 'getUserProfile').mockResolvedValue({
       personalise: { state: PersonaliseState.Personalised },
     });
     // Only one feed-service mock: a second call would have no nock match and fail.

--- a/src/integrations/feed/generators.ts
+++ b/src/integrations/feed/generators.ts
@@ -18,7 +18,7 @@ import {
   SimpleFeedConfigGenerator,
 } from './configs';
 import { LofnClient } from '../lofn';
-import { snotraClient } from '../snotra/clients';
+import { snotraUserApiClient } from '../snotra/clients';
 import { GarmrService } from '../garmr';
 import { FeedOrderBy } from '../../entity/Feed';
 import { postTypes } from '../../entity/posts/Post';
@@ -131,7 +131,7 @@ export const getForYouByTagFeedGenerator = (tags: string[]): FeedGenerator =>
 
 export const dailyFeedConfigGenerator = new FeedDailyConfigGenerator(
   baseFeedConfig,
-  snotraClient,
+  snotraUserApiClient,
   opts,
 );
 

--- a/src/integrations/snotra/clients.ts
+++ b/src/integrations/snotra/clients.ts
@@ -90,3 +90,19 @@ const garmrSnotraService = new GarmrService({
 export const snotraClient = new SnotraClient(process.env.SNOTRA_ORIGIN!, {
   garmr: garmrSnotraService,
 });
+
+const garmrSnotraUserApiService = new GarmrService({
+  service: 'snotra-user-api',
+  breakerOpts: {
+    halfOpenAfter: 5 * 1000,
+    threshold: 0.1,
+    duration: 10 * 1000,
+  },
+});
+
+export const snotraUserApiClient = new SnotraClient(
+  process.env.SNOTRA_USER_API_ORIGIN!,
+  {
+    garmr: garmrSnotraUserApiService,
+  },
+);


### PR DESCRIPTION
## Problem

`FeedDailyConfigGenerator` resolves the user's personalise state to pick between `daily_v1` (personalised) and `daily_cs_v1` (cold start). It was constructed with the shared `snotraClient`, which points at `SNOTRA_ORIGIN` (the snotra memory API). That origin serves `/api/v1/memstore/shortprofile` but not `/api/v1/user/profile`, so every `getUserProfile` call fails with a 404.

Because `resolvePersonaliseState` swallows the error and returns `undefined`, the generator always falls back to the personalised config:

- `daily_cs_v1` is never selected in production (zero requests in `fss_events` over the last 20 days).
- Cold-start users (no sauron embeddings yet) get an empty daily feed from `daily_v1` — observed via the `failed to resolve snotra personalise state for daily feed` error logged on every dailyHeadlines request, and a chunk of daily-posts responses returning 0 posts for recently onboarded users.

## Fix

Add `snotraUserApiClient` pointing at `SNOTRA_USER_API_ORIGIN` (the same origin the personalized digest flow already uses for `getUserProfile`) and wire it into `dailyFeedConfigGenerator`. Existing `snotraClient` consumers (`getProfile` / memstore endpoints) are untouched.

Verified `daily_cs_v1` itself returns posts when exercised directly against the feed service with production-shaped payloads, so fixing state resolution is enough to restore the cold-start path.

## Tests

Updated the `getUserProfile` spies in `__tests__/feeds.ts` to target the new client.