### PR TITLE
feat(keywords): allow moderators to edit tag title and description

### DIFF
--- a/__tests__/keywords.ts
+++ b/__tests__/keywords.ts
@@ -11,7 +11,13 @@ import {
   testQueryErrorCode,
 } from './helpers';
 import { Roles } from '../src/roles';
-import { ArticlePost, Keyword, PostKeyword, Source } from '../src/entity';
+import {
+  ArticlePost,
+  Keyword,
+  KeywordStatus,
+  PostKeyword,
+  Source,
+} from '../src/entity';
 import { sourcesFixture } from './fixture/source';
 import { postsFixture } from './fixture/post';
 import { DataSource } from 'typeorm';
@@ -192,8 +198,8 @@ describe('query keyword', () => {
 
 describe('mutation allowKeyword', () => {
   const MUTATION = `
-  mutation AllowKeyword($keyword: String!, $title: String) {
-    allowKeyword(keyword: $keyword, title: $title) {
+  mutation AllowKeyword($keyword: String!, $title: String, $description: String) {
+    allowKeyword(keyword: $keyword, title: $title, description: $description) {
       _
     }
   }`;
@@ -270,6 +276,27 @@ describe('mutation allowKeyword', () => {
     });
   });
 
+  it('should persist description to flags when provided', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        keyword: 'ai-coding',
+        title: 'AI Coding',
+        description: 'Writing code with AI assistance.',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'ai-coding' });
+    expect(keyword?.status).toEqual('allow');
+    expect(keyword?.flags).toEqual({
+      title: 'AI Coding',
+      description: 'Writing code with AI assistance.',
+    });
+  });
+
   it('should leave existing flags untouched when title is omitted', async () => {
     roles = [Roles.Moderator];
     loggedUser = '1';
@@ -290,6 +317,119 @@ describe('mutation allowKeyword', () => {
       title: 'Rust',
       description: 'A systems language',
     });
+  });
+});
+
+describe('mutation updateKeywordFlags', () => {
+  const MUTATION = `
+  mutation UpdateKeywordFlags($keyword: String!, $title: String, $description: String, $roadmap: String) {
+    updateKeywordFlags(keyword: $keyword, title: $title, description: $description, roadmap: $roadmap) {
+      _
+    }
+  }`;
+
+  it('should not authorize when not moderator', () =>
+    testModeratorMutationAuthorization({
+      mutation: MUTATION,
+      variables: { keyword: 'java', title: 'Java' },
+    }));
+
+  it('should update title and description without changing status', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'frontend-development',
+      occurrences: 20,
+      status: KeywordStatus.Allow,
+      flags: { title: 'Frontend Development' },
+    });
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        keyword: 'frontend-development',
+        title: 'Frontend',
+        description: 'Building user interfaces for the web.',
+      },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'frontend-development' });
+    expect(keyword?.status).toEqual('allow');
+    expect(keyword?.flags).toEqual({
+      title: 'Frontend',
+      description: 'Building user interfaces for the web.',
+    });
+  });
+
+  it('should merge into existing flags without clobbering other keys', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'llm',
+      occurrences: 20,
+      status: KeywordStatus.Allow,
+      flags: { title: 'LLM', onboarding: true },
+    });
+    const res = await client.mutate(MUTATION, {
+      variables: { keyword: 'llm', description: 'Large language models.' },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'llm' });
+    expect(keyword?.flags).toEqual({
+      title: 'LLM',
+      description: 'Large language models.',
+      onboarding: true,
+    });
+  });
+
+  it('should safely persist text containing quotes and apostrophes', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'frontend',
+      occurrences: 20,
+      status: KeywordStatus.Allow,
+    });
+    const description =
+      'It\'s about the "user interface" layer -- don\'t skip it.';
+    const res = await client.mutate(MUTATION, {
+      variables: { keyword: 'frontend', description },
+    });
+    expect(res.errors).toBeFalsy();
+    const keyword = await con
+      .getRepository(Keyword)
+      .findOneBy({ value: 'frontend' });
+    expect(keyword?.flags.description).toEqual(description);
+  });
+
+  it('should throw validation error when no flag is provided', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    await con.getRepository(Keyword).save({
+      value: 'rust',
+      occurrences: 20,
+      status: KeywordStatus.Allow,
+    });
+    return testMutationErrorCode(
+      client,
+      { mutation: MUTATION, variables: { keyword: 'rust' } },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should throw not found when keyword does not exist', async () => {
+    roles = [Roles.Moderator];
+    loggedUser = '1';
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { keyword: 'does-not-exist', title: 'Nope' },
+      },
+      'NOT_FOUND',
+    );
   });
 });
 

--- a/src/schema/keywords.ts
+++ b/src/schema/keywords.ts
@@ -9,8 +9,9 @@ import {
 import graphorm from '../graphorm';
 import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
 import { GQLEmptyResponse } from './common';
-import { MoreThanOrEqual } from 'typeorm';
-import { updateFlagsStatement } from '../common/utils';
+import { EntityManager, MoreThanOrEqual } from 'typeorm';
+import { ValidationError } from 'apollo-server-errors';
+import { NotFoundError } from '../errors';
 
 export interface GQLKeyword {
   value: string;
@@ -28,6 +29,13 @@ interface GQLKeywordSearchResults {
 
 interface GQLKeywordArgs {
   keyword: string;
+}
+
+interface GQLKeywordFlagsArgs {
+  keyword: string;
+  title?: string;
+  description?: string;
+  roadmap?: string;
 }
 
 interface GQLSynonymKeywordArgs {
@@ -121,8 +129,20 @@ export const typeDefs = /* GraphQL */ `
     """
     Add keyword to the allowlist
     """
-    allowKeyword(keyword: String!, title: String): EmptyResponse
-      @auth(requires: [MODERATOR])
+    allowKeyword(
+      keyword: String!
+      title: String
+      description: String
+    ): EmptyResponse @auth(requires: [MODERATOR])
+    """
+    Update the public flags (title, description, roadmap) of a keyword
+    """
+    updateKeywordFlags(
+      keyword: String!
+      title: String
+      description: String
+      roadmap: String
+    ): EmptyResponse @auth(requires: [MODERATOR])
     """
     Add keyword to the denylist
     """
@@ -138,6 +158,40 @@ export const typeDefs = /* GraphQL */ `
 `;
 
 const PENDING_THRESHOLD = 25;
+
+/**
+ * Keeps only the provided public flags, so omitted arguments never clear
+ * existing values. Returns null when there is nothing to update.
+ */
+const pickKeywordFlags = (
+  flags: KeywordFlagsPublic,
+): KeywordFlagsPublic | null => {
+  const entries = Object.entries(flags).filter(
+    ([, value]) => value !== undefined && value !== null,
+  );
+  return entries.length ? Object.fromEntries(entries) : null;
+};
+
+/**
+ * Merges the given flags into keyword.flags using a bound parameter, so
+ * free text values (descriptions contain quotes and apostrophes) are safe.
+ * Returns the number of affected rows.
+ */
+const mergeKeywordFlags = async (
+  entityManager: EntityManager,
+  keyword: string,
+  flags: KeywordFlagsPublic,
+): Promise<number> => {
+  const { affected } = await entityManager
+    .getRepository(Keyword)
+    .createQueryBuilder()
+    .update()
+    .set({ flags: () => `flags || :keywordFlags::jsonb` })
+    .where({ value: keyword })
+    .setParameter('keywordFlags', JSON.stringify(flags))
+    .execute();
+  return affected ?? 0;
+};
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
   Query: {
@@ -230,7 +284,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
   Mutation: {
     allowKeyword: async (
       source,
-      { keyword, title }: GQLKeywordArgs & { title?: string },
+      { keyword, title, description }: GQLKeywordFlagsArgs,
       ctx: AuthContext,
     ): Promise<GQLEmptyResponse> => {
       await ctx.con.transaction(async (entityManager) => {
@@ -239,13 +293,28 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           value: keyword,
           status: KeywordStatus.Allow,
         });
-        if (title) {
-          await repo.update(
-            { value: keyword },
-            { flags: updateFlagsStatement<Keyword>({ title }) },
-          );
+        const flags = pickKeywordFlags({ title, description });
+        if (flags) {
+          await mergeKeywordFlags(entityManager, keyword, flags);
         }
       });
+      return { _: true };
+    },
+    updateKeywordFlags: async (
+      source,
+      { keyword, title, description, roadmap }: GQLKeywordFlagsArgs,
+      ctx: AuthContext,
+    ): Promise<GQLEmptyResponse> => {
+      const flags = pickKeywordFlags({ title, description, roadmap });
+      if (!flags) {
+        throw new ValidationError(
+          'At least one of title, description or roadmap must be provided',
+        );
+      }
+      const affected = await mergeKeywordFlags(ctx.con.manager, keyword, flags);
+      if (!affected) {
+        throw new NotFoundError('Keyword not found');
+      }
       return { _: true };
     },
     denyKeyword: async (


### PR DESCRIPTION
## Why

Tag pages render `keyword.flags.title` and `keyword.flags.description`, but only `title` was writable — via `allowKeyword`. `description` is exposed in the public `KeywordFlagsPublic` type and shown in the app, yet there was no mutation to set it, so every copy change needed a manual production DB update.

## What

- `allowKeyword(keyword, title, description)` — added optional `description`.
- New `updateKeywordFlags(keyword, title, description, roadmap)` moderator mutation — edits the public flags of an **existing** keyword without touching its status. Throws `ValidationError` if no flag is passed, `NotFoundError` if the keyword doesn't exist.
- Both paths merge into `flags` through a bound `:keywordFlags::jsonb` parameter instead of `updateFlagsStatement`'s string interpolation. Descriptions are free-text prose full of apostrophes and quotes, which would break (or inject into) the interpolated statement.
- Omitted arguments are filtered out, so partial updates never clear existing flag values.

## Tests

`__tests__/keywords.ts`:
- `allowKeyword` persists `description` alongside `title`.
- `updateKeywordFlags`: moderator auth, title+description update leaves status untouched, merge preserves unrelated flags (`onboarding`), quotes/apostrophes round-trip intact, validation error when no flags given, not-found for unknown keyword.

> Note: `pnpm test` / `tsc` were not run — no Node toolchain in this environment. CI covers it.

🤖 Opened by Smith on behalf of @nimrodkra.
