### PR TITLE
fix: debezium and clickhouse publications

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -1,5 +1,6 @@
 debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
 debezium.source.slot.name=%slot_name%
+debezium.source.publication.name=api_debezium
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
 debezium.source.database.hostname=%hostname%

--- a/.infra/clickhouse-sync.yml
+++ b/.infra/clickhouse-sync.yml
@@ -51,6 +51,7 @@ database.allowPublicKeyRetrieval: "true"
 snapshot.mode: "no_data"
 
 slot.name: "clickhouse_sync"
+publication.name: "clickhouse_sync"
 
 # offset.flush.interval.ms: The number of milliseconds to wait before flushing recent offsets to Kafka. This ensures that offsets are committed within the specified time interval.
 offset.flush.timeout.ms: 10000


### PR DESCRIPTION
## What changed

- configure the daily CDC connector to use the api_debezium publication
- configure ClickHouse sync to use the clickhouse_sync publication

## Why

The connectors should not share the default Debezium publication. Giving each connector an explicit publication isolates its publication lifecycle and lets later rollout changes be made independently.

## Scope

Heartbeat support, post.views exclusion, and filtered publication auto-creation are intentionally deferred to follow-up PRs.

## Validation

- pnpm run build
- pnpm run lint
- git diff --check