### PR TITLE
feat: exempt squad moderators and admins from post rate limits

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3518,6 +3518,63 @@ describe('mutation sharePost', () => {
       }
     });
 
+    it.each([SourceMemberRoles.Moderator, SourceMemberRoles.Admin])(
+      'should bypass rate limit for squad %s',
+      async (role) => {
+        loggedUser = '1';
+
+        await con
+          .getRepository(SourceMember)
+          .update({ sourceId: 's1', userId: '1' }, { role });
+
+        for (let i = 0; i < 3; i++) {
+          const res = await client.mutate(MUTATION, {
+            variables: variables,
+          });
+          expect(res.errors).toBeFalsy();
+        }
+        expect(await getRedisObject(redisKey)).toBeFalsy();
+      },
+    );
+
+    it('should still rate limit privileged members posting to other squads', async () => {
+      loggedUser = '1';
+
+      await con.getRepository(SquadSource).save({
+        id: 's2',
+        handle: 's2',
+        name: 'Other Squad',
+        private: false,
+        memberPostingRank: 0,
+      });
+      await con.getRepository(SourceMember).save([
+        {
+          sourceId: 's1',
+          userId: '1',
+          referralToken: 'rt',
+          role: SourceMemberRoles.Admin,
+        },
+        {
+          sourceId: 's2',
+          userId: '1',
+          referralToken: 'rt2',
+          role: SourceMemberRoles.Member,
+        },
+      ]);
+
+      const res = await client.mutate(MUTATION, {
+        variables: { ...variables, sourceId: 's2' },
+      });
+      expect(res.errors).toBeFalsy();
+
+      await testMutationErrorCode(
+        client,
+        { mutation: MUTATION, variables: { ...variables, sourceId: 's2' } },
+        'RATE_LIMITED',
+        'Take a break. You already posted enough in the last 30 seconds',
+      );
+    });
+
     describe('high rate squads', () => {
       beforeEach(async () => {
         await con.getRepository(SquadSource).save({

--- a/src/common/rateLimit.ts
+++ b/src/common/rateLimit.ts
@@ -1,5 +1,7 @@
 import { DataSource, EntityManager, MoreThan } from 'typeorm';
 import { Comment, Post, User } from '../entity';
+import { SourceMember } from '../entity/SourceMember';
+import { sourceRoleRank } from '../roles';
 import { remoteConfig } from '../remoteConfig';
 import { subDays } from 'date-fns';
 import { GraphQLError } from 'graphql/index';
@@ -58,10 +60,31 @@ const ensureReputationBasedRateLimit = async (
   }
 };
 
+export const isPrivilegedSquadMember = async (
+  con: DataSource | EntityManager,
+  { userId, sourceId }: { userId?: string; sourceId?: string },
+): Promise<boolean> => {
+  if (!userId || !sourceId) {
+    return false;
+  }
+
+  const member = await con.getRepository(SourceMember).findOne({
+    select: ['role'],
+    where: { userId, sourceId },
+  });
+
+  return !!member && sourceRoleRank[member.role] >= sourceRoleRank.moderator;
+};
+
 export const ensurePostRateLimit = async (
   con: DataSource | EntityManager,
   userId: string,
+  sourceId?: string,
 ): Promise<void> => {
+  if (await isPrivilegedSquadMember(con, { userId, sourceId })) {
+    return;
+  }
+
   return ensureReputationBasedRateLimit(
     con,
     userId,

--- a/src/common/rateLimit.ts
+++ b/src/common/rateLimit.ts
@@ -6,6 +6,7 @@ import { remoteConfig } from '../remoteConfig';
 import { subDays } from 'date-fns';
 import { GraphQLError } from 'graphql/index';
 import { isPlusMember } from '../paddle';
+import { queryReadReplica } from './queryReadReplica';
 
 export class RateLimitError extends GraphQLError {
   extensions = {};
@@ -63,23 +64,25 @@ const ensureReputationBasedRateLimit = async (
 };
 
 export const isPrivilegedSquadMember = async (
-  con: DataSource | EntityManager,
+  con: DataSource,
   { userId, sourceId }: { userId?: string; sourceId?: string },
 ): Promise<boolean> => {
   if (!userId || !sourceId) {
     return false;
   }
 
-  const member = await con.getRepository(SourceMember).findOne({
-    select: ['role'],
-    where: { userId, sourceId },
-  });
+  const member = await queryReadReplica(con, ({ queryRunner }) =>
+    queryRunner.manager.getRepository(SourceMember).findOne({
+      select: ['role'],
+      where: { userId, sourceId },
+    }),
+  );
 
   return !!member && sourceRoleRank[member.role] >= sourceRoleRank.moderator;
 };
 
 export const ensurePostRateLimit = async (
-  con: DataSource | EntityManager,
+  con: DataSource,
   userId: string,
   sourceId?: string,
 ): Promise<void> => {

--- a/src/common/rateLimit.ts
+++ b/src/common/rateLimit.ts
@@ -33,16 +33,18 @@ const ensureReputationBasedRateLimit = async (
   count: Promise<number>,
   countThreshold: number,
   errorMessage: string,
+  isExempt: Promise<boolean> = Promise.resolve(false),
 ): Promise<void> => {
-  const [user, countValue] = await Promise.all([
+  const [user, countValue, exempt] = await Promise.all([
     con.getRepository(User).findOneOrFail({
       select: ['id', 'reputation', 'subscriptionFlags'],
       where: { id: userId },
     }),
     count,
+    isExempt,
   ]);
 
-  if (isPlusMember(user.subscriptionFlags?.cycle)) {
+  if (exempt || isPlusMember(user.subscriptionFlags?.cycle)) {
     return;
   }
 
@@ -81,10 +83,6 @@ export const ensurePostRateLimit = async (
   userId: string,
   sourceId?: string,
 ): Promise<void> => {
-  if (await isPrivilegedSquadMember(con, { userId, sourceId })) {
-    return;
-  }
-
   return ensureReputationBasedRateLimit(
     con,
     userId,
@@ -95,6 +93,7 @@ export const ensurePostRateLimit = async (
     }),
     remoteConfig.vars?.postRateLimit ?? 0,
     `Take a break. You already posted enough`,
+    isPrivilegedSquadMember(con, { userId, sourceId }),
   );
 };
 

--- a/src/directive/rateLimit.ts
+++ b/src/directive/rateLimit.ts
@@ -17,7 +17,7 @@ import { Context } from '../Context';
 import { logger } from '../logger';
 import { WATERCOOLER_ID } from '../common';
 import { counters } from '../telemetry';
-import { RateLimitError } from '../common/rateLimit';
+import { isPrivilegedSquadMember, RateLimitError } from '../common/rateLimit';
 
 export const highRateLimitedSquads = [WATERCOOLER_ID];
 
@@ -131,10 +131,32 @@ const rateLimiterConfig: RateLimitOptions<Context, IRateLimiterRedisOptions> = {
     storeClient: singleRedisClient,
   },
   limiterClass: CustomRateLimiterRedis,
-  pointsCalculator: (directiveArgs, source, args, context, info) => {
+  pointsCalculator: async (directiveArgs, source, args, context, info) => {
     switch (info.fieldName) {
       case 'parseOpportunity':
         return context.isTeamMember ? 0 : 1;
+      case 'createFreeformPost':
+      case 'createPollPost':
+      case 'submitExternalLink':
+      case 'sharePost':
+      case 'createSourcePostModeration': {
+        const isPrivileged = await isPrivilegedSquadMember(context.con, {
+          userId: context.userId,
+          sourceId: args.sourceId as string,
+        });
+
+        if (isPrivileged) {
+          return 0;
+        }
+
+        return defaultPointsCalculator(
+          directiveArgs,
+          source,
+          args,
+          context,
+          info,
+        );
+      }
       default:
         return defaultPointsCalculator(
           directiveArgs,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -2754,7 +2754,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           props.sourceId,
           SourcePermissions.PostRequest,
         ),
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId, props.sourceId),
       ]);
 
       const pendingPost = await validateSourcePostModeration(ctx, props);
@@ -2978,7 +2978,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
 
       await Promise.all([
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId, sourceId),
       ]);
 
       const { id } = await createFreeformPost(ctx.con, ctx, args);
@@ -3261,7 +3261,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
 
       await Promise.all([
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId, sourceId),
       ]);
       await ctx.con.transaction(async (manager) => {
         const existingPost = await findPostByUrl(
@@ -3345,7 +3345,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           .where('post.id = :id', { id })
           .getOneOrFail(),
         ensureSourcePermissions(ctx, sourceId, SourcePermissions.Post),
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId, sourceId),
       ]);
 
       if (post.deleted) {
@@ -3723,7 +3723,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
 
       await Promise.all([
         sourceCheck,
-        ensurePostRateLimit(ctx.con, ctx.userId),
+        ensurePostRateLimit(ctx.con, ctx.userId, args.sourceId),
       ]);
 
       const id = await generateShortId();


### PR DESCRIPTION
## Changes

Squad moderators and admins were still being rate limited when posting to squads they moderate. Posting goes through two independent throttles, and neither was aware of squad roles:

1. The `@rateLimit(limit: 1, duration: 30)` directive on `createFreeformPost`, `createPollPost`, `submitExternalLink`, `sharePost`, and `createSourcePostModeration` (Redis, shared `:createPost` key per user).
2. `ensurePostRateLimit` — the daily post cap from remote config (already exempted Plus and high-reputation users).

Both layers now skip users whose `SourceMember` role in the **target** squad is moderator or above:

- New `isPrivilegedSquadMember` helper in `src/common/rateLimit.ts`; `ensurePostRateLimit` accepts an optional `sourceId` and returns early for privileged members.
- The directive's `pointsCalculator` charges 0 points for the five post mutations when the poster is privileged in `args.sourceId`.
- All five `ensurePostRateLimit` call sites pass the target `sourceId`.

The exemption is squad-scoped: an admin of squad A posting to squad B where they are a plain member is still rate limited. Comment rate limits are intentionally untouched.

## Tests

- Moderator and admin bypass both limits (no Redis key accrues).
- Privileged members posting to squads where they are plain members are still limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)