### PR TITLE
fix(worlds): a deleted account must not take down the whole run

### DIFF
--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -211,7 +211,12 @@ describe('userWorldClickhouse cron', () => {
     // it. This is the failure that took down the first production run.
     await runWith([
       ...delta,
-      { userId: 'deleted-user', date: '2026-07-02', nicheId: nicheJs, reads: 9 },
+      {
+        userId: 'deleted-user',
+        date: '2026-07-02',
+        nicheId: nicheJs,
+        reads: 9,
+      },
     ]);
 
     expect(await con.getRepository(UserNicheGrowth).count()).toBe(delta.length);

--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -204,6 +204,31 @@ describe('userWorldClickhouse cron', () => {
     );
   });
 
+  it('should skip users that no longer exist in postgres', async () => {
+    // The delta is built from a ClickHouse mirror of the user table, which lags.
+    // A row for an account Postgres has already deleted violates the growth FK and
+    // aborts the whole transaction — so the rest of the batch must not be lost with
+    // it. This is the failure that took down the first production run.
+    await runWith([
+      ...delta,
+      { userId: 'deleted-user', date: '2026-07-02', nicheId: nicheJs, reads: 9 },
+    ]);
+
+    expect(await con.getRepository(UserNicheGrowth).count()).toBe(delta.length);
+    expect(
+      await con
+        .getRepository(UserNicheGrowth)
+        .countBy({ userId: 'deleted-user' }),
+    ).toBe(0);
+
+    // the surviving rows still fold into districts exactly as they would have
+    const district = await con
+      .getRepository(UserNicheAnalytics)
+      .findOneByOrFail({ userId: '1', nicheId: nicheJs });
+    expect(district.reads).toBe(5);
+    expect(district.activeDays).toBe(2);
+  });
+
   it('should be a no-op when run twice on the same day', async () => {
     await runWith(delta);
     const { cursor } = await getRedisHash(cronConfigRedisKey);

--- a/src/common/clickhouse/worldRules.ts
+++ b/src/common/clickhouse/worldRules.ts
@@ -106,6 +106,16 @@ const asSqlList = (values: readonly string[]): string =>
  * resolved post), `pn` (one niche per post), `nc` (niche slugs), `du` (excluded
  * posts), `pv` (private posts), `reg` (registered users). `api.source` is not
  * touched — the first-party exclusion uses ids directly.
+ *
+ * `reg` drops deleted accounts. Unlike `api.post_niche`, `api.user` collapses
+ * normally, so `is_deleted` is a usable tombstone — 159,359 of 1,992,627 mirrored
+ * users carry one. Keeping them was not merely wasted work: the growth table has a
+ * real FK to `"user"`, so a single read by an account Postgres has already removed
+ * aborts the entire run. That is how this cron failed on its first production run.
+ *
+ * This narrows the gap but cannot close it — see `userWorldClickhouse`, which also
+ * filters against Postgres itself, because the mirror lags and an account can be
+ * deleted while the cron is mid-flight.
  */
 export const worldRulesCte = /* sql */ `
 res AS (
@@ -144,7 +154,9 @@ du AS (
 pv AS (
   SELECT id FROM api.post GROUP BY id
   HAVING argMax(private, _version) = 1 AND argMax(sourceId, _version) != 'unknown'),
-reg AS (SELECT id FROM api.user GROUP BY id)`;
+reg AS (
+  SELECT id FROM api.user GROUP BY id
+  HAVING argMax(is_deleted, _version) = 0)`;
 
 /**
  * Reads in `[cursor, until)`, deduplicated to one row per (user, post) within the

--- a/src/cron/userWorldClickhouse.ts
+++ b/src/cron/userWorldClickhouse.ts
@@ -172,11 +172,36 @@ export const userWorldClickhouseCron: Cron = {
     // districts are left alone. Advancing districts from the raw delta instead of
     // from what was actually inserted is what would double-count.
     let inserted: UserWorldDelta[] = [];
+    let skipped = 0;
 
     await con.transaction(async (manager) => {
+      // 0. Keep only users Postgres still has.
+      //
+      //    The delta comes from a ClickHouse mirror of `api.user`. The query already
+      //    drops deletion tombstones, but the mirror lags: an account removed since
+      //    the last replicated batch is still live there and already gone here. The
+      //    growth table has a real FK to "user", so one such row does not skip a
+      //    user — it aborts the run. That is exactly how the first production run
+      //    failed, and with `restartPolicy: OnFailure` it then retried the same
+      //    doomed insert until the deadline killed it.
+      //
+      //    FOR KEY SHARE is the lock the FK check takes anyway, taken earlier. That
+      //    is what makes the filter hold rather than merely narrow the window: it
+      //    blocks deletion of these rows for the rest of the transaction, so a user
+      //    cannot disappear between this SELECT and the INSERT below. It does not
+      //    block ordinary profile updates, which take a weaker lock.
+      const present: { id: string }[] = await manager.query(
+        'SELECT id FROM "user" WHERE id = ANY($1) FOR KEY SHARE',
+        [[...new Set(data.map((row) => row.userId))]],
+      );
+      const known = new Set(present.map((row) => row.id));
+      const insertable = data.filter((row) => known.has(row.userId));
+
+      skipped = data.length - insertable.length;
+
       // 1. Append to the growth log. The composite key makes replaying a window a
       //    no-op, which is what lets the cron be rerun after a partial failure.
-      for (const rows of chunk(data, GROWTH_CHUNK_SIZE)) {
+      for (const rows of chunk(insertable, GROWTH_CHUNK_SIZE)) {
         const result = await manager
           .createQueryBuilder()
           .insert()
@@ -326,6 +351,10 @@ export const userWorldClickhouseCron: Cron = {
       {
         rows: data.length,
         inserted: inserted.length,
+        // Rows for users the mirror still lists but Postgres no longer has. A
+        // handful is normal replication lag; a sudden jump means the mirror has
+        // fallen behind and worlds are being built from stale membership.
+        skipped,
         users: new Set(data.map((row) => row.userId)).size,
         queryParams,
       },


### PR DESCRIPTION
The `user-world-clickhouse` cron failed on its first production run:

```
Key (userId)=(1ku42HtSS2zWyPTK2j9Fq) is not present in table "user"
constraint: FK_user_niche_growth_userId
```

## What happened

The delta is built from a ClickHouse mirror of `api.user`, and `reg` selected **every** id in it. Unlike `api.post_niche`, `api.user` collapses normally, so `is_deleted` is a usable tombstone — and **159,359 of 1,992,627** mirrored users carry one. We were ignoring them.

`user_niche_growth` has a real FK to `"user"`. So one read by one deleted account didn't skip that user — it aborted the transaction. With `restartPolicy: OnFailure` the pod then retried the same doomed insert, burning a full ClickHouse day-scan (~2 min) per attempt until `activeDeadlineSeconds` killed it.

Yesterday's delta (2026-08-02) carried **35 such rows across 28 accounts** — enough to lose all 13,616.

## The fix, in two layers

**1. `reg` drops tombstoned accounts.** Fixes the observed failure, and is what we meant all along: we should not be building worlds for deleted accounts.

**2. The cron also filters against Postgres itself.** Layer 1 narrows the gap but cannot close it — the mirror lags, so an account deleted since the last replicated batch is live there and already gone here, and an account can be deleted *while the cron runs*.

The filter uses `FOR KEY SHARE`: the same lock the FK check takes anyway, just taken early enough to hold for the rest of the transaction. That's what makes it a guarantee rather than a narrower window — a user cannot vanish between the `SELECT` and the `INSERT`. Ordinary profile updates take a weaker lock and are unaffected.

Skipped rows are logged. A handful is normal replication lag; a jump means the mirror has fallen behind and worlds are being built from stale membership.

## Verification

Measured against production ClickHouse and Postgres for 2026-08-02:

| | |
|---|---|
| delta rows / users | 13,616 / 6,898 |
| removed by the tombstone filter | 35 rows / 28 users |
| of the remaining 6,870 users, **missing from Postgres** | **0** |

So layer 1 fully explains this failure — layer 2 is there because "zero today" isn't "zero always".

Also sanity-checked that the day itself is complete rather than truncated: 08-02 is a Sunday, and it lands at 13.6k alongside the two previous weekends (07-25 12,999 · 07-26 13,050 · 08-01 12,295) against weekdays at 24–29k.

New test covers a delta containing a row for a user Postgres doesn't have: the batch survives, that row is dropped, districts fold exactly as they otherwise would.

Local suite couldn't run (port 5432 held by an unrelated container on my machine) — relying on CI. `tsc` is clean for the touched files, and the new `FOR KEY SHARE` statement was validated against production in a rolled-back transaction.

## On the retry policy

I initially wanted to cut `backoffLimit: 6` here and no longer think that is right. Six identical
day-scans were waste only because the failure was deterministic. With that fixed, what is left is
mostly transient — a ClickHouse timeout, a Postgres connection blip — and retries genuinely help
there. The cost is bounded by `activeDeadlineSeconds: 3600` either way, and a failed run already
self-heals: the cursor does not advance, so the next day covers a two-day window. Leaving it at 6.
