### PR TITLE
fix: use via instead of ref query param on redirect

### DIFF
--- a/__tests__/redirector.ts
+++ b/__tests__/redirector.ts
@@ -42,14 +42,14 @@ describe('GET /r/:postId', () => {
     return request(app.server)
       .get('/r/p1')
       .expect(302)
-      .expect('Location', 'http://p1.com/?r=dailydev');
+      .expect('Location', 'http://p1.com/?via=dailydev');
   });
 
   it('should redirect to youtube post url', () => {
     return request(app.server)
       .get('/r/yt1')
       .expect(302)
-      .expect('Location', 'https://youtu.be/T_AbQGe7fuU?r=dailydev');
+      .expect('Location', 'https://youtu.be/T_AbQGe7fuU?via=dailydev');
   });
 
   it('should render redirect html and notify view event', async () => {
@@ -61,9 +61,9 @@ describe('GET /r/:postId', () => {
       .expect(200)
       .expect('content-type', 'text/html')
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
-      .expect('link', `<http://p1.com/?r=dailydev>; rel="preconnect"`)
+      .expect('link', `<http://p1.com/?via=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?r=dailydev"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?via=dailydev"></head></html>',
       );
     expect(notifyView).toBeCalledWith(
       expect.anything(),
@@ -82,9 +82,9 @@ describe('GET /r/:postId', () => {
       .expect(200)
       .expect('content-type', 'text/html')
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
-      .expect('link', `<http://p1.com/?r=dailydev>; rel="preconnect"`)
+      .expect('link', `<http://p1.com/?via=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?r=dailydev#id"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?via=dailydev#id"></head></html>',
       );
   });
 
@@ -95,7 +95,7 @@ describe('GET /r/:postId', () => {
     return request(app.server)
       .get('/r/p1')
       .expect(302)
-      .expect('Location', 'http://p1.com/?a=b&r=dailydev');
+      .expect('Location', 'http://p1.com/?a=b&via=dailydev');
   });
 
   it('should redirect to post page when url is not available', async () => {
@@ -118,7 +118,7 @@ describe('GET /r/:postId', () => {
       .expect(302)
       .expect(
         'Location',
-        'http://p1.com/hello%20world/%f0%9f%9a%80-to-the-%F0%9F%8C%94?r=dailydev',
+        'http://p1.com/hello%20world/%f0%9f%9a%80-to-the-%F0%9F%8C%94?via=dailydev',
       );
   });
 });

--- a/__tests__/redirector.ts
+++ b/__tests__/redirector.ts
@@ -42,14 +42,14 @@ describe('GET /r/:postId', () => {
     return request(app.server)
       .get('/r/p1')
       .expect(302)
-      .expect('Location', 'http://p1.com/?ref=dailydev');
+      .expect('Location', 'http://p1.com/?r=dailydev');
   });
 
   it('should redirect to youtube post url', () => {
     return request(app.server)
       .get('/r/yt1')
       .expect(302)
-      .expect('Location', 'https://youtu.be/T_AbQGe7fuU?ref=dailydev');
+      .expect('Location', 'https://youtu.be/T_AbQGe7fuU?r=dailydev');
   });
 
   it('should render redirect html and notify view event', async () => {
@@ -61,9 +61,9 @@ describe('GET /r/:postId', () => {
       .expect(200)
       .expect('content-type', 'text/html')
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
-      .expect('link', `<http://p1.com/?ref=dailydev>; rel="preconnect"`)
+      .expect('link', `<http://p1.com/?r=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?r=dailydev"></head></html>',
       );
     expect(notifyView).toBeCalledWith(
       expect.anything(),
@@ -82,9 +82,9 @@ describe('GET /r/:postId', () => {
       .expect(200)
       .expect('content-type', 'text/html')
       .expect('referrer-policy', 'origin, origin-when-cross-origin')
-      .expect('link', `<http://p1.com/?ref=dailydev>; rel="preconnect"`)
+      .expect('link', `<http://p1.com/?r=dailydev>; rel="preconnect"`)
       .expect(
-        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?ref=dailydev#id"></head></html>',
+        '<html><head><meta name="robots" content="noindex,nofollow"><meta http-equiv="refresh" content="0;URL=http://p1.com/?r=dailydev#id"></head></html>',
       );
   });
 
@@ -95,7 +95,7 @@ describe('GET /r/:postId', () => {
     return request(app.server)
       .get('/r/p1')
       .expect(302)
-      .expect('Location', 'http://p1.com/?a=b&ref=dailydev');
+      .expect('Location', 'http://p1.com/?a=b&r=dailydev');
   });
 
   it('should redirect to post page when url is not available', async () => {
@@ -118,7 +118,7 @@ describe('GET /r/:postId', () => {
       .expect(302)
       .expect(
         'Location',
-        'http://p1.com/hello%20world/%f0%9f%9a%80-to-the-%F0%9F%8C%94?ref=dailydev',
+        'http://p1.com/hello%20world/%f0%9f%9a%80-to-the-%F0%9F%8C%94?r=dailydev',
       );
   });
 });

--- a/src/routes/redirector.ts
+++ b/src/routes/redirector.ts
@@ -35,7 +35,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         return res.status(302).redirect(getDiscussionLink(post.slug));
       }
       const url = new URL(post.url);
-      url.searchParams.append('ref', 'dailydev');
+      url.searchParams.append('r', 'dailydev');
       const encodedUri = encodeUrl(url.href);
       if (req.isBot) {
         return res.status(302).redirect(encodedUri);

--- a/src/routes/redirector.ts
+++ b/src/routes/redirector.ts
@@ -35,7 +35,7 @@ export default async function (fastify: FastifyInstance): Promise<void> {
         return res.status(302).redirect(getDiscussionLink(post.slug));
       }
       const url = new URL(post.url);
-      url.searchParams.append('r', 'dailydev');
+      url.searchParams.append('via', 'dailydev');
       const encodedUri = encodeUrl(url.href);
       if (req.isBot) {
         return res.status(302).redirect(encodedUri);


### PR DESCRIPTION
Links to Substack (and some other sites) break when we append `ref` as a query param on the outbound redirect. Renamed the attribution param to `via`, the conventional share-attribution name.

Only affects `/r/:postId` redirects — the `roadmap.sh?ref=dailydev` partner link is unchanged.

https://claude.ai/code/session_013o9WhBTGKXCzrUzmUCVTZE