### PR TITLE
feat: fall back to onboarding follows when seeding tag-chip feeds

### DIFF
--- a/__tests__/common/seedTagChipFeeds.ts
+++ b/__tests__/common/seedTagChipFeeds.ts
@@ -7,7 +7,10 @@ import { Keyword } from '../../src/entity/Keyword';
 import { Feed, FeedOrigin } from '../../src/entity/Feed';
 import { FeedTag } from '../../src/entity/FeedTag';
 import { ContentPreferenceKeyword } from '../../src/entity/contentPreference/ContentPreferenceKeyword';
-import { ContentPreferenceStatus } from '../../src/entity/contentPreference/types';
+import {
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../../src/entity/contentPreference/types';
 import { feedClient } from '../../src/integrations/feed/generators';
 import { recswipeClient } from '../../src/integrations/recswipe/clients';
 import { seedTagChipFeedsIfNeeded } from '../../src/common/seedTagChipFeeds';
@@ -154,13 +157,53 @@ describe('seedTagChipFeedsIfNeeded', () => {
     });
   });
 
-  it('seeds nothing when feedClient and recswipe both return empty', async () => {
+  it('seeds nothing when feedClient, recswipe and onboarding follows are all empty', async () => {
     getUserTagsMock.mockResolvedValue([]);
     recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 5 });
 
     expect(await getChipFeeds('1')).toHaveLength(0);
+  });
+
+  it('falls back to onboarding follows when feedClient and recswipe return nothing', async () => {
+    getUserTagsMock.mockResolvedValue([]);
+    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
+    await saveFixtures(con, ContentPreferenceKeyword, [
+      {
+        feedId: '1',
+        keywordId: 'javascript',
+        referenceId: 'javascript',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+      {
+        feedId: '1',
+        keywordId: 'nodejs',
+        referenceId: 'nodejs',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+      {
+        feedId: '1',
+        keywordId: 'webdev',
+        referenceId: 'webdev',
+        status: ContentPreferenceStatus.Blocked,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+    ]);
+
+    await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 5 });
+
+    const feeds = await getChipFeeds('1');
+    expect(feeds.map((f) => f.flags.name).sort()).toEqual([
+      'JavaScript',
+      'Node.js',
+    ]);
+    expect(recommendTagsMock).toHaveBeenCalled();
   });
 
   it("caps the seed count at the user's remaining feed headroom", async () => {

--- a/src/common/seedTagChipFeeds.ts
+++ b/src/common/seedTagChipFeeds.ts
@@ -84,9 +84,11 @@ const reserveSeedSlot = async ({
 };
 
 const getSeedTagValues = async ({
+  con,
   userId,
   limit,
 }: {
+  con: DataSource;
   userId: string;
   limit: number;
 }): Promise<string[]> => {
@@ -117,6 +119,24 @@ const getSeedTagValues = async ({
         'recswipeClient.recommendTags failed; seeding tag-chip feeds with feedClient tags only',
       );
     }
+  }
+
+  if (!values.length) {
+    const followed = await queryReadReplica(con, ({ queryRunner }) =>
+      queryRunner.manager.getRepository(ContentPreferenceKeyword).find({
+        select: ['keywordId'],
+        where: {
+          userId,
+          feedId: userId,
+          status: ContentPreferenceStatus.Follow,
+        },
+        take: limit,
+      }),
+    );
+    values = dedupeKeepOrder(followed.map((pref) => pref.keywordId)).slice(
+      0,
+      limit,
+    );
   }
 
   return values;
@@ -153,7 +173,11 @@ export const seedTagChipFeedsIfNeeded = async ({
     return false;
   }
 
-  const values = await getSeedTagValues({ userId, limit: effectiveLimit });
+  const values = await getSeedTagValues({
+    con,
+    userId,
+    limit: effectiveLimit,
+  });
   if (!values.length) {
     return false;
   }


### PR DESCRIPTION
When feedClient.getUserTags and recswipe both return nothing (e.g. a user who just completed onboarding before the feed service indexed their tags), seed the tag-chip feeds from the user's onboarding-selected follows (ContentPreferenceKeyword, status Follow, main feed) instead of seeding nothing.