### PR TITLE
feat: fall back to onboarding-selected tags in feedTagsList

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -6347,20 +6347,110 @@ describe('query feedTagsList', () => {
     });
   });
 
-  it('should cache empty and return empty when feed service fails', async () => {
+  it('should cache empty and return empty when all sources are empty', async () => {
     loggedUser = '1';
     nock('http://localhost:6000')
       .post('/api/user_tags')
       .replyWithError('feed service down');
+    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     const res = await client.query(QUERY, { variables: { limit: 5 } });
     expect(res.errors).toBeFalsy();
     expect(res.data.feedTagsList.tags).toEqual([]);
-    expect(recommendTagsMock).not.toHaveBeenCalled();
 
     const user = await con.getRepository(User).findOneBy({ id: '1' });
     expect(user?.flags?.feedTagsList?.tags).toEqual([]);
     expect(user?.flags?.feedTagsList?.updatedAt).toEqual(expect.any(String));
+  });
+
+  it('should fall back to onboarding-selected tags when feed and recswipe return nothing', async () => {
+    loggedUser = '1';
+    await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
+    await saveFixtures(con, Keyword, [
+      { value: 'onboarding-1', status: 'allow' },
+      { value: 'onboarding-2', status: 'allow' },
+      { value: 'onboarding-blocked', status: 'allow' },
+    ]);
+    await saveFixtures(con, ContentPreferenceKeyword, [
+      {
+        feedId: '1',
+        keywordId: 'onboarding-1',
+        referenceId: 'onboarding-1',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+      {
+        feedId: '1',
+        keywordId: 'onboarding-2',
+        referenceId: 'onboarding-2',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+      {
+        feedId: '1',
+        keywordId: 'onboarding-blocked',
+        referenceId: 'onboarding-blocked',
+        status: ContentPreferenceStatus.Blocked,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+    ]);
+
+    nock('http://localhost:6000')
+      .post('/api/user_tags')
+      .reply(200, { data: [] });
+    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
+
+    const res = await client.query(QUERY, { variables: { limit: 5 } });
+    expect(res.errors).toBeFalsy();
+    expect(recommendTagsMock).toHaveBeenCalled();
+    expect(res.data.feedTagsList.tags).toEqual([
+      { value: 'onboarding-1', label: 'onboarding-1' },
+      { value: 'onboarding-2', label: 'onboarding-2' },
+    ]);
+
+    const user = await con.getRepository(User).findOneBy({ id: '1' });
+    expect(user?.flags?.feedTagsList?.tags).toEqual([
+      { value: 'onboarding-1', label: 'onboarding-1' },
+      { value: 'onboarding-2', label: 'onboarding-2' },
+    ]);
+  });
+
+  it('should not use onboarding fallback when feed service returns tags', async () => {
+    loggedUser = '1';
+    await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
+    await saveFixtures(con, Keyword, [
+      { value: 'onboarding-1', status: 'allow' },
+    ]);
+    await saveFixtures(con, ContentPreferenceKeyword, [
+      {
+        feedId: '1',
+        keywordId: 'onboarding-1',
+        referenceId: 'onboarding-1',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+    ]);
+
+    nock('http://localhost:6000')
+      .post('/api/user_tags')
+      .reply(200, {
+        data: ['ai-coding', 'llm', 'claude-code', 'ai-agents', 'anthropic'],
+      });
+
+    const res = await client.query(QUERY, { variables: { limit: 5 } });
+    expect(res.errors).toBeFalsy();
+    expect(recommendTagsMock).not.toHaveBeenCalled();
+    expect(res.data.feedTagsList.tags).toEqual([
+      { value: 'ai-coding', label: 'ai-coding' },
+      { value: 'llm', label: 'llm' },
+      { value: 'claude-code', label: 'claude-code' },
+      { value: 'ai-agents', label: 'ai-agents' },
+      { value: 'anthropic', label: 'anthropic' },
+    ]);
   });
 
   it('should dedupe overlap between feed and recswipe results', async () => {

--- a/src/common/feedTagsList.ts
+++ b/src/common/feedTagsList.ts
@@ -2,6 +2,8 @@ import type { DataSource } from 'typeorm';
 import { In } from 'typeorm';
 import { User } from '../entity/user/User';
 import { Keyword } from '../entity/Keyword';
+import { ContentPreferenceKeyword } from '../entity/contentPreference/ContentPreferenceKeyword';
+import { ContentPreferenceStatus } from '../entity/contentPreference/types';
 import { feedClient } from '../integrations/feed/generators';
 import { recswipeClient } from '../integrations/recswipe/clients';
 import { queryReadReplica } from './queryReadReplica';
@@ -105,19 +107,12 @@ export const getFeedTagsList = async ({
     return { tags: cached.tags.slice(0, limit) };
   }
 
-  let values: string[];
+  let values: string[] = [];
   try {
-    values = await feedClient.getUserTags(userId, limit);
+    values = dedupeKeepOrder(await feedClient.getUserTags(userId, limit));
   } catch (err) {
-    logger.error(
-      { err, userId },
-      'feedClient.getUserTags failed; caching empty feedTagsList',
-    );
-    await writeCache({ con, userId, tags: [] });
-    return { tags: [] };
+    logger.error({ err, userId }, 'feedClient.getUserTags failed');
   }
-
-  values = dedupeKeepOrder(values);
 
   if (values.length < limit) {
     try {
@@ -135,6 +130,24 @@ export const getFeedTagsList = async ({
         'recswipeClient.recommendTags failed; using feedClient tags only',
       );
     }
+  }
+
+  if (!values.length) {
+    const followed = await queryReadReplica(con, ({ queryRunner }) =>
+      queryRunner.manager.getRepository(ContentPreferenceKeyword).find({
+        select: ['keywordId'],
+        where: {
+          userId,
+          feedId: userId,
+          status: ContentPreferenceStatus.Follow,
+        },
+        take: limit,
+      }),
+    );
+    values = dedupeKeepOrder(followed.map((pref) => pref.keywordId)).slice(
+      0,
+      limit,
+    );
   }
 
   const tags = await resolveLabels({ con, values });


### PR DESCRIPTION
When both the feed service and recswipe return no tags, fall back to the user's onboarding-selected tags (ContentPreferenceKeyword follows). A feed service failure now also flows through recswipe and the fallback instead of short-circuiting to an empty cached result.