### PR TITLE
feat: unified view logging – count article views on post open

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -4617,11 +4617,11 @@ describe('mutation viewPost', () => {
     expect(notifyView).toBeCalledTimes(1);
   });
 
-  it('should should not submit view event for articles', async () => {
+  it('should submit view event for articles', async () => {
     loggedUser = '1';
     const res = await client.mutate(MUTATION, { variables });
     expect(res.errors).toBeFalsy();
-    expect(notifyView).toBeCalledTimes(0);
+    expect(notifyView).toBeCalledTimes(1);
   });
 });
 

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -3408,16 +3408,14 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
     ): Promise<GQLEmptyResponse> => {
       const post = await ctx.con.getRepository(Post).findOneByOrFail({ id });
       await ensureSourcePermissions(ctx, post.sourceId);
-      if (post.type !== PostType.Article) {
-        await notifyView(
-          ctx.log,
-          post.id,
-          ctx.userId,
-          ctx.req.headers['referer'],
-          new Date(),
-          post.tagsStr?.split?.(',') ?? [],
-        );
-      }
+      await notifyView(
+        ctx.log,
+        post.id,
+        ctx.userId,
+        ctx.req.headers['referer'],
+        new Date(),
+        post.tagsStr?.split?.(',') ?? [],
+      );
       return { _: true };
     },
     dismissPostFeedback: async (


### PR DESCRIPTION
## Summary

Removes the `post.type !== PostType.Article` guard in the `viewPost` GraphQL mutation (`src/schema/posts.ts`) so `notifyView` is called for every post type, not just non-articles.

**Before:** Article views were only counted (view row + reading-streak day) when a user clicked "Read article," which hits the `GET /r/:postId` redirector. Opening the article post page/modal in-app did not log a view.

**After:** Opening the post page/modal now logs a view for articles too, matching every other post type (share, freeform, video, etc.), which already called `notifyView` from `viewPost`.

**Dedup safety:** The views worker dedupes `View` rows per `(userId, postId)` within a one-week window and increments the reading streak at most once per day, so a user who both opens the post and later clicks through via `/r/:postId` will not be double-counted.

**No deploy-order constraint:** There is the companion frontend PR dailydotdev/apps#6380. Either side can deploy first — the mutation change here is additive (it doesn't change the `viewPost` API shape), and the frontend's `viewPost` call sites are unchanged, so this backend PR and the frontend PR are independently deployable in either order.

## Changes

- `src/schema/posts.ts`: `viewPost` resolver now unconditionally calls `notifyView` after `ensureSourcePermissions`, for all post types.
- `__tests__/posts.ts`: replaced the test asserting articles do *not* trigger `notifyView` with one asserting they *do* (`should submit view event for articles`), consistent with the existing non-article assertion. Auth/permission tests (`UNAUTHENTICATED`, `NOT_FOUND`, `FORBIDDEN`) untouched.

## Test plan

- [x] `NODE_ENV=test npx jest __tests__/posts.ts --testEnvironment=node --runInBand -t "viewPost"` — all 5 tests in `describe('mutation viewPost')` pass (had to run pending local migrations against the `api_test` DB first; local infra — postgres/redis — was available in this environment).
- [x] Full `__tests__/posts.ts` suite: 365 passed, 0 failed.
- [x] `npx eslint src/schema/posts.ts __tests__/posts.ts --max-warnings 0` — clean.
- [x] `pnpm run build` (`tsc`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
