### PR TITLE
refactor: derive region from MaxMind GeoIP instead of x-client-region

### DIFF
--- a/.infra/index.ts
+++ b/.infra/index.ts
@@ -440,9 +440,6 @@ if (isAdhocEnv) {
         { targetPort: 3000, port: 80, name: 'http' },
         { targetPort: 9464, port: 9464, name: 'metrics' },
       ],
-      backendConfig: {
-        customRequestHeaders: ['X-Client-Region:{client_region}'],
-      },
       podAnnotations: podAnnotations,
       ...vols,
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,23 @@ The migration generator compares entities against the local database schema. Ens
   const result = await executeGraphql(fastify.con, query);
   ```
 
+**Prefer `typeof` for undefined checks:**
+
+- **Use `typeof value === 'undefined'`** instead of `value === undefined` when checking whether a value is undefined.
+- **Example pattern**:
+
+  ```typescript
+  // BAD: direct comparison to undefined
+  if (this._region === undefined) {
+    this._region = getGeo({ ip: this.req.ip }).country ?? '';
+  }
+
+  // GOOD: typeof check
+  if (typeof this._region === 'undefined') {
+    this._region = getGeo({ ip: this.req.ip }).country ?? '';
+  }
+  ```
+
 **Zod patterns:**
 
 - Use `.nullish()` instead of `.nullable().optional()` - they are equivalent but `.nullish()` is more concise

--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -115,8 +115,8 @@ const BASE_BODY = {
     sessionId: expect.any(String),
     visitId: expect.any(String),
   },
-  exp: { f: 'enc', e: [], a: {} },
-  geo: {},
+  exp: { f: 'enc', e: [], a: { region: 'US' } },
+  geo: { region: 'US', continent: 'NA' },
   engagementCreatives: [],
 };
 
@@ -1811,6 +1811,7 @@ describe('boot experimentation', () => {
     expect(res.body.exp.a).toEqual({
       search: 1,
       squad: 1,
+      region: 'US',
     });
   });
 });

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -12,6 +12,7 @@ import { Roles } from './roles';
 import { DataLoaderService } from './dataLoaderService';
 import { ContentLanguage } from './types';
 import { remoteConfig } from './remoteConfig';
+import { getGeo } from './common/geo';
 
 export class Context {
   req: FastifyRequest;
@@ -19,6 +20,7 @@ export class Context {
   loader: GraphQLDatabaseLoader;
   dataLoader: DataLoaderService;
   contentLanguage: ContentLanguage | null;
+  private _region?: string;
 
   constructor(req: FastifyRequest, con: DataSource) {
     this.req = req;
@@ -69,7 +71,10 @@ export class Context {
   }
 
   get region(): string {
-    return (this.req.headers['x-client-region'] as string) ?? '';
+    if (typeof this._region === 'undefined') {
+      this._region = getGeo({ ip: this.req.ip }).country ?? '';
+    }
+    return this._region;
   }
 
   getRepository<Entity extends ObjectLiteral>(

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -85,7 +85,7 @@ import { maxFeedsPerUser, type CoresRole, type TLocation } from '../types';
 import { queryReadReplica } from '../common/queryReadReplica';
 import { queryDataSource } from '../common/queryDataSource';
 import { isPlusMember } from '../paddle';
-import { Continent, countryCodeToContinent } from '../common/geo';
+import { Continent, countryCodeToContinent, getGeo } from '../common/geo';
 import { getBalance, type GetBalanceResult } from '../common/njord';
 import { logger } from '../logger';
 import { checkQuestProgress } from '../common/quest/progress';
@@ -322,11 +322,11 @@ const updateLastExtensionUse = async ({
 };
 
 const geoSection = (req: FastifyRequest): BaseBoot['geo'] => {
-  const region = req.headers['x-client-region'] as string;
+  const region = getGeo({ ip: req.ip }).country;
 
   return {
     region,
-    continent: countryCodeToContinent[region],
+    continent: region ? countryCodeToContinent[region] : undefined,
   };
 };
 


### PR DESCRIPTION
Replace the GCP-LB-injected x-client-region header with the existing MaxMind GeoIP lookup (getGeo) as the source of client region. The Context.region getter and boot geoSection now resolve country from the request IP, memoized per-request, keeping the empty-string fallback so downstream consumers (Paddle pricing, blockedCountries gate, contribution eligibility, experimentation) are unchanged.