### PR TITLE
feat: delegate team member feedback to huginn autopilot

### DIFF
--- a/__tests__/integrations/linear/feedbackIssue.ts
+++ b/__tests__/integrations/linear/feedbackIssue.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.LINEAR_API_KEY;
   delete process.env.LINEAR_FEEDBACK_TEAM_ID;
+  delete process.env.LINEAR_HUGINN_AGENT_ID;
 });
 
 describe('createFeedbackIssue - Client Environment section', () => {
@@ -137,5 +138,59 @@ describe('createFeedbackIssue - Client Environment section', () => {
     expect(description).toContain('### Client Environment');
     expect(description).toContain('| **User Agent** | Mozilla/5.0 |');
     expect(description).not.toContain('| **Viewport** |');
+  });
+});
+
+describe('createFeedbackIssue - huginn autopilot delegation', () => {
+  const baseInput = {
+    feedbackId: 'fb-1',
+    userId: 'user-1',
+    category: 1,
+    description: 'Something is broken',
+    classification: null,
+  };
+
+  it('should delegate team member feedback to huginn with autopilot label', async () => {
+    process.env.LINEAR_HUGINN_AGENT_ID = 'huginn-agent-id';
+
+    await createFeedbackIssue({ ...baseInput, isTeamMember: true });
+
+    expect(mockCreateIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ delegateId: 'huginn-agent-id' }),
+    );
+    expect(mockCreateIssueLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'huginn:autopilot' }),
+    );
+    expect(mockCreateIssue.mock.calls[0][0].labelIds).toContain('label-1');
+  });
+
+  it('should reuse existing autopilot label when present', async () => {
+    process.env.LINEAR_HUGINN_AGENT_ID = 'huginn-agent-id';
+    mockIssueLabels.mockResolvedValue({
+      nodes: [{ id: 'autopilot-label', name: 'huginn:autopilot' }],
+    });
+
+    await createFeedbackIssue({ ...baseInput, isTeamMember: true });
+
+    expect(mockCreateIssue.mock.calls[0][0].labelIds).toContain(
+      'autopilot-label',
+    );
+  });
+
+  it('should not delegate feedback from non-team members', async () => {
+    process.env.LINEAR_HUGINN_AGENT_ID = 'huginn-agent-id';
+
+    await createFeedbackIssue({ ...baseInput, isTeamMember: false });
+
+    expect(mockCreateIssue.mock.calls[0][0].delegateId).toBeUndefined();
+    expect(mockCreateIssueLabel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'huginn:autopilot' }),
+    );
+  });
+
+  it('should not delegate when huginn agent id is not configured', async () => {
+    await createFeedbackIssue({ ...baseInput, isTeamMember: true });
+
+    expect(mockCreateIssue.mock.calls[0][0].delegateId).toBeUndefined();
   });
 });

--- a/__tests__/workers/feedbackClassify.ts
+++ b/__tests__/workers/feedbackClassify.ts
@@ -1,6 +1,7 @@
 import { expectSuccessfulTypedBackground } from '../helpers';
 import worker from '../../src/workers/feedbackClassify';
 import { Feedback, FeedbackStatus } from '../../src/entity/Feedback';
+import { Feature, FeatureType, FeatureValue } from '../../src/entity/Feature';
 import { User } from '../../src/entity';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../../src/db';
@@ -118,6 +119,33 @@ describe('feedbackClassify worker', () => {
           platform: 'MacIntel',
           theme: 'dark',
         },
+        isTeamMember: false,
+      }),
+    );
+  });
+
+  it('should flag team member feedback for huginn delegation', async () => {
+    await con.getRepository(Feature).save({
+      feature: FeatureType.Team,
+      userId: '1',
+      value: FeatureValue.Allow,
+    });
+
+    const feedback = await con.getRepository(Feedback).save({
+      userId: '1',
+      category: 1,
+      description: 'Team member feedback',
+      status: FeedbackStatus.Pending,
+      flags: {},
+    });
+
+    await expectSuccessfulTypedBackground<'api.v1.feedback-created'>(worker, {
+      feedbackId: feedback.id,
+    });
+
+    expect(mockCreateFeedbackIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isTeamMember: true,
       }),
     );
   });

--- a/src/integrations/linear/index.ts
+++ b/src/integrations/linear/index.ts
@@ -57,7 +57,10 @@ interface CreateFeedbackIssueInput {
   clientInfo?: z.infer<typeof feedbackClientInfoSchema> | null;
   classification: FeedbackClassification | null;
   screenshotUrl?: string | null;
+  isTeamMember?: boolean;
 }
+
+export const HUGINN_AUTOPILOT_LABEL = 'huginn:autopilot';
 
 interface CreateFeedbackIssueResult {
   id: string;
@@ -208,6 +211,32 @@ ${screenshotSection}
 `;
 };
 
+const getAutopilotLabelId = async (
+  linearInstance: LinearClient,
+  teamId: string,
+): Promise<string | null> => {
+  try {
+    const existingLabels = await linearInstance.issueLabels({
+      filter: { name: { eqIgnoreCase: HUGINN_AUTOPILOT_LABEL } },
+    });
+
+    const existing = existingLabels.nodes[0];
+    if (existing) {
+      return existing.id;
+    }
+
+    const payload = await linearInstance.createIssueLabel({
+      teamId,
+      name: HUGINN_AUTOPILOT_LABEL,
+      color: '#f59e0b',
+    });
+    const label = await payload.issueLabel;
+    return label ? label.id : null;
+  } catch {
+    return null;
+  }
+};
+
 export const createFeedbackIssue = async (
   input: CreateFeedbackIssueInput,
 ): Promise<CreateFeedbackIssueResult | null> => {
@@ -215,6 +244,7 @@ export const createFeedbackIssue = async (
   if (!client || !client.instance) {
     return null;
   }
+  const linearInstance = client.instance;
 
   const teamId = process.env.LINEAR_FEEDBACK_TEAM_ID;
   if (!teamId) {
@@ -234,13 +264,39 @@ export const createFeedbackIssue = async (
           return `[Feedback] ${categoryDisplay}: ${firstLine.slice(0, 80)}${firstLine.length > 80 ? '...' : ''}`;
         })();
 
-    const issuePayload = await client.instance!.createIssue({
+    const huginnAgentId = process.env.LINEAR_HUGINN_AGENT_ID;
+    const delegateToHuginn = Boolean(input.isTeamMember && huginnAgentId);
+
+    const labelIds = await getOrCreateLabels(linearInstance, teamId, input);
+
+    if (delegateToHuginn) {
+      const autopilotLabelId = await getAutopilotLabelId(
+        linearInstance,
+        teamId,
+      );
+      if (autopilotLabelId) {
+        labelIds.push(autopilotLabelId);
+      }
+    }
+
+    // delegateId is supported by the live Linear API but missing from the
+    // pinned SDK's IssueCreateInput typings; delegating to the Huginn agent
+    // creates an agent session which starts its autopilot flow
+    const issueInput: Parameters<LinearClient['createIssue']>[0] & {
+      delegateId?: string;
+    } = {
       teamId,
       title,
       description,
       priority,
-      labelIds: await getOrCreateLabels(client.instance!, teamId, input),
-    });
+      labelIds,
+    };
+
+    if (delegateToHuginn) {
+      issueInput.delegateId = huginnAgentId;
+    }
+
+    const issuePayload = await linearInstance.createIssue(issueInput);
 
     const issue = await issuePayload.issue;
     if (!issue) {

--- a/src/workers/feedbackClassify.ts
+++ b/src/workers/feedbackClassify.ts
@@ -1,12 +1,14 @@
 import { TypedWorker } from './worker';
 import { Feedback, FeedbackStatus } from '../entity/Feedback';
+import { Feature, FeatureType, FeatureValue } from '../entity/Feature';
 import { getBragiClient } from '../integrations/bragi';
 import { createFeedbackIssue } from '../integrations/linear';
 
 /**
  * Worker that processes new feedback submissions:
  * 1. Calls Bragi for classification
- * 2. Creates Linear issue with classification metadata
+ * 2. Creates Linear issue with classification metadata; feedback from team
+ *    members is delegated to the Huginn agent in autopilot mode
  * 3. Updates feedback record with classification and Linear issue info
  *
  * Status is set to Accepted, which triggers a CDC event that the
@@ -70,6 +72,14 @@ const worker: TypedWorker<'api.v1.feedback-created'> = {
           }
         : null;
 
+      const isTeamMember = await con.getRepository(Feature).exists({
+        where: {
+          userId: feedback.userId,
+          feature: FeatureType.Team,
+          value: FeatureValue.Allow,
+        },
+      });
+
       const issue = await createFeedbackIssue({
         feedbackId,
         userId: feedback.userId,
@@ -80,6 +90,7 @@ const worker: TypedWorker<'api.v1.feedback-created'> = {
         clientInfo: feedback.clientInfo,
         classification,
         screenshotUrl: feedback.screenshotUrl,
+        isTeamMember,
       });
 
       if (!issue) {


### PR DESCRIPTION
## What
When in-app feedback is submitted by a **team member**, the Linear issue created by the `feedbackClassify` worker is now:
- tagged with the `huginn:autopilot` label (found case-insensitively, created on the feedback team if missing)
- **delegated to the Huginn Linear agent** via `delegateId` at issue creation

Delegation fires Huginn's agent-session webhook, and the autopilot label makes it skip planning/approval and go straight to execution.

## How
- `feedbackClassify` worker checks the `feature` table (`feature='team'`, `value=1`) for the feedback author and passes `isTeamMember` to `createFeedbackIssue`
- `delegateId` is supported by the live Linear API but missing from our pinned `@linear/sdk` 28 typings — the SDK passes the input object verbatim as GraphQL variables, so it's typed via a local intersection instead of an SDK upgrade
- Non-team feedback and missing-config cases are unchanged

## Config required before this does anything
Add `LINEAR_HUGINN_AGENT_ID` (Huginn's Linear agent viewer/app-user id) to the API env in Pulumi config. Without it, delegation is silently skipped.

## Testing
- `pnpm run build` + `pnpm run lint` pass
- New integration tests for delegation (team member, non-team, missing env, existing label reuse) and worker-level `isTeamMember` resolution — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)