### PR TITLE
feat(quests): add watercooler feed visit quest

### DIFF
--- a/__tests__/quests.ts
+++ b/__tests__/quests.ts
@@ -1070,6 +1070,11 @@ describe('quest progress hooks', () => {
       name: 'Rainy day queue',
       description: 'Visit the Read it later page',
     },
+    {
+      eventType: QuestEventType.VisitWatercoolerFeed,
+      name: 'Off the clock',
+      description: 'Visit the Watercooler feed',
+    },
   ])(
     'should complete %s client-side page visit quests',
     async ({ eventType, name, description }) => {

--- a/src/entity/Quest.ts
+++ b/src/entity/Quest.ts
@@ -30,6 +30,7 @@ export enum QuestEventType {
   VisitExplorePage = 'visit_explore_page',
   VisitDiscussionsPage = 'visit_discussions_page',
   VisitReadItLaterPage = 'visit_read_it_later_page',
+  VisitWatercoolerFeed = 'visit_watercooler_feed',
   FeedbackSubmit = 'feedback_submit',
   SquadJoin = 'squad_join',
   FollowerGain = 'follower_gain',

--- a/src/migration/1785660000000-AddWatercoolerQuest.ts
+++ b/src/migration/1785660000000-AddWatercoolerQuest.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const questId = '90401648-7bb2-455d-a087-14fc64aba1b1';
+
+export class AddWatercoolerQuest1785660000000 implements MigrationInterface {
+  name = 'AddWatercoolerQuest1785660000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "quest" (
+        "id",
+        "name",
+        "description",
+        "type",
+        "eventType",
+        "criteria",
+        "active"
+      )
+      VALUES
+        (
+          '${questId}',
+          'Off the clock',
+          'Visit the Watercooler feed',
+          'daily',
+          'visit_watercooler_feed',
+          '{"targetCount": 1}',
+          true
+        )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "quest_reward" ("questId", "type", "amount")
+      VALUES
+        ('${questId}', 'xp', 10),
+        ('${questId}', 'cores', 5)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "quest_reward"
+      WHERE "questId" = '${questId}'
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "quest"
+      WHERE "id" = '${questId}'
+    `);
+  }
+}

--- a/src/schema/quests.ts
+++ b/src/schema/quests.ts
@@ -98,6 +98,7 @@ const CLIENT_TRACKABLE_QUEST_EVENT_TYPES = new Set<QuestEventType>([
   QuestEventType.VisitExplorePage,
   QuestEventType.VisitDiscussionsPage,
   QuestEventType.VisitReadItLaterPage,
+  QuestEventType.VisitWatercoolerFeed,
   QuestEventType.ViewUserProfile,
 ]);
 
@@ -716,6 +717,7 @@ export const typeDefs = /* GraphQL */ `
     visit_explore_page
     visit_discussions_page
     visit_read_it_later_page
+    visit_watercooler_feed
     view_user_profile
   }
 


### PR DESCRIPTION
Adds a daily quest for visiting the new Watercooler feed (`/watercooler`).

- New `QuestEventType.VisitWatercoolerFeed` (`visit_watercooler_feed`), client-tracked via `trackQuestEvent` like the other page-visit quests
- Migration seeds the quest — **Off the clock** / _Visit the Watercooler feed_ — as an active `daily` quest with 10 XP + 5 cores, matching the sibling visit quests
- No entity schema change: `rotateQuestPeriod` picks from all active daily quests, so the new row enters rotation automatically

Frontend follow-up: map `visit_watercooler_feed` to `/watercooler` and fire `trackQuestEvent` on feed visit.

https://claude.ai/code/session_01WgUTkVqFRmFjArgZ5K44Wv