### PR TITLE
fix(achievements): follower_gain progress uses absolute follower count

### DIFF
--- a/src/common/achievement/index.ts
+++ b/src/common/achievement/index.ts
@@ -269,6 +269,7 @@ export async function checkAchievementProgress(
     }
 
     const absoluteValueEventTypes: AchievementEventType[] = [
+      AchievementEventType.FollowerGain,
       AchievementEventType.ReferralCount,
       AchievementEventType.ReputationGain,
       AchievementEventType.ReadingStreak,

--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -108,7 +108,7 @@ import {
   triggerTypedEvent,
 } from '../../common';
 import { ChangeMessage, ChangeObject, CoresRole, UserVote } from '../../types';
-import { DataSource, IsNull } from 'typeorm';
+import { DataSource, In, IsNull } from 'typeorm';
 import { FastifyBaseLogger } from 'fastify';
 import { updateAlerts } from '../../schema/alerts';
 import { CommentReport } from '../../entity/CommentReport';
@@ -2178,7 +2178,10 @@ const onContentPreferenceChange = async (
               where: {
                 referenceId: contentPreferenceUser.referenceId,
                 type: ContentPreferenceType.User,
-                status: ContentPreferenceStatus.Follow,
+                status: In([
+                  ContentPreferenceStatus.Follow,
+                  ContentPreferenceStatus.Subscribed,
+                ]),
               },
             });
           await checkAchievementProgress(


### PR DESCRIPTION
## Problem

User feedback (ENG-1796): the **Prophet** achievement ("Gain 100 followers") showed **99/100** progress for a user with only **15 followers**.

## Root cause

`follower_gain` achievements (Prophet, Shepherd) are evaluated in `checkAchievementProgress`, but `AchievementEventType.FollowerGain` was **missing** from `absoluteValueEventTypes`. As a result:

- The CDC handler (`onContentPreferenceChange`) computes the real `followerCount` and passes it as `currentValue`, but the code fell through to the **milestone** evaluator, which ignores `currentValue` and just does `progress += 1` on every follow event.
- On unfollow (`op === 'd'`) only Quest progress is decremented — the achievement progress is never brought back down.

So progress increments on every follow and never decrements, drifting far above the real follower count over follow/unfollow churn.

The retroactive backfill handler (`handleFollowerGain`) already does it correctly — it counts `content_preference` where `status IN ('follow','subscribed')` and **sets** progress to that absolute value. The live path and the backfill disagreed.

## Fix

1. Add `AchievementEventType.FollowerGain` to `absoluteValueEventTypes` so progress is **set** to the true follower count (already computed and passed as `currentValue`) instead of incremented.
2. Align the live follower count filter in `primary.ts` to `status IN (follow, subscribed)` to match the retroactive handler.

## Follow-up (not in this PR)

Re-run the `FollowerGain` retroactive sync to correct users whose progress already drifted (e.g. the reporter would go from 99 back to 15).

Fixes ENG-1796
