### PR TITLE
refactor: drop recswipe from tag-chip feed seeding

### DIFF
--- a/__tests__/common/seedTagChipFeeds.ts
+++ b/__tests__/common/seedTagChipFeeds.ts
@@ -12,7 +12,6 @@ import {
   ContentPreferenceType,
 } from '../../src/entity/contentPreference/types';
 import { feedClient } from '../../src/integrations/feed/generators';
-import { recswipeClient } from '../../src/integrations/recswipe/clients';
 import { seedTagChipFeedsIfNeeded } from '../../src/common/seedTagChipFeeds';
 
 jest.mock('../../src/integrations/feed/generators', () => ({
@@ -22,18 +21,8 @@ jest.mock('../../src/integrations/feed/generators', () => ({
   },
 }));
 
-jest.mock('../../src/integrations/recswipe/clients', () => ({
-  ...jest.requireActual('../../src/integrations/recswipe/clients'),
-  recswipeClient: {
-    recommendTags: jest.fn(),
-  },
-}));
-
 const getUserTagsMock = feedClient.getUserTags as jest.MockedFunction<
   typeof feedClient.getUserTags
->;
-const recommendTagsMock = recswipeClient.recommendTags as jest.MockedFunction<
-  typeof recswipeClient.recommendTags
 >;
 
 let con: DataSource;
@@ -44,7 +33,6 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   getUserTagsMock.mockReset();
-  recommendTagsMock.mockReset();
   await saveFixtures(con, User, usersFixture);
   // main feed (id === userId) — ContentPreferenceKeyword.feedId FKs to feed.id
   await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
@@ -88,7 +76,6 @@ describe('seedTagChipFeedsIfNeeded', () => {
       const tags = await con.getRepository(FeedTag).findBy({ feedId: feed.id });
       expect(tags).toHaveLength(1);
     }
-    expect(recommendTagsMock).not.toHaveBeenCalled();
   });
 
   it('falls back to the keyword value when no title exists', async () => {
@@ -119,56 +106,29 @@ describe('seedTagChipFeedsIfNeeded', () => {
 
   it('does not retry even when the previous attempt yielded zero feeds', async () => {
     getUserTagsMock.mockResolvedValue([]);
-    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 5 });
     expect(await getChipFeeds('1')).toHaveLength(0);
 
     // a second call must NOT call upstream again — flag is set
     getUserTagsMock.mockClear();
-    recommendTagsMock.mockClear();
     getUserTagsMock.mockResolvedValue(['javascript']);
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [{ tag: 'nodejs', score: 0.9 }],
-    });
 
     await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 5 });
     expect(await getChipFeeds('1')).toHaveLength(0);
     expect(getUserTagsMock).not.toHaveBeenCalled();
-    expect(recommendTagsMock).not.toHaveBeenCalled();
   });
 
-  it('backfills with recswipe when feedClient returns fewer than limit', async () => {
-    getUserTagsMock.mockResolvedValue(['javascript']);
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [
-        { tag: 'nodejs', score: 0.9 },
-        { tag: 'webdev', score: 0.8 },
-      ],
-    });
-
-    await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 3 });
-
-    const feeds = await getChipFeeds('1');
-    expect(feeds).toHaveLength(3);
-    expect(recommendTagsMock).toHaveBeenCalledWith('1', {
-      selectedTags: ['javascript'],
-      n: 2,
-    });
-  });
-
-  it('seeds nothing when feedClient, recswipe and onboarding follows are all empty', async () => {
+  it('seeds nothing when feedClient and onboarding follows are both empty', async () => {
     getUserTagsMock.mockResolvedValue([]);
-    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 5 });
 
     expect(await getChipFeeds('1')).toHaveLength(0);
   });
 
-  it('falls back to onboarding follows when feedClient and recswipe return nothing', async () => {
+  it('falls back to onboarding follows when feedClient returns nothing', async () => {
     getUserTagsMock.mockResolvedValue([]);
-    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
     await saveFixtures(con, ContentPreferenceKeyword, [
       {
         feedId: '1',
@@ -203,7 +163,6 @@ describe('seedTagChipFeedsIfNeeded', () => {
       'JavaScript',
       'Node.js',
     ]);
-    expect(recommendTagsMock).toHaveBeenCalled();
   });
 
   it("caps the seed count at the user's remaining feed headroom", async () => {
@@ -246,26 +205,28 @@ describe('seedTagChipFeedsIfNeeded', () => {
 
     expect(await getChipFeeds('1')).toHaveLength(0);
     expect(getUserTagsMock).not.toHaveBeenCalled();
-    expect(recommendTagsMock).not.toHaveBeenCalled();
 
     // flag is still set — bootstrap won't retry on next call.
     const user = await con.getRepository(User).findOneByOrFail({ id: '1' });
     expect(user.flags?.tagChipFeedsSeededAt).toEqual(expect.any(String));
   });
 
-  it('falls back to recswipe only when feedClient fails', async () => {
+  it('falls back to onboarding follows when feedClient fails', async () => {
     getUserTagsMock.mockRejectedValue(new Error('boom'));
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [{ tag: 'nodejs', score: 0.9 }],
-    });
+    await saveFixtures(con, ContentPreferenceKeyword, [
+      {
+        feedId: '1',
+        keywordId: 'nodejs',
+        referenceId: 'nodejs',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      },
+    ]);
 
     await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 2 });
 
     const feeds = await getChipFeeds('1');
     expect(feeds.map((f) => f.flags.name)).toEqual(['Node.js']);
-    expect(recommendTagsMock).toHaveBeenCalledWith('1', {
-      selectedTags: [],
-      n: 2,
-    });
   });
 });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -74,7 +74,6 @@ import { maxFeedsPerUser, UserVote } from '../src/types';
 import { SubmissionFailErrorMessage } from '../src/errors';
 import { baseFeedConfig, FeedConfigName } from '../src/integrations/feed';
 import { feedClient } from '../src/integrations/feed/generators';
-import { recswipeClient } from '../src/integrations/recswipe/clients';
 import {
   ContentPreferenceStatus,
   ContentPreferenceType,
@@ -84,17 +83,6 @@ import { ContentPreferenceKeyword } from '../src/entity/contentPreference/Conten
 import { ContentPreferenceWord } from '../src/entity/contentPreference/ContentPreferenceWord';
 import { ContentPreferenceUser } from '../src/entity/contentPreference/ContentPreferenceUser';
 import { SubscriptionCycles } from '../src/paddle';
-
-jest.mock('../src/integrations/recswipe/clients', () => ({
-  ...jest.requireActual('../src/integrations/recswipe/clients'),
-  recswipeClient: {
-    recommendTags: jest.fn(),
-  },
-}));
-
-const recommendTagsMock = recswipeClient.recommendTags as jest.MockedFunction<
-  typeof recswipeClient.recommendTags
->;
 
 let app: FastifyInstance;
 let con: DataSource;
@@ -4864,8 +4852,6 @@ describe('query feedList', () => {
     let getUserTagsSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      recommendTagsMock.mockReset();
-      recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
       getUserTagsSpy = jest
         .spyOn(feedClient, 'getUserTags')
         .mockResolvedValue([]);
@@ -4890,7 +4876,6 @@ describe('query feedList', () => {
         .getMany();
       expect(chipFeeds).toHaveLength(0);
       expect(getUserTagsSpy).not.toHaveBeenCalled();
-      expect(recommendTagsMock).not.toHaveBeenCalled();
     });
 
     it('excludes existing tag-chip feeds from the response when omitted', async () => {
@@ -6177,10 +6162,6 @@ describe('query feedTagsList', () => {
     }
   `;
 
-  beforeEach(() => {
-    recommendTagsMock.mockReset();
-  });
-
   it('should require auth', async () => {
     return testQueryErrorCode(
       client,
@@ -6211,7 +6192,6 @@ describe('query feedTagsList', () => {
       { value: 'anthropic', label: 'anthropic' },
     ]);
     expect(capturedBody).toEqual({ user_id: '1', limit: 5 });
-    expect(recommendTagsMock).not.toHaveBeenCalled();
 
     const user = await con.getRepository(User).findOneBy({ id: '1' });
     expect(user?.flags?.feedTagsList?.tags).toEqual([
@@ -6327,41 +6307,11 @@ describe('query feedTagsList', () => {
     expect(nock.pendingMocks()).toEqual([]);
   });
 
-  it('should backfill with recswipe when feed returns fewer than limit', async () => {
-    loggedUser = '1';
-    nock('http://localhost:6000')
-      .post('/api/user_tags')
-      .reply(200, { data: ['ai-coding', 'llm'] });
-
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [
-        { tag: 'machine-learning', score: 0.9 },
-        { tag: 'pytorch', score: 0.8 },
-        { tag: 'tensorflow', score: 0.7 },
-      ],
-    });
-
-    const res = await client.query(QUERY, { variables: { limit: 5 } });
-    expect(res.errors).toBeFalsy();
-    expect(res.data.feedTagsList.tags).toEqual([
-      { value: 'ai-coding', label: 'ai-coding' },
-      { value: 'llm', label: 'llm' },
-      { value: 'machine-learning', label: 'machine-learning' },
-      { value: 'pytorch', label: 'pytorch' },
-      { value: 'tensorflow', label: 'tensorflow' },
-    ]);
-    expect(recommendTagsMock).toHaveBeenCalledWith('1', {
-      selectedTags: ['ai-coding', 'llm'],
-      n: 3,
-    });
-  });
-
   it('should cache empty and return empty when all sources are empty', async () => {
     loggedUser = '1';
     nock('http://localhost:6000')
       .post('/api/user_tags')
       .replyWithError('feed service down');
-    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     const res = await client.query(QUERY, { variables: { limit: 5 } });
     expect(res.errors).toBeFalsy();
@@ -6372,7 +6322,7 @@ describe('query feedTagsList', () => {
     expect(user?.flags?.feedTagsList?.updatedAt).toEqual(expect.any(String));
   });
 
-  it('should fall back to onboarding-selected tags when feed and recswipe return nothing', async () => {
+  it('should fall back to onboarding-selected tags when feed service returns nothing', async () => {
     loggedUser = '1';
     await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
     await saveFixtures(con, Keyword, [
@@ -6410,11 +6360,9 @@ describe('query feedTagsList', () => {
     nock('http://localhost:6000')
       .post('/api/user_tags')
       .reply(200, { data: [] });
-    recommendTagsMock.mockResolvedValue({ recommended_tags: [] });
 
     const res = await client.query(QUERY, { variables: { limit: 5 } });
     expect(res.errors).toBeFalsy();
-    expect(recommendTagsMock).toHaveBeenCalled();
     expect(res.data.feedTagsList.tags).toEqual([
       { value: 'onboarding-1', label: 'onboarding-1' },
       { value: 'onboarding-2', label: 'onboarding-2' },
@@ -6452,7 +6400,6 @@ describe('query feedTagsList', () => {
 
     const res = await client.query(QUERY, { variables: { limit: 5 } });
     expect(res.errors).toBeFalsy();
-    expect(recommendTagsMock).not.toHaveBeenCalled();
     expect(res.data.feedTagsList.tags).toEqual([
       { value: 'ai-coding', label: 'ai-coding' },
       { value: 'llm', label: 'llm' },
@@ -6462,54 +6409,17 @@ describe('query feedTagsList', () => {
     ]);
   });
 
-  it('should dedupe overlap between feed and recswipe results', async () => {
-    loggedUser = '1';
-    nock('http://localhost:6000')
-      .post('/api/user_tags')
-      .reply(200, { data: ['ai-coding', 'llm'] });
-
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [
-        { tag: 'llm', score: 0.95 },
-        { tag: 'machine-learning', score: 0.9 },
-        { tag: 'pytorch', score: 0.8 },
-        { tag: 'tensorflow', score: 0.7 },
-      ],
-    });
-
-    const res = await client.query(QUERY, { variables: { limit: 5 } });
-    expect(res.errors).toBeFalsy();
-    expect(res.data.feedTagsList.tags).toEqual([
-      { value: 'ai-coding', label: 'ai-coding' },
-      { value: 'llm', label: 'llm' },
-      { value: 'machine-learning', label: 'machine-learning' },
-      { value: 'pytorch', label: 'pytorch' },
-      { value: 'tensorflow', label: 'tensorflow' },
-    ]);
-  });
-
   it('should dedupe duplicates within the feed-service response', async () => {
     loggedUser = '1';
     nock('http://localhost:6000')
       .post('/api/user_tags')
       .reply(200, { data: ['rust', 'rust', 'golang', 'rust'] });
 
-    recommendTagsMock.mockResolvedValue({
-      recommended_tags: [
-        { tag: 'docker', score: 0.9 },
-        { tag: 'kubernetes', score: 0.8 },
-        { tag: 'python', score: 0.7 },
-      ],
-    });
-
     const res = await client.query(QUERY, { variables: { limit: 5 } });
     expect(res.errors).toBeFalsy();
     expect(res.data.feedTagsList.tags).toEqual([
       { value: 'rust', label: 'rust' },
       { value: 'golang', label: 'golang' },
-      { value: 'docker', label: 'docker' },
-      { value: 'kubernetes', label: 'kubernetes' },
-      { value: 'python', label: 'python' },
     ]);
   });
 

--- a/src/common/feedTagsList.ts
+++ b/src/common/feedTagsList.ts
@@ -5,7 +5,6 @@ import { Keyword } from '../entity/Keyword';
 import { ContentPreferenceKeyword } from '../entity/contentPreference/ContentPreferenceKeyword';
 import { ContentPreferenceStatus } from '../entity/contentPreference/types';
 import { feedClient } from '../integrations/feed/generators';
-import { recswipeClient } from '../integrations/recswipe/clients';
 import { queryReadReplica } from './queryReadReplica';
 import { updateFlagsStatement } from './utils';
 import { ONE_DAY_IN_SECONDS } from './constants';
@@ -109,27 +108,12 @@ export const getFeedTagsList = async ({
 
   let values: string[] = [];
   try {
-    values = dedupeKeepOrder(await feedClient.getUserTags(userId, limit));
+    values = dedupeKeepOrder(await feedClient.getUserTags(userId, limit)).slice(
+      0,
+      limit,
+    );
   } catch (err) {
     logger.error({ err, userId }, 'feedClient.getUserTags failed');
-  }
-
-  if (values.length < limit) {
-    try {
-      const supplement = await recswipeClient.recommendTags(userId, {
-        selectedTags: values,
-        n: limit - values.length,
-      });
-      const supplementTags = (supplement.recommended_tags ?? []).map(
-        (t) => t.tag,
-      );
-      values = dedupeKeepOrder([...values, ...supplementTags]).slice(0, limit);
-    } catch (err) {
-      logger.error(
-        { err, userId },
-        'recswipeClient.recommendTags failed; using feedClient tags only',
-      );
-    }
   }
 
   if (!values.length) {

--- a/src/common/seedTagChipFeeds.ts
+++ b/src/common/seedTagChipFeeds.ts
@@ -10,7 +10,6 @@ import {
   ContentPreferenceType,
 } from '../entity/contentPreference/types';
 import { feedClient } from '../integrations/feed/generators';
-import { recswipeClient } from '../integrations/recswipe/clients';
 import { queryReadReplica } from './queryReadReplica';
 import { generateShortId } from '../ids';
 import { logger } from '../logger';
@@ -101,24 +100,8 @@ const getSeedTagValues = async ({
   } catch (err) {
     logger.error(
       { err, userId },
-      'feedClient.getUserTags failed; tag-chip seeding will fall back to recswipe',
+      'feedClient.getUserTags failed; tag-chip seeding will fall back to onboarding follows',
     );
-  }
-
-  if (values.length < limit) {
-    try {
-      const supplement = await recswipeClient.recommendTags(userId, {
-        selectedTags: values,
-        n: limit - values.length,
-      });
-      const recommended = (supplement.recommended_tags ?? []).map((t) => t.tag);
-      values = dedupeKeepOrder([...values, ...recommended]).slice(0, limit);
-    } catch (err) {
-      logger.error(
-        { err, userId },
-        'recswipeClient.recommendTags failed; seeding tag-chip feeds with feedClient tags only',
-      );
-    }
   }
 
   if (!values.length) {
@@ -141,8 +124,9 @@ const getSeedTagValues = async ({
 };
 
 /**
- * Lazily seeds one custom feed per tag (feedClient.getUserTags + recswipe backfill)
- * the first time the caller opts in via `includeTagChipFeeds`. Gated by
+ * Lazily seeds one custom feed per tag (feedClient.getUserTags, falling back to
+ * the user's onboarding follows) the first time the caller opts in via
+ * `includeTagChipFeeds`. Gated by
  * `User.flags.tagChipFeedsSeededAt`: set atomically before any seed work
  * happens, so a second call is a guaranteed no-op even if the first failed
  * mid-flight. Skipped if the user is at the `maxFeedsPerUser` cap (no chip

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -1047,8 +1047,8 @@ export const typeDefs = /* GraphQL */ `
       last: Int
       """
       When true, lazily seed one custom feed per main-feed followed keyword
-      (with recswipe backfill) for the caller if they have none yet. The client
-      decides when to opt in (e.g. behind a GrowthBook rollout flag).
+      for the caller if they have none yet. The client decides when to opt in
+      (e.g. behind a GrowthBook rollout flag).
       """
       includeTagChipFeeds: Boolean = false
     ): FeedConnection! @auth


### PR DESCRIPTION
recswipe no longer works, so remove the recommendTags backfill step. Chip seeding now uses feedClient.getUserTags with the onboarding-follows fallback when it returns nothing.