### PR TITLE
revert: use default Debezium publications

### DIFF
--- a/.infra/application.properties
+++ b/.infra/application.properties
@@ -1,6 +1,5 @@
 debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
 debezium.source.slot.name=%slot_name%
-debezium.source.publication.name=api_debezium
 debezium.source.offset.storage.file.filename=data/offsets.dat
 debezium.source.offset.flush.interval.ms=0
 debezium.source.database.hostname=%hostname%

--- a/.infra/clickhouse-sync.yml
+++ b/.infra/clickhouse-sync.yml
@@ -51,7 +51,6 @@ database.allowPublicKeyRetrieval: "true"
 snapshot.mode: "no_data"
 
 slot.name: "clickhouse_sync"
-publication.name: "clickhouse_sync"
 
 # offset.flush.interval.ms: The number of milliseconds to wait before flushing recent offsets to Kafka. This ensures that offsets are committed within the specified time interval.
 offset.flush.timeout.ms: 10000


### PR DESCRIPTION
## What changed

- removes the explicit `api_debezium` publication from the daily CDC connector
- removes the explicit `clickhouse_sync` publication from the ClickHouse connector
- restores the publication configuration that existed before #4001

## Why

This temporarily rolls back the separate-publication rollout while the generated-column and replica-identity interaction is reconsidered.

## Scope

This is only the two-line inverse of #4001. It does not include heartbeat support, filtered publication creation, or column exclusions.

## Validation

- verified the diff contains only the two publication-name deletions
- `git diff --check`
