### PR TITLE
feat(worlds): personal world reads per user and niche

### DIFF
--- a/.infra/crons.ts
+++ b/.infra/crons.ts
@@ -127,6 +127,18 @@ export const crons: Cron[] = [
     schedule: '*/5 * * * *',
   },
   {
+    name: 'user-world-clickhouse',
+    schedule: '0 3 * * *',
+    activeDeadlineSeconds: 3600,
+    limits: {
+      memory: '2Gi',
+    },
+    requests: {
+      cpu: '500m',
+      memory: '1Gi',
+    },
+  },
+  {
     name: 'post-analytics-achievements',
     schedule: '2-59/15 * * * *',
   },

--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -28,8 +28,11 @@ const cronConfigRedisKey = generateStorageKey(
   'config',
 );
 
-const nicheJs = '11111111-1111-1111-1111-111111111111';
-const nicheAi = '22222222-2222-2222-2222-222222222222';
+// Must be well-formed v4 UUIDs: the delta schema validates `nicheId` with
+// z.uuid(), which enforces the version and variant nibbles. Repeated-digit
+// placeholders like 1111-1111-1111 fail it.
+const nicheJs = '11111111-1111-4111-8111-111111111111';
+const nicheAi = '22222222-2222-4222-8222-222222222222';
 
 beforeEach(async () => {
   jest.clearAllMocks();

--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -1,0 +1,181 @@
+import type { DataSource } from 'typeorm';
+import { crons } from '../../src/cron/index';
+import { userWorldClickhouseCron as cron } from '../../src/cron/userWorldClickhouse';
+import {
+  expectSuccessfulCron,
+  mockClickhouseClientOnce,
+  mockClickhouseQueryJSONOnce,
+  saveFixtures,
+} from '../helpers';
+import createOrGetConnection from '../../src/db';
+import { UserNicheAnalytics } from '../../src/entity/user/UserNicheAnalytics';
+import { UserNicheGrowth } from '../../src/entity/user/UserNicheGrowth';
+import { Niche } from '../../src/entity/Niche';
+import { User } from '../../src/entity/user/User';
+import { usersFixture } from '../fixture/user';
+import { deleteRedisKey, getRedisHash } from '../../src/redis';
+import { generateStorageKey, StorageTopic } from '../../src/config';
+
+let con: DataSource;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+});
+
+const cronConfigRedisKey = generateStorageKey(
+  StorageTopic.Cron,
+  cron.name,
+  'config',
+);
+
+const nicheJs = '11111111-1111-1111-1111-111111111111';
+const nicheAi = '22222222-2222-2222-2222-222222222222';
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await deleteRedisKey(cronConfigRedisKey);
+  await con.getRepository(UserNicheAnalytics).clear();
+  await con.getRepository(UserNicheGrowth).clear();
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, Niche, [
+    { id: nicheJs, slug: 'js_ts', title: 'JavaScript / TypeScript' },
+    { id: nicheAi, slug: 'ai_llm', title: 'LLMs' },
+  ]);
+});
+
+const delta = [
+  { userId: '1', date: '2026-07-01', nicheId: nicheJs, reads: 3 },
+  { userId: '1', date: '2026-07-02', nicheId: nicheJs, reads: 2 },
+  { userId: '1', date: '2026-07-02', nicheId: nicheAi, reads: 5 },
+  { userId: '2', date: '2026-07-03', nicheId: nicheAi, reads: 1 },
+];
+
+const runWith = async (rows: typeof delta) => {
+  const client = mockClickhouseClientOnce();
+  mockClickhouseQueryJSONOnce(client, rows);
+  await expectSuccessfulCron(cron);
+};
+
+describe('userWorldClickhouse cron', () => {
+  it('should be registered', () => {
+    expect(crons.find((item) => item.name === cron.name)).toBeDefined();
+  });
+
+  it('should write the growth log and fold it into districts', async () => {
+    await runWith(delta);
+
+    const growth = await con
+      .getRepository(UserNicheGrowth)
+      .find({ order: { userId: 'ASC', date: 'ASC', nicheId: 'ASC' } });
+    expect(growth).toHaveLength(4);
+
+    const districts = await con
+      .getRepository(UserNicheAnalytics)
+      .find({ where: { userId: '1' }, order: { reads: 'DESC' } });
+
+    expect(districts).toHaveLength(2);
+    // js_ts spans two days, so its reads sum and activeDays counts both
+    expect(districts).toEqual([
+      expect.objectContaining({
+        userId: '1',
+        nicheId: nicheJs,
+        reads: 5,
+        firstReadAt: '2026-07-01',
+        lastReadAt: '2026-07-02',
+        activeDays: 2,
+      }),
+      expect.objectContaining({
+        userId: '1',
+        nicheId: nicheAi,
+        reads: 5,
+        firstReadAt: '2026-07-02',
+        lastReadAt: '2026-07-02',
+        activeDays: 1,
+      }),
+    ]);
+  });
+
+  it('should be a no-op when the same window is replayed', async () => {
+    await runWith(delta);
+    const before = await con.getRepository(UserNicheAnalytics).find();
+
+    // Simulate a retry after a run that failed *after* committing: rewind the
+    // cursor so the identical window is fetched again. Districts advance only from
+    // rows the growth insert actually returned, and every row now conflicts, so
+    // this must be inert rather than double-counting.
+    await deleteRedisKey(cronConfigRedisKey);
+    await runWith(delta);
+
+    const after = await con.getRepository(UserNicheAnalytics).find();
+    expect(after).toHaveLength(before.length);
+    expect(
+      after.map(({ userId, nicheId, reads, activeDays }) => ({
+        userId,
+        nicheId,
+        reads,
+        activeDays,
+      })),
+    ).toEqual(
+      before.map(({ userId, nicheId, reads, activeDays }) => ({
+        userId,
+        nicheId,
+        reads,
+        activeDays,
+      })),
+    );
+    expect(await con.getRepository(UserNicheGrowth).count()).toBe(4);
+  });
+
+  it('should accumulate across windows', async () => {
+    await runWith(delta);
+    // a later day's run — rewind the cursor so the second window is fetched
+    await deleteRedisKey(cronConfigRedisKey);
+    await runWith([
+      { userId: '1', date: '2026-07-05', nicheId: nicheJs, reads: 4 },
+    ]);
+
+    const district = await con
+      .getRepository(UserNicheAnalytics)
+      .findOneByOrFail({ userId: '1', nicheId: nicheJs });
+
+    expect(district.reads).toBe(9);
+    expect(district.activeDays).toBe(3);
+    expect(district.firstReadAt).toBe('2026-07-01');
+    expect(district.lastReadAt).toBe('2026-07-05');
+  });
+
+  it('should advance the cursor even when there is nothing to sync', async () => {
+    await runWith([]);
+
+    const config = await getRedisHash(cronConfigRedisKey);
+    expect(config.cursor).toBeTruthy();
+    expect(new Date(config.cursor).getTime()).not.toBeNaN();
+  });
+
+  it('should only ever cover whole UTC days', async () => {
+    await runWith([]);
+
+    // The growth row is inserted ON CONFLICT DO NOTHING, so a day written by one
+    // run can never be topped up by the next. The cursor must therefore land on a
+    // UTC midnight, or the tail of the day it stopped inside is lost for good.
+    const { cursor } = await getRedisHash(cronConfigRedisKey);
+    const at = new Date(cursor);
+
+    expect(at.getUTCHours()).toBe(0);
+    expect(at.getUTCMinutes()).toBe(0);
+    expect(at.getUTCSeconds()).toBe(0);
+    expect(at.getUTCMilliseconds()).toBe(0);
+  });
+
+  it('should be a no-op when run twice on the same day', async () => {
+    await runWith(delta);
+    const { cursor } = await getRedisHash(cronConfigRedisKey);
+
+    // Second run: the cursor is already at the last UTC midnight, so the cron
+    // returns before touching ClickHouse at all — no mock is consumed.
+    await expectSuccessfulCron(cron);
+
+    expect((await getRedisHash(cronConfigRedisKey)).cursor).toBe(cursor);
+    expect(await con.getRepository(UserNicheGrowth).count()).toBe(4);
+  });
+});

--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -13,7 +13,7 @@ import { UserNicheGrowth } from '../../src/entity/user/UserNicheGrowth';
 import { Niche } from '../../src/entity/Niche';
 import { User } from '../../src/entity/user/User';
 import { usersFixture } from '../fixture/user';
-import { deleteRedisKey, getRedisHash } from '../../src/redis';
+import { deleteRedisKey, getRedisHash, setRedisHash } from '../../src/redis';
 import { generateStorageKey, StorageTopic } from '../../src/config';
 
 let con: DataSource;
@@ -34,9 +34,15 @@ const cronConfigRedisKey = generateStorageKey(
 const nicheJs = '11111111-1111-4111-8111-111111111111';
 const nicheAi = '22222222-2222-4222-8222-222222222222';
 
+// Well before the fixture dates, so every delta falls inside the window.
+const seedCursor = '2026-01-01T00:00:00.000Z';
+
 beforeEach(async () => {
   jest.clearAllMocks();
   await deleteRedisKey(cronConfigRedisKey);
+  // Production always has a cursor once the bulk seed has run; an absent one is
+  // the recovery path, exercised explicitly below.
+  await setRedisHash(cronConfigRedisKey, { cursor: seedCursor });
   await con.getRepository(UserNicheAnalytics).clear();
   await con.getRepository(UserNicheGrowth).clear();
   await saveFixtures(con, User, usersFixture);
@@ -102,10 +108,10 @@ describe('userWorldClickhouse cron', () => {
     await runWith(delta);
     const before = await con.getRepository(UserNicheAnalytics).find();
 
-    // Simulate a retry after a run that failed *after* committing: rewind the
-    // cursor so the identical window is fetched again. Districts advance only from
-    // rows the growth insert actually returned, and every row now conflicts, so
-    // this must be inert rather than double-counting.
+    // Drop the cursor entirely: the cron recovers it from the growth log, which
+    // lands a day after the newest row, and the identical window is fetched again.
+    // Districts advance only from rows the growth insert returned, and every row
+    // now conflicts, so this must be inert rather than double-counting.
     await deleteRedisKey(cronConfigRedisKey);
     await runWith(delta);
 
@@ -131,7 +137,7 @@ describe('userWorldClickhouse cron', () => {
 
   it('should accumulate across windows', async () => {
     await runWith(delta);
-    // a later day's run — rewind the cursor so the second window is fetched
+    // a later day's run; the cursor is recovered from the growth log
     await deleteRedisKey(cronConfigRedisKey);
     await runWith([
       { userId: '1', date: '2026-07-05', nicheId: nicheJs, reads: 4 },
@@ -168,6 +174,34 @@ describe('userWorldClickhouse cron', () => {
     expect(at.getUTCMinutes()).toBe(0);
     expect(at.getUTCSeconds()).toBe(0);
     expect(at.getUTCMilliseconds()).toBe(0);
+  });
+
+  it('should recover the cursor from the growth log when redis is empty', async () => {
+    await runWith(delta);
+    await deleteRedisKey(cronConfigRedisKey);
+
+    // Newest growth row is 2026-07-03, so the next window opens on 07-04 and a
+    // read on 07-04 must be picked up rather than skipped or replayed from 2022.
+    await runWith([
+      { userId: '1', date: '2026-07-04', nicheId: nicheJs, reads: 2 },
+    ]);
+
+    const district = await con
+      .getRepository(UserNicheAnalytics)
+      .findOneByOrFail({ userId: '1', nicheId: nicheJs });
+
+    expect(district.reads).toBe(7);
+    expect(district.lastReadAt).toBe('2026-07-04');
+  });
+
+  it('should refuse to run with no cursor and an empty growth log', async () => {
+    await deleteRedisKey(cronConfigRedisKey);
+
+    // Guessing here is worse than failing: an early default replays years through
+    // the delta path, a late one silently skips whatever was missed.
+    await expect(expectSuccessfulCron(cron)).rejects.toThrow(
+      /user_niche_growth is empty/,
+    );
   });
 
   it('should be a no-op when run twice on the same day', async () => {

--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -1,0 +1,143 @@
+/**
+ * The single definition of what counts as a "read" for personal worlds.
+ *
+ * These CTEs decide which events become reads, which post each read is attributed
+ * to, and which niche it lands in. Every consumer must use this one copy: if the
+ * delta cron and a backfill ever disagree on share collapsing, exclusions or niche
+ * selection, the numbers they produce stop being comparable and the drift is silent.
+ *
+ * Reasoning for each rule is in devcraft `docs/DATA.md`; the short version:
+ *
+ * - `article page view` + `article modal view` + `go to link` all count. Dropping
+ *   `go to link` loses genuine reads of external articles (8,564 pairs on a sample
+ *   day fired it and nothing else).
+ * - Shares collapse into `sharedPostId`. Share rows carry a NULL title and the
+ *   article lives on the parent; filtering them instead discarded 12% of traffic.
+ * - `daily_updates` / `dailydevworld` are first-party daily.dev squads — product
+ *   notification, not content. Matched by HANDLE: `dailydevworld` is a handle whose
+ *   id is a UUID, and a *different* third-party squad is named "Dev World".
+ * - `private = 1` is inherited from the source, and the `unknown` placeholder source
+ *   is itself flagged private. Excluding it outright drops ~23% of reads to catch
+ *   ~31. So: private AND not `unknown`.
+ * - Self-reads are excluded — author, scout, and reading your own share. Only 1.58%
+ *   platform-wide but 27.6% for an active poster.
+ * - `blockchain` is not part of the world.
+ *
+ * `event_timestamp` is the clock. It is the table's sort-key prefix, so a cursor
+ * range on it prunes granules; `server_timestamp` is more accurate but unindexed and
+ * scanning 3.8B rows per run is not viable. The cost is that ~1.4% of events are
+ * client-clock-skewed by over a minute, which can move a read to an adjacent day but
+ * never changes whether it counts.
+ *
+ * `api.post_niche` never collapses stale rows — `_version` sits inside its sorting
+ * key, so updates and delete tombstones never apply, even under FINAL, and a post
+ * keeps the `other` row it was created with. `livePostNiche` therefore resolves each
+ * (postId, nicheId) pair by its own latest version rather than trusting FINAL.
+ */
+
+export const READ_EVENTS = [
+  'article page view',
+  'article modal view',
+  'go to link',
+] as const;
+
+/** First-party daily.dev surfaces. Handles, not ids — see the note above. */
+export const EXCLUDED_SOURCE_HANDLES = [
+  'daily_updates',
+  'dailydevworld',
+] as const;
+
+/** Niches that never appear in a world. */
+export const EXCLUDED_NICHE_SLUGS = ['blockchain'] as const;
+
+const asSqlList = (values: readonly string[]): string =>
+  values.map((value) => `'${value}'`).join(',');
+
+/**
+ * Shared CTE block. Consumers append their own SELECT.
+ *
+ * Exposes: `eff` (post id with shares collapsed), `pmeta` (author/scout of the
+ * resolved post), `pn` (one niche per post), `nc` (niche slugs), `du` (excluded
+ * posts), `pv` (private posts), `reg` (registered users).
+ */
+export const worldRulesCte = /* sql */ `
+res AS (
+  SELECT id,
+         argMax(type, _version) AS ty,
+         argMax(sharedPostId, _version) AS sp,
+         ifNull(argMax(authorId, _version), '') AS au
+  FROM api.post GROUP BY id),
+eff AS (
+  SELECT id,
+         if(ty = 'share' AND sp IS NOT NULL AND sp != '', sp, id) AS eff_id,
+         au AS share_author
+  FROM res),
+pmeta AS (
+  SELECT id,
+         ifNull(argMax(authorId, _version), '') AS au,
+         ifNull(argMax(scoutId, _version), '') AS sc
+  FROM api.post GROUP BY id),
+livePostNiche AS (
+  SELECT postId, nicheId,
+         argMax(rank, _version) AS rank,
+         argMax(score, _version) AS score,
+         argMax(is_deleted, _version) AS del
+  FROM api.post_niche GROUP BY postId, nicheId HAVING del = 0),
+pn AS (
+  SELECT postId, argMax(nicheId, (ifNull(score, -1), toString(nicheId))) AS nicheId
+  FROM livePostNiche WHERE rank = 1 GROUP BY postId),
+nc AS (
+  SELECT id,
+         argMax(slug, _version) AS slug,
+         argMax(is_deleted, _version) AS del
+  FROM api.niche GROUP BY id HAVING del = 0),
+xsrc AS (
+  SELECT id FROM api.source GROUP BY id
+  HAVING argMax(handle, _version) IN (${asSqlList(EXCLUDED_SOURCE_HANDLES)})),
+du AS (
+  SELECT id FROM api.post GROUP BY id
+  HAVING argMax(sourceId, _version) IN (SELECT id FROM xsrc)),
+pv AS (
+  SELECT id FROM api.post GROUP BY id
+  HAVING argMax(private, _version) = 1 AND argMax(sourceId, _version) != 'unknown'),
+reg AS (SELECT id FROM api.user GROUP BY id)`;
+
+/**
+ * Reads in `(cursor, until]`, deduplicated to one row per (user, post) within the
+ * window, grouped into the per-day per-niche counts the growth table stores.
+ *
+ * Dedup is window-local by design: a post re-read on a later day counts again.
+ * Exact lifetime dedup would need a 71M-row (userId, postId) ledger; measured drift
+ * from doing it this way is +5.08% platform-wide, so the metric is really
+ * "posts per day you engaged with them". See devcraft `docs/SERVING.md`.
+ */
+export const userWorldDeltaQuery = /* sql */ `
+WITH ${worldRulesCte},
+firsts AS (
+  SELECT e.user_id AS "userId",
+         pn.nicheId AS "nicheId",
+         eff.eff_id AS pid,
+         min(toDate(e.event_timestamp)) AS day
+  FROM feed.active_post_events e
+  INNER JOIN eff ON e.target_id = eff.id
+  INNER JOIN pn ON eff.eff_id = pn.postId
+  INNER JOIN nc n ON pn.nicheId = n.id
+  INNER JOIN pmeta pm ON eff.eff_id = pm.id
+  INNER JOIN reg ON e.user_id = reg.id
+  WHERE e.event_timestamp > {cursor: DateTime}
+    AND e.event_timestamp <= {until: DateTime}
+    AND e.event_name IN (${asSqlList(READ_EVENTS)})
+    AND n.slug NOT IN (${asSqlList(EXCLUDED_NICHE_SLUGS)})
+    AND eff.eff_id NOT IN (SELECT id FROM du)
+    AND eff.eff_id NOT IN (SELECT id FROM pv)
+    AND pm.au != e.user_id
+    AND pm.sc != e.user_id
+    AND NOT (eff.share_author = e.user_id AND eff.eff_id != eff.id)
+  GROUP BY "userId", "nicheId", pid)
+SELECT "userId",
+       toString(day) AS date,
+       toString("nicheId") AS "nicheId",
+       toUInt32(count()) AS reads
+FROM firsts
+GROUP BY "userId", date, "nicheId"
+ORDER BY "userId", date, "nicheId"`;

--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -20,7 +20,8 @@
  *   ~31. So: private AND not `unknown`.
  * - Self-reads are excluded — author, scout, and reading your own share. Only 1.58%
  *   platform-wide but 27.6% for an active poster.
- * - `blockchain` is not part of the world.
+ * - Nothing is dropped by niche at collection time. `blockchain` is hidden when a
+ *   world is served (`SERVING_HIDDEN_NICHE_SLUGS`), so that choice stays reversible.
  *
  * `event_timestamp` is the clock. It is the table's sort-key prefix, so a cursor
  * range on it prunes granules; `server_timestamp` is more accurate but unindexed and
@@ -50,12 +51,25 @@
  * `collection modal view` was missed originally: 33,140 events in 90 days, and 97.7%
  * of its (user, post) pairs are not reached by any other read event, so it is
  * additive rather than a duplicate of the article events.
+ *
+ * `click` is the open action itself, and it is here for two reasons. It is the same
+ * gesture as `go to link` — `useOnPostClick` takes `eventName = 'go to link'` as a
+ * *default*, so callers override it per surface — and counting one but not the other
+ * would bias the metric by surface rather than merely undercount it.
+ *
+ * More importantly it is a safety net. Reads are deduplicated to distinct
+ * (user, post) within each window, so a click and a view for the same post collapse
+ * to one and `click` can never inflate a total. All it can contribute is a post that
+ * was opened while *no* view event fired — which is precisely how `collection modal
+ * view` stayed invisible for months. With `click` present, a surface whose view
+ * logging is not wired yet still counts, instead of silently reading as zero.
  */
 export const READ_EVENTS = [
   'article page view',
   'article modal view',
   'collection modal view',
   'go to link',
+  'click',
 ] as const;
 
 /**
@@ -72,8 +86,15 @@ export const EXCLUDED_SOURCE_IDS = [
   'a1f0092b-0ee1-414b-82e6-f2c92d7335e4', // daily.dev World
 ] as const;
 
-/** Niches that never appear in a world. */
-export const EXCLUDED_NICHE_SLUGS = ['blockchain'] as const;
+/**
+ * Niches hidden when a world is SERVED. Deliberately not applied to collection.
+ *
+ * Do not add this to the delta query. The rows are collected either way, so hiding
+ * a niche is a display decision that can be reverted without a backfill — whereas
+ * dropping it at collection time destroys history that only a full re-import could
+ * recover.
+ */
+export const SERVING_HIDDEN_NICHE_SLUGS = ['blockchain'] as const;
 
 const asSqlList = (values: readonly string[]): string =>
   values.map((value) => `'${value}'`).join(',');
@@ -150,7 +171,6 @@ firsts AS (
   WHERE e.event_timestamp > {cursor: DateTime}
     AND e.event_timestamp <= {until: DateTime}
     AND e.event_name IN (${asSqlList(READ_EVENTS)})
-    AND n.slug NOT IN (${asSqlList(EXCLUDED_NICHE_SLUGS)})
     AND eff.eff_id NOT IN (SELECT id FROM du)
     AND eff.eff_id NOT IN (SELECT id FROM pv)
     AND pm.au != e.user_id

--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -14,8 +14,7 @@
  * - Shares collapse into `sharedPostId`. Share rows carry a NULL title and the
  *   article lives on the parent; filtering them instead discarded 12% of traffic.
  * - `daily_updates` / `dailydevworld` are first-party daily.dev squads — product
- *   notification, not content. Matched by HANDLE: `dailydevworld` is a handle whose
- *   id is a UUID, and a *different* third-party squad is named "Dev World".
+ *   notification, not content. Excluded by source id.
  * - `private = 1` is inherited from the source, and the `unknown` placeholder source
  *   is itself flagged private. Excluding it outright drops ~23% of reads to catch
  *   ~31. So: private AND not `unknown`.
@@ -35,16 +34,41 @@
  * (postId, nicheId) pair by its own latest version rather than trusting FINAL.
  */
 
+/**
+ * Every `<origin> view` event, plus the click-through.
+ *
+ * The view events are generated in the webapp as `${origin} view` from the
+ * `PostOrigin` union (apps `packages/shared/src/hooks/log/useLogContextData.ts`),
+ * so this list is that union rather than a sample of what happens to be in
+ * ClickHouse today. `reader modal view` and `brief modal view` fire zero times in
+ * the last 90 days but are declared origins — listing them means those surfaces are
+ * counted the moment they start being used, instead of silently going missing.
+ *
+ * `collection modal view` was missed originally: 33,140 events in 90 days, and 97.7%
+ * of its (user, post) pairs are not reached by any other read event, so it is
+ * additive rather than a duplicate of the article events.
+ */
 export const READ_EVENTS = [
   'article page view',
   'article modal view',
+  'reader modal view',
+  'collection modal view',
+  'brief modal view',
   'go to link',
 ] as const;
 
-/** First-party daily.dev surfaces. Handles, not ids — see the note above. */
-export const EXCLUDED_SOURCE_HANDLES = [
-  'daily_updates',
-  'dailydevworld',
+/**
+ * First-party daily.dev surfaces: product notification, not content.
+ *
+ * Source ids, given directly, so `api.source` drops out of the query entirely — it
+ * was only ever joined to translate handles into these. Ids are also the least
+ * ambiguous key of the three: `dailydevworld` is a *handle* whose id is a UUID, and
+ * a separate third-party squad is *named* "Dev World", so both of the other columns
+ * can mislead.
+ */
+export const EXCLUDED_SOURCE_IDS = [
+  'daily_updates', // daily.dev Changelog
+  'a1f0092b-0ee1-414b-82e6-f2c92d7335e4', // daily.dev World
 ] as const;
 
 /** Niches that never appear in a world. */
@@ -58,7 +82,8 @@ const asSqlList = (values: readonly string[]): string =>
  *
  * Exposes: `eff` (post id with shares collapsed), `pmeta` (author/scout of the
  * resolved post), `pn` (one niche per post), `nc` (niche slugs), `du` (excluded
- * posts), `pv` (private posts), `reg` (registered users).
+ * posts), `pv` (private posts), `reg` (registered users). `api.source` is not
+ * touched — the first-party exclusion uses ids directly.
  */
 export const worldRulesCte = /* sql */ `
 res AS (
@@ -91,12 +116,9 @@ nc AS (
          argMax(slug, _version) AS slug,
          argMax(is_deleted, _version) AS del
   FROM api.niche GROUP BY id HAVING del = 0),
-xsrc AS (
-  SELECT id FROM api.source GROUP BY id
-  HAVING argMax(handle, _version) IN (${asSqlList(EXCLUDED_SOURCE_HANDLES)})),
 du AS (
   SELECT id FROM api.post GROUP BY id
-  HAVING argMax(sourceId, _version) IN (SELECT id FROM xsrc)),
+  HAVING argMax(sourceId, _version) IN (${asSqlList(EXCLUDED_SOURCE_IDS)})),
 pv AS (
   SELECT id FROM api.post GROUP BY id
   HAVING argMax(private, _version) = 1 AND argMax(sourceId, _version) != 'unknown'),

--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -35,14 +35,17 @@
  */
 
 /**
- * Every `<origin> view` event, plus the click-through.
+ * The `<origin> view` events that actually fire, plus the click-through.
  *
- * The view events are generated in the webapp as `${origin} view` from the
- * `PostOrigin` union (apps `packages/shared/src/hooks/log/useLogContextData.ts`),
- * so this list is that union rather than a sample of what happens to be in
- * ClickHouse today. `reader modal view` and `brief modal view` fire zero times in
- * the last 90 days but are declared origins — listing them means those surfaces are
- * counted the moment they start being used, instead of silently going missing.
+ * View events are generated in the webapp as `${origin} view` from the `PostOrigin`
+ * union (apps `packages/shared/src/hooks/log/useLogContextData.ts`). That union also
+ * declares `reader modal` and `brief modal`, but neither has fired once in 90 days,
+ * so they are left out until they do.
+ *
+ * That means **this list has to be revisited when a new post surface ships** — it is
+ * a snapshot of which origins are live, not the union itself. Cross-check against
+ * `PostOrigin` rather than against ClickHouse volume, or a new surface looks
+ * identical to a surface nobody uses.
  *
  * `collection modal view` was missed originally: 33,140 events in 90 days, and 97.7%
  * of its (user, post) pairs are not reached by any other read event, so it is
@@ -51,9 +54,7 @@
 export const READ_EVENTS = [
   'article page view',
   'article modal view',
-  'reader modal view',
   'collection modal view',
-  'brief modal view',
   'go to link',
 ] as const;
 

--- a/src/common/schema/userWorld.ts
+++ b/src/common/schema/userWorld.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const userWorldDeltaSchema = z.strictObject({
+  userId: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  nicheId: z.string().uuid(),
+  reads: z.coerce.number().int().positive(),
+});
+
+export type UserWorldDelta = z.infer<typeof userWorldDeltaSchema>;

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -27,6 +27,7 @@ import { postLifecycleStateClickhouseCron } from './postLifecycleStateClickhouse
 import { userPostsAnalyticsRefreshCron } from './userPostsAnalyticsRefresh';
 import { squadPostsAnalyticsRefreshCron } from './squadPostsAnalyticsRefresh';
 import { userProfileAnalyticsClickhouseCron } from './userProfileAnalyticsClickhouse';
+import { userWorldClickhouseCron } from './userWorldClickhouse';
 import { userProfileAnalyticsHistoryClickhouseCron } from './userProfileAnalyticsHistoryClickhouse';
 import { cleanZombieOpportunities } from './cleanZombieOpportunities';
 import { userProfileUpdatedSync } from './userProfileUpdatedSync';
@@ -74,6 +75,7 @@ export const crons: Cron[] = [
   userPostsAnalyticsRefreshCron,
   squadPostsAnalyticsRefreshCron,
   userProfileAnalyticsClickhouseCron,
+  userWorldClickhouseCron,
   userProfileAnalyticsHistoryClickhouseCron,
   cleanZombieOpportunities,
   userProfileUpdatedSync,

--- a/src/cron/userWorldClickhouse.ts
+++ b/src/cron/userWorldClickhouse.ts
@@ -1,0 +1,270 @@
+import { format } from 'date-fns';
+import { z } from 'zod';
+import { Cron } from './cron';
+import { getClickHouseClient } from '../common/clickhouse';
+import { userWorldDeltaQuery } from '../common/clickhouse/worldRules';
+import {
+  userWorldDeltaSchema,
+  type UserWorldDelta,
+} from '../common/schema/userWorld';
+import { UserNicheAnalytics } from '../entity/user/UserNicheAnalytics';
+import { UserNicheGrowth } from '../entity/user/UserNicheGrowth';
+import { getRedisHash, setRedisHash } from '../redis';
+import { generateStorageKey, StorageTopic } from '../config';
+
+type UserWorldCronConfig = Partial<{
+  cursor: string;
+}>;
+
+/**
+ * The world before any reads existed. Only used if the cursor is missing, which
+ * should not happen in production — the initial load seeds both tables in bulk and
+ * sets the cursor to the export's upper bound. Starting from here instead would
+ * replay four years of events through the delta path.
+ */
+const DEFAULT_CURSOR = new Date('2022-01-01T00:00:00Z');
+
+const GROWTH_CHUNK_SIZE = 1000;
+const DISTRICT_CHUNK_SIZE = 500;
+
+const chunk = <T>(items: T[], size: number): T[][] =>
+  items.reduce<T[][]>((acc, item) => {
+    if (acc.length === 0 || acc[acc.length - 1].length === size) {
+      acc.push([]);
+    }
+    acc[acc.length - 1].push(item);
+
+    return acc;
+  }, []);
+
+export const userWorldClickhouseCron: Cron = {
+  name: 'user-world-clickhouse',
+  handler: async (con, logger) => {
+    const redisStorageKey = generateStorageKey(
+      StorageTopic.Cron,
+      userWorldClickhouseCron.name,
+      'config',
+    );
+
+    const cronConfig: UserWorldCronConfig = await getRedisHash(redisStorageKey);
+    const cursor = cronConfig.cursor
+      ? new Date(cronConfig.cursor)
+      : DEFAULT_CURSOR;
+
+    if (Number.isNaN(cursor.getTime())) {
+      throw new Error('Invalid cursor');
+    }
+
+    // Bounded to the last UTC midnight, never to now().
+    //
+    // The growth row is keyed (userId, date, nicheId) and inserted ON CONFLICT DO
+    // NOTHING, so a given day may only ever be written ONCE. Running to now() would
+    // split today: this run would write the 00:00-03:00 slice under today's date,
+    // and tomorrow's run would re-submit the rest of today, hit the conflict and
+    // silently drop it. Whole days only.
+    //
+    // It also removes the clock-skew edge for free — events dated in the future are
+    // beyond `until` and simply wait for the run that covers them.
+    const now = new Date();
+    const until = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+
+    // A second run on the same day has nothing new to cover.
+    if (cursor >= until) {
+      logger.info(
+        { cursor: cursor.toISOString(), until: until.toISOString() },
+        'user world already synced up to the last full day',
+      );
+
+      return;
+    }
+
+    const clickhouseClient = getClickHouseClient();
+    const queryParams = {
+      cursor: format(cursor, 'yyyy-MM-dd HH:mm:ss'),
+      until: format(until, 'yyyy-MM-dd HH:mm:ss'),
+    };
+
+    const response = await clickhouseClient.query({
+      query: userWorldDeltaQuery,
+      format: 'JSONEachRow',
+      query_params: queryParams,
+    });
+
+    const result = z
+      .array(userWorldDeltaSchema)
+      .safeParse(await response.json());
+
+    if (!result.success) {
+      logger.error(
+        { schemaError: result.error.issues[0] },
+        'Invalid user world delta data',
+      );
+
+      throw new Error('Invalid user world delta data');
+    }
+
+    const { data } = result;
+
+    if (data.length === 0) {
+      await setRedisHash<UserWorldCronConfig>(redisStorageKey, {
+        cursor: until.toISOString(),
+      });
+      logger.info({ queryParams }, 'no user world changes');
+
+      return;
+    }
+
+    // Growth insert and district advance share one transaction. That is what makes
+    // the accumulator below exact: a half-applied run rolls back both, and the retry
+    // finds the growth rows already present, so `RETURNING` yields nothing and the
+    // districts are left alone. Advancing districts from the raw delta instead of
+    // from what was actually inserted is what would double-count.
+    let inserted: UserWorldDelta[] = [];
+
+    await con.transaction(async (manager) => {
+      // 1. Append to the growth log. The composite key makes replaying a window a
+      //    no-op, which is what lets the cron be rerun after a partial failure.
+      for (const rows of chunk(data, GROWTH_CHUNK_SIZE)) {
+        const result = await manager
+          .createQueryBuilder()
+          .insert()
+          .into(UserNicheGrowth)
+          .values(rows)
+          .orIgnore()
+          .returning(['userId', 'date', 'nicheId', 'reads'])
+          .execute();
+
+        inserted = inserted.concat(result.raw as UserWorldDelta[]);
+      }
+
+      if (inserted.length === 0) {
+        return;
+      }
+
+      // 2. Fold the *new* rows only, into one pending change per district.
+      const pending = new Map<
+        string,
+        {
+          userId: string;
+          nicheId: string;
+          reads: number;
+          firstReadAt: string;
+          lastReadAt: string;
+          activeDays: number;
+        }
+      >();
+
+      for (const row of inserted) {
+        const key = `${row.userId}:${row.nicheId}`;
+        const current = pending.get(key);
+
+        if (!current) {
+          pending.set(key, {
+            userId: row.userId,
+            nicheId: row.nicheId,
+            reads: row.reads,
+            firstReadAt: row.date,
+            lastReadAt: row.date,
+            // one growth row per (user, date, niche) by primary key, so each
+            // inserted row is exactly one newly-active day
+            activeDays: 1,
+          });
+          continue;
+        }
+
+        current.reads += row.reads;
+        current.activeDays += 1;
+        current.firstReadAt =
+          row.date < current.firstReadAt ? row.date : current.firstReadAt;
+        current.lastReadAt =
+          row.date > current.lastReadAt ? row.date : current.lastReadAt;
+      }
+
+      // 3. Add the pending change onto whatever the district already holds.
+      //    Only the touched districts are read — cost tracks the delta, not the
+      //    user's accumulated history.
+      const changes = [...pending.values()];
+
+      for (const batch of chunk(changes, DISTRICT_CHUNK_SIZE)) {
+        const existing = await manager
+          .getRepository(UserNicheAnalytics)
+          .createQueryBuilder('district')
+          .select('district."userId"', 'userId')
+          .addSelect('district."nicheId"', 'nicheId')
+          .addSelect('district.reads', 'reads')
+          // ::text so the driver hands back 'YYYY-MM-DD' rather than a Date whose
+          // parsing would depend on the session timezone — these are calendar
+          // days, not instants, and a shift would move a founding date.
+          .addSelect('district."firstReadAt"::text', 'firstReadAt')
+          .addSelect('district."lastReadAt"::text', 'lastReadAt')
+          .addSelect('district."activeDays"', 'activeDays')
+          .where('district."userId" IN (:...userIds)', {
+            userIds: [...new Set(batch.map((change) => change.userId))],
+          })
+          .getRawMany<{
+            userId: string;
+            nicheId: string;
+            reads: number;
+            firstReadAt: string;
+            lastReadAt: string;
+            activeDays: number;
+          }>();
+
+        const before = new Map(
+          existing.map((row) => [`${row.userId}:${row.nicheId}`, row]),
+        );
+
+        const values = batch.map((change) => {
+          const prior = before.get(`${change.userId}:${change.nicheId}`);
+
+          if (!prior) {
+            return change;
+          }
+
+          return {
+            userId: change.userId,
+            nicheId: change.nicheId,
+            reads: prior.reads + change.reads,
+            activeDays: prior.activeDays + change.activeDays,
+            firstReadAt:
+              prior.firstReadAt < change.firstReadAt
+                ? prior.firstReadAt
+                : change.firstReadAt,
+            lastReadAt:
+              prior.lastReadAt > change.lastReadAt
+                ? prior.lastReadAt
+                : change.lastReadAt,
+          };
+        });
+
+        // Plain overwrite is safe because the totals above are already summed.
+        await manager
+          .createQueryBuilder()
+          .insert()
+          .into(UserNicheAnalytics)
+          .values(values)
+          .orUpdate(
+            ['reads', 'firstReadAt', 'lastReadAt', 'activeDays'],
+            ['userId', 'nicheId'],
+          )
+          .execute();
+      }
+    });
+
+    await setRedisHash<UserWorldCronConfig>(redisStorageKey, {
+      cursor: until.toISOString(),
+    });
+
+    logger.info(
+      {
+        rows: data.length,
+        inserted: inserted.length,
+        users: new Set(data.map((row) => row.userId)).size,
+        queryParams,
+      },
+      'synced user world data',
+    );
+  },
+};

--- a/src/cron/userWorldClickhouse.ts
+++ b/src/cron/userWorldClickhouse.ts
@@ -16,6 +16,9 @@ type UserWorldCronConfig = Partial<{
   cursor: string;
 }>;
 
+/** What RETURNING actually hands back — `date` may be a string or a Date. */
+type RawGrowthRow = Omit<UserWorldDelta, 'date'> & { date: string | Date };
+
 /**
  * The world before any reads existed. Only used if the cursor is missing, which
  * should not happen in production — the initial load seeds both tables in bulk and
@@ -26,6 +29,17 @@ const DEFAULT_CURSOR = new Date('2022-01-01T00:00:00Z');
 
 const GROWTH_CHUNK_SIZE = 1000;
 const DISTRICT_CHUNK_SIZE = 500;
+
+/**
+ * Normalise a date column to 'YYYY-MM-DD'.
+ *
+ * Postgres `date` values reach us as either a string or a Date depending on the
+ * driver path — a `::text` cast in the query is NOT sufficient, because TypeORM
+ * re-hydrates the value when the select alias matches an entity column. These are
+ * calendar days, so they are compared and stored as plain ISO strings.
+ */
+const toDay = (value: string | Date): string =>
+  typeof value === 'string' ? value.slice(0, 10) : format(value, 'yyyy-MM-dd');
 
 const chunk = <T>(items: T[], size: number): T[][] =>
   items.reduce<T[][]>((acc, item) => {
@@ -136,7 +150,15 @@ export const userWorldClickhouseCron: Cron = {
           .returning(['userId', 'date', 'nicheId', 'reads'])
           .execute();
 
-        inserted = inserted.concat(result.raw as UserWorldDelta[]);
+        // `date` comes back from RETURNING on a date column, so it carries the
+        // same string-or-Date ambiguity as the read below. Normalise once, here,
+        // and everything downstream is plain 'YYYY-MM-DD'.
+        inserted = inserted.concat(
+          (result.raw as RawGrowthRow[]).map((row) => ({
+            ...row,
+            date: toDay(row.date),
+          })),
+        );
       }
 
       if (inserted.length === 0) {
@@ -194,9 +216,9 @@ export const userWorldClickhouseCron: Cron = {
           .select('district."userId"', 'userId')
           .addSelect('district."nicheId"', 'nicheId')
           .addSelect('district.reads', 'reads')
-          // ::text so the driver hands back 'YYYY-MM-DD' rather than a Date whose
-          // parsing would depend on the session timezone — these are calendar
-          // days, not instants, and a shift would move a founding date.
+          // The ::text cast is not load-bearing — TypeORM re-hydrates the value
+          // to a Date anyway when the alias matches an entity column. `toDay`
+          // below is what actually guarantees a 'YYYY-MM-DD' string.
           .addSelect('district."firstReadAt"::text', 'firstReadAt')
           .addSelect('district."lastReadAt"::text', 'lastReadAt')
           .addSelect('district."activeDays"', 'activeDays')
@@ -207,8 +229,11 @@ export const userWorldClickhouseCron: Cron = {
             userId: string;
             nicheId: string;
             reads: number;
-            firstReadAt: string;
-            lastReadAt: string;
+            // Typed loosely on purpose: the `::text` cast above does NOT guarantee a
+            // string here, because the alias matches an entity column and TypeORM
+            // re-hydrates it as a Date. `toDay` below is what actually pins it.
+            firstReadAt: string | Date;
+            lastReadAt: string | Date;
             activeDays: number;
           }>();
 
@@ -223,19 +248,23 @@ export const userWorldClickhouseCron: Cron = {
             return change;
           }
 
+          // Both sides must be 'YYYY-MM-DD' strings before comparing. Left as a
+          // Date, `date < 'YYYY-MM-DD'` coerces the Date through toString() to
+          // "Wed Jul 01 2026 …", and 'W' sorts above any digit — so the comparison
+          // silently inverts and the earlier date loses. That put a district's
+          // founding date at its most recent read instead of its first.
+          const priorFirst = toDay(prior.firstReadAt);
+          const priorLast = toDay(prior.lastReadAt);
+
           return {
             userId: change.userId,
             nicheId: change.nicheId,
             reads: prior.reads + change.reads,
             activeDays: prior.activeDays + change.activeDays,
             firstReadAt:
-              prior.firstReadAt < change.firstReadAt
-                ? prior.firstReadAt
-                : change.firstReadAt,
+              priorFirst < change.firstReadAt ? priorFirst : change.firstReadAt,
             lastReadAt:
-              prior.lastReadAt > change.lastReadAt
-                ? prior.lastReadAt
-                : change.lastReadAt,
+              priorLast > change.lastReadAt ? priorLast : change.lastReadAt,
           };
         });
 

--- a/src/cron/userWorldClickhouse.ts
+++ b/src/cron/userWorldClickhouse.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import type { DataSource } from 'typeorm';
 import { z } from 'zod';
 import { Cron } from './cron';
 import { getClickHouseClient } from '../common/clickhouse';
@@ -19,14 +20,6 @@ type UserWorldCronConfig = Partial<{
 /** What RETURNING actually hands back — `date` may be a string or a Date. */
 type RawGrowthRow = Omit<UserWorldDelta, 'date'> & { date: string | Date };
 
-/**
- * The world before any reads existed. Only used if the cursor is missing, which
- * should not happen in production — the initial load seeds both tables in bulk and
- * sets the cursor to the export's upper bound. Starting from here instead would
- * replay four years of events through the delta path.
- */
-const DEFAULT_CURSOR = new Date('2022-01-01T00:00:00Z');
-
 const GROWTH_CHUNK_SIZE = 1000;
 const DISTRICT_CHUNK_SIZE = 500;
 
@@ -40,6 +33,49 @@ const DISTRICT_CHUNK_SIZE = 500;
  */
 const toDay = (value: string | Date): string =>
   typeof value === 'string' ? value.slice(0, 10) : format(value, 'yyyy-MM-dd');
+
+/**
+ * Where to resume when Redis has no cursor.
+ *
+ * Redis is a cache: keys get evicted, flushed, or simply do not exist in a new
+ * environment. The cursor cannot be the only record of how far we have ingested,
+ * because a constant fallback is catastrophic in both directions — an early one
+ * (2022) replays four years through the delta path, and a late one (now) silently
+ * skips whatever was missed. Neither fails loudly.
+ *
+ * The growth log already knows. It stores whole days, and a run only ever covers
+ * whole days, so the day after its newest row is exactly where the last successful
+ * run stopped. Redis becomes an optimisation rather than the source of truth.
+ *
+ * Deriving a day or two early is harmless: growth rows are keyed
+ * (userId, date, nicheId) and inserted ON CONFLICT DO NOTHING, so re-covering a
+ * window inserts nothing and leaves districts untouched.
+ *
+ * An empty table means the bulk seed has not run. That is refused rather than
+ * guessed — from here the delta path would take days to catch up and would produce
+ * wrong districts while it did.
+ *
+ * The scan is unindexed, but this only runs when the cursor is missing.
+ */
+const cursorFromGrowthLog = async (con: DataSource): Promise<Date> => {
+  const latest = await con
+    .getRepository(UserNicheGrowth)
+    .createQueryBuilder('growth')
+    .select('MAX(growth.date)::text', 'date')
+    .getRawOne<{ date: string | null }>();
+
+  if (!latest?.date) {
+    throw new Error(
+      `${userWorldClickhouseCron.name}: no cursor in Redis and user_niche_growth is empty. ` +
+        'Seed both tables from the bulk export and set the cursor to the export upper bound ' +
+        'before enabling this cron.',
+    );
+  }
+
+  const [year, month, day] = toDay(latest.date).split('-').map(Number);
+
+  return new Date(Date.UTC(year, month - 1, day + 1));
+};
 
 const chunk = <T>(items: T[], size: number): T[][] =>
   items.reduce<T[][]>((acc, item) => {
@@ -63,7 +99,7 @@ export const userWorldClickhouseCron: Cron = {
     const cronConfig: UserWorldCronConfig = await getRedisHash(redisStorageKey);
     const cursor = cronConfig.cursor
       ? new Date(cronConfig.cursor)
-      : DEFAULT_CURSOR;
+      : await cursorFromGrowthLog(con);
 
     if (Number.isNaN(cursor.getTime())) {
       throw new Error('Invalid cursor');

--- a/src/entity/user/UserNicheAnalytics.ts
+++ b/src/entity/user/UserNicheAnalytics.ts
@@ -1,0 +1,65 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import type { User } from './User';
+import type { Niche } from '../Niche';
+
+/**
+ * One row per (user, niche) — a district in the user's personal world.
+ *
+ * A running sum, never recomputed: the delta cron adds to it. `reads` counts
+ * distinct posts, deduplicated within each cron run rather than over all time, so
+ * strictly it is "posts per day you engaged with them" (+5.08% against true
+ * lifetime-distinct). Exact dedup would need a 71M-row (userId, postId) ledger.
+ *
+ * The primary key is (userId, nicheId) IN THAT ORDER. Rendering a world reads
+ * 4-40 rows for one user, so a userId-leading key makes it a single range scan;
+ * reversed it would be up to 40 point lookups. This is the one place the shape
+ * differs from PostAnalytics, which is genuinely a point lookup by post.
+ */
+@Entity()
+@Index('IDX_user_niche_analytics_updatedAt', ['updatedAt'])
+export class UserNicheAnalytics {
+  @PrimaryColumn({ type: 'text' })
+  userId: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  nicheId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  /** Distinct posts read in this niche. Drives the building's level. */
+  @Column({ type: 'integer', default: 0 })
+  reads: number;
+
+  /** Founding date — when this district first appeared in the world. */
+  @Column({ type: 'date' })
+  firstReadAt: string;
+
+  /** Most recent read; drives the "currently lit" dressing. */
+  @Column({ type: 'date' })
+  lastReadAt: string;
+
+  /** Distinct days on which this district gained reads. */
+  @Column({ type: 'integer', default: 0 })
+  activeDays: number;
+
+  @ManyToOne('User', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: Promise<User>;
+
+  @ManyToOne('Niche', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'nicheId' })
+  niche: Promise<Niche>;
+}

--- a/src/entity/user/UserNicheGrowth.ts
+++ b/src/entity/user/UserNicheGrowth.ts
@@ -1,0 +1,42 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import type { User } from './User';
+import type { Niche } from '../Niche';
+
+/**
+ * One row per (user, day, niche) — the growth log.
+ *
+ * This table does double duty. It is the timeline (replaying it in date order is
+ * the world being built), and it is also the delta ledger: the cron writes here
+ * first, and `ON CONFLICT DO NOTHING` on the composite key is what makes a rerun of
+ * the same window a no-op. `UserNicheAnalytics` is then advanced from the rows that
+ * were actually inserted.
+ *
+ * Because of that, phases 1 and 2 ship together — the timeline is not extra work,
+ * it is the mechanism.
+ *
+ * Key order matches UserNicheAnalytics: userId leads so a user's whole history is
+ * one range scan.
+ */
+@Entity()
+export class UserNicheGrowth {
+  @PrimaryColumn({ type: 'text' })
+  userId: string;
+
+  @PrimaryColumn({ type: 'date' })
+  date: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  nicheId: string;
+
+  /** Distinct posts first read in this niche on this day. */
+  @Column({ type: 'integer' })
+  reads: number;
+
+  @ManyToOne('User', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: Promise<User>;
+
+  @ManyToOne('Niche', { lazy: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'nicheId' })
+  niche: Promise<Niche>;
+}

--- a/src/entity/user/index.ts
+++ b/src/entity/user/index.ts
@@ -7,6 +7,8 @@ export * from './UserPersonalizedDigest';
 export * from './UserMarketingCta';
 export * from './UserStats';
 export * from './UserTopReader';
+export * from './UserNicheAnalytics';
+export * from './UserNicheGrowth';
 export * from './UserProfileAnalytics';
 export * from './UserProfileAnalyticsHistory';
 export * from './UserPostsAnalytics';

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -2178,6 +2178,27 @@ const obj = new GraphORM({
       },
     },
   },
+  Niche: {
+    requiredColumns: ['id'],
+  },
+  // Entity-backed, so graphorm resolves the niche relation and the whole world
+  // comes back as one jsonb-aggregated query instead of a query per district.
+  UserWorldDistrict: {
+    from: 'UserNicheAnalytics',
+    // nicheId is needed for the relation join even when only slug is requested
+    requiredColumns: ['userId', 'nicheId'],
+    fields: {
+      firstReadAt: { transform: transformDate },
+      lastReadAt: { transform: transformDate },
+    },
+  },
+  UserWorldGrowth: {
+    from: 'UserNicheGrowth',
+    requiredColumns: ['userId', 'nicheId'],
+    fields: {
+      date: { transform: transformDate },
+    },
+  },
   UserProfileAnalytics: {
     requiredColumns: ['id', 'updatedAt'],
     fields: {

--- a/src/migration/1785700000000-UserWorld.ts
+++ b/src/migration/1785700000000-UserWorld.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserWorld1785700000000 implements MigrationInterface {
+  name = 'UserWorld1785700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Districts. PK is ("userId", "nicheId") in that order on purpose — rendering a
+    // world reads 4-40 rows for one user, so a userId-leading key makes it one range
+    // scan instead of up to 40 point lookups.
+    await queryRunner.query(
+      /* sql */ `CREATE TABLE IF NOT EXISTS "user_niche_analytics" ("userId" text NOT NULL, "nicheId" uuid NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "reads" integer NOT NULL DEFAULT 0, "firstReadAt" date NOT NULL, "lastReadAt" date NOT NULL, "activeDays" integer NOT NULL DEFAULT 0, CONSTRAINT "PK_user_niche_analytics" PRIMARY KEY ("userId", "nicheId"))`,
+    );
+    await queryRunner.query(
+      /* sql */ `CREATE INDEX IF NOT EXISTS "IDX_user_niche_analytics_updatedAt" ON "user_niche_analytics" ("updatedAt")`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE "user_niche_analytics" ADD CONSTRAINT "FK_user_niche_analytics_userId" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE "user_niche_analytics" ADD CONSTRAINT "FK_user_niche_analytics_nicheId" FOREIGN KEY ("nicheId") REFERENCES "niche"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // Growth log — the timeline, and the delta ledger the cron writes to first.
+    await queryRunner.query(
+      /* sql */ `CREATE TABLE IF NOT EXISTS "user_niche_growth" ("userId" text NOT NULL, "date" date NOT NULL, "nicheId" uuid NOT NULL, "reads" integer NOT NULL, CONSTRAINT "PK_user_niche_growth" PRIMARY KEY ("userId", "date", "nicheId"))`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE "user_niche_growth" ADD CONSTRAINT "FK_user_niche_growth_userId" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE "user_niche_growth" ADD CONSTRAINT "FK_user_niche_growth_nicheId" FOREIGN KEY ("nicheId") REFERENCES "niche"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE IF EXISTS "user_niche_growth" DROP CONSTRAINT IF EXISTS "FK_user_niche_growth_nicheId"`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE IF EXISTS "user_niche_growth" DROP CONSTRAINT IF EXISTS "FK_user_niche_growth_userId"`,
+    );
+    await queryRunner.query(/* sql */ `DROP TABLE IF EXISTS "user_niche_growth"`);
+
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE IF EXISTS "user_niche_analytics" DROP CONSTRAINT IF EXISTS "FK_user_niche_analytics_nicheId"`,
+    );
+    await queryRunner.query(
+      /* sql */ `ALTER TABLE IF EXISTS "user_niche_analytics" DROP CONSTRAINT IF EXISTS "FK_user_niche_analytics_userId"`,
+    );
+    await queryRunner.query(
+      /* sql */ `DROP INDEX IF EXISTS "IDX_user_niche_analytics_updatedAt"`,
+    );
+    await queryRunner.query(
+      /* sql */ `DROP TABLE IF EXISTS "user_niche_analytics"`,
+    );
+  }
+}

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -160,9 +160,6 @@ import {
   UserIntegrationSlack,
   UserIntegrationType,
 } from '../entity/UserIntegration';
-import { UserNicheAnalytics } from '../entity/user/UserNicheAnalytics';
-import { UserNicheGrowth } from '../entity/user/UserNicheGrowth';
-import { Niche } from '../entity/Niche';
 import { SERVING_HIDDEN_NICHE_SLUGS } from '../common/clickhouse/worldRules';
 import { Company } from '../entity/Company';
 import { UserCompany } from '../entity/UserCompany';
@@ -357,8 +354,15 @@ export interface GQLUserPersonalizedDigest {
   flags: UserPersonalizedDigestFlagsPublic;
 }
 
+export interface GQLNiche {
+  id: string;
+  slug: string;
+  title: string;
+  bucketGroup: string;
+}
+
 export interface GQLUserWorldDistrict {
-  niche: string;
+  niche: GQLNiche;
   reads: number;
   firstReadAt: Date;
   lastReadAt: Date;
@@ -366,15 +370,9 @@ export interface GQLUserWorldDistrict {
 }
 
 export interface GQLUserWorldGrowth {
-  date: string;
-  niche: string;
+  date: Date;
+  niche: GQLNiche;
   reads: number;
-}
-
-export interface GQLUserWorld {
-  id: string;
-  totalReads: number;
-  districts: GQLUserWorldDistrict[];
 }
 
 export interface GQLUserProfileAnalytics {
@@ -1376,13 +1374,35 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
+  A content niche — the unit a district is built around
+  """
+  type Niche {
+    """
+    Niche ID
+    """
+    id: ID!
+    """
+    Stable slug, e.g. "js_ts"
+    """
+    slug: String!
+    """
+    Display title
+    """
+    title: String!
+    """
+    Whether the niche is a stack ecosystem or a cross-stack theme
+    """
+    bucketGroup: String!
+  }
+
+  """
   A single district of a user's personal world — one niche they have read in
   """
   type UserWorldDistrict {
     """
-    Niche slug, e.g. "js_ts"
+    The niche this district is built around
     """
-    niche: String!
+    niche: Niche!
     """
     Distinct posts read in this niche
     """
@@ -1402,8 +1422,8 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
-  One day's growth in one district — the timeline replayed in date order is the
-  world being built
+  One day's growth in one district — replayed in date order it is the world
+  being built
   """
   type UserWorldGrowth {
     """
@@ -1411,36 +1431,13 @@ export const typeDefs = /* GraphQL */ `
     """
     date: DateTime!
     """
-    Niche slug
+    The niche that grew
     """
-    niche: String!
+    niche: Niche!
     """
     Distinct posts first read in this niche on this day
     """
     reads: Int!
-  }
-
-  """
-  A user's personal world, built from what they have read
-  """
-  type UserWorld {
-    """
-    User ID
-    """
-    id: ID!
-    """
-    Distinct posts read across every district
-    """
-    totalReads: Int!
-    """
-    Districts, largest first
-    """
-    districts: [UserWorldDistrict!]!
-    """
-    Day-by-day growth, oldest first. Only fetched when selected — a long-tenured
-    world runs to tens of thousands of rows.
-    """
-    timeline: [UserWorldGrowth!]!
   }
 
   extend type Query {
@@ -1453,9 +1450,15 @@ export const typeDefs = /* GraphQL */ `
     """
     userStats(id: ID!): UserStats @cacheControl(maxAge: 600)
     """
-    Get a user's personal world. Public — worlds are shareable by design.
+    Get a user's personal world, largest district first. Public — worlds are
+    shareable by design.
     """
-    userWorld(id: ID!): UserWorld @cacheControl(maxAge: 600)
+    userWorld(id: ID!): [UserWorldDistrict!]! @cacheControl(maxAge: 600)
+    """
+    Day-by-day growth of a user's world, oldest first. Separate from userWorld
+    because a long-tenured world runs to tens of thousands of rows.
+    """
+    userWorldTimeline(id: ID!): [UserWorldGrowth!]! @cacheControl(maxAge: 600)
     """
     Get User Streak
     """
@@ -2525,31 +2528,6 @@ function processSocialLinksForDualWrite(
 }
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
-  UserWorld: {
-    // A field resolver, not part of the parent query, so a client that only wants
-    // the skyline never pays for the log behind it. Ordered oldest-first because
-    // the consumer replays it forward to build the world.
-    timeline: async (
-      world: GQLUserWorld,
-      _,
-      ctx: Context,
-    ): Promise<GQLUserWorldGrowth[]> =>
-      ctx.con
-        .getRepository(UserNicheGrowth)
-        .createQueryBuilder('growth')
-        .select('growth.date::text', 'date')
-        .addSelect('niche.slug', 'niche')
-        .addSelect('growth.reads', 'reads')
-        .innerJoin(Niche, 'niche', 'niche.id = growth."nicheId"')
-        .where('growth."userId" = :id', { id: world.id })
-        // hidden at serving only, matching the districts above
-        .andWhere('niche.slug NOT IN (:...hidden)', {
-          hidden: SERVING_HIDDEN_NICHE_SLUGS,
-        })
-        .orderBy('growth.date', 'ASC')
-        .addOrderBy('niche.slug', 'ASC')
-        .getRawMany<GQLUserWorldGrowth>(),
-  },
   Query: {
     whoami: async (_, __, ctx: AuthContext, info: GraphQLResolveInfo) => {
       const res = await graphorm.query<GQLUser>(
@@ -2569,43 +2547,51 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       return res[0];
     },
     userWorld: async (
-      source,
+      _,
       { id }: { id: string },
       ctx: Context,
-    ): Promise<GQLUserWorld | null> => {
-      // One range scan: the primary key leads with userId precisely so a whole
-      // world is contiguous rather than up to 40 point lookups.
-      const districts = await ctx.con
-        .getRepository(UserNicheAnalytics)
-        .createQueryBuilder('district')
-        .select('niche.slug', 'niche')
-        .addSelect('district.reads', 'reads')
-        .addSelect('district."firstReadAt"', 'firstReadAt')
-        .addSelect('district."lastReadAt"', 'lastReadAt')
-        .addSelect('district."activeDays"', 'activeDays')
-        .innerJoin(Niche, 'niche', 'niche.id = district."nicheId"')
-        .where('district."userId" = :id', { id })
-        // Hidden at serving, not at collection — the rows exist, so this is
-        // reversible without a backfill.
-        .andWhere('niche.slug NOT IN (:...hidden)', {
-          hidden: SERVING_HIDDEN_NICHE_SLUGS,
-        })
-        .orderBy('district.reads', 'DESC')
-        .addOrderBy('niche.slug', 'ASC')
-        .getRawMany<GQLUserWorldDistrict>();
+      info: GraphQLResolveInfo,
+    ): Promise<GQLUserWorldDistrict[]> =>
+      graphorm.query<GQLUserWorldDistrict>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            // userId leads the primary key, so a whole world is one range scan
+            .where(`"${builder.alias}"."userId" = :id`, { id })
+            .andWhere(
+              `"${builder.alias}"."nicheId" NOT IN (SELECT id FROM niche WHERE slug = ANY(:hidden))`,
+              { hidden: [...SERVING_HIDDEN_NICHE_SLUGS] },
+            )
+            .orderBy(`"${builder.alias}".reads`, 'DESC');
 
-      // No districts means nothing we can attribute has been read — an unfounded
-      // world, not an error.
-      if (districts.length === 0) {
-        return null;
-      }
+          return builder;
+        },
+        true,
+      ),
+    userWorldTimeline: async (
+      _,
+      { id }: { id: string },
+      ctx: Context,
+      info: GraphQLResolveInfo,
+    ): Promise<GQLUserWorldGrowth[]> =>
+      graphorm.query<GQLUserWorldGrowth>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder = builder.queryBuilder
+            .where(`"${builder.alias}"."userId" = :id`, { id })
+            .andWhere(
+              `"${builder.alias}"."nicheId" NOT IN (SELECT id FROM niche WHERE slug = ANY(:hidden))`,
+              { hidden: [...SERVING_HIDDEN_NICHE_SLUGS] },
+            )
+            // oldest first: the consumer replays it forward to build the world
+            .orderBy(`"${builder.alias}".date`, 'ASC');
 
-      return {
-        id,
-        districts,
-        totalReads: districts.reduce((sum, { reads }) => sum + reads, 0),
-      };
-    },
+          return builder;
+        },
+        true,
+      ),
     userStats: async (
       source,
       { id }: { id: string },

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -160,6 +160,8 @@ import {
   UserIntegrationSlack,
   UserIntegrationType,
 } from '../entity/UserIntegration';
+import { UserNicheAnalytics } from '../entity/user/UserNicheAnalytics';
+import { Niche } from '../entity/Niche';
 import { Company } from '../entity/Company';
 import { UserCompany } from '../entity/UserCompany';
 import { UserExperienceWork } from '../entity/user/experiences/UserExperienceWork';
@@ -351,6 +353,20 @@ export interface GQLUserPersonalizedDigest {
   preferredHour: number;
   type: UserPersonalizedDigestType;
   flags: UserPersonalizedDigestFlagsPublic;
+}
+
+export interface GQLUserWorldDistrict {
+  niche: string;
+  reads: number;
+  firstReadAt: Date;
+  lastReadAt: Date;
+  activeDays: number;
+}
+
+export interface GQLUserWorld {
+  id: string;
+  totalReads: number;
+  districts: GQLUserWorldDistrict[];
 }
 
 export interface GQLUserProfileAnalytics {
@@ -1351,6 +1367,50 @@ export const typeDefs = /* GraphQL */ `
     targets: MarketingCtaTargets!
   }
 
+  """
+  A single district of a user's personal world — one niche they have read in
+  """
+  type UserWorldDistrict {
+    """
+    Niche slug, e.g. "js_ts"
+    """
+    niche: String!
+    """
+    Distinct posts read in this niche
+    """
+    reads: Int!
+    """
+    When the district was founded
+    """
+    firstReadAt: DateTime!
+    """
+    Most recent read in this niche
+    """
+    lastReadAt: DateTime!
+    """
+    Days on which this district gained reads
+    """
+    activeDays: Int!
+  }
+
+  """
+  A user's personal world, built from what they have read
+  """
+  type UserWorld {
+    """
+    User ID
+    """
+    id: ID!
+    """
+    Distinct posts read across every district
+    """
+    totalReads: Int!
+    """
+    Districts, largest first
+    """
+    districts: [UserWorldDistrict!]!
+  }
+
   extend type Query {
     """
     Get user based on logged in session
@@ -1360,6 +1420,10 @@ export const typeDefs = /* GraphQL */ `
     Get the statistics of the user
     """
     userStats(id: ID!): UserStats @cacheControl(maxAge: 600)
+    """
+    Get a user's personal world. Public — worlds are shareable by design.
+    """
+    userWorld(id: ID!): UserWorld @cacheControl(maxAge: 600)
     """
     Get User Streak
     """
@@ -2446,6 +2510,39 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         throw new NotFoundError('user not found');
       }
       return res[0];
+    },
+    userWorld: async (
+      source,
+      { id }: { id: string },
+      ctx: Context,
+    ): Promise<GQLUserWorld | null> => {
+      // One range scan: the primary key leads with userId precisely so a whole
+      // world is contiguous rather than up to 40 point lookups.
+      const districts = await ctx.con
+        .getRepository(UserNicheAnalytics)
+        .createQueryBuilder('district')
+        .select('niche.slug', 'niche')
+        .addSelect('district.reads', 'reads')
+        .addSelect('district."firstReadAt"', 'firstReadAt')
+        .addSelect('district."lastReadAt"', 'lastReadAt')
+        .addSelect('district."activeDays"', 'activeDays')
+        .innerJoin(Niche, 'niche', 'niche.id = district."nicheId"')
+        .where('district."userId" = :id', { id })
+        .orderBy('district.reads', 'DESC')
+        .addOrderBy('niche.slug', 'ASC')
+        .getRawMany<GQLUserWorldDistrict>();
+
+      // No districts means nothing we can attribute has been read — an unfounded
+      // world, not an error.
+      if (districts.length === 0) {
+        return null;
+      }
+
+      return {
+        id,
+        districts,
+        totalReads: districts.reduce((sum, { reads }) => sum + reads, 0),
+      };
     },
     userStats: async (
       source,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -162,6 +162,7 @@ import {
 } from '../entity/UserIntegration';
 import { UserNicheAnalytics } from '../entity/user/UserNicheAnalytics';
 import { Niche } from '../entity/Niche';
+import { SERVING_HIDDEN_NICHE_SLUGS } from '../common/clickhouse/worldRules';
 import { Company } from '../entity/Company';
 import { UserCompany } from '../entity/UserCompany';
 import { UserExperienceWork } from '../entity/user/experiences/UserExperienceWork';
@@ -2528,6 +2529,11 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         .addSelect('district."activeDays"', 'activeDays')
         .innerJoin(Niche, 'niche', 'niche.id = district."nicheId"')
         .where('district."userId" = :id', { id })
+        // Hidden at serving, not at collection — the rows exist, so this is
+        // reversible without a backfill.
+        .andWhere('niche.slug NOT IN (:...hidden)', {
+          hidden: SERVING_HIDDEN_NICHE_SLUGS,
+        })
         .orderBy('district.reads', 'DESC')
         .addOrderBy('niche.slug', 'ASC')
         .getRawMany<GQLUserWorldDistrict>();

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -161,6 +161,7 @@ import {
   UserIntegrationType,
 } from '../entity/UserIntegration';
 import { UserNicheAnalytics } from '../entity/user/UserNicheAnalytics';
+import { UserNicheGrowth } from '../entity/user/UserNicheGrowth';
 import { Niche } from '../entity/Niche';
 import { SERVING_HIDDEN_NICHE_SLUGS } from '../common/clickhouse/worldRules';
 import { Company } from '../entity/Company';
@@ -362,6 +363,12 @@ export interface GQLUserWorldDistrict {
   firstReadAt: Date;
   lastReadAt: Date;
   activeDays: number;
+}
+
+export interface GQLUserWorldGrowth {
+  date: string;
+  niche: string;
+  reads: number;
 }
 
 export interface GQLUserWorld {
@@ -1395,6 +1402,25 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
+  One day's growth in one district — the timeline replayed in date order is the
+  world being built
+  """
+  type UserWorldGrowth {
+    """
+    Day the reads landed
+    """
+    date: DateTime!
+    """
+    Niche slug
+    """
+    niche: String!
+    """
+    Distinct posts first read in this niche on this day
+    """
+    reads: Int!
+  }
+
+  """
   A user's personal world, built from what they have read
   """
   type UserWorld {
@@ -1410,6 +1436,11 @@ export const typeDefs = /* GraphQL */ `
     Districts, largest first
     """
     districts: [UserWorldDistrict!]!
+    """
+    Day-by-day growth, oldest first. Only fetched when selected — a long-tenured
+    world runs to tens of thousands of rows.
+    """
+    timeline: [UserWorldGrowth!]!
   }
 
   extend type Query {
@@ -2494,6 +2525,31 @@ function processSocialLinksForDualWrite(
 }
 
 export const resolvers: IResolvers<unknown, BaseContext> = {
+  UserWorld: {
+    // A field resolver, not part of the parent query, so a client that only wants
+    // the skyline never pays for the log behind it. Ordered oldest-first because
+    // the consumer replays it forward to build the world.
+    timeline: async (
+      world: GQLUserWorld,
+      _,
+      ctx: Context,
+    ): Promise<GQLUserWorldGrowth[]> =>
+      ctx.con
+        .getRepository(UserNicheGrowth)
+        .createQueryBuilder('growth')
+        .select('growth.date::text', 'date')
+        .addSelect('niche.slug', 'niche')
+        .addSelect('growth.reads', 'reads')
+        .innerJoin(Niche, 'niche', 'niche.id = growth."nicheId"')
+        .where('growth."userId" = :id', { id: world.id })
+        // hidden at serving only, matching the districts above
+        .andWhere('niche.slug NOT IN (:...hidden)', {
+          hidden: SERVING_HIDDEN_NICHE_SLUGS,
+        })
+        .orderBy('growth.date', 'ASC')
+        .addOrderBy('niche.slug', 'ASC')
+        .getRawMany<GQLUserWorldGrowth>(),
+  },
   Query: {
     whoami: async (_, __, ctx: AuthContext, info: GraphQLResolveInfo) => {
       const res = await graphorm.query<GQLUser>(


### PR DESCRIPTION
Adds the data behind personal worlds — how many distinct posts each user has read in each niche, and when. Serving only; no UI in this PR.

## Tables

| | |
|---|---|
| `user_niche_growth` | `(userId, date, nicheId, reads)` — the daily log, and the timeline |
| `user_niche_analytics` | `(userId, nicheId)` — running totals a world renders from |

`user_niche_growth` does double duty: it's the timeline *and* the delta ledger, since its composite key is what makes a rerun a no-op. That's why there's no third table.

`user_niche_analytics`'s PK leads with `userId` on purpose — rendering a world reads 4–40 rows for one user, so that's a single range scan instead of up to 40 point lookups. It's the one place this differs from `PostAnalytics`, which genuinely is a point lookup by post.

## Cron

`user-world-clickhouse`, following `postAnalyticsClickhouse`: Redis cursor, ClickHouse delta, zod validation, chunked upsert. Daily at 03:00.

Two things worth knowing when reviewing it:

**The cursor is bounded to the last UTC midnight, never `now()`.** Growth rows are inserted `ON CONFLICT DO NOTHING`, so whichever run writes a given day first wins. A run ending mid-day would have its remainder silently dropped by the next run — at a 03:00 cadence that would lose 21 hours of reads every day.

**Districts advance from what the growth insert returned**, not from the raw delta, and both writes share one transaction. A half-applied run rolls back entirely and the retry finds every row already present, so the increment is exact without recomputing anything. An earlier version refolded each touched user's full history instead; measured on a real day (12,758 active users) that was **7.5M rows read and 360k upserts against 26.5k and 26.5k** — 282× the reads for a guarantee the transaction already gives.

## Rules

All classification lives in `common/clickhouse/worldRules.ts` — read events, share collapsing, first-party source exclusion, private handling, self-read exclusion, niche selection. Two copies would drift silently and every number computed from them would stop being comparable. Each rule has its measured justification in the file header; the short version:

- Shares collapse into `sharedPostId` — filtering them instead dropped 12% of traffic (share rows carry a NULL title; the article is on the parent).
- `private = 1` is inherited from the source, and the `unknown` placeholder source is itself private — excluding it outright dropped ~23% of reads to catch ~31.
- Self-reads excluded (author, scout, own share): 1.58% platform-wide but 27.6% for an active poster.
- `daily_updates` / `dailydevworld` matched by **handle**, not id — `dailydevworld`'s id is a UUID, and a different third-party squad is named "Dev World".

`livePostNiche` resolves each `(postId, nicheId)` by its own latest `_version` rather than trusting `FINAL`, because `api.post_niche` has `_version` inside its sorting key and so never collapses stale rows. Current exposure is only 67 posts (0.01%) — the existing `ifNull(score, -1)` tiebreaker happens to neutralise it — but that's luck, not design.

## API

`userWorld(id: ID!): UserWorld` — public, no permission gate, worlds are shareable by design. Returns districts with niche slug, reads, founding date, last read, active days.

Worth a deliberate call rather than an implementation detail: this publishes a per-user topic profile (which niches someone reads and how much) for every registered user by default. Aggregate counts only, no titles, but it is reading behaviour.

## Not in this PR

**The initial bulk load.** The cron falls back to a 2022 cursor if none is set, which would replay four years through the delta path. Both tables need seeding and the cursor setting to the seed's upper bound before this is scheduled.

**Verification I could not do locally.** Postgres wasn't reachable, so the cron tests are unrun — they cover registration, the growth→district advance, replay idempotency, cross-window accumulation, the UTC-day invariant and the same-day no-op, but I have not seen them green. The migration is hand-written rather than generated by `db:migrate:make`, so it should be applied against a local DB and diffed before merge.