### PR TITLE
fix: skip post view-only ClickHouse updates

### DIFF
--- a/.infra/clickhouse-sync.yml
+++ b/.infra/clickhouse-sync.yml
@@ -27,7 +27,8 @@ plugin.name: "pgoutput"
 # table.include.list: An optional list of regular expressions that match fully-qualified table identifiers for tables to be monitored;
 table.include.list: "public.post,public.source,public.keyword,public.niche,public.keyword_niche,public.user,public.content_preference,public.post_keyword,public.post_niche,public.comment,public.campaign,public.post_relation,public.user_personalized_digest,public.user_company,public.highlights_canonical"
 
-column.exclude.list: "public\\.user\\.(email|name)"
+column.exclude.list: "public\\.user\\.(email|name),public\\.post\\.views"
+skip.messages.without.change: "true"
 
 # clickhouse.server.url: Specify only the hostname of the Clickhouse Server.
 clickhouse.server.url: "%clickhouse_host%"


### PR DESCRIPTION
## What changed

- exclude `public.post.views` from the ClickHouse Sync Debezium event payload
- enable `skip.messages.without.change` for the ClickHouse Sync connector

## Why

View-count increments produce a high volume of `post` updates even though ClickHouse does not need those changes. Because `post` uses `REPLICA IDENTITY FULL`, Debezium can detect when an update changed only excluded columns and drop that event before the sink pipeline.

Updates that also modify another included `post` column continue to replicate, with `views` omitted.

This does not change the PostgreSQL publication or the daily-api Debezium connector.

## Validation

- `pnpm run build`
- `pnpm run lint`
- YAML parse via Prettier
- `git diff --check`
