### PR TITLE
feat(personal-context): generate & persist user personal context

### DIFF
--- a/.infra/common.ts
+++ b/.infra/common.ts
@@ -39,6 +39,14 @@ export const workers: Worker[] = [
   },
   {
     topic: 'user-updated',
+    subscription: 'api.user-updated-personal-context',
+  },
+  {
+    topic: 'api.v1.github-account-linked',
+    subscription: 'api.github-account-linked-personal-context',
+  },
+  {
+    topic: 'user-updated',
     subscription: 'api.user-updated-plus-subscribed-custom-feed',
   },
   {
@@ -426,6 +434,10 @@ export const workers: Worker[] = [
   {
     topic: 'post-upvoted',
     subscription: 'api.post-upvoted-interest-signal',
+  },
+  {
+    topic: 'api.v1.personal-context-generated',
+    subscription: 'api.personal-context-generated',
   },
   {
     topic: 'api.v1.interest-content-available',

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -30,6 +30,7 @@ jest.mock('../src/remoteConfig', () => ({
       ignoredWorkEmailDomains: ['igored.com', 'ignored.org'],
       rateLimitReputationThreshold: 1,
       headlineChannelMinPosts: 3,
+      personalContextEnabled: true,
       pricingIds: { pricingGift: 'yearly' },
       fees: {
         transfer: 5,

--- a/__tests__/workers/personalContext/githubAccountLinked.ts
+++ b/__tests__/workers/personalContext/githubAccountLinked.ts
@@ -1,0 +1,76 @@
+import nock from 'nock';
+import { DataSource } from 'typeorm';
+import { githubAccountLinkedWorker } from '../../../src/workers/personalContext/githubAccountLinked';
+import { triggerTypedEvent } from '../../../src/common/typedPubsub';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../../helpers';
+import { User } from '../../../src/entity';
+import {
+  PersonalContextSource,
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../../src/entity/user/UserPersonalContext';
+import { usersFixture } from '../../fixture/user';
+import createOrGetConnection from '../../../src/db';
+
+jest.mock('../../../src/common/typedPubsub', () => ({
+  ...jest.requireActual('../../../src/common/typedPubsub'),
+  triggerTypedEvent: jest.fn(),
+}));
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+  await saveFixtures(con, User, usersFixture);
+  await con.query(`DELETE FROM ba_account`);
+});
+
+const linkGithubAccount = () =>
+  con.query(
+    `INSERT INTO ba_account (id, "accountId", "providerId", "userId", "accessToken") VALUES ('acc-1', '123', 'github', '1', 'gh-token')`,
+  );
+
+describe('githubAccountLinked', () => {
+  it('resolves the github login and requests context for a linked account', async () => {
+    await linkGithubAccount();
+    nock('https://api.github.com')
+      .get('/user')
+      .reply(200, { login: 'octocat' });
+
+    await expectSuccessfulTypedBackground(githubAccountLinkedWorker, {
+      userId: '1',
+    });
+
+    const row = await con
+      .getRepository(UserPersonalContext)
+      .findOneBy({ userId: '1', source: PersonalContextSource.Github });
+    expect(row).toMatchObject({
+      sourceValue: 'octocat',
+      verified: true,
+      status: PersonalContextStatus.Pending,
+    });
+    expect(triggerTypedEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      'api.v1.generate-personal-context',
+      expect.objectContaining({
+        userId: '1',
+        sources: [{ kind: PersonalContextSource.Github, value: 'octocat' }],
+      }),
+    );
+  });
+
+  it('does nothing when the user has no linked github account', async () => {
+    await expectSuccessfulTypedBackground(githubAccountLinkedWorker, {
+      userId: '1',
+    });
+
+    const count = await con.getRepository(UserPersonalContext).count();
+    expect(count).toBe(0);
+    expect(triggerTypedEvent).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/workers/personalContext/githubAccountLinked.ts
+++ b/__tests__/workers/personalContext/githubAccountLinked.ts
@@ -73,4 +73,23 @@ describe('githubAccountLinked', () => {
     expect(count).toBe(0);
     expect(triggerTypedEvent).not.toHaveBeenCalled();
   });
+
+  it('marks the source failed and does not publish on a github api error', async () => {
+    await linkGithubAccount();
+    nock('https://api.github.com').get('/user').times(2).reply(401);
+
+    await expectSuccessfulTypedBackground(githubAccountLinkedWorker, {
+      userId: '1',
+    });
+
+    const row = await con
+      .getRepository(UserPersonalContext)
+      .findOneBy({ userId: '1', source: PersonalContextSource.Github });
+    expect(row).toMatchObject({
+      sourceValue: '123',
+      status: PersonalContextStatus.Error,
+    });
+    expect(row?.error).toBeTruthy();
+    expect(triggerTypedEvent).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/workers/personalContext/personalContextGenerated.ts
+++ b/__tests__/workers/personalContext/personalContextGenerated.ts
@@ -1,0 +1,101 @@
+import { DataSource } from 'typeorm';
+import { personalContextGeneratedWorker } from '../../../src/workers/personalContext/personalContextGenerated';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../../helpers';
+import { User } from '../../../src/entity';
+import {
+  PersonalContextSource,
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../../src/entity/user/UserPersonalContext';
+import { usersFixture } from '../../fixture/user';
+import createOrGetConnection from '../../../src/db';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  await saveFixtures(con, User, usersFixture);
+  await con.getRepository(UserPersonalContext).save({
+    userId: '1',
+    source: PersonalContextSource.Website,
+    sourceValue: 'https://new.dev',
+    verified: true,
+    status: PersonalContextStatus.Pending,
+    correlationId: 'corr-1',
+    requestedAt: new Date(),
+  });
+});
+
+const getRow = () =>
+  con
+    .getRepository(UserPersonalContext)
+    .findOneBy({ userId: '1', source: PersonalContextSource.Website });
+
+describe('personalContextGenerated', () => {
+  it('stores the synthesized context on a matching correlationId', async () => {
+    await expectSuccessfulTypedBackground(personalContextGeneratedWorker, {
+      userId: '1',
+      correlationId: 'corr-1',
+      status: 'ok',
+      profileText: 'A backend engineer who loves Go.',
+      context: {
+        profile_text: 'A backend engineer who loves Go.',
+        ranking_signals: { boost_tags: ['go', 'rust'], mute_tags: ['php'] },
+      },
+    });
+
+    const row = await getRow();
+    expect(row).toMatchObject({
+      status: PersonalContextStatus.Ok,
+      profileText: 'A backend engineer who loves Go.',
+      boostTags: ['go', 'rust'],
+      muteTags: ['php'],
+    });
+    expect(row?.generatedAt).toBeTruthy();
+    expect(row?.context).toMatchObject({
+      ranking_signals: { boost_tags: ['go', 'rust'], mute_tags: ['php'] },
+    });
+  });
+
+  it('ignores a stale response whose correlationId no longer matches', async () => {
+    await expectSuccessfulTypedBackground(personalContextGeneratedWorker, {
+      userId: '1',
+      correlationId: 'stale',
+      status: 'ok',
+      profileText: 'should not be stored',
+      context: { ranking_signals: { boost_tags: ['x'], mute_tags: [] } },
+    });
+
+    const row = await getRow();
+    expect(row).toMatchObject({
+      status: PersonalContextStatus.Pending,
+      profileText: null,
+    });
+  });
+
+  it('records an error status and preserves prior profile text', async () => {
+    await con
+      .getRepository(UserPersonalContext)
+      .update(
+        { userId: '1', source: PersonalContextSource.Website },
+        { status: PersonalContextStatus.Ok, profileText: 'previous good text' },
+      );
+
+    await expectSuccessfulTypedBackground(personalContextGeneratedWorker, {
+      userId: '1',
+      correlationId: 'corr-1',
+      status: 'error',
+      error: 'could not read source',
+    });
+
+    const row = await getRow();
+    expect(row).toMatchObject({
+      status: PersonalContextStatus.Error,
+      error: 'could not read source',
+      profileText: 'previous good text',
+    });
+  });
+});

--- a/__tests__/workers/personalContext/personalContextGenerated.ts
+++ b/__tests__/workers/personalContext/personalContextGenerated.ts
@@ -51,8 +51,6 @@ describe('personalContextGenerated', () => {
     expect(row).toMatchObject({
       status: PersonalContextStatus.Ok,
       profileText: 'A backend engineer who loves Go.',
-      boostTags: ['go', 'rust'],
-      muteTags: ['php'],
     });
     expect(row?.generatedAt).toBeTruthy();
     expect(row?.context).toMatchObject({

--- a/__tests__/workers/personalContext/userUpdatedPersonalContext.ts
+++ b/__tests__/workers/personalContext/userUpdatedPersonalContext.ts
@@ -1,0 +1,94 @@
+import { DataSource } from 'typeorm';
+import { userUpdatedPersonalContextWorker } from '../../../src/workers/personalContext/userUpdatedPersonalContext';
+import { triggerTypedEvent } from '../../../src/common/typedPubsub';
+import { ChangeObject } from '../../../src/types';
+import { expectSuccessfulTypedBackground, saveFixtures } from '../../helpers';
+import { User } from '../../../src/entity';
+import {
+  PersonalContextSource,
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../../src/entity/user/UserPersonalContext';
+import { usersFixture } from '../../fixture/user';
+import createOrGetConnection from '../../../src/db';
+
+jest.mock('../../../src/common/typedPubsub', () => ({
+  ...jest.requireActual('../../../src/common/typedPubsub'),
+  triggerTypedEvent: jest.fn(),
+}));
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await saveFixtures(con, User, usersFixture);
+});
+
+const base = {
+  id: '1',
+  portfolio: 'https://old.dev',
+} as ChangeObject<User>;
+
+const invoke = (
+  oldProfile: Partial<ChangeObject<User>>,
+  newProfile: Partial<ChangeObject<User>>,
+) =>
+  expectSuccessfulTypedBackground(userUpdatedPersonalContextWorker, {
+    user: { ...base, ...oldProfile } as ChangeObject<User>,
+    newProfile: { ...base, ...newProfile } as ChangeObject<User>,
+  });
+
+describe('userUpdatedPersonalContext', () => {
+  it('requests context and stores a pending website row when portfolio changes', async () => {
+    await invoke(
+      { portfolio: 'https://old.dev' },
+      { portfolio: 'https://new.dev' },
+    );
+
+    const row = await con
+      .getRepository(UserPersonalContext)
+      .findOneBy({ userId: '1', source: PersonalContextSource.Website });
+
+    expect(row).toMatchObject({
+      userId: '1',
+      source: PersonalContextSource.Website,
+      sourceValue: 'https://new.dev',
+      verified: true,
+      status: PersonalContextStatus.Pending,
+    });
+    expect(row?.correlationId).toBeTruthy();
+    expect(triggerTypedEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      'api.v1.generate-personal-context',
+      expect.objectContaining({
+        userId: '1',
+        sources: [
+          { kind: PersonalContextSource.Website, value: 'https://new.dev' },
+        ],
+      }),
+    );
+  });
+
+  it('does nothing when portfolio is unchanged', async () => {
+    await invoke(
+      { portfolio: 'https://same.dev', name: 'old' },
+      { portfolio: 'https://same.dev', name: 'new' },
+    );
+
+    const count = await con.getRepository(UserPersonalContext).count();
+    expect(count).toBe(0);
+    expect(triggerTypedEvent).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the new portfolio is empty', async () => {
+    await invoke({ portfolio: 'https://old.dev' }, { portfolio: '' });
+
+    const count = await con.getRepository(UserPersonalContext).count();
+    expect(count).toBe(0);
+    expect(triggerTypedEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -777,6 +777,17 @@ export const getBetterAuthOptions = (pool: Pool): BetterAuthOptions => {
           },
         },
       },
+      account: {
+        create: {
+          after: async (account) => {
+            if (account.providerId === 'github') {
+              await triggerTypedEvent(logger, 'api.v1.github-account-linked', {
+                userId: account.userId,
+              });
+            }
+          },
+        },
+      },
     },
     emailAndPassword: {
       enabled: true,

--- a/src/common/personalContext/requestPersonalContext.ts
+++ b/src/common/personalContext/requestPersonalContext.ts
@@ -1,0 +1,52 @@
+import type { DataSource, EntityManager } from 'typeorm';
+import {
+  PersonalContextSource,
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../entity/user/UserPersonalContext';
+import { generateShortId } from '../../ids';
+import { triggerTypedEvent } from '../typedPubsub';
+import { logger } from '../../logger';
+
+export const requestPersonalContext = async ({
+  con,
+  userId,
+  source,
+  value,
+  verified,
+}: {
+  con: DataSource | EntityManager;
+  userId: string;
+  source: PersonalContextSource;
+  value?: string | null;
+  verified: boolean;
+}): Promise<boolean> => {
+  if (!value) {
+    return false;
+  }
+
+  const correlationId = await generateShortId();
+
+  await con.transaction(async (manager) => {
+    await manager.getRepository(UserPersonalContext).upsert(
+      {
+        userId,
+        source,
+        sourceValue: value,
+        verified,
+        status: PersonalContextStatus.Pending,
+        correlationId,
+        requestedAt: new Date(),
+      },
+      ['userId', 'source'],
+    );
+
+    await triggerTypedEvent(logger, 'api.v1.generate-personal-context', {
+      userId,
+      correlationId,
+      sources: [{ kind: source, value }],
+    });
+  });
+
+  return true;
+};

--- a/src/common/personalContext/requestPersonalContext.ts
+++ b/src/common/personalContext/requestPersonalContext.ts
@@ -27,25 +27,23 @@ export const requestPersonalContext = async ({
 
   const correlationId = await generateShortId();
 
-  await con.transaction(async (manager) => {
-    await manager.getRepository(UserPersonalContext).upsert(
-      {
-        userId,
-        source,
-        sourceValue: value,
-        verified,
-        status: PersonalContextStatus.Pending,
-        correlationId,
-        requestedAt: new Date(),
-      },
-      ['userId', 'source'],
-    );
-
-    await triggerTypedEvent(logger, 'api.v1.generate-personal-context', {
+  await con.getRepository(UserPersonalContext).upsert(
+    {
       userId,
+      source,
+      sourceValue: value,
+      verified,
+      status: PersonalContextStatus.Pending,
       correlationId,
-      sources: [{ kind: source, value }],
-    });
+      requestedAt: new Date(),
+    },
+    ['userId', 'source'],
+  );
+
+  await triggerTypedEvent(logger, 'api.v1.generate-personal-context', {
+    userId,
+    correlationId,
+    sources: [{ kind: source, value }],
   });
 
   return true;

--- a/src/common/schema/personalContext.ts
+++ b/src/common/schema/personalContext.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+const personalContextSourceRefSchema = z.object({
+  kind: z.string(),
+  value: z.string(),
+});
+
+export const generatePersonalContextSchema = z.object({
+  userId: z.string(),
+  correlationId: z.string().optional(),
+  sources: z.array(personalContextSourceRefSchema),
+});
+
+const personalContextRankingSignalsSchema = z.object({
+  boost_tags: z.array(z.string()).default([]),
+  mute_tags: z.array(z.string()).default([]),
+});
+
+const personalContextContextSchema = z
+  .object({
+    headline: z.string().nullish(),
+    summary: z.string().nullish(),
+    seniority: z.string().nullish(),
+    current_focus: z.string().nullish(),
+    learning_goals: z.array(z.string()).nullish(),
+    ranking_signals: personalContextRankingSignalsSchema.nullish(),
+    profile_text: z.string().nullish(),
+  })
+  .catchall(z.unknown());
+
+export const personalContextGeneratedSchema = z.object({
+  userId: z.string(),
+  correlationId: z.string().optional(),
+  status: z.enum(['ok', 'error']),
+  context: personalContextContextSchema.optional(),
+  profileText: z.string().optional(),
+  evidence: z.array(z.unknown()).optional(),
+  errors: z.array(z.unknown()).optional(),
+  error: z.string().optional(),
+});

--- a/src/common/typedPubsub.ts
+++ b/src/common/typedPubsub.ts
@@ -57,6 +57,10 @@ import type {
   opportunityFeedbackSchema,
   rejectionFeedbackClassificationSchema,
 } from './schema/opportunityMatch';
+import type {
+  generatePersonalContextSchema,
+  personalContextGeneratedSchema,
+} from './schema/personalContext';
 
 export type PubSubSchema = {
   'pub-request': {
@@ -342,6 +346,15 @@ export type PubSubSchema = {
   'api.v1.generate-channel-digest': {
     digestKey: string;
     scheduledAt: string;
+  };
+  'api.v1.generate-personal-context': z.infer<
+    typeof generatePersonalContextSchema
+  >;
+  'api.v1.personal-context-generated': z.infer<
+    typeof personalContextGeneratedSchema
+  >;
+  'api.v1.github-account-linked': {
+    userId: string;
   };
 };
 

--- a/src/entity/user/UserPersonalContext.ts
+++ b/src/entity/user/UserPersonalContext.ts
@@ -2,7 +2,6 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  Index,
   JoinColumn,
   ManyToOne,
   PrimaryColumn,
@@ -22,9 +21,8 @@ export enum PersonalContextStatus {
 }
 
 @Entity()
-@Index('IDX_user_personal_context_user_id', ['userId'])
 export class UserPersonalContext {
-  @PrimaryColumn({ type: 'text' })
+  @PrimaryColumn({ type: 'varchar', length: 36 })
   userId: string;
 
   @PrimaryColumn({ type: 'text' })
@@ -41,12 +39,6 @@ export class UserPersonalContext {
 
   @Column({ type: 'text', nullable: true })
   profileText: string | null;
-
-  @Column({ type: 'text', array: true, default: () => `'{}'` })
-  boostTags: string[];
-
-  @Column({ type: 'text', array: true, default: () => `'{}'` })
-  muteTags: string[];
 
   @Column({ type: 'jsonb', nullable: true })
   context: Record<string, unknown> | null;

--- a/src/entity/user/UserPersonalContext.ts
+++ b/src/entity/user/UserPersonalContext.ts
@@ -1,0 +1,75 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type { User } from './User';
+
+export enum PersonalContextSource {
+  Github = 'github',
+  Website = 'website',
+}
+
+export enum PersonalContextStatus {
+  Pending = 'pending',
+  Ok = 'ok',
+  Error = 'error',
+}
+
+@Entity()
+@Index('IDX_user_personal_context_user_id', ['userId'])
+export class UserPersonalContext {
+  @PrimaryColumn({ type: 'text' })
+  userId: string;
+
+  @PrimaryColumn({ type: 'text' })
+  source: PersonalContextSource;
+
+  @Column({ type: 'text' })
+  sourceValue: string;
+
+  @Column({ type: 'boolean', default: false })
+  verified: boolean;
+
+  @Column({ type: 'text', default: PersonalContextStatus.Pending })
+  status: PersonalContextStatus;
+
+  @Column({ type: 'text', nullable: true })
+  profileText: string | null;
+
+  @Column({ type: 'text', array: true, default: () => `'{}'` })
+  boostTags: string[];
+
+  @Column({ type: 'text', array: true, default: () => `'{}'` })
+  muteTags: string[];
+
+  @Column({ type: 'jsonb', nullable: true })
+  context: Record<string, unknown> | null;
+
+  @Column({ type: 'text', nullable: true })
+  error: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  correlationId: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  requestedAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  generatedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne('User', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: Promise<User>;
+}

--- a/src/integrations/github/clients.ts
+++ b/src/integrations/github/clients.ts
@@ -1,6 +1,10 @@
 import fetch from 'node-fetch';
 import { GarmrService, IGarmrService, GarmrNoopService } from '../garmr';
-import { IGitHubClient, GitHubSearchResponse } from './types';
+import {
+  IGitHubClient,
+  GitHubSearchResponse,
+  GitHubAuthenticatedUser,
+} from './types';
 
 export class GitHubClient implements IGitHubClient {
   private readonly baseUrl: string;
@@ -44,6 +48,26 @@ export class GitHubClient implements IGitHubClient {
       }
 
       return response.json() as Promise<GitHubSearchResponse>;
+    });
+  }
+
+  async getAuthenticatedUser(token: string): Promise<GitHubAuthenticatedUser> {
+    return this.garmr.execute(async () => {
+      const response = await fetch(`${this.baseUrl}/user`, {
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'daily.dev',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `GitHub API error: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      return response.json() as Promise<GitHubAuthenticatedUser>;
     });
   }
 }

--- a/src/integrations/github/types.ts
+++ b/src/integrations/github/types.ts
@@ -29,9 +29,14 @@ export interface GQLGitHubRepository {
   description: string | null;
 }
 
+export interface GitHubAuthenticatedUser {
+  login: string;
+}
+
 export interface IGitHubClient extends IGarmrClient {
   searchRepositories(
     query: string,
     limit?: number,
   ): Promise<GitHubSearchResponse>;
+  getAuthenticatedUser(token: string): Promise<GitHubAuthenticatedUser>;
 }

--- a/src/migration/1784811495083-UserPersonalContext.ts
+++ b/src/migration/1784811495083-UserPersonalContext.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserPersonalContext1784811495083 implements MigrationInterface {
+  name = 'UserPersonalContext1784811495083';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "user_personal_context" ("userId" character varying NOT NULL, "source" text NOT NULL, "sourceValue" text NOT NULL, "verified" boolean NOT NULL DEFAULT false, "status" text NOT NULL DEFAULT 'pending', "profileText" text, "boostTags" text array NOT NULL DEFAULT '{}', "muteTags" text array NOT NULL DEFAULT '{}', "context" jsonb, "error" text, "correlationId" text, "requestedAt" TIMESTAMP WITH TIME ZONE, "generatedAt" TIMESTAMP WITH TIME ZONE, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_359a238fc279d413ede7eb473ee" PRIMARY KEY ("userId", "source"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_user_personal_context_user_id" ON "user_personal_context" ("userId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_personal_context" ADD CONSTRAINT "FK_8d89fb7a971d70503156013ba08" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE IF EXISTS "user_personal_context" DROP CONSTRAINT IF EXISTS "FK_8d89fb7a971d70503156013ba08"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_user_personal_context_user_id"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_personal_context"`);
+  }
+}

--- a/src/migration/1784811495083-UserPersonalContext.ts
+++ b/src/migration/1784811495083-UserPersonalContext.ts
@@ -5,10 +5,7 @@ export class UserPersonalContext1784811495083 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE IF NOT EXISTS "user_personal_context" ("userId" character varying NOT NULL, "source" text NOT NULL, "sourceValue" text NOT NULL, "verified" boolean NOT NULL DEFAULT false, "status" text NOT NULL DEFAULT 'pending', "profileText" text, "boostTags" text array NOT NULL DEFAULT '{}', "muteTags" text array NOT NULL DEFAULT '{}', "context" jsonb, "error" text, "correlationId" text, "requestedAt" TIMESTAMP WITH TIME ZONE, "generatedAt" TIMESTAMP WITH TIME ZONE, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_359a238fc279d413ede7eb473ee" PRIMARY KEY ("userId", "source"))`,
-    );
-    await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_user_personal_context_user_id" ON "user_personal_context" ("userId")`,
+      `CREATE TABLE IF NOT EXISTS "user_personal_context" ("userId" character varying(36) NOT NULL, "source" text NOT NULL, "sourceValue" text NOT NULL, "verified" boolean NOT NULL DEFAULT false, "status" text NOT NULL DEFAULT 'pending', "profileText" text, "context" jsonb, "error" text, "correlationId" text, "requestedAt" TIMESTAMP WITH TIME ZONE, "generatedAt" TIMESTAMP WITH TIME ZONE, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_359a238fc279d413ede7eb473ee" PRIMARY KEY ("userId", "source"))`,
     );
     await queryRunner.query(
       `ALTER TABLE "user_personal_context" ADD CONSTRAINT "FK_8d89fb7a971d70503156013ba08" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -18,9 +15,6 @@ export class UserPersonalContext1784811495083 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE IF EXISTS "user_personal_context" DROP CONSTRAINT IF EXISTS "FK_8d89fb7a971d70503156013ba08"`,
-    );
-    await queryRunner.query(
-      `DROP INDEX IF EXISTS "public"."IDX_user_personal_context_user_id"`,
     );
     await queryRunner.query(`DROP TABLE IF EXISTS "user_personal_context"`);
   }

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -68,6 +68,7 @@ export type RemoteConfigValue = {
   contributionProgram: ContributionProgramConfig;
   headlineChannelMinPosts: number;
   excludedMarketingCta: string[];
+  personalContextEnabled: boolean;
 };
 
 class RemoteConfig {

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -70,6 +70,9 @@ import { userInterestRunWorker } from './interest/userInterestRun';
 import { postVisibleInterestMatchWorker } from './interest/postVisibleInterestMatch';
 import { postUpvotedInterestSignalWorker } from './interest/postUpvotedInterestSignal';
 import { userUpdatedPlusSubscriptionBriefWorker } from './userUpdatedPlusSubscriptionBrief';
+import { userUpdatedPersonalContextWorker } from './personalContext/userUpdatedPersonalContext';
+import { githubAccountLinkedWorker } from './personalContext/githubAccountLinked';
+import { personalContextGeneratedWorker } from './personalContext/personalContextGenerated';
 import { postAddedSlackChannelSendBriefWorker } from './postAddedSlackChannelSendBrief';
 import campaignUpdatedAction from './campaignUpdatedAction';
 import campaignUpdatedSlack from './campaignUpdatedSlack';
@@ -165,6 +168,9 @@ export const typedWorkers: BaseTypedWorker<any>[] = [
   postVisibleInterestMatchWorker,
   postUpvotedInterestSignalWorker,
   userUpdatedPlusSubscriptionBriefWorker,
+  userUpdatedPersonalContextWorker,
+  githubAccountLinkedWorker,
+  personalContextGeneratedWorker,
   postAddedSlackChannelSendBriefWorker,
   postAnalyticsUpdate,
   postAuthorReputationEvent,

--- a/src/workers/personalContext/githubAccountLinked.ts
+++ b/src/workers/personalContext/githubAccountLinked.ts
@@ -1,5 +1,9 @@
 import { TypedWorker } from '../worker';
-import { PersonalContextSource } from '../../entity/user/UserPersonalContext';
+import {
+  PersonalContextSource,
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../entity/user/UserPersonalContext';
 import { requestPersonalContext } from '../../common/personalContext/requestPersonalContext';
 import { gitHubClient } from '../../integrations/github/clients';
 import { remoteConfig } from '../../remoteConfig';
@@ -7,7 +11,7 @@ import { remoteConfig } from '../../remoteConfig';
 export const githubAccountLinkedWorker: TypedWorker<'api.v1.github-account-linked'> =
   {
     subscription: 'api.github-account-linked-personal-context',
-    handler: async (message, con) => {
+    handler: async (message, con, logger) => {
       const {
         data: { userId },
       } = message;
@@ -17,7 +21,7 @@ export const githubAccountLinkedWorker: TypedWorker<'api.v1.github-account-linke
       }
 
       const [account] = await con.query(
-        `SELECT "accessToken" FROM ba_account WHERE "userId" = $1 AND "providerId" = 'github' LIMIT 1`,
+        `SELECT "accountId", "accessToken" FROM ba_account WHERE "userId" = $1 AND "providerId" = 'github' LIMIT 1`,
         [userId],
       );
 
@@ -25,9 +29,30 @@ export const githubAccountLinkedWorker: TypedWorker<'api.v1.github-account-linke
         return;
       }
 
-      const { login } = await gitHubClient.getAuthenticatedUser(
-        account.accessToken,
-      );
+      let login: string;
+      try {
+        ({ login } = await gitHubClient.getAuthenticatedUser(
+          account.accessToken,
+        ));
+      } catch (err) {
+        logger.error(
+          { err, userId, provider: 'personal context' },
+          'failed to resolve github login for personal context',
+        );
+        await con.getRepository(UserPersonalContext).upsert(
+          {
+            userId,
+            source: PersonalContextSource.Github,
+            sourceValue: account.accountId,
+            verified: true,
+            status: PersonalContextStatus.Error,
+            error: err instanceof Error ? err.message : String(err),
+            generatedAt: new Date(),
+          },
+          ['userId', 'source'],
+        );
+        return;
+      }
 
       await requestPersonalContext({
         con,

--- a/src/workers/personalContext/githubAccountLinked.ts
+++ b/src/workers/personalContext/githubAccountLinked.ts
@@ -1,0 +1,40 @@
+import { TypedWorker } from '../worker';
+import { PersonalContextSource } from '../../entity/user/UserPersonalContext';
+import { requestPersonalContext } from '../../common/personalContext/requestPersonalContext';
+import { gitHubClient } from '../../integrations/github/clients';
+import { remoteConfig } from '../../remoteConfig';
+
+export const githubAccountLinkedWorker: TypedWorker<'api.v1.github-account-linked'> =
+  {
+    subscription: 'api.github-account-linked-personal-context',
+    handler: async (message, con) => {
+      const {
+        data: { userId },
+      } = message;
+
+      if (!remoteConfig.vars.personalContextEnabled) {
+        return;
+      }
+
+      const [account] = await con.query(
+        `SELECT "accessToken" FROM ba_account WHERE "userId" = $1 AND "providerId" = 'github' LIMIT 1`,
+        [userId],
+      );
+
+      if (!account?.accessToken) {
+        return;
+      }
+
+      const { login } = await gitHubClient.getAuthenticatedUser(
+        account.accessToken,
+      );
+
+      await requestPersonalContext({
+        con,
+        userId,
+        source: PersonalContextSource.Github,
+        value: login,
+        verified: true,
+      });
+    },
+  };

--- a/src/workers/personalContext/personalContextGenerated.ts
+++ b/src/workers/personalContext/personalContextGenerated.ts
@@ -1,0 +1,45 @@
+import { TypedWorker } from '../worker';
+import {
+  PersonalContextStatus,
+  UserPersonalContext,
+} from '../../entity/user/UserPersonalContext';
+
+export const personalContextGeneratedWorker: TypedWorker<'api.v1.personal-context-generated'> =
+  {
+    subscription: 'api.personal-context-generated',
+    handler: async (message, con) => {
+      const { data } = message;
+      const { userId, correlationId, status } = data;
+
+      if (!correlationId) {
+        return;
+      }
+
+      const repo = con.getRepository(UserPersonalContext);
+      const row = await repo.findOneBy({ userId, correlationId });
+
+      if (!row) {
+        return;
+      }
+
+      row.generatedAt = new Date();
+
+      if (status === 'error') {
+        row.status = PersonalContextStatus.Error;
+        row.error = data.error ?? 'unknown error';
+        await repo.save(row);
+        return;
+      }
+
+      const rankingSignals = data.context?.ranking_signals;
+
+      row.status = PersonalContextStatus.Ok;
+      row.profileText = data.profileText ?? null;
+      row.boostTags = rankingSignals?.boost_tags ?? [];
+      row.muteTags = rankingSignals?.mute_tags ?? [];
+      row.context = data.context ?? null;
+      row.error = null;
+
+      await repo.save(row);
+    },
+  };

--- a/src/workers/personalContext/personalContextGenerated.ts
+++ b/src/workers/personalContext/personalContextGenerated.ts
@@ -31,12 +31,8 @@ export const personalContextGeneratedWorker: TypedWorker<'api.v1.personal-contex
         return;
       }
 
-      const rankingSignals = data.context?.ranking_signals;
-
       row.status = PersonalContextStatus.Ok;
       row.profileText = data.profileText ?? null;
-      row.boostTags = rankingSignals?.boost_tags ?? [];
-      row.muteTags = rankingSignals?.mute_tags ?? [];
       row.context = data.context ?? null;
       row.error = null;
 

--- a/src/workers/personalContext/userUpdatedPersonalContext.ts
+++ b/src/workers/personalContext/userUpdatedPersonalContext.ts
@@ -1,0 +1,30 @@
+import { TypedWorker } from '../worker';
+import { isChanged } from '../cdc/common';
+import { PersonalContextSource } from '../../entity/user/UserPersonalContext';
+import { requestPersonalContext } from '../../common/personalContext/requestPersonalContext';
+import { remoteConfig } from '../../remoteConfig';
+
+export const userUpdatedPersonalContextWorker: TypedWorker<'user-updated'> = {
+  subscription: 'api.user-updated-personal-context',
+  handler: async (message, con) => {
+    const {
+      data: { newProfile, user: oldUser },
+    } = message;
+
+    if (!remoteConfig.vars.personalContextEnabled) {
+      return;
+    }
+
+    if (!isChanged(oldUser, newProfile, 'portfolio')) {
+      return;
+    }
+
+    await requestPersonalContext({
+      con,
+      userId: newProfile.id,
+      source: PersonalContextSource.Website,
+      value: newProfile.portfolio,
+      verified: true,
+    });
+  },
+};


### PR DESCRIPTION
Write-only integration with the personal-context-engine (PCE):

- CDC on user-updated (portfolio change) triggers the website source
- better-auth account.create.after hook triggers the github source, resolving the login via the GitHub API from the linked ba_account
- shared requestPersonalContext helper upserts a pending row and publishes api.v1.generate-personal-context in one transaction
- result worker persists profileText + boost/mute tags, guarded by a per-(userId,source) correlationId stale check
- gated behind the opt-in personalContextEnabled remote config flag
- still not doing anything with it, just saving
- social links handling coming later once I confirm this works