### PR TITLE
fix: isolate ClickHouse publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  common: dailydotdev/common@0.0.19
+  common: dailydotdev/common@0.0.20
 
 jobs:
   build-app:

--- a/.infra/clickhouse-sync.yml
+++ b/.infra/clickhouse-sync.yml
@@ -51,6 +51,8 @@ database.allowPublicKeyRetrieval: "true"
 snapshot.mode: "no_data"
 
 slot.name: "clickhouse_sync"
+publication.name: "clickhouse_sync"
+publication.autocreate.mode: "disabled"
 
 # offset.flush.interval.ms: The number of milliseconds to wait before flushing recent offsets to Kafka. This ensures that offsets are committed within the specified time interval.
 offset.flush.timeout.ms: 10000

--- a/src/migration/1784621038147-CreateClickHousePublication.ts
+++ b/src/migration/1784621038147-CreateClickHousePublication.ts
@@ -10,22 +10,7 @@ export class CreateClickHousePublication1784621038147 implements MigrationInterf
 
     await queryRunner.query(/* sql */ `
       CREATE PUBLICATION "clickhouse_sync"
-        FOR TABLE
-          "public"."post",
-          "public"."source",
-          "public"."keyword",
-          "public"."niche",
-          "public"."keyword_niche",
-          "public"."user",
-          "public"."content_preference",
-          "public"."post_keyword",
-          "public"."post_niche",
-          "public"."comment",
-          "public"."campaign",
-          "public"."post_relation",
-          "public"."user_personalized_digest",
-          "public"."user_company",
-          "public"."highlights_canonical"
+        FOR ALL TABLES
         WITH (publish_generated_columns = stored)
     `);
   }

--- a/src/migration/1784621038147-CreateClickHousePublication.ts
+++ b/src/migration/1784621038147-CreateClickHousePublication.ts
@@ -1,0 +1,38 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateClickHousePublication1784621038147 implements MigrationInterface {
+  name = 'CreateClickHousePublication1784621038147';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP PUBLICATION IF EXISTS "clickhouse_sync"
+    `);
+
+    await queryRunner.query(/* sql */ `
+      CREATE PUBLICATION "clickhouse_sync"
+        FOR TABLE
+          "public"."post",
+          "public"."source",
+          "public"."keyword",
+          "public"."niche",
+          "public"."keyword_niche",
+          "public"."user",
+          "public"."content_preference",
+          "public"."post_keyword",
+          "public"."post_niche",
+          "public"."comment",
+          "public"."campaign",
+          "public"."post_relation",
+          "public"."user_personalized_digest",
+          "public"."user_company",
+          "public"."highlights_canonical"
+        WITH (publish_generated_columns = stored)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DROP PUBLICATION IF EXISTS "clickhouse_sync"
+    `);
+  }
+}


### PR DESCRIPTION
## What changed

- creates a dedicated all-tables `clickhouse_sync` publication
- enables PostgreSQL 18 stored generated-column publishing
- configures only ClickHouse sync to use the publication with connector autocreation disabled
- retains `table.include.list` as the ClickHouse connector's table filter
- replaces any legacy `clickhouse_sync` publication during migration
- updates the shared CircleCI orb to `0.0.20`, which pins the Google Cloud CLI version

## Why

ClickHouse sync can be isolated from the shared `dbz_publication` without changing API Debezium. The publication must publish stored generated columns because `post` uses `REPLICA IDENTITY FULL` and contains generated `slug`; connector-created publications default to generated columns disabled and would block post updates.

Using an all-tables publication keeps the database migration independent of the connector's evolving table list. PostgreSQL can stream changes for every table to this replication slot, while Debezium emits only tables matched by the existing `table.include.list`.

The shared orb update avoids intermittent Docker and Pulumi failures caused by resolving the latest Google Cloud CLI version from its release-notes page.

## Validation

- complete 540-migration chain on PostgreSQL 18
- migration rollback and reapply
- legacy all-tables publication replacement
- no-op `post` update succeeds with `publish_generated_columns = stored`
- `pnpm run build`
- `pnpm run lint`
- CircleCI config validation with the private-orb organization context
- Prettier and `git diff --check`
