### PR TITLE
fix(cdc): guard null title in isFreeformPostLongEnough

### DIFF
--- a/src/workers/cdc/primary.ts
+++ b/src/workers/cdc/primary.ts
@@ -208,7 +208,7 @@ const convertUserToChangeObject = (user: User): ChangeObject<User> => ({
 const isFreeformPostLongEnough = (
   freeform: ChangeMessage<FreeformPost>,
 ): boolean =>
-  (freeform.payload.after!.title!.length || 0) +
+  (freeform.payload.after!.title?.length || 0) +
     (freeform.payload.after!.content?.length || 0) >=
   FREEFORM_POST_MINIMUM_CONTENT_LENGTH;
 


### PR DESCRIPTION
## Problem

Incident #354 — Pub/Sub subscription `api-cdc` built a backlog with oldest unacked message age growing past 5800s.

Root cause is a poison-pill CDC message, not scaling. `api-bg` threw on every redelivery starting 2026-08-02 10:16:22 UTC:

```
TypeError: Cannot read properties of null (reading 'length')
    at isFreeformPostLongEnough (src/workers/cdc/primary.ts:208)
    at onPostChange
```

The trigger was a freeform post create (`op=c`, post id `VlYEzuaSk`) with `title = null`. The handler threw, the message was never acked, and it was redelivered roughly every 50-60s indefinitely.

## Cause

```ts
(freeform.payload.after!.title!.length || 0) +
  (freeform.payload.after!.content?.length || 0) >= ...
```

`title` is nullable on `Post`, but it was accessed with a non-null assertion. `content` on the next line already uses optional chaining.

## Fix

Use `title?.length` to match the existing `content?.length` handling. Once deployed, the stuck message processes and the backlog drains on its own.

---
🤖 Opened by Smith on behalf of @idoshamun