### PR TITLE
fix(worlds): make the delta window half-open

### DIFF
--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -147,8 +147,16 @@ pv AS (
 reg AS (SELECT id FROM api.user GROUP BY id)`;
 
 /**
- * Reads in `(cursor, until]`, deduplicated to one row per (user, post) within the
+ * Reads in `[cursor, until)`, deduplicated to one row per (user, post) within the
  * window, grouped into the per-day per-niche counts the growth table stores.
+ *
+ * The window is half-open, [cursor, until). Both bounds matter. With `<= until` an
+ * event on the exact millisecond of midnight is pulled into the *previous* day's
+ * run while carrying the *next* day's date; the run after it then collects the rest
+ * of that day, conflicts on (userId, date, nicheId), and DO NOTHING silently drops
+ * it. With `> cursor` instead of `>=`, an event landing exactly on a cursor is in
+ * neither window and is lost outright. Half-open intervals tile with no gap and no
+ * overlap, which is what the ON CONFLICT dedup depends on.
  *
  * Dedup is window-local by design: a post re-read on a later day counts again.
  * Exact lifetime dedup would need a 71M-row (userId, postId) ledger; measured drift
@@ -168,8 +176,8 @@ firsts AS (
   INNER JOIN nc n ON pn.nicheId = n.id
   INNER JOIN pmeta pm ON eff.eff_id = pm.id
   INNER JOIN reg ON e.user_id = reg.id
-  WHERE e.event_timestamp > {cursor: DateTime}
-    AND e.event_timestamp <= {until: DateTime}
+  WHERE e.event_timestamp >= {cursor: DateTime}
+    AND e.event_timestamp < {until: DateTime}
     AND e.event_name IN (${asSqlList(READ_EVENTS)})
     AND eff.eff_id NOT IN (SELECT id FROM du)
     AND eff.eff_id NOT IN (SELECT id FROM pv)


### PR DESCRIPTION
Follow-up to #4038, found while verifying that the cron gives an identical result whether it runs at 03:00 or 04:00 — it does, but checking exposed this.

## The bug

The delta window is `> cursor AND <= until`, half-open on the wrong side.

`event_timestamp` is `DateTime64(3)`. An event on the exact millisecond of UTC midnight satisfies `<= until`, so it is pulled into the **previous** day's run while carrying the **next** day's date. That writes a growth row for a day the run does not otherwise cover. The following run then collects the rest of that day, conflicts on `(userId, date, nicheId)`, and `ON CONFLICT DO NOTHING` drops it — silently losing that user's entire day in that niche.

Roughly 0.05% chance per day at current volume, so about one in five over a year, and invisible when it happens.

## Why both bounds change

Fixing only the upper bound moves the problem: with `> cursor`, an event landing exactly on a cursor is in neither window and is lost outright. `[cursor, until)` tiles with no gap and no overlap, which is the property the `ON CONFLICT` dedup assumes.

## Not a behaviour change day to day

`until` is still the last UTC midnight, so any run on a given UTC day produces an identical window and the in-progress day never leaks in. This only affects the exact-midnight boundary.

Being merged before the production backfill is seeded, so the seed and the first delta agree on the boundary.