### PR TITLE
Update pre-merge app.daily.dev references to the apex domain

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -85,7 +85,7 @@ Allow: /devcards/
 Allow: /graphql
 Allow: /boot
 Allow: /sitemaps/
-Sitemap: https://app.daily.dev/api/sitemaps/index.xml
+Sitemap: https://daily.dev/api/sitemaps/index.xml
 Disallow: /`),
   );
 
@@ -110,7 +110,7 @@ You can follow the discussion here.
 https://x.com/dailydotdev/status/1798960336667893866
 
 In the interim we suggest using the web version.
-https://app.daily.dev`,
+https://daily.dev`,
     );
   });
 

--- a/src/routes/llms.txt
+++ b/src/routes/llms.txt
@@ -17,7 +17,7 @@ All API requests require a Bearer token:
 Authorization: Bearer dda_your_token_here
 ```
 
-Tokens are created at https://app.daily.dev/settings/api (requires Plus subscription).
+Tokens are created at https://daily.dev/settings/api (requires Plus subscription).
 
 ## Base URL
 

--- a/src/routes/sitemaps.ts
+++ b/src/routes/sitemaps.ts
@@ -78,7 +78,7 @@ const toSitemapUrlSetStream = (
   );
 
 const getSitemapUrlPrefix = (): string =>
-  normalizePrefix(process.env.COMMENTS_PREFIX || 'https://app.daily.dev');
+  normalizePrefix(process.env.COMMENTS_PREFIX || 'https://daily.dev');
 
 const getPostSitemapUrl = (prefix: string, slug: string): string =>
   `${prefix}/posts/${slug}`;


### PR DESCRIPTION
## Why

Post domain merge, four spots in this repo still reference `app.daily.dev`. Three of them are crawler- or agent-facing:

1. **robots.txt** (`src/routes/index.ts`): declares `Sitemap: https://app.daily.dev/api/sitemaps/index.xml`. The canonical location is `https://daily.dev/api/sitemaps/index.xml` (the old URL 308s there, but sitemap declarations shouldn't point at redirects).
2. **`getSitemapUrlPrefix()`** (`src/routes/sitemaps.ts`): falls back to `https://app.daily.dev` when `COMMENTS_PREFIX` is unset. Production sets the env var so live sitemaps are correct today, but any env regression would silently emit the stale domain across all ~124K sitemap URLs. Defense in depth: the fallback now matches the live domain.
3. **Public API llms.txt** (`src/routes/llms.txt`): points agents at `app.daily.dev/settings/api` for token creation. `daily.dev/settings/api` verified to resolve directly (HTTP 200, no redirect).
4. The Firefox `/v1/auth/authorize` notice suggests `app.daily.dev` as the web version (cosmetic).

## Notes

No behavior change while `COMMENTS_PREFIX` is set correctly; `.env` test config sets its own prefix, and no test pins the old fallback. This rides alongside dailydotdev/recruiter-landing#396 (apex llms.txt now represents the app) and dailydotdev/apps#6390 (removes the unreachable webapp llms.txt).