### PR TITLE
feat: statuslineHeadlines query with server-rendered statusline lines

### DIFF
--- a/__tests__/statusline.ts
+++ b/__tests__/statusline.ts
@@ -1,0 +1,159 @@
+import nock from 'nock';
+import { DataSource } from 'typeorm';
+import {
+  disposeGraphQLTesting,
+  GraphQLTestClient,
+  GraphQLTestingState,
+  initializeGraphQLTesting,
+  MockContext,
+  saveFixtures,
+} from './helpers';
+import createOrGetConnection from '../src/db';
+import { deleteRedisKey, getRedisObject } from '../src/redis';
+import { generateStorageKey, StorageKey, StorageTopic } from '../src/config';
+import { ArticlePost } from '../src/entity/posts/ArticlePost';
+import { HighlightsCanonical } from '../src/entity/HighlightsCanonical';
+import { Source } from '../src/entity/Source';
+import { HighlightSignificance } from '../src/common/channelHighlight/significance';
+import { PostType } from '../src/entity/posts/Post';
+import { sourcesFixture } from './fixture/source';
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+let loggedUser: string | null = null;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(
+    () => new MockContext(con, loggedUser),
+  );
+  client = state.client;
+});
+
+afterAll(async () => {
+  await disposeGraphQLTesting(state);
+});
+
+const cacheKey = generateStorageKey(
+  StorageTopic.Feed,
+  StorageKey.Statusline,
+  'global',
+);
+
+beforeEach(async () => {
+  loggedUser = null;
+  nock.cleanAll();
+  await deleteRedisKey(cacheKey);
+});
+
+const QUERY = `
+  query StatuslineHeadlines($first: Int) {
+    statuslineHeadlines(first: $first)
+  }
+`;
+
+const createTestPosts = async () => {
+  await saveFixtures(con, Source, sourcesFixture);
+  await con.getRepository(ArticlePost).save(
+    ['s1', 's2', 's3', 's4'].map((id, index) => ({
+      id,
+      shortId: id,
+      title: `Statusline Post ${index + 1}`,
+      url: `https://example.com/${id}`,
+      score: 0,
+      sourceId: 'a',
+      visible: true,
+      upvotes: index * 10,
+      createdAt: new Date('2026-03-19T09:00:00.000Z'),
+      type: PostType.Article,
+      metadataChangedAt: new Date('2026-03-19T09:00:00.000Z'),
+    })),
+  );
+};
+
+const mockFeedService = (ids: string[]) =>
+  nock('http://localhost:6000')
+    .post('/api/feed')
+    .reply(200, { data: ids.map((post_id) => ({ post_id })) });
+
+const stripEscapes = (line: string): string =>
+  line
+    .replace(/\u001b\]8;;[^\u001b]*\u001b\\/g, '')
+    .replace(/\u001b\[[0-9;]*m/g, '');
+
+describe('query statuslineHeadlines', () => {
+  it('should interleave rendered headline and popular lines with links', async () => {
+    await createTestPosts();
+    await con.getRepository(HighlightsCanonical).save([
+      {
+        postId: 's1',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Breaking statusline headline',
+        significance: HighlightSignificance.Breaking,
+      },
+      {
+        postId: 's2',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-19T10:20:00.000Z'),
+        headline: 'Routine headline should not appear',
+        significance: HighlightSignificance.Routine,
+      },
+    ]);
+    mockFeedService(['s3', 's4']);
+
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    const lines = res.data.statuslineHeadlines as string[];
+    expect(lines.map(stripEscapes)).toEqual([
+      'daily.dev Breaking statusline headline',
+      'daily.dev Statusline Post 3 ▲20',
+      'daily.dev Statusline Post 4 ▲30',
+    ]);
+    expect(lines[0]).toContain(
+      `${process.env.URL_PREFIX}/c/s1?utm_source=claude-code&utm_medium=statusline`,
+    );
+    expect(lines[1]).toContain('\u001b]8;;');
+    expect(lines[1]).toContain('\u001b[1m');
+  });
+
+  it('should dedupe posts appearing in both feeds and respect first', async () => {
+    await createTestPosts();
+    await con.getRepository(HighlightsCanonical).save([
+      {
+        postId: 's3',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Curated take on post three',
+        significance: HighlightSignificance.Major,
+      },
+    ]);
+    mockFeedService(['s3', 's4']);
+
+    const res = await client.query(QUERY, { variables: { first: 2 } });
+
+    expect(res.errors).toBeFalsy();
+    expect(
+      (res.data.statuslineHeadlines as string[]).map(stripEscapes),
+    ).toEqual([
+      'daily.dev Curated take on post three ▲20',
+      'daily.dev Statusline Post 4 ▲30',
+    ]);
+  });
+
+  it('should serve from cache without hitting the feed service again', async () => {
+    await createTestPosts();
+    mockFeedService(['s3']);
+
+    const first = await client.query(QUERY);
+    expect(first.errors).toBeFalsy();
+    expect(await getRedisObject(cacheKey)).toBeTruthy();
+
+    // no nock registered for a second call — would throw on a network hit
+    const second = await client.query(QUERY);
+    expect(second.errors).toBeFalsy();
+    expect(second.data).toEqual(first.data);
+  });
+});

--- a/__tests__/statusline.ts
+++ b/__tests__/statusline.ts
@@ -143,6 +143,27 @@ describe('query statuslineHeadlines', () => {
     ]);
   });
 
+  it('should degrade to headlines only when the feed service fails', async () => {
+    await createTestPosts();
+    await con.getRepository(HighlightsCanonical).save([
+      {
+        postId: 's1',
+        channels: ['vibes'],
+        highlightedAt: new Date('2026-03-19T10:40:00.000Z'),
+        headline: 'Surviving headline',
+        significance: HighlightSignificance.Breaking,
+      },
+    ]);
+    nock('http://localhost:6000').post('/api/feed').reply(500);
+
+    const res = await client.query(QUERY);
+
+    expect(res.errors).toBeFalsy();
+    expect(
+      (res.data.statuslineHeadlines as string[]).map(stripEscapes),
+    ).toEqual(['daily.dev Surviving headline']);
+  });
+
   it('should serve from cache without hitting the feed service again', async () => {
     await createTestPosts();
     mockFeedService(['s3']);

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export enum StorageKey {
   HasLiveRooms = 'has_live_rooms',
   DailyFeed = 'daily',
   CpaSource = 'cpa_source',
+  Statusline = 'statusline',
 }
 
 export const generateStorageKey = (

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -51,6 +51,7 @@ import * as highlights from './schema/highlights';
 import * as archive from './schema/archive';
 import * as liveRooms from './schema/liveRooms';
 import * as spotlight from './schema/spotlight';
+import * as statusline from './schema/statusline';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import {
   rateLimitTypeDefs,
@@ -120,6 +121,7 @@ export const schema = urlDirective.transformer(
                 liveRooms.typeDefs,
                 archive.typeDefs,
                 spotlight.typeDefs,
+                statusline.typeDefs,
               ],
               resolvers: traceResolvers(
                 merge(
@@ -170,6 +172,7 @@ export const schema = urlDirective.transformer(
                   liveRooms.resolvers,
                   archive.resolvers,
                   spotlight.resolvers,
+                  statusline.resolvers,
                 ),
               ),
             }),

--- a/src/schema/highlights.ts
+++ b/src/schema/highlights.ts
@@ -153,7 +153,7 @@ export const typeDefs = /* GraphQL */ `
   }
 `;
 
-const majorHeadlineSignificances = [
+export const majorHeadlineSignificances = [
   HighlightSignificance.Breaking,
   HighlightSignificance.Major,
 ];
@@ -171,7 +171,7 @@ type HighlightsFilters = {
   significances?: HighlightSignificance[];
 };
 
-const applyVisiblePostFilter = <T extends HighlightsCanonical>(
+export const applyVisiblePostFilter = <T extends HighlightsCanonical>(
   builder: SelectQueryBuilder<T>,
   alias: string,
 ): SelectQueryBuilder<T> =>
@@ -185,7 +185,7 @@ const applyVisiblePostFilter = <T extends HighlightsCanonical>(
     )`,
   );
 
-const applyHighlightsFilters = <T extends HighlightsCanonical>(
+export const applyHighlightsFilters = <T extends HighlightsCanonical>(
   builder: SelectQueryBuilder<T>,
   alias: string,
   { channel, significances }: HighlightsFilters,

--- a/src/schema/statusline.ts
+++ b/src/schema/statusline.ts
@@ -1,0 +1,171 @@
+import { IResolvers } from '@graphql-tools/utils';
+import { In } from 'typeorm';
+import { BaseContext, Context } from '../Context';
+import { ONE_MINUTE_IN_SECONDS } from '../common/constants';
+import { queryReadReplica } from '../common/queryReadReplica';
+import { generateStorageKey, StorageKey, StorageTopic } from '../config';
+import { HighlightsCanonical } from '../entity/HighlightsCanonical';
+import { Post, PostType } from '../entity/posts/Post';
+import { feedGenerators } from '../integrations/feed/generators';
+import { getFeedResponsePostIds } from '../integrations/feed/types';
+import { getRedisObject, setRedisObjectWithExpiry } from '../redis';
+import {
+  applyHighlightsFilters,
+  applyVisiblePostFilter,
+  majorHeadlineSignificances,
+} from './highlights';
+
+export const typeDefs = /* GraphQL */ `
+  extend type Query {
+    """
+    Pre-rendered terminal statusline lines (ANSI styling + OSC 8 hyperlinks)
+    for the daily.dev Claude Code plugin: curated major headlines interleaved
+    with the popular feed. Rendering lives server-side so content and format
+    can change without a plugin release.
+    """
+    statuslineHeadlines(first: Int): [String!]!
+  }
+`;
+
+type StatuslineItem = {
+  postId: string;
+  title: string;
+  upvotes: number;
+};
+
+const statuslineCacheKey = generateStorageKey(
+  StorageTopic.Feed,
+  StorageKey.Statusline,
+  'global',
+);
+const statuslineCacheSeconds = 5 * ONE_MINUTE_IN_SECONDS;
+const defaultLines = 40;
+const maxLines = 60;
+const headlinesCount = 10;
+const popularCount = 30;
+const titleMaxChars = 90;
+// Anonymous placeholder so a logged-in caller's preferences never shape the
+// globally cached feed-service response.
+const statuslineFeedUserId = 'claude-code-statusline';
+
+const ESC = '\u001b';
+const styled = (code: string, value: string) =>
+  `${ESC}[${code}m${value}${ESC}[0m`;
+const hyperlink = (url: string, value: string) =>
+  `${ESC}]8;;${url}${ESC}\\${value}${ESC}]8;;${ESC}\\`;
+
+const renderLine = ({ postId, title, upvotes }: StatuslineItem): string => {
+  const truncated =
+    title.length > titleMaxChars
+      ? `${title.slice(0, titleMaxChars - 1)}…`
+      : title;
+  const url = `${process.env.URL_PREFIX}/c/${postId}?utm_source=claude-code&utm_medium=statusline`;
+  const stats = upvotes > 0 ? ` ${styled('2', `▲${upvotes}`)}` : '';
+  return `${styled('38;5;135', 'daily.dev')} ${hyperlink(url, styled('1', truncated))}${stats}`;
+};
+
+const fetchHeadlines = (ctx: Context): Promise<StatuslineItem[]> =>
+  queryReadReplica(ctx.con, ({ queryRunner }) => {
+    const builder = queryRunner.manager
+      .getRepository(HighlightsCanonical)
+      .createQueryBuilder('hc')
+      .select('hc."postId"', 'postId')
+      .addSelect('hc."headline"', 'title')
+      .addSelect('p."upvotes"', 'upvotes')
+      .innerJoin(Post, 'p', 'p."id" = hc."postId"')
+      .orderBy('hc."highlightedAt"', 'DESC')
+      .addOrderBy('hc."id"', 'DESC')
+      .limit(headlinesCount);
+
+    return applyVisiblePostFilter(
+      applyHighlightsFilters(builder, 'hc', {
+        significances: majorHeadlineSignificances,
+      }),
+      'hc',
+    ).getRawMany<StatuslineItem>();
+  });
+
+const fetchPopular = async (ctx: Context): Promise<StatuslineItem[]> => {
+  const generator = feedGenerators['popular'];
+  if (!generator) {
+    return [];
+  }
+
+  const response = await generator.generate(ctx, {
+    user_id: statuslineFeedUserId,
+    page_size: popularCount,
+    offset: 0,
+    allowed_post_types: [
+      PostType.Article,
+      PostType.Collection,
+      PostType.VideoYouTube,
+    ],
+  });
+  const ids = getFeedResponsePostIds(response);
+  if (!ids.length) {
+    return [];
+  }
+
+  const posts = await queryReadReplica(ctx.con, ({ queryRunner }) =>
+    queryRunner.manager.getRepository(Post).find({
+      select: ['id', 'title', 'upvotes'],
+      where: {
+        id: In(ids),
+        visible: true,
+        deleted: false,
+        banned: false,
+        private: false,
+      },
+    }),
+  );
+  const byId = new Map(posts.map((post) => [post.id, post]));
+
+  return ids.flatMap((id) => {
+    const post = byId.get(id);
+    return post?.title
+      ? [{ postId: post.id, title: post.title, upvotes: post.upvotes }]
+      : [];
+  });
+};
+
+export const resolvers: IResolvers<unknown, BaseContext> = {
+  Query: {
+    statuslineHeadlines: async (
+      _,
+      args: { first?: number | null },
+      ctx: Context,
+    ): Promise<string[]> => {
+      const first = Math.min(args.first || defaultLines, maxLines);
+      const cached = await getRedisObject(statuslineCacheKey);
+      if (cached) {
+        return (JSON.parse(cached) as string[]).slice(0, first);
+      }
+
+      const [headlines, popular] = await Promise.all([
+        fetchHeadlines(ctx),
+        fetchPopular(ctx),
+      ]);
+
+      // Interleave curated headlines with popular posts so the rotation
+      // alternates flavors; dedupe posts that appear in both feeds.
+      const seen = new Set<string>();
+      const lines: string[] = [];
+      const max = Math.max(headlines.length, popular.length);
+      for (let i = 0; i < max; i++) {
+        for (const item of [headlines[i], popular[i]]) {
+          if (item && !seen.has(item.postId)) {
+            seen.add(item.postId);
+            lines.push(renderLine(item));
+          }
+        }
+      }
+
+      await setRedisObjectWithExpiry(
+        statuslineCacheKey,
+        JSON.stringify(lines),
+        statuslineCacheSeconds,
+      );
+      return lines.slice(0, first);
+    },
+  },
+};

--- a/src/schema/statusline.ts
+++ b/src/schema/statusline.ts
@@ -141,10 +141,13 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         return (JSON.parse(cached) as string[]).slice(0, first);
       }
 
-      const [headlines, popular] = await Promise.all([
-        fetchHeadlines(ctx),
-        fetchPopular(ctx),
-      ]);
+      // Feeds degrade independently — a feed-service outage still leaves
+      // curated headlines on the statusline (and vice versa).
+      const [headlines, popular] = (
+        await Promise.allSettled([fetchHeadlines(ctx), fetchPopular(ctx)])
+      ).map((result) =>
+        result.status === 'fulfilled' ? result.value : [],
+      ) as [StatuslineItem[], StatuslineItem[]];
 
       // Interleave curated headlines with popular posts so the rotation
       // alternates flavors; dedupe posts that appear in both feeds.


### PR DESCRIPTION
## Why

The Claude Code plugin's statusline currently queries `majorHeadlines` + `anonymousFeed` and renders the lines itself, which means every content or formatting change requires a plugin version release. This moves rendering server-side so we can change the mix, copy, and styling with a regular API deploy.

## What

New anonymous query:

```graphql
statuslineHeadlines(first: Int): [String!]!
```

Returns pre-rendered terminal lines — ANSI styling + OSC 8 hyperlinks pointing at the `/c/:id` click-tracking redirect with statusline UTM params — interleaving curated major headlines with the popular feed, deduped.

- Feed is generated for a fixed anonymous placeholder id so a logged-in caller's preferences never shape the shared response.
- Result cached in Redis for 5 minutes (one cache for all plugin instances, protects the feed service).
- Reuses the exported highlight filters from `schema/highlights.ts`; popular posts hydrated from the read replica with visibility filters.

## Testing

- New integration suite `__tests__/statusline.ts`: interleave + rendering + links, cross-feed dedupe + `first`, and Redis cache short-circuit (no feed-service hit on the second call).
- `__tests__/highlights.ts` still green after the helper exports; build + lint pass.

## Rollout

Deploy this before merging the plugin change (dailydotdev/daily#2132 follow-up) that switches the statusline to this query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)