### PR TITLE
fix(njord): exclude non-award products from the products catalog

### DIFF
--- a/__tests__/njord.ts
+++ b/__tests__/njord.ts
@@ -814,6 +814,16 @@ describe('query products', () => {
           restricted: true,
         },
       },
+      {
+        id: 'e1c2a9d0-5b4f-4f8a-8c3d-7f6e9a0b1c2d',
+        name: 'Streak freeze 3-pack',
+        image: 'https://daily.dev/freeze.jpg',
+        type: ProductType.StreakFreeze,
+        value: 80,
+        flags: {
+          quantity: 3,
+        },
+      },
     ]);
   });
 
@@ -828,6 +838,19 @@ describe('query products', () => {
         ({ node }: { node: { id: string } }) => node.id,
       ),
     ).not.toContain('b3d9d8b1-1f2e-4c3a-9d6f-2a5e7c1b0f4d');
+  });
+
+  it('should exclude non-award products from the catalog', async () => {
+    loggedUser = 't-awpm-1';
+
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(
+      res.data.products.edges.map(
+        ({ node }: { node: { id: string } }) => node.id,
+      ),
+    ).not.toContain('e1c2a9d0-5b4f-4f8a-8c3d-7f6e9a0b1c2d');
   });
 
   it('should return products sorted by value', async () => {

--- a/src/schema/njord.ts
+++ b/src/schema/njord.ts
@@ -321,6 +321,9 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         (node, index) => pageGenerator.nodeToCursor(page, args, node, index),
         (builder) => {
           builder.queryBuilder
+            .andWhere(`${builder.alias}.type = :type`, {
+              type: ProductType.Award,
+            })
             .andWhere(
               `(${builder.alias}.flags->>'restricted') IS DISTINCT FROM 'true'`,
             )


### PR DESCRIPTION
## What
The `products` query feeds the award picker but only filtered on the `restricted` flag — streak freeze products (added in #4011) share the `product` table and were leaking into the awards section. Filter the catalog to `type = award`.

Freeze packs are unaffected: the streak UI uses the dedicated `streakFreezeProducts` query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)