### PR TITLE
fix: keep x-trends public but hide all its posts from feed

### DIFF
--- a/__tests__/workers/postUpdated.ts
+++ b/__tests__/workers/postUpdated.ts
@@ -25,7 +25,7 @@ import {
   YouTubePost,
 } from '../../src/entity';
 import { PostRelationType } from '../../src/entity/posts/PostRelation';
-import { sourcesFixture } from '../fixture/source';
+import { createSource, sourcesFixture } from '../fixture/source';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
 import { randomUUID } from 'crypto';
@@ -1146,6 +1146,50 @@ it('should set social twitter showOnFeed based on order field', async () => {
     });
     expect(post.showOnFeed).toEqual(expectedShowOnFeed);
     expect(post.flags.showOnFeed).toEqual(expectedShowOnFeed);
+  }
+});
+
+it('should force showOnFeed false for aggregation-only sources regardless of order', async () => {
+  await con
+    .getRepository(Source)
+    .save(
+      createSource('x-trends', 'Trending on X', 'http://image.com/x-trends'),
+    );
+
+  const cases = [
+    {
+      yggdrasilId: randomUUID(),
+      url: 'https://x.com/dailydotdev/status/2001',
+      content: 'x-trends tweet without order',
+    },
+    {
+      yggdrasilId: randomUUID(),
+      url: 'https://x.com/dailydotdev/status/2002',
+      content: 'x-trends tweet with order',
+      order: 1,
+    },
+  ];
+
+  for (const { yggdrasilId, url, content, order } of cases) {
+    await expectSuccessfulBackground(worker, {
+      id: yggdrasilId,
+      content_type: PostType.SocialTwitter,
+      url,
+      source_id: 'x-trends',
+      ...(order ? { order } : {}),
+      extra: {
+        subtype: 'tweet',
+        content,
+      },
+    });
+  }
+
+  for (const { yggdrasilId } of cases) {
+    const post = await con.getRepository(SocialTwitterPost).findOneByOrFail({
+      yggdrasilId,
+    });
+    expect(post.showOnFeed).toEqual(false);
+    expect(post.flags.showOnFeed).toEqual(false);
   }
 });
 

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -61,6 +61,12 @@ export const DIGEST_SOURCE = 'digest';
 
 export const AGENTS_DIGEST_SOURCE = 'agents_digest';
 
+export const X_TRENDS_SOURCE = 'x-trends';
+
+// Aggregation-only sources: they stay public (so their posts remain
+// accessible/linkable) but individual posts must never surface in feeds.
+export const FEED_HIDDEN_SOURCES = new Set<string>([X_TRENDS_SOURCE]);
+
 @Entity()
 @Index('IDX_source_activ_priva_img_name_handl_type', [
   'active',

--- a/src/migration/1784730000000-HideXTrendsFromFeed.ts
+++ b/src/migration/1784730000000-HideXTrendsFromFeed.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HideXTrendsFromFeed1784730000000 implements MigrationInterface {
+  name = 'HideXTrendsFromFeed1784730000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // x-trends is an aggregation-only source: it stays public but none of its
+    // posts should surface in feeds. Backfill any that leaked in with
+    // showOnFeed = true.
+    await queryRunner.query(
+      `UPDATE post SET flags = flags || '{"showOnFeed": false}', "showOnFeed" = false WHERE "sourceId" = 'x-trends' AND "showOnFeed" = true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // No-op: we intentionally do not restore feed visibility for x-trends
+    // posts, since they must never be shown on feed.
+  }
+}

--- a/src/workers/postUpdated/common.ts
+++ b/src/workers/postUpdated/common.ts
@@ -1,5 +1,6 @@
 import * as he from 'he';
 import {
+  FEED_HIDDEN_SOURCES,
   findAuthor,
   mergeKeywords,
   parseReadTime,
@@ -110,6 +111,11 @@ export const buildCommonPostFields = ({
     ? data?.extra?.duration / 60
     : undefined;
 
+  // Aggregation-only sources are public but must never show posts on feed,
+  // regardless of the per-post order/showOnFeed hint from ingestion.
+  const resolvedShowOnFeed =
+    sourceId && FEED_HIDDEN_SOURCES.has(sourceId) ? false : showOnFeed;
+
   return {
     origin: data?.origin as PostOrigin,
     authorId,
@@ -130,10 +136,10 @@ export const buildCommonPostFields = ({
     siteTwitter: data?.extra?.site_twitter,
     toc: data?.extra?.toc,
     contentCuration: data?.extra?.content_curation,
-    showOnFeed,
+    showOnFeed: resolvedShowOnFeed,
     flags: {
       private: privacy,
-      showOnFeed,
+      showOnFeed: resolvedShowOnFeed,
       sentAnalyticsReport: privacy || !authorId,
     },
     yggdrasilId: data?.id,


### PR DESCRIPTION
## What

`x-trends` (**Trending on X**) is meant to be an **aggregation-only** source — it stays **public/linkable**, but its individual posts should **never** appear in feeds.

Today they leak: over the last 10 days these posts drew ~697 impressions across ~227 users (106 today), because ingestion decides feed visibility purely from the payload:

```ts
// src/workers/postUpdated/socialTwitter/processing.ts
showOnFeed: !data?.order
```

Any tweet that arrives **without** an `order` value defaults to `showOnFeed: true` and becomes a standalone public feed post. Of 190 `social:twitter` posts, 73 leaked this way.

## Change

- **`entity/Source.ts`** — add `X_TRENDS_SOURCE` + `FEED_HIDDEN_SOURCES` set (aggregation-only sources that stay public but are hidden from feed).
- **`workers/postUpdated/common.ts`** — in `buildCommonPostFields`, force `showOnFeed=false` (both column and `flags`) when the source is in `FEED_HIDDEN_SOURCES`, regardless of the per-post `order` hint. Covers every post type routed through the builder, not just twitter.
- **Migration `HideXTrendsFromFeed`** — backfill already-leaked posts (`sourceId = 'x-trends' AND showOnFeed = true` → false).
- **Test** — asserts x-trends posts are hidden both with and without `order`.

The source stays `active: true, private: false` per requirement — only feed visibility of its posts changes.

## Notes

- Full `tsc`/integration tests need Postgres + more memory than the authoring sandbox (2GB) allows, so they run in CI. ESLint passes on all changed files locally.
- Adding another aggregation-only source later is a one-line addition to `FEED_HIDDEN_SOURCES`.