### PR TITLE
feat(squads): gate posting by reputation

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -3096,6 +3096,127 @@ describe('mutation reportPost', () => {
   });
 });
 
+describe('squad posting reputation gate', () => {
+  const MUTATION = /* GraphQL */ `
+    mutation SharePost($sourceId: ID!, $id: ID!, $commentary: String) {
+      sharePost(sourceId: $sourceId, id: $id, commentary: $commentary) {
+        id
+      }
+    }
+  `;
+
+  const variables = { sourceId: 'rep', id: 'p1', commentary: 'My comment' };
+
+  beforeEach(async () => {
+    await con.getRepository(SquadSource).save({
+      id: 'rep',
+      name: 'Reputation Squad',
+      handle: 'reputationSquad',
+      type: SourceType.Squad,
+      active: true,
+      private: false,
+      moderationRequired: false,
+      postingMinReputation: 250,
+      memberPostingRank: sourceRoleRank[SourceMemberRoles.Member],
+      memberInviteRank: sourceRoleRank[SourceMemberRoles.Member],
+    });
+    await con.getRepository(SourceMember).save([
+      {
+        userId: '1',
+        sourceId: 'rep',
+        role: SourceMemberRoles.Member,
+        referralToken: randomUUID(),
+      },
+      {
+        userId: '2',
+        sourceId: 'rep',
+        role: SourceMemberRoles.Member,
+        referralToken: randomUUID(),
+      },
+      {
+        userId: '3',
+        sourceId: 'rep',
+        role: SourceMemberRoles.Moderator,
+        referralToken: randomUUID(),
+      },
+    ]);
+    await con.getRepository(User).update({ id: '1' }, { reputation: 10 });
+    await con.getRepository(User).update({ id: '2' }, { reputation: 250 });
+    await con.getRepository(User).update({ id: '3' }, { reputation: 0 });
+  });
+
+  it('should block a member below the threshold', async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors?.[0].message).toEqual(
+      'You need at least 250 reputation points to post in this Squad',
+    );
+  });
+
+  it('should allow a member exactly at the threshold', async () => {
+    loggedUser = '2';
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+  });
+
+  it('should let moderators post regardless of their reputation', async () => {
+    loggedUser = '3';
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+  });
+
+  it('should not offer the moderation queue as a fallback', async () => {
+    loggedUser = '1';
+
+    await testMutationErrorCode(
+      client,
+      {
+        mutation: /* GraphQL */ `
+          mutation CreateSourcePostModeration(
+            $sourceId: ID!
+            $title: String
+            $content: String
+            $type: String!
+          ) {
+            createSourcePostModeration(
+              sourceId: $sourceId
+              title: $title
+              content: $content
+              type: $type
+            ) {
+              id
+            }
+          }
+        `,
+        variables: {
+          sourceId: 'rep',
+          title: 'Title',
+          content: 'Content',
+          type: PostType.Freeform,
+        },
+      },
+      'FORBIDDEN',
+    );
+  });
+
+  it('should ignore the gate once the threshold is cleared', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update({ id: 'rep' }, { postingMinReputation: null });
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+  });
+});
+
 describe('mutation sharePost', () => {
   const MUTATION = /* GraphQL */ `
     mutation SharePost(

--- a/__tests__/sources.ts
+++ b/__tests__/sources.ts
@@ -3178,6 +3178,7 @@ describe('mutation editSquad', () => {
       $isPrivate: Boolean
       $categoryId: ID
       $moderationRequired: Boolean
+      $postingMinReputation: Int
     ) {
       editSquad(
         sourceId: $sourceId
@@ -3189,6 +3190,7 @@ describe('mutation editSquad', () => {
         isPrivate: $isPrivate
         categoryId: $categoryId
         moderationRequired: $moderationRequired
+        postingMinReputation: $postingMinReputation
       ) {
         id
         category {
@@ -3237,6 +3239,128 @@ describe('mutation editSquad', () => {
       .getRepository(SquadSource)
       .findOneBy({ id: variables.sourceId });
     expect(squad?.moderationRequired).toEqual(true);
+  });
+
+  it('should set a reputation threshold for posting', async () => {
+    loggedUser = '1';
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        memberPostingRole: SourceMemberRoles.Member,
+        postingMinReputation: 250,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const squad = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(squad?.postingMinReputation).toEqual(250);
+  });
+
+  it('should clear the reputation threshold when set to null', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update({ id: 's1' }, { postingMinReputation: 250 });
+
+    const res = await client.mutate(MUTATION, {
+      variables: { ...variables, postingMinReputation: null },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const squad = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(squad?.postingMinReputation).toBeNull();
+  });
+
+  it('should leave the reputation threshold untouched when omitted', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update({ id: 's1' }, { postingMinReputation: 250 });
+
+    const res = await client.mutate(MUTATION, { variables });
+
+    expect(res.errors).toBeFalsy();
+
+    const squad = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(squad?.postingMinReputation).toEqual(250);
+  });
+
+  it('should not allow a negative reputation threshold', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...variables, postingMinReputation: -1 },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow moderation and a reputation threshold together', async () => {
+    loggedUser = '1';
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: {
+          ...variables,
+          moderationRequired: true,
+          postingMinReputation: 250,
+        },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should not allow a reputation threshold on an already moderated squad', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update({ id: 's1' }, { moderationRequired: true });
+
+    return testMutationErrorCode(
+      client,
+      {
+        mutation: MUTATION,
+        variables: { ...variables, postingMinReputation: 250 },
+      },
+      'GRAPHQL_VALIDATION_FAILED',
+    );
+  });
+
+  it('should allow switching from moderation to a reputation threshold', async () => {
+    loggedUser = '1';
+    await con
+      .getRepository(SquadSource)
+      .update({ id: 's1' }, { moderationRequired: true });
+
+    const res = await client.mutate(MUTATION, {
+      variables: {
+        ...variables,
+        moderationRequired: false,
+        postingMinReputation: 250,
+      },
+    });
+
+    expect(res.errors).toBeFalsy();
+
+    const squad = await con
+      .getRepository(SquadSource)
+      .findOneBy({ id: variables.sourceId });
+    expect(squad?.moderationRequired).toEqual(false);
+    expect(squad?.postingMinReputation).toEqual(250);
   });
 
   it('should not authorize when not logged in', () =>

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -702,7 +702,7 @@ export const checkIfUserPostInSourceDirectlyOrThrow = async (
     throw new ForbiddenError('Access denied!');
   }
 
-  return canPostToSquad(source as SquadSource, squadMember);
+  return canPostToSquad(con, source as SquadSource, squadMember);
 };
 
 export const createPostIntoSourceId = async (

--- a/src/entity/Source.ts
+++ b/src/entity/Source.ts
@@ -193,6 +193,11 @@ export class SquadSource extends Source {
   @Column({ default: false })
   moderationRequired: boolean;
 
+  // null disables the gate; otherwise plain members need at least this much
+  // reputation to post. Mutually exclusive with moderationRequired.
+  @Column({ type: 'integer', nullable: true })
+  postingMinReputation: number | null;
+
   @Column({ type: 'text', array: true, default: () => "'{}'" })
   linkedSourceIds: string[];
 }

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1311,7 +1311,7 @@ const obj = new GraphORM({
         select: (ctx: Context, alias: string, qb: QueryBuilder): string => {
           const query = qb
             .select(
-              `array["memberPostingRank", "memberInviteRank", "postingMinReputation", (SELECT "reputation" FROM "user" WHERE "id" = ${alias}."userId")]`,
+              `array["memberPostingRank", "memberInviteRank", "postingMinReputation", (SELECT u."reputation" FROM "user" u WHERE u."id" = ${alias}."userId")]`,
             )
             .from(Source, 'postingSquad')
             .where(`postingSquad.id = ${alias}."sourceId"`);

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -1310,24 +1310,40 @@ const obj = new GraphORM({
       permissions: {
         select: (ctx: Context, alias: string, qb: QueryBuilder): string => {
           const query = qb
-            .select('array["memberPostingRank", "memberInviteRank"]')
+            .select(
+              `array["memberPostingRank", "memberInviteRank", "postingMinReputation", (SELECT "reputation" FROM "user" WHERE "id" = ${alias}."userId")]`,
+            )
             .from(Source, 'postingSquad')
             .where(`postingSquad.id = ${alias}."sourceId"`);
           return `${query.getQuery()}`;
         },
-        transform: (value: [number, number], ctx: Context, parent) => {
+        transform: (
+          value: [number, number, number | null, number | null],
+          ctx: Context,
+          parent,
+        ) => {
           const member = parent as SourceMember;
 
           if (!ctx.userId || member.userId !== ctx.userId) {
             return null;
           }
 
-          const [memberPostingRank, memberInviteRank] = value;
-
-          return getPermissionsForMember(member, {
+          const [
             memberPostingRank,
             memberInviteRank,
-          });
+            postingMinReputation,
+            userReputation,
+          ] = value;
+
+          return getPermissionsForMember(
+            member,
+            {
+              memberPostingRank,
+              memberInviteRank,
+              postingMinReputation,
+            },
+            userReputation,
+          );
         },
       },
       roleRank: {

--- a/src/migration/1785657831047-SquadPostingMinReputation.ts
+++ b/src/migration/1785657831047-SquadPostingMinReputation.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SquadPostingMinReputation1785657831047
+  implements MigrationInterface
+{
+  name = 'SquadPostingMinReputation1785657831047';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "source" ADD COLUMN IF NOT EXISTS "postingMinReputation" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "source" DROP COLUMN IF EXISTS "postingMinReputation"`,
+    );
+  }
+}

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -432,7 +432,12 @@ const getSquads = async (
       .addSelect('"moderationRequired"')
       .addSelect('"memberPostingRank"')
       .addSelect('"postingMinReputation"')
-      .addSelect('u."reputation"', 'userReputation')
+      // Joining "user" here would make the unqualified selects above ambiguous,
+      // since source and user share id/name/image/type column names.
+      .addSelect(
+        '(SELECT u."reputation" FROM "user" u WHERE u."id" = sm."userId")',
+        'userReputation',
+      )
       .addSelect('sm."favoritedAt"', 'favoritedAt')
       .from(SourceMember, 'sm')
       .innerJoin(
@@ -440,7 +445,6 @@ const getSquads = async (
         's',
         'sm."sourceId" = s."id" and s."type" = \'squad\'',
       )
-      .innerJoin(User, 'u', 'u."id" = sm."userId"')
       .where('sm."userId" = :userId', { userId })
       .andWhere('sm."role" != :role', { role: SourceMemberRoles.Blocked })
       .orderBy('sm."favoritedAt" IS NULL', 'ASC')
@@ -457,9 +461,12 @@ const getSquads = async (
       >();
 
     return sources.map((source) => {
+      // postingMinReputation and the viewer's reputation are only needed to
+      // resolve permissions, so they stay out of the payload.
       const {
         role,
         memberPostingRank,
+        postingMinReputation,
         userReputation,
         image,
         favoritedAt,
@@ -468,10 +475,7 @@ const getSquads = async (
 
       const permissions = getPermissionsForMember(
         { role },
-        {
-          memberPostingRank,
-          postingMinReputation: restSource.postingMinReputation,
-        },
+        { memberPostingRank, postingMinReputation },
         userReputation,
       );
       // we only send posting and moderation permissions from boot to keep the payload small

--- a/src/routes/boot.ts
+++ b/src/routes/boot.ts
@@ -431,6 +431,8 @@ const getSquads = async (
       .addSelect('role')
       .addSelect('"moderationRequired"')
       .addSelect('"memberPostingRank"')
+      .addSelect('"postingMinReputation"')
+      .addSelect('u."reputation"', 'userReputation')
       .addSelect('sm."favoritedAt"', 'favoritedAt')
       .from(SourceMember, 'sm')
       .innerJoin(
@@ -438,6 +440,7 @@ const getSquads = async (
         's',
         'sm."sourceId" = s."id" and s."type" = \'squad\'',
       )
+      .innerJoin(User, 'u', 'u."id" = sm."userId"')
       .where('sm."userId" = :userId', { userId })
       .andWhere('sm."role" != :role', { role: SourceMemberRoles.Blocked })
       .orderBy('sm."favoritedAt" IS NULL', 'ASC')
@@ -447,17 +450,29 @@ const getSquads = async (
         GQLSource & {
           role: SourceMemberRoles;
           memberPostingRank: number;
+          postingMinReputation: number | null;
+          userReputation: number | null;
           favoritedAt: Date | null;
         }
       >();
 
     return sources.map((source) => {
-      const { role, memberPostingRank, image, favoritedAt, ...restSource } =
-        source;
+      const {
+        role,
+        memberPostingRank,
+        userReputation,
+        image,
+        favoritedAt,
+        ...restSource
+      } = source;
 
       const permissions = getPermissionsForMember(
         { role },
-        { memberPostingRank },
+        {
+          memberPostingRank,
+          postingMinReputation: restSource.postingMinReputation,
+        },
+        userReputation,
       );
       // we only send posting and moderation permissions from boot to keep the payload small
       const essentialPermissions = permissions.filter(

--- a/src/schema/sources.ts
+++ b/src/schema/sources.ts
@@ -128,6 +128,7 @@ export interface GQLSource {
   flags?: SourceFlagsPublic;
   description?: string;
   moderationRequired?: boolean;
+  postingMinReputation?: number | null;
   moderationPostCount?: number;
 }
 
@@ -303,6 +304,11 @@ export const typeDefs = /* GraphQL */ `
     Enable post moderation for the squad
     """
     moderationRequired: Boolean
+
+    """
+    Minimum reputation members need in order to post. Null disables the gate.
+    """
+    postingMinReputation: Int
 
     """
     Count of post waiting for moderation
@@ -817,6 +823,10 @@ export const typeDefs = /* GraphQL */ `
       """
       moderationRequired: Boolean
       """
+      Minimum reputation members need in order to post. Null disables the gate.
+      """
+      postingMinReputation: Int
+      """
       Whether the Squad should be private or not
       """
       isPrivate: Boolean
@@ -866,6 +876,10 @@ export const typeDefs = /* GraphQL */ `
       Enable post moderation for the squad
       """
       moderationRequired: Boolean
+      """
+      Minimum reputation members need in order to post. Null disables the gate.
+      """
+      postingMinReputation: Int
       """
       Whether the Squad should be private or not
       """
@@ -1118,6 +1132,8 @@ const hasPermissionCheck = (
 
 export const sourceTypesWithMembers = ['squad'];
 
+export const MAX_POSTING_MIN_REPUTATION = 1000000;
+
 export const canAccessSource = async (
   ctx: Context,
   source: Source,
@@ -1215,11 +1231,12 @@ export const isPrivilegedMember = async (
 
 type PostPermissions = SourcePermissions.Post | SourcePermissions.PostRequest;
 
-export const canPostToSquad = (
+export const canPostToSquad = async (
+  con: DataSource | EntityManager,
   squad: SquadSource,
   sourceMember: SourceMember | null,
   permission: PostPermissions = SourcePermissions.Post,
-): boolean => {
+): Promise<boolean> => {
   if (!sourceMember) {
     return false;
   }
@@ -1232,7 +1249,25 @@ export const canPostToSquad = (
     }
   }
 
-  return memberRank >= squad.memberPostingRank;
+  if (memberRank < squad.memberPostingRank) {
+    return false;
+  }
+
+  // Moderators and admins are never held back by the reputation gate, mirroring
+  // how they bypass moderationRequired.
+  if (
+    typeof squad.postingMinReputation !== 'number' ||
+    memberRank > sourceRoleRank.member
+  ) {
+    return true;
+  }
+
+  const user = await con.getRepository(User).findOne({
+    where: { id: sourceMember.userId },
+    select: ['reputation'],
+  });
+
+  return (user?.reputation ?? 0) >= squad.postingMinReputation;
 };
 
 const validateSquadData = async (
@@ -1243,10 +1278,13 @@ const validateSquadData = async (
     memberPostingRole,
     memberInviteRole,
     categoryId,
+    moderationRequired,
+    postingMinReputation,
   }: Pick<SquadSource, 'handle' | 'name' | 'description' | 'categoryId'> & {
     memberPostingRole?: SourceMemberRoles;
     memberInviteRole?: SourceMemberRoles;
     moderationRequired?: boolean;
+    postingMinReputation?: number | null;
   },
   entityManager: DataSource | EntityManager,
   handleChanged = true,
@@ -1287,10 +1325,47 @@ const validateSquadData = async (
     throw new ValidationError('Invalid member invite role');
   }
 
+  if (typeof postingMinReputation === 'number') {
+    if (
+      !Number.isInteger(postingMinReputation) ||
+      postingMinReputation < 0 ||
+      postingMinReputation > MAX_POSTING_MIN_REPUTATION
+    ) {
+      throw new ValidationError(
+        `Reputation threshold must be a whole number between 0 and ${MAX_POSTING_MIN_REPUTATION}`,
+      );
+    }
+
+    // The two gates answer the same question differently, so allowing both would
+    // leave the squad in a state no UI can represent.
+    if (moderationRequired) {
+      throw new ValidationError(
+        'Post moderation and a reputation threshold cannot be enabled together',
+      );
+    }
+  }
+
   return handle;
 };
 
 const postPermissions = [SourcePermissions.Post, SourcePermissions.PostRequest];
+
+// The reputation gate is the only denial reason worth spelling out: the member
+// can act on it, unlike a role restriction they cannot change themselves.
+const getPostingDeniedMessage = (
+  squad: SquadSource,
+  sourceMember: SourceMember | null,
+): string => {
+  const blockedByReputation =
+    typeof squad.postingMinReputation === 'number' &&
+    !!sourceMember &&
+    sourceRoleRank[sourceMember.role] === sourceRoleRank.member &&
+    sourceRoleRank[sourceMember.role] >= squad.memberPostingRank;
+
+  return blockedByReputation
+    ? `You need at least ${squad.postingMinReputation} reputation points to post in this Squad`
+    : 'Posting not allowed!';
+};
 
 export const ensureSourcePermissions = async (
   ctx: Context,
@@ -1330,14 +1405,19 @@ export const ensureSourcePermissions = async (
 
     if (
       source.type === SourceType.Squad &&
-      postPermissions.includes(permission) &&
-      !canPostToSquad(
-        source as SquadSource,
+      postPermissions.includes(permission)
+    ) {
+      const squad = source as SquadSource;
+      const canPost = await canPostToSquad(
+        ctx.con,
+        squad,
         sourceMember,
         permission as PostPermissions,
-      )
-    ) {
-      throw new ForbiddenError('Posting not allowed!');
+      );
+
+      if (!canPost) {
+        throw new ForbiddenError(getPostingDeniedMessage(squad, sourceMember));
+      }
     }
 
     return source;
@@ -1446,6 +1526,7 @@ interface SquadInputArgs {
   memberPostingRole?: SourceMemberRoles;
   memberInviteRole?: SourceMemberRoles;
   moderationRequired?: boolean;
+  postingMinReputation?: number | null;
   isPrivate?: boolean;
   categoryId?: string;
 }
@@ -1547,7 +1628,13 @@ export const removeSourceMember = async ({
 
 export const getPermissionsForMember = (
   member: Pick<SourceMember, 'role'>,
-  source: Partial<Pick<SquadSource, 'memberPostingRank' | 'memberInviteRank'>>,
+  source: Partial<
+    Pick<
+      SquadSource,
+      'memberPostingRank' | 'memberInviteRank' | 'postingMinReputation'
+    >
+  >,
+  userReputation?: number | null,
 ): SourcePermissions[] => {
   const permissions =
     roleSourcePermissions[member.role] ?? roleSourcePermissions.member;
@@ -1556,6 +1643,14 @@ export const getPermissionsForMember = (
   const permissionsToRemove: SourcePermissions[] = [];
 
   if (source.memberPostingRank && memberRank < source.memberPostingRank) {
+    permissionsToRemove.push(SourcePermissions.Post);
+  }
+
+  if (
+    typeof source.postingMinReputation === 'number' &&
+    memberRank === sourceRoleRank[SourceMemberRoles.Member] &&
+    (userReputation ?? 0) < source.postingMinReputation
+  ) {
     permissionsToRemove.push(SourcePermissions.Post);
   }
 
@@ -2603,6 +2698,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         memberPostingRole = SourceMemberRoles.Member,
         memberInviteRole = SourceMemberRoles.Member,
         moderationRequired,
+        postingMinReputation,
         isPrivate = true,
         categoryId,
       }: SquadCreateInputArgs,
@@ -2627,6 +2723,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           memberPostingRole,
           memberInviteRole,
           categoryId,
+          moderationRequired,
+          postingMinReputation,
         },
         ctx.con,
       );
@@ -2644,6 +2742,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             memberPostingRank: sourceRoleRank[memberPostingRole],
             memberInviteRank: sourceRoleRank[memberInviteRole],
             moderationRequired,
+            postingMinReputation: postingMinReputation ?? null,
           });
 
           if (!isNullOrUndefined(isPrivate) && !isPrivate) {
@@ -2707,6 +2806,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         memberPostingRole,
         memberInviteRole,
         moderationRequired,
+        postingMinReputation,
         isPrivate,
         categoryId,
       }: SquadEditInputArgs,
@@ -2725,6 +2825,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         );
       }
 
+      // Both gates are validated against the merged state so a partial update
+      // cannot leave the squad moderated and reputation-gated at once.
+      const squad = source as SquadSource;
+      const nextModerationRequired =
+        moderationRequired ?? squad.moderationRequired;
+      const nextPostingMinReputation =
+        typeof postingMinReputation === 'undefined'
+          ? squad.postingMinReputation
+          : postingMinReputation;
+
       const handle = await validateSquadData(
         {
           handle: inputHandle,
@@ -2733,6 +2843,8 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           memberPostingRole,
           memberInviteRole,
           categoryId,
+          moderationRequired: nextModerationRequired,
+          postingMinReputation: nextPostingMinReputation,
         },
         ctx.con,
         inputHandle !== source.handle,
@@ -2749,6 +2861,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           ? sourceRoleRank[memberInviteRole]
           : undefined,
         moderationRequired,
+        postingMinReputation,
       };
 
       if (!isNullOrUndefined(isPrivate)) {


### PR DESCRIPTION
Squads today are either open or fully moderated. This adds a third, mutually exclusive option: only members with at least N reputation can post. Members below the threshold are blocked outright, with no moderation queue fallback.

## Changes

- `SquadSource.postingMinReputation` (nullable int) holds the threshold, plus a migration.
- `canPostToSquad` is now async and loads reputation only when the gate is set. Moderators and admins bypass it, mirroring how they bypass `moderationRequired`.
- `getPermissionsForMember` strips `Post` for members below the threshold, so boot and graphorm hide the composer rather than letting the post fail on submit. Boot joins `user` for the reputation; graphorm reads it via a subselect.
- `editSquad` validates the merged state, so a partial update cannot leave a squad both moderated and reputation-gated.
- Denials from the reputation gate return a specific message ("You need at least N reputation points to post in this Squad") since it is the one denial a member can act on.

## Notes

- Threshold must be a whole number between 0 and 1,000,000.
- Frontend PR: https://github.com/dailydotdev/apps/pull/6408
- Tests were not run locally: port 5432 is held by an unrelated container on this machine, so the API suite is relying on CI here.

https://claude.ai/code/session_01YDfs5kxvMN3i7WRp1y3mmm