### PR TITLE
fix(worlds): close the niche FK gap and cover the serving layer

### DIFF
--- a/__tests__/cron/userWorldClickhouse.ts
+++ b/__tests__/cron/userWorldClickhouse.ts
@@ -234,6 +234,30 @@ describe('userWorldClickhouse cron', () => {
     expect(district.activeDays).toBe(2);
   });
 
+  it('should skip niches that no longer exist in postgres', async () => {
+    // Same exposure as the user case and the same total blast radius — `nicheId`
+    // is also a foreign key, so one row naming a niche Postgres has dropped aborts
+    // the run. Rarer only because the catalogue is curated rather than user-driven.
+    const nicheGone = '33333333-3333-4333-8333-333333333333';
+
+    await runWith([
+      ...delta,
+      { userId: '1', date: '2026-07-02', nicheId: nicheGone, reads: 7 },
+    ]);
+
+    expect(await con.getRepository(UserNicheGrowth).count()).toBe(delta.length);
+    expect(
+      await con.getRepository(UserNicheAnalytics).countBy({
+        nicheId: nicheGone,
+      }),
+    ).toBe(0);
+
+    const district = await con
+      .getRepository(UserNicheAnalytics)
+      .findOneByOrFail({ userId: '1', nicheId: nicheJs });
+    expect(district.reads).toBe(5);
+  });
+
   it('should be a no-op when run twice on the same day', async () => {
     await runWith(delta);
     const { cursor } = await getRedisHash(cronConfigRedisKey);

--- a/__tests__/userWorld.ts
+++ b/__tests__/userWorld.ts
@@ -1,0 +1,268 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../src/db';
+import {
+  GraphQLTestClient,
+  GraphQLTestingState,
+  MockContext,
+  disposeGraphQLTesting,
+  initializeGraphQLTesting,
+  saveFixtures,
+} from './helpers';
+import { User } from '../src/entity';
+import { Niche, NicheBucketGroup } from '../src/entity/Niche';
+import { UserNicheAnalytics } from '../src/entity/user/UserNicheAnalytics';
+import { UserNicheGrowth } from '../src/entity/user/UserNicheGrowth';
+import { usersFixture } from './fixture/user';
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+let loggedUser: string | null = null;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(
+    () => new MockContext(con, loggedUser),
+  );
+  client = state.client;
+});
+
+afterAll(() => disposeGraphQLTesting(state));
+
+const nicheJs = '11111111-1111-4111-8111-111111111111';
+const nicheAi = '22222222-2222-4222-8222-222222222222';
+// The one niche hidden at serving time. Deliberately given the largest district
+// below, so a test that forgets to exclude it fails on ordering too.
+const nicheChain = '33333333-3333-4333-8333-333333333333';
+
+beforeEach(async () => {
+  loggedUser = null;
+  await con.getRepository(UserNicheAnalytics).clear();
+  await con.getRepository(UserNicheGrowth).clear();
+  await saveFixtures(con, User, usersFixture);
+  await saveFixtures(con, Niche, [
+    {
+      id: nicheJs,
+      slug: 'js_ts',
+      title: 'JavaScript / TypeScript',
+      bucketGroup: NicheBucketGroup.Ecosystem,
+    },
+    {
+      id: nicheAi,
+      slug: 'ai_llm',
+      title: 'LLMs',
+      bucketGroup: NicheBucketGroup.Theme,
+    },
+    {
+      id: nicheChain,
+      slug: 'blockchain',
+      title: 'Blockchain',
+      bucketGroup: NicheBucketGroup.Theme,
+    },
+  ]);
+
+  await saveFixtures(con, UserNicheAnalytics, [
+    {
+      userId: '1',
+      nicheId: nicheJs,
+      reads: 50,
+      firstReadAt: '2026-01-01',
+      lastReadAt: '2026-06-01',
+      activeDays: 20,
+    },
+    {
+      userId: '1',
+      nicheId: nicheAi,
+      reads: 80,
+      firstReadAt: '2026-02-01',
+      lastReadAt: '2026-07-01',
+      activeDays: 30,
+    },
+    {
+      userId: '1',
+      nicheId: nicheChain,
+      reads: 100,
+      firstReadAt: '2026-03-01',
+      lastReadAt: '2026-07-02',
+      activeDays: 40,
+    },
+    // a second world, to prove one user's districts never leak into another's
+    {
+      userId: '2',
+      nicheId: nicheJs,
+      reads: 7,
+      firstReadAt: '2026-05-01',
+      lastReadAt: '2026-05-02',
+      activeDays: 2,
+    },
+  ]);
+
+  await saveFixtures(con, UserNicheGrowth, [
+    { userId: '1', date: '2026-02-01', nicheId: nicheAi, reads: 5 },
+    { userId: '1', date: '2026-01-01', nicheId: nicheJs, reads: 3 },
+    { userId: '1', date: '2026-03-01', nicheId: nicheChain, reads: 9 },
+    { userId: '2', date: '2026-05-01', nicheId: nicheJs, reads: 7 },
+  ]);
+});
+
+describe('query userWorld', () => {
+  const QUERY = `query UserWorld($id: ID!) {
+    userWorld(id: $id) {
+      reads
+      firstReadAt
+      lastReadAt
+      activeDays
+      niche {
+        id
+        slug
+        title
+        bucketGroup
+      }
+    }
+  }`;
+
+  it('should return districts largest first with the niche resolved', async () => {
+    const res = await client.query(QUERY, { variables: { id: '1' } });
+
+    expect(res.errors).toBeFalsy();
+    // blockchain is hidden at serving time even though it is the largest
+    expect(res.data.userWorld).toEqual([
+      {
+        reads: 80,
+        firstReadAt: new Date('2026-02-01').toISOString(),
+        lastReadAt: new Date('2026-07-01').toISOString(),
+        activeDays: 30,
+        niche: {
+          id: nicheAi,
+          slug: 'ai_llm',
+          title: 'LLMs',
+          bucketGroup: 'theme',
+        },
+      },
+      {
+        reads: 50,
+        firstReadAt: new Date('2026-01-01').toISOString(),
+        lastReadAt: new Date('2026-06-01').toISOString(),
+        activeDays: 20,
+        niche: {
+          id: nicheJs,
+          slug: 'js_ts',
+          title: 'JavaScript / TypeScript',
+          bucketGroup: 'ecosystem',
+        },
+      },
+    ]);
+  });
+
+  it('should be public', async () => {
+    // worlds are shareable by design, so an anonymous viewer gets the same answer
+    loggedUser = null;
+    const anonymous = await client.query(QUERY, { variables: { id: '1' } });
+
+    loggedUser = '2';
+    const signedIn = await client.query(QUERY, { variables: { id: '1' } });
+
+    expect(anonymous.errors).toBeFalsy();
+    expect(signedIn.errors).toBeFalsy();
+    expect(anonymous.data).toEqual(signedIn.data);
+  });
+
+  it('should not leak another user world', async () => {
+    const res = await client.query(QUERY, { variables: { id: '2' } });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userWorld).toHaveLength(1);
+    expect(res.data.userWorld[0].reads).toBe(7);
+    expect(res.data.userWorld[0].niche.slug).toBe('js_ts');
+  });
+
+  it('should return an empty world rather than an error', async () => {
+    // a brand new account has no districts yet; that is a valid empty world, and
+    // the non-null list type means a null here would surface as a GraphQL error
+    const res = await client.query(QUERY, { variables: { id: '3' } });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userWorld).toEqual([]);
+  });
+
+  it('should resolve without requesting the niche relation', async () => {
+    // `nicheId` is a requiredColumn purely so graphorm can join the relation. If
+    // that were wrong, dropping the relation from the selection would break the
+    // query rather than simply return fewer fields.
+    const res = await client.query(
+      `query UserWorld($id: ID!) { userWorld(id: $id) { reads } }`,
+      { variables: { id: '1' } },
+    );
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userWorld).toEqual([{ reads: 80 }, { reads: 50 }]);
+  });
+});
+
+describe('query userWorldTimeline', () => {
+  const QUERY = `query UserWorldTimeline($id: ID!) {
+    userWorldTimeline(id: $id) {
+      date
+      reads
+      niche {
+        slug
+      }
+    }
+  }`;
+
+  it('should return growth oldest first, hiding served-hidden niches', async () => {
+    const res = await client.query(QUERY, { variables: { id: '1' } });
+
+    expect(res.errors).toBeFalsy();
+    // oldest first: the consumer replays this forward to build the world
+    expect(res.data.userWorldTimeline).toEqual([
+      {
+        date: new Date('2026-01-01').toISOString(),
+        reads: 3,
+        niche: { slug: 'js_ts' },
+      },
+      {
+        date: new Date('2026-02-01').toISOString(),
+        reads: 5,
+        niche: { slug: 'ai_llm' },
+      },
+    ]);
+  });
+
+  it('should be public', async () => {
+    loggedUser = null;
+    const anonymous = await client.query(QUERY, { variables: { id: '1' } });
+
+    loggedUser = '2';
+    const signedIn = await client.query(QUERY, { variables: { id: '1' } });
+
+    expect(anonymous.errors).toBeFalsy();
+    expect(anonymous.data).toEqual(signedIn.data);
+  });
+
+  it('should return an empty timeline rather than an error', async () => {
+    const res = await client.query(QUERY, { variables: { id: '3' } });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.userWorldTimeline).toEqual([]);
+  });
+
+  it('should agree with the districts it accumulates into', async () => {
+    // The timeline is the ledger the districts are folded from, so the two must
+    // never disagree about how much a niche was read.
+    const timeline = await client.query(QUERY, { variables: { id: '2' } });
+    const world = await client.query(
+      `query UserWorld($id: ID!) { userWorld(id: $id) { reads niche { slug } } }`,
+      { variables: { id: '2' } },
+    );
+
+    expect(timeline.errors).toBeFalsy();
+    expect(world.errors).toBeFalsy();
+
+    const summed = timeline.data.userWorldTimeline.reduce(
+      (total: number, row: { reads: number }) => total + row.reads,
+      0,
+    );
+    expect(summed).toBe(world.data.userWorld[0].reads);
+  });
+});

--- a/src/cron/userWorldClickhouse.ts
+++ b/src/cron/userWorldClickhouse.ts
@@ -173,31 +173,48 @@ export const userWorldClickhouseCron: Cron = {
     // from what was actually inserted is what would double-count.
     let inserted: UserWorldDelta[] = [];
     let skipped = 0;
+    let missingNiches = 0;
 
     await con.transaction(async (manager) => {
-      // 0. Keep only users Postgres still has.
+      // 0. Keep only rows whose user AND niche Postgres still has.
       //
-      //    The delta comes from a ClickHouse mirror of `api.user`. The query already
-      //    drops deletion tombstones, but the mirror lags: an account removed since
-      //    the last replicated batch is still live there and already gone here. The
-      //    growth table has a real FK to "user", so one such row does not skip a
-      //    user — it aborts the run. That is exactly how the first production run
-      //    failed, and with `restartPolicy: OnFailure` it then retried the same
-      //    doomed insert until the deadline killed it.
+      //    The delta comes from ClickHouse mirrors of `api.user` and `api.niche`.
+      //    The query already drops deletion tombstones, but the mirrors lag: a row
+      //    removed since the last replicated batch is still live there and already
+      //    gone here. Both columns are foreign keys, so one such row does not skip
+      //    a district — it aborts the run. That is exactly how the first production
+      //    run failed on the user side, and with `restartPolicy: OnFailure` it then
+      //    retried the same doomed insert until the deadline killed it.
+      //
+      //    The two differ only in how often the window is open, not in what happens
+      //    when it is. Users delete themselves continuously, which is why that side
+      //    broke on day one; niches are a small catalogue changed by hand, so the
+      //    same failure is rare rather than impossible. Rare and total is still
+      //    worth two cheap lookups.
       //
       //    FOR KEY SHARE is the lock the FK check takes anyway, taken earlier. That
-      //    is what makes the filter hold rather than merely narrow the window: it
-      //    blocks deletion of these rows for the rest of the transaction, so a user
-      //    cannot disappear between this SELECT and the INSERT below. It does not
-      //    block ordinary profile updates, which take a weaker lock.
-      const present: { id: string }[] = await manager.query(
+      //    is what makes this a guarantee rather than a narrower window: it blocks
+      //    deletion of these rows for the rest of the transaction, so neither a user
+      //    nor a niche can disappear between these SELECTs and the INSERT below. It
+      //    does not block ordinary updates, which take a weaker lock.
+      const presentUsers: { id: string }[] = await manager.query(
         'SELECT id FROM "user" WHERE id = ANY($1) FOR KEY SHARE',
         [[...new Set(data.map((row) => row.userId))]],
       );
-      const known = new Set(present.map((row) => row.id));
-      const insertable = data.filter((row) => known.has(row.userId));
+      const presentNiches: { id: string }[] = await manager.query(
+        'SELECT id FROM "niche" WHERE id = ANY($1) FOR KEY SHARE',
+        [[...new Set(data.map((row) => row.nicheId))]],
+      );
+
+      const knownUsers = new Set(presentUsers.map((row) => row.id));
+      const knownNiches = new Set(presentNiches.map((row) => row.id));
+      const insertable = data.filter(
+        (row) => knownUsers.has(row.userId) && knownNiches.has(row.nicheId),
+      );
 
       skipped = data.length - insertable.length;
+      missingNiches =
+        new Set(data.map((row) => row.nicheId)).size - knownNiches.size;
 
       // 1. Append to the growth log. The composite key makes replaying a window a
       //    no-op, which is what lets the cron be rerun after a partial failure.
@@ -351,10 +368,15 @@ export const userWorldClickhouseCron: Cron = {
       {
         rows: data.length,
         inserted: inserted.length,
-        // Rows for users the mirror still lists but Postgres no longer has. A
-        // handful is normal replication lag; a sudden jump means the mirror has
-        // fallen behind and worlds are being built from stale membership.
+        // Rows dropped because the mirror still lists a user or niche Postgres no
+        // longer has. A handful is normal replication lag; a sudden jump means a
+        // mirror has fallen behind and worlds are being built from stale membership.
         skipped,
+        // Broken out because the two mean different things. Missing users are
+        // routine — people delete accounts all day. A missing niche is not: the
+        // catalogue is curated, so anything above zero means the niche mirror is
+        // stale and reads are being filed under a niche that no longer exists.
+        missingNiches,
         users: new Set(data.map((row) => row.userId)).size,
         queryParams,
       },


### PR DESCRIPTION
Follow-up to #4041. Two gaps that fix left behind.

## 1. The niche side of the same exposure

#4041 closed the mirror-lag hole for users and not for niches. `nicheId` is a foreign key on **both** world tables, and `nc` reads from a ClickHouse mirror that lags Postgres exactly like the user mirror does.

The two differ only in **how often** the window is open, not in what happens when it is:

| | frequency | blast radius |
|---|---|---|
| user deleted mid-lag | continuous — people delete accounts all day | whole run aborts |
| niche deleted mid-lag | rare — small curated catalogue, changed by hand | whole run aborts |

Rare and total is still worth one extra lookup per run. Same `FOR KEY SHARE` pattern, taken in the same transaction, so neither a user nor a niche can disappear between the check and the insert.

`missingNiches` is logged separately from `skipped` because the two mean different things. Missing users are routine. **A missing niche is not** — the catalogue is curated, so anything above zero means the niche mirror is stale and reads are being filed under an entry that no longer exists.

## 2. The serving layer had no tests

`userWorld` and `userWorldTimeline` shipped in #4038 and have only ever been verified by reading the tables directly. The graphorm mapping could have been wrong in ways none of the cron work would catch. New `__tests__/userWorld.ts` covers:

- districts returned largest-first, with the `niche` relation resolved through graphorm
- `blockchain` excluded via `SERVING_HIDDEN_NICHE_SLUGS` — it's deliberately given the *largest* district in the fixtures, so forgetting the exclusion fails on ordering too
- both queries are public, and anonymous and signed-in viewers get identical answers
- one user's districts never leak into another's world
- an account with no districts gets `[]`, not an error — the non-null list type means a null would surface as a GraphQL error
- `userWorld` still resolves when the `niche` relation is *not* selected, which is what `requiredColumns: ['userId', 'nicheId']` exists for
- the timeline sums to the districts it is folded into

Cron tests gain a niche-missing case, which also exercises the `uuid[]` binding on the new lookup.

## Verification

Local suite still can't run here (port 5432 held by an unrelated container, and `src/data-source.ts` hardcodes the port), so CI is the check. Lint and `tsc` are clean for the touched files.

Worth noting what this does *not* change: the write path verified in production earlier today is untouched apart from the extra niche lookup. Yesterday's backfill via the cron reconciled exactly (13,581 rows / 6,870 users / 0 skipped, `growth_reads == district_reads`, no ongoing-day leakage), and a second run was correctly inert.