### PR TITLE
fix: agent source ownership via UserInterest, not source.userId

### DIFF
--- a/__tests__/interests.ts
+++ b/__tests__/interests.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers';
 import { ArticlePost, Source, User } from '../src/entity';
 import { Feed, FeedOrigin } from '../src/entity/Feed';
-import { AgentSource, SourceType } from '../src/entity/Source';
+import { AgentSource, SourceType, SourceUser } from '../src/entity/Source';
 import { UserInterest, UserInterestStatus } from '../src/entity/UserInterest';
 import {
   InterestFinding,
@@ -159,6 +159,23 @@ describe('mutation createInterest', () => {
       (call) => call[1] === 'api.v1.interest-run-requested',
     );
     expect(runCall?.[2]).toEqual({ interestId });
+  });
+
+  it('should succeed when the user already has a user source', async () => {
+    loggedUser = '1';
+    await con.getRepository(SourceUser).save({
+      id: 'su-1',
+      name: 'user source',
+      handle: 'su-1',
+      private: true,
+      userId: '1',
+    });
+
+    const res = await client.mutate(CREATE_INTEREST, {
+      variables: { query: 'cool zig projects' },
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.createInterest.id).toBeTruthy();
   });
 });
 
@@ -460,7 +477,6 @@ describe('query interestPosts', () => {
       name: 'agent source',
       handle: 'agent-isrc-1',
       private: true,
-      userId: '1',
     });
     await con.getRepository(UserInterest).save({
       id: 'uir-1',

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -205,14 +205,4 @@ export class SourceUser extends Source {
 }
 
 @ChildEntity(SourceType.Agent)
-export class AgentSource extends Source {
-  @Column({ type: 'text', default: null })
-  userId: string | null;
-
-  @OneToOne('User', { lazy: true, onDelete: 'CASCADE' })
-  @JoinColumn({
-    name: 'userId',
-    foreignKeyConstraintName: 'FK_source_agent_user_id',
-  })
-  user: Promise<User>;
-}
+export class AgentSource extends Source {}

--- a/src/schema/interests.ts
+++ b/src/schema/interests.ts
@@ -295,7 +295,6 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           name: query.slice(0, 100),
           handle: `agent-${sourceId}`,
           private: true,
-          userId,
         });
 
         await manager.getRepository(Feed).save({

--- a/src/workers/userDeletionCleanup.ts
+++ b/src/workers/userDeletionCleanup.ts
@@ -1,6 +1,9 @@
 import type { DataSource } from 'typeorm';
+import { In } from 'typeorm';
 import type { FastifyBaseLogger } from 'fastify';
 import { TypedWorker } from './worker';
+import { UserInterest } from '../entity/UserInterest';
+import { Source } from '../entity/Source';
 import {
   Alerts,
   Bookmark,
@@ -309,6 +312,18 @@ const worker: TypedWorker<'api.v1.user-deletion-requested'> = {
     await con.getRepository(UserPersonalizedDigest).delete({ userId });
     await con.getRepository(UserMarketingCta).delete({ userId });
     await con.getRepository(SourceUser).delete({ userId });
+    const agentSourceIds = (
+      await con
+        .getRepository(UserInterest)
+        .createQueryBuilder('ui')
+        .select('ui."sourceId"', 'sourceId')
+        .where('ui."userId" = :userId', { userId })
+        .andWhere('ui."sourceId" IS NOT NULL')
+        .getRawMany<{ sourceId: string }>()
+    ).map((row) => row.sourceId);
+    if (agentSourceIds.length) {
+      await con.getRepository(Source).delete({ id: In(agentSourceIds) });
+    }
     await con.getRepository(SourceMember).delete({ userId });
     await con.getRepository(UserAchievement).delete({ userId });
     await con.getRepository(UserExperience).delete({ userId });


### PR DESCRIPTION
source.userId is globally unique (SourceUser), so an AgentSource collided for any user who already had a user source. Drop userId from AgentSource; ownership is UserInterest.userId <-> UserInterest.sourceId (both indexed). Since there's no user->source FK to cascade, userDeletionCleanup now deletes the user's agent sources (via UserInterest.sourceId) before the user row is removed; their posts cascade via Post.sourceId.