### PR TITLE
feat(feeds): filter a user's upvoted posts by niche

### DIFF
--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -35,6 +35,8 @@ import {
   YouTubePost,
 } from '../src/entity';
 import { PollOption } from '../src/entity/polls/PollOption';
+import { Niche, NicheBucketGroup } from '../src/entity/Niche';
+import { PostNiche } from '../src/entity/PostNiche';
 import { SourceMemberRoles } from '../src/roles';
 import { snotraUserApiClient } from '../src/integrations/snotra/clients';
 import { PersonaliseState } from '../src/integrations/snotra/types';
@@ -4540,8 +4542,8 @@ describe('query feedPreview', () => {
 
 describe('query userUpvotedFeed', () => {
   const QUERY = `
-  query UserUpvotedFeed($userId: ID!, $first: Int, $after: String) {
-    userUpvotedFeed(userId: $userId, first: $first, after: $after) {
+  query UserUpvotedFeed($userId: ID!, $first: Int, $after: String, $niches: [String!]) {
+    userUpvotedFeed(userId: $userId, first: $first, after: $after, niches: $niches) {
       ${feedFields()}
     }
   }
@@ -4589,6 +4591,65 @@ describe('query userUpvotedFeed', () => {
     res.data.userUpvotedFeed.edges.forEach(({ node }) =>
       expect(['p1', 'p3']).toContain(node.id),
     );
+  });
+
+  describe('niches filter', () => {
+    const jsTsId = '3a5b0ff5-5f4e-4b3f-9d2e-1c5a6b7c8d9e';
+    const rustId = '4b6c1aa6-6a5f-4c40-8e3f-2d6b7c8d9e0f';
+
+    beforeEach(async () => {
+      await saveFixtures(con, Niche, [
+        {
+          id: jsTsId,
+          slug: 'js_ts',
+          title: 'JS/TS',
+          bucketGroup: NicheBucketGroup.Ecosystem,
+        },
+        {
+          id: rustId,
+          slug: 'rust',
+          title: 'Rust',
+          bucketGroup: NicheBucketGroup.Ecosystem,
+        },
+      ]);
+      // p1 is JS/TS only, p3 is primarily Rust with JS/TS as its secondary
+      await saveFixtures(con, PostNiche, [
+        { postId: 'p1', nicheId: jsTsId, rank: 1 },
+        { postId: 'p3', nicheId: rustId, rank: 1 },
+        { postId: 'p3', nicheId: jsTsId, rank: 2 },
+      ]);
+    });
+
+    it('should only return upvotes in the given niches', async () => {
+      const res = await client.query(QUERY, {
+        variables: { userId: '2', niches: ['rust'] },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.userUpvotedFeed.edges.map(({ node }) => node.id)).toEqual(
+        ['p3'],
+      );
+    });
+
+    it('should match a secondary niche of a post', async () => {
+      const res = await client.query(QUERY, {
+        variables: { userId: '2', niches: ['js_ts'] },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(
+        res.data.userUpvotedFeed.edges.map(({ node }) => node.id).sort(),
+      ).toEqual(['p1', 'p3']);
+    });
+
+    it('should return nothing for an unknown niche', async () => {
+      const res = await client.query(QUERY, {
+        variables: { userId: '2', niches: ['nope'] },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.userUpvotedFeed.edges).toEqual([]);
+    });
   });
 });
 

--- a/src/common/feedGenerator.ts
+++ b/src/common/feedGenerator.ts
@@ -42,6 +42,8 @@ import { ContentPreference } from '../entity/contentPreference/ContentPreference
 import { ContentPreferenceWord } from '../entity/contentPreference/ContentPreferenceWord';
 import { ContentPreferenceUser } from '../entity/contentPreference/ContentPreferenceUser';
 import { whereNotUserBlocked } from './contentPreference';
+import { Niche } from '../entity/Niche';
+import { PostNiche } from '../entity/PostNiche';
 
 export const WATERCOOLER_ID = 'fd062672-63b7-4a10-87bd-96dcd10e9613';
 
@@ -59,6 +61,26 @@ export const whereTags = (
       [variableAlias]: tags.map((tag) => tag.toLowerCase()),
     })
     .andWhere(`pk."postId" = ${alias}.id`)
+    .getQuery();
+  return `EXISTS${query}`;
+};
+
+/**
+ * Matches posts labeled with any of the given niche slugs, at either rank —
+ * a post's secondary niche is still that post being about that niche.
+ */
+export const whereNiches = (
+  niches: string[],
+  builder: SelectQueryBuilder<Post>,
+  alias: string,
+): string => {
+  const query = builder
+    .subQuery()
+    .select('1')
+    .from(PostNiche, 'pn')
+    .innerJoin(Niche, 'n', 'n.id = pn."nicheId"')
+    .where('n.slug IN (:...niches)', { niches })
+    .andWhere(`pn."postId" = ${alias}.id`)
     .getQuery();
   return `EXISTS${query}`;
 };

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -40,6 +40,7 @@ import {
   tagFeedBuilder,
   toGQLEnum,
   whereKeyword,
+  whereNiches,
   whereTags,
 } from '../common';
 import { isMockEnabled } from '../mocks/common';
@@ -854,6 +855,11 @@ export const typeDefs = /* GraphQL */ `
       Array of supported post types
       """
       supportedTypes: [String!]
+
+      """
+      Only return posts labeled with any of these niche slugs
+      """
+      niches: [String!]
     ): PostConnection!
 
     """
@@ -2294,7 +2300,12 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
         info,
       ),
     userUpvotedFeed: feedResolver(
-      (ctx, { userId }: { userId: string } & FeedArgs, builder, alias) =>
+      (
+        ctx,
+        { userId, niches }: { userId: string; niches?: string[] } & FeedArgs,
+        builder,
+        alias,
+      ) => {
         builder
           .addSelect('up.votedAt', 'votedAt')
           .innerJoin(
@@ -2302,7 +2313,16 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             'up',
             `up."postId" = ${alias}.id AND up."userId" = :author AND vote = :vote`,
             { author: userId, vote: UserVote.Up },
-          ),
+          );
+
+        if (niches?.length) {
+          builder.andWhere((subBuilder) =>
+            whereNiches(niches, subBuilder, alias),
+          );
+        }
+
+        return builder;
+      },
       upvotedPageGenerator,
       applyUpvotedPaging,
       {


### PR DESCRIPTION
Adds an optional `niches: [String!]` argument to `userUpvotedFeed`, taking niche slugs (e.g. `["js_ts", "rust"]`) — the same slugs `userWorld` already returns on its districts, so a client can filter the upvote feed straight from a district.

A post matches if it carries the niche at **either** rank: its secondary niche is still that post being about that niche. Implemented as `whereNiches` in `feedGenerator`, mirroring the existing `whereTags`/`whereKeyword` `EXISTS` pattern; the subquery hits `IDX_post_niche_niche_rank`.

Omitting the argument leaves the feed unchanged.

Local Postgres wasn't available, so the new tests haven't been run locally — CI covers them.

https://claude.ai/code/session_01WovKJQZKbEA8MP3dGJzjzM