### PR TITLE
fix: let interest owner view their private agent-source posts

### DIFF
--- a/__tests__/interests.ts
+++ b/__tests__/interests.ts
@@ -470,6 +470,61 @@ describe('mutation deleteInterest', () => {
   });
 });
 
+const POST_QUERY = `
+  query Post($id: ID!) {
+    post(id: $id) {
+      id
+    }
+  }
+`;
+
+describe('agent source post access', () => {
+  beforeEach(async () => {
+    await con.getRepository(AgentSource).save({
+      id: 'asrc-1',
+      name: 'agent source',
+      handle: 'agent-asrc-1',
+      private: true,
+    });
+    await con.getRepository(UserInterest).save({
+      id: 'uir-acc',
+      userId: '1',
+      query: 'cool zig projects',
+      status: UserInterestStatus.Active,
+      sourceId: 'asrc-1',
+    });
+    await saveFixtures(con, ArticlePost, [
+      {
+        id: 'apost-acc',
+        shortId: 'apost-acc',
+        title: 'Agent summary',
+        url: 'http://agent.com/1',
+        sourceId: 'asrc-1',
+        private: true,
+        visible: true,
+      },
+    ]);
+  });
+
+  it('lets the interest owner view an agent-source post', async () => {
+    loggedUser = '1';
+    const res = await client.query(POST_QUERY, {
+      variables: { id: 'apost-acc' },
+    });
+    expect(res.errors).toBeFalsy();
+    expect(res.data.post).toMatchObject({ id: 'apost-acc' });
+  });
+
+  it('denies a non-owner from viewing an agent-source post', async () => {
+    loggedUser = '2';
+    return testQueryErrorCode(
+      client,
+      { query: POST_QUERY, variables: { id: 'apost-acc' } },
+      'FORBIDDEN',
+    );
+  });
+});
+
 describe('query interestPosts', () => {
   beforeEach(async () => {
     await con.getRepository(AgentSource).save({

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -16,6 +16,7 @@ import {
   User,
 } from '../entity';
 import { SourceType, SourceUser } from '../entity/Source';
+import { UserInterest } from '../entity/UserInterest';
 import { SourceStack } from '../entity/sources/SourceStack';
 import {
   Roles,
@@ -1128,6 +1129,20 @@ export const canAccessSource = async (
   const isSystemModerator = ctx.roles?.includes(Roles.Moderator);
   if (isSystemModerator) {
     return true;
+  }
+
+  if (
+    permission === SourcePermissions.View &&
+    source.type === SourceType.Agent
+  ) {
+    if (!ctx.userId) {
+      return false;
+    }
+    const ownsInterest = await ctx.con.getRepository(UserInterest).findOne({
+      select: ['id'],
+      where: { sourceId: source.id, userId: ctx.userId },
+    });
+    return !!ownsInterest;
   }
 
   if (permission === SourcePermissions.View && !source.private) {


### PR DESCRIPTION
Agent sources are private with no members, so canAccessSource denied View on their posts (post(id) -> ensureSourcePermissions) for everyone, owner included. Grant View on a private agent source when the viewer owns the interest that points to it (UserInterest.sourceId + userId, indexed, only for type=agent).