### PR TITLE
feat: forward TCF consent from boot to skadi engagement ads

### DIFF
--- a/__tests__/boot.ts
+++ b/__tests__/boot.ts
@@ -2395,13 +2395,52 @@ describe('engagement creatives', () => {
     nock(process.env.SKADI_ORIGIN)
       .post('/private', {
         placement: 'default_engagement',
-        metadata: { USERID: '1' },
+        metadata: { USERID: '1', GDPR: '0' },
       })
       .reply(200, skadiResponse);
 
     const res = await request(app.server)
       .get(BASE_PATH)
       .set('User-Agent', TEST_UA)
+      .set('Cookie', await mockLoggedInCookie())
+      .expect(200);
+
+    expect(res.body.engagementCreatives).toEqual([expectedCreative]);
+  });
+
+  it('should forward a valid x-gdpr-consent header to skadi', async () => {
+    const tcString =
+      'CQAbcDEfGhIjKlMnOpQrStUvWxYz.II7Nd_X__bX9n-_7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX32E7NF36tq4KmR4ku1bBIQNtHMnUDUmxaolVrzHsak2cpyNKJ_JkknsZe2dYGF9Pn9lD-YKZ7_5_9_f52T_9_9_-39z3_9f___dv_-__-vjf_599n_v9fV_78_Kf9______-____________8A';
+
+    nock(process.env.SKADI_ORIGIN)
+      .post('/private', {
+        placement: 'default_engagement',
+        metadata: { USERID: '1', GDPR: '0', GDPR_CONSENT: tcString },
+      })
+      .reply(200, skadiResponse);
+
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('x-gdpr-consent', tcString)
+      .set('Cookie', await mockLoggedInCookie())
+      .expect(200);
+
+    expect(res.body.engagementCreatives).toEqual([expectedCreative]);
+  });
+
+  it('should silently drop an invalid x-gdpr-consent header', async () => {
+    nock(process.env.SKADI_ORIGIN)
+      .post('/private', {
+        placement: 'default_engagement',
+        metadata: { USERID: '1', GDPR: '0' },
+      })
+      .reply(200, skadiResponse);
+
+    const res = await request(app.server)
+      .get(BASE_PATH)
+      .set('User-Agent', TEST_UA)
+      .set('x-gdpr-consent', 'not a valid tc string!{}')
       .set('Cookie', await mockLoggedInCookie())
       .expect(200);
 

--- a/src/common/schema/consent.ts
+++ b/src/common/schema/consent.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const tcfConsentHeaderSchema = z
+  .string()
+  .min(1)
+  .max(4096)
+  .regex(/^[A-Za-z0-9\-_.~]+$/);

--- a/src/integrations/skadi/clients.ts
+++ b/src/integrations/skadi/clients.ts
@@ -4,6 +4,7 @@ import {
   SkadiResponse,
   type EngagementCreative,
   type SkadiAd,
+  type SkadiConsentMetadata,
 } from './types';
 import { GarmrNoopService, IGarmrService, GarmrService } from '../garmr';
 import { fetchOptions as globalFetchOptions } from '../../http';
@@ -34,7 +35,7 @@ export class SkadiClient<TValue> implements ISkadiClient<TValue> {
     placement: string,
     metadata: {
       USERID: string;
-    },
+    } & SkadiConsentMetadata,
     options?: {
       cid?: string;
     },

--- a/src/integrations/skadi/types.ts
+++ b/src/integrations/skadi/types.ts
@@ -40,12 +40,19 @@ export type EngagementCreative = {
   source_id?: string;
 };
 
+// IAB TCF consent signals, keyed by skadi's typed metadata names.
+export type SkadiConsentMetadata = {
+  GDPR?: '0' | '1';
+  GDPR_CONSENT?: string;
+  ADDTL_CONSENT?: string;
+};
+
 export interface ISkadiClient<TValue> {
   getAd(
     placement: string,
     metadata: {
       USERID: string;
-    },
+    } & SkadiConsentMetadata,
     options?: {
       // Campaign id forwarded as a `cid` query param (e.g. from the user's
       // referralOrigin) so skadi can target a specific campaign.

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -104,7 +104,9 @@ import { asyncRetry } from '../integrations/retry';
 import {
   skadiEngagementClient,
   type EngagementCreative,
+  type SkadiConsentMetadata,
 } from '../integrations/skadi';
+import { tcfConsentHeaderSchema } from '../common/schema/consent';
 import { isMockEnabled } from '../mocks/common';
 import { mockSkadiEngagementResponse } from '../mocks/skadi/engagement';
 import { LiveRoom } from '../entity/LiveRoom';
@@ -327,6 +329,28 @@ const geoSection = (req: FastifyRequest): BaseBoot['geo'] => {
   return {
     region,
     continent: region ? countryCodeToContinent[region] : undefined,
+  };
+};
+
+// Regions the webapp treats as outside GDPR coverage (mirrors `outsideGdpr`
+// in the apps repo) — keep both lists in sync.
+const gdprExemptRegions = ['US', 'IL'];
+
+const consentSection = (
+  req: FastifyRequest,
+  geo: BaseBoot['geo'],
+): SkadiConsentMetadata => {
+  const gdprApplies =
+    geo.continent === Continent.Europe ||
+    !gdprExemptRegions.includes(geo.region ?? '');
+
+  const header = tcfConsentHeaderSchema.safeParse(
+    req.headers['x-gdpr-consent'],
+  );
+
+  return {
+    GDPR: gdprApplies ? '1' : '0',
+    ...(header.success && { GDPR_CONSENT: header.data }),
   };
 };
 
@@ -713,6 +737,7 @@ const getLocation = async (
 const getEngagementCreatives = async (
   userId: string,
   cid?: string,
+  consent?: SkadiConsentMetadata,
 ): Promise<EngagementCreative[]> => {
   const mocked = isMockEnabled();
 
@@ -725,7 +750,7 @@ const getEngagementCreatives = async (
       ? mockSkadiEngagementResponse
       : await skadiEngagementClient.getAd(
           'default_engagement',
-          { USERID: userId },
+          { USERID: userId, ...consent },
           { cid },
         );
 
@@ -850,6 +875,7 @@ const loggedInBoot = async ({
       getEngagementCreatives(
         userId,
         getReferralFromCookie({ req })?.referralOrigin,
+        consentSection(req, geo),
       ),
       getLiveRoomsBoot(con),
       getDailyBoot({ userId }),
@@ -1058,6 +1084,7 @@ const anonymousBoot = async (
     getEngagementCreatives(
       req.trackingId ?? '',
       getReferralFromCookie({ req })?.referralOrigin,
+      consentSection(req, geo),
     ),
     getLiveRoomsBoot(con),
   ]);


### PR DESCRIPTION
Part of the iubenda CMP rollout. The webapp stores the TCF consent string after the user answers the CMP banner and sends it on the next boot as an `x-gdpr-consent` header.

- `consentSection` in `src/routes/boot.ts`: validates the header via a zod schema (`src/common/schema/consent.ts`, invalid → silently dropped) and derives `GDPR: '0' | '1'` from the existing geo lookup, aligned with the webapp's `outsideGdpr = ['US','IL']` logic so client and server agree.
- Consent keys ride inside the existing `metadata` map on `skadiEngagementClient.getAd` (matches skadi's new typed metadata keys — dailydotdev/skadi#352), for both logged-in and anonymous boot.
- Digest email ads untouched (no request context; out of scope this iteration).

Deploy after skadi, before the apps flag ramp. Tests: boot suite extended for header present/absent/invalid.