### PR TITLE
feat: seed tag-chip feeds from clustered topics

### DIFF
--- a/__tests__/common/seedTagChipFeeds.ts
+++ b/__tests__/common/seedTagChipFeeds.ts
@@ -13,16 +13,23 @@ import {
 } from '../../src/entity/contentPreference/types';
 import { feedClient } from '../../src/integrations/feed/generators';
 import { seedTagChipFeedsIfNeeded } from '../../src/common/seedTagChipFeeds';
+import { TagChipSeedStrategy } from '../../src/types';
+import { remoteConfig } from '../../src/remoteConfig';
 
 jest.mock('../../src/integrations/feed/generators', () => ({
   ...jest.requireActual('../../src/integrations/feed/generators'),
   feedClient: {
     getUserTags: jest.fn(),
+    getTopics: jest.fn(),
   },
 }));
 
 const getUserTagsMock = feedClient.getUserTags as jest.MockedFunction<
   typeof feedClient.getUserTags
+>;
+
+const getTopicsMock = feedClient.getTopics as jest.MockedFunction<
+  typeof feedClient.getTopics
 >;
 
 let con: DataSource;
@@ -33,6 +40,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   getUserTagsMock.mockReset();
+  getTopicsMock.mockReset();
   await saveFixtures(con, User, usersFixture);
   // main feed (id === userId) — ContentPreferenceKeyword.feedId FKs to feed.id
   await saveFixtures(con, Feed, [{ id: '1', userId: '1' }]);
@@ -228,5 +236,184 @@ describe('seedTagChipFeedsIfNeeded', () => {
 
     const feeds = await getChipFeeds('1');
     expect(feeds.map((f) => f.flags.name)).toEqual(['Node.js']);
+  });
+
+  it('records the strategy that seeded the user', async () => {
+    getUserTagsMock.mockResolvedValue(['javascript']);
+
+    await seedTagChipFeedsIfNeeded({ con, userId: '1', limit: 2 });
+
+    const user = await con.getRepository(User).findOneByOrFail({ id: '1' });
+    expect(user.flags?.tagChipFeedsSeedStrategy).toEqual(
+      TagChipSeedStrategy.V1,
+    );
+  });
+
+  describe('V2 strategy', () => {
+    const saveOnboardingFollows = (tags: string[]) =>
+      saveFixtures(
+        con,
+        ContentPreferenceKeyword,
+        tags.map((tag) => ({
+          feedId: '1',
+          keywordId: tag,
+          referenceId: tag,
+          status: ContentPreferenceStatus.Follow,
+          type: ContentPreferenceType.Keyword,
+          userId: '1',
+        })),
+      );
+
+    const seedV2 = (limit = 5) =>
+      seedTagChipFeedsIfNeeded({
+        con,
+        userId: '1',
+        limit,
+        strategy: TagChipSeedStrategy.V2,
+      });
+
+    const getFeedTags = (feedId: string) =>
+      con
+        .getRepository(FeedTag)
+        .find({ where: { feedId }, order: { tag: 'ASC' } });
+
+    beforeEach(() => {
+      remoteConfig.vars.tagChipTopicsClusterThreshold = 0.4;
+    });
+
+    afterEach(() => {
+      remoteConfig.vars.tagChipTopicsClusterThreshold = undefined;
+    });
+
+    it('seeds one multi-tag feed per clustered topic', async () => {
+      await saveOnboardingFollows(['javascript', 'nodejs', 'webdev']);
+      getTopicsMock.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript', 'nodejs'] },
+        { label: 'webdev', tags: ['webdev'] },
+      ]);
+
+      await seedV2();
+
+      const feeds = await getChipFeeds('1');
+      expect(feeds.map((f) => f.flags.name).sort()).toEqual([
+        'JavaScript',
+        'webdev',
+      ]);
+
+      const [grouped] = feeds.filter((f) => f.flags.name === 'JavaScript');
+      expect((await getFeedTags(grouped.id)).map((t) => t.tag)).toEqual([
+        'javascript',
+        'nodejs',
+      ]);
+
+      const prefs = await con
+        .getRepository(ContentPreferenceKeyword)
+        .findBy({ feedId: grouped.id });
+      expect(prefs.map((p) => p.keywordId).sort()).toEqual([
+        'javascript',
+        'nodejs',
+      ]);
+      expect(
+        prefs.every((p) => p.status === ContentPreferenceStatus.Follow),
+      ).toBe(true);
+    });
+
+    it('sends every non-blocked onboarding tag plus the configured threshold', async () => {
+      await saveOnboardingFollows(['javascript', 'nodejs']);
+      await saveFixtures(con, ContentPreferenceKeyword, [
+        {
+          feedId: '1',
+          keywordId: 'webdev',
+          referenceId: 'webdev',
+          status: ContentPreferenceStatus.Blocked,
+          type: ContentPreferenceType.Keyword,
+          userId: '1',
+        },
+      ]);
+      getTopicsMock.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript', 'nodejs'] },
+      ]);
+
+      await seedV2(2);
+
+      expect(getTopicsMock).toHaveBeenCalledWith(['javascript', 'nodejs'], 0.4);
+      expect(getUserTagsMock).not.toHaveBeenCalled();
+    });
+
+    it('caps the seeded topics at the limit', async () => {
+      await saveOnboardingFollows(['javascript', 'nodejs', 'webdev']);
+      getTopicsMock.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript'] },
+        { label: 'nodejs', tags: ['nodejs'] },
+        { label: 'webdev', tags: ['webdev'] },
+      ]);
+
+      await seedV2(2);
+
+      expect(await getChipFeeds('1')).toHaveLength(2);
+    });
+
+    it('drops topics with duplicate labels or no tags', async () => {
+      await saveOnboardingFollows(['javascript', 'nodejs']);
+      getTopicsMock.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript'] },
+        { label: 'javascript', tags: ['nodejs'] },
+        { label: 'nodejs', tags: [] },
+      ]);
+
+      await seedV2();
+
+      const feeds = await getChipFeeds('1');
+      expect(feeds.map((f) => f.flags.name)).toEqual(['JavaScript']);
+    });
+
+    it('falls back to the V1 path when clustering fails', async () => {
+      await saveOnboardingFollows(['javascript']);
+      getTopicsMock.mockRejectedValue(new Error('boom'));
+      getUserTagsMock.mockResolvedValue(['nodejs']);
+
+      await seedV2(2);
+
+      const feeds = await getChipFeeds('1');
+      expect(feeds.map((f) => f.flags.name)).toEqual(['Node.js']);
+      expect(await getFeedTags(feeds[0].id)).toHaveLength(1);
+    });
+
+    it('falls back to the V1 path when clustering returns nothing', async () => {
+      await saveOnboardingFollows(['javascript']);
+      getTopicsMock.mockResolvedValue([]);
+      getUserTagsMock.mockResolvedValue(['nodejs']);
+
+      await seedV2(2);
+
+      expect((await getChipFeeds('1')).map((f) => f.flags.name)).toEqual([
+        'Node.js',
+      ]);
+    });
+
+    it('falls back to the V1 path when the user has no onboarding tags', async () => {
+      getUserTagsMock.mockResolvedValue(['javascript']);
+
+      await seedV2(2);
+
+      expect(getTopicsMock).not.toHaveBeenCalled();
+      expect((await getChipFeeds('1')).map((f) => f.flags.name)).toEqual([
+        'JavaScript',
+      ]);
+    });
+
+    it('records the V2 strategy on the user', async () => {
+      await saveOnboardingFollows(['javascript']);
+      getTopicsMock.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript'] },
+      ]);
+
+      await seedV2();
+
+      const user = await con.getRepository(User).findOneByOrFail({ id: '1' });
+      expect(user.flags?.tagChipFeedsSeedStrategy).toEqual(
+        TagChipSeedStrategy.V2,
+      );
+    });
   });
 });

--- a/__tests__/feeds.ts
+++ b/__tests__/feeds.ts
@@ -72,7 +72,7 @@ import createOrGetConnection from '../src/db';
 import { randomUUID } from 'crypto';
 import { usersFixture } from './fixture/user';
 import { base64 } from 'graphql-relay/utils/base64';
-import { maxFeedsPerUser, UserVote } from '../src/types';
+import { maxFeedsPerUser, TagChipSeedStrategy, UserVote } from '../src/types';
 import { SubmissionFailErrorMessage } from '../src/errors';
 import { baseFeedConfig, FeedConfigName } from '../src/integrations/feed';
 import { feedClient } from '../src/integrations/feed/generators';
@@ -4999,6 +4999,89 @@ describe('query feedList', () => {
         .getMany();
       expect(chipFeeds).toHaveLength(1);
       expect(getUserTagsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tagChipSeedStrategy arg', () => {
+    const QUERY_WITH_STRATEGY = `
+      query FeedList(
+        $includeTagChipFeeds: Boolean
+        $tagChipSeedStrategy: TagChipSeedStrategy
+      ) {
+        feedList(
+          includeTagChipFeeds: $includeTagChipFeeds
+          tagChipSeedStrategy: $tagChipSeedStrategy
+        ) {
+          edges {
+            node {
+              flags {
+                name
+                origin
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    let getUserTagsSpy: jest.SpyInstance;
+    let getTopicsSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getUserTagsSpy = jest
+        .spyOn(feedClient, 'getUserTags')
+        .mockResolvedValue([]);
+      getTopicsSpy = jest.spyOn(feedClient, 'getTopics').mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      getUserTagsSpy.mockRestore();
+      getTopicsSpy.mockRestore();
+    });
+
+    it('defaults to V1 when omitted', async () => {
+      getUserTagsSpy.mockResolvedValue(['javascript']);
+
+      const res = await client.query(QUERY_WITH_STRATEGY, {
+        variables: { includeTagChipFeeds: true },
+      });
+      expect(res.errors).toBeFalsy();
+
+      expect(getTopicsSpy).not.toHaveBeenCalled();
+      const user = await con.getRepository(User).findOneByOrFail({ id: '1' });
+      expect(user.flags?.tagChipFeedsSeedStrategy).toEqual(
+        TagChipSeedStrategy.V1,
+      );
+    });
+
+    it('seeds clustered topics when V2', async () => {
+      await con.getRepository(ContentPreferenceKeyword).save({
+        feedId: '1',
+        keywordId: 'javascript',
+        referenceId: 'javascript',
+        status: ContentPreferenceStatus.Follow,
+        type: ContentPreferenceType.Keyword,
+        userId: '1',
+      });
+      getTopicsSpy.mockResolvedValue([
+        { label: 'javascript', tags: ['javascript'] },
+      ]);
+
+      const res = await client.query(QUERY_WITH_STRATEGY, {
+        variables: {
+          includeTagChipFeeds: true,
+          tagChipSeedStrategy: TagChipSeedStrategy.V2,
+        },
+      });
+      expect(res.errors).toBeFalsy();
+
+      expect(getTopicsSpy).toHaveBeenCalled();
+      expect(getUserTagsSpy).not.toHaveBeenCalled();
+
+      const seededNames = res.data.feedList.edges
+        .filter((e) => e.node.flags.origin === FeedOrigin.TagChip)
+        .map((e) => e.node.flags.name);
+      expect(seededNames).toEqual(['javascript']);
     });
   });
 });

--- a/__tests__/integrations/feed.ts
+++ b/__tests__/integrations/feed.ts
@@ -245,6 +245,56 @@ describe('FeedClient', () => {
       expect(tags).toEqual([]);
     });
   });
+
+  describe('getTopics', () => {
+    const topics = [
+      { label: 'docker', tags: ['docker', 'kubernetes'] },
+      { label: 'react', tags: ['react'] },
+    ];
+
+    it('should return the clustered topics from the feed service', async () => {
+      nock(url)
+        .post('/api/topics', {
+          allowed_tags: ['kubernetes', 'docker', 'react'],
+          cluster_threshold: 0.4,
+        })
+        .reply(200, { data: topics });
+
+      const feedClient = new FeedClient(url);
+      expect(
+        await feedClient.getTopics(['kubernetes', 'docker', 'react'], 0.4),
+      ).toEqual(topics);
+    });
+
+    it('should omit the threshold when not provided', async () => {
+      nock(url)
+        .post('/api/topics', { allowed_tags: ['react'] })
+        .reply(200, { data: [{ label: 'react', tags: ['react'] }] });
+
+      const feedClient = new FeedClient(url);
+      expect(await feedClient.getTopics(['react'])).toEqual([
+        { label: 'react', tags: ['react'] },
+      ]);
+    });
+
+    it('should return an empty array when data is missing', async () => {
+      nock(url)
+        .post('/api/topics', { allowed_tags: ['react'] })
+        .reply(200, {});
+
+      const feedClient = new FeedClient(url);
+      expect(await feedClient.getTopics(['react'])).toEqual([]);
+    });
+
+    it('should degrade to an empty list when the feed service errors', async () => {
+      nock(url)
+        .post('/api/topics', { allowed_tags: ['react'] })
+        .reply(500, {});
+
+      const feedClient = new FeedClient(url);
+      expect(await feedClient.getTopics(['react'])).toEqual([]);
+    });
+  });
 });
 
 describe('connectionFromNodes with staleCursor', () => {

--- a/src/common/channelDigest/headlineFollows.ts
+++ b/src/common/channelDigest/headlineFollows.ts
@@ -1,7 +1,6 @@
 import type { DataSource, EntityManager } from 'typeorm';
-import { In, Not } from 'typeorm';
+import { In } from 'typeorm';
 import { randomUUID } from 'crypto';
-import { ContentPreferenceKeyword } from '../../entity/contentPreference/ContentPreferenceKeyword';
 import { ContentPreferenceSource } from '../../entity/contentPreference/ContentPreferenceSource';
 import { ContentPreferenceStatus } from '../../entity/contentPreference/types';
 import { ChannelDigest } from '../../entity/ChannelDigest';
@@ -12,6 +11,7 @@ import { SourceMemberRoles } from '../../roles';
 import { queryReadReplica } from '../queryReadReplica';
 import { remoteConfig } from '../../remoteConfig';
 import { getChannelDigestSourceIds } from './definitions';
+import { getUserOnboardingTags } from '../feed';
 
 const defaultHeadlineChannelMinPosts = 10;
 
@@ -35,25 +35,6 @@ const markBackfilled = async ({
     .execute();
 
   return result.raw.length > 0;
-};
-
-const getUserOnboardingTags = async ({
-  con,
-  userId,
-}: {
-  con: DataSource;
-  userId: string;
-}): Promise<string[]> => {
-  const preferences = await con.getRepository(ContentPreferenceKeyword).find({
-    select: ['referenceId'],
-    where: {
-      userId,
-      feedId: userId,
-      status: Not(ContentPreferenceStatus.Blocked),
-    },
-  });
-
-  return preferences.map((preference) => preference.referenceId);
 };
 
 const resolveHeadlineChannelSourcesForUser = async ({

--- a/src/common/feed.ts
+++ b/src/common/feed.ts
@@ -1,7 +1,31 @@
-import { DataSource, EntityManager } from 'typeorm';
+import { DataSource, EntityManager, Not } from 'typeorm';
 import { Feed, FeedOrigin } from '../entity/Feed';
 import { ValidationError } from 'apollo-server-errors';
 import { SubmissionFailErrorMessage } from '../errors';
+import { ContentPreferenceKeyword } from '../entity/contentPreference/ContentPreferenceKeyword';
+import { ContentPreferenceStatus } from '../entity/contentPreference/types';
+
+export const getUserOnboardingTags = async ({
+  con,
+  userId,
+  limit,
+}: {
+  con: DataSource | EntityManager;
+  userId: string;
+  limit?: number;
+}): Promise<string[]> => {
+  const preferences = await con.getRepository(ContentPreferenceKeyword).find({
+    select: ['referenceId'],
+    where: {
+      userId,
+      feedId: userId,
+      status: Not(ContentPreferenceStatus.Blocked),
+    },
+    ...(typeof limit === 'number' && { take: limit }),
+  });
+
+  return preferences.map((preference) => preference.referenceId);
+};
 
 export const countUserOwnedFeeds = ({
   con,

--- a/src/common/seedTagChipFeeds.ts
+++ b/src/common/seedTagChipFeeds.ts
@@ -10,11 +10,13 @@ import {
   ContentPreferenceType,
 } from '../entity/contentPreference/types';
 import { feedClient } from '../integrations/feed/generators';
+import type { FeedTopic } from '../integrations/feed/types';
 import { queryReadReplica } from './queryReadReplica';
 import { generateShortId } from '../ids';
 import { logger } from '../logger';
-import { maxFeedsPerUser } from '../types';
-import { countUserOwnedFeeds } from './feed';
+import { maxFeedsPerUser, TagChipSeedStrategy } from '../types';
+import { countUserOwnedFeeds, getUserOnboardingTags } from './feed';
+import { remoteConfig } from '../remoteConfig';
 
 export const TAG_CHIP_FEED_LIMIT = 5;
 
@@ -64,9 +66,11 @@ const resolveLabel = async ({
 const reserveSeedSlot = async ({
   con,
   userId,
+  strategy,
 }: {
   con: DataSource;
   userId: string;
+  strategy: TagChipSeedStrategy;
 }): Promise<boolean> => {
   const result = await con
     .createQueryBuilder()
@@ -76,7 +80,10 @@ const reserveSeedSlot = async ({
     .andWhere(`(flags->>'tagChipFeedsSeededAt') IS NULL`)
     .setParameter(
       'seededJson',
-      JSON.stringify({ tagChipFeedsSeededAt: new Date().toISOString() }),
+      JSON.stringify({
+        tagChipFeedsSeededAt: new Date().toISOString(),
+        tagChipFeedsSeedStrategy: strategy,
+      }),
     )
     .execute();
 
@@ -106,43 +113,78 @@ const getSeedTagValues = async ({
   }
 
   if (!values.length) {
-    const followed = await con.getRepository(ContentPreferenceKeyword).find({
-      select: ['keywordId'],
-      where: {
-        userId,
-        feedId: userId,
-        status: ContentPreferenceStatus.Follow,
-      },
-      take: limit,
-    });
-    values = dedupeKeepOrder(followed.map((pref) => pref.keywordId)).slice(
-      0,
-      limit,
-    );
+    values = dedupeKeepOrder(
+      await getUserOnboardingTags({ con, userId, limit }),
+    ).slice(0, limit);
   }
 
   return values;
 };
 
+const getSeedTopics = async ({
+  con,
+  userId,
+  limit,
+}: {
+  con: DataSource;
+  userId: string;
+  limit: number;
+}): Promise<FeedTopic[]> => {
+  const tags = dedupeKeepOrder(await getUserOnboardingTags({ con, userId }));
+
+  if (!tags.length) {
+    return [];
+  }
+
+  const topics = await feedClient.getTopics(
+    tags,
+    remoteConfig.vars.tagChipTopicsClusterThreshold,
+  );
+  const seenLabels = new Set<string>();
+
+  return topics
+    .map(({ label, tags: topicTags }) => ({
+      label,
+      tags: dedupeKeepOrder(topicTags ?? []),
+    }))
+    .filter(({ label, tags: topicTags }) => {
+      if (!label || !topicTags.length || seenLabels.has(label)) {
+        return false;
+      }
+
+      seenLabels.add(label);
+
+      return true;
+    })
+    .slice(0, limit);
+};
+
 /**
- * Lazily seeds one custom feed per tag (feedClient.getUserTags, falling back to
- * the user's onboarding follows) the first time the caller opts in via
- * `includeTagChipFeeds`. Gated by
- * `User.flags.tagChipFeedsSeededAt`: set atomically before any seed work
- * happens, so a second call is a guaranteed no-op even if the first failed
- * mid-flight. Skipped if the user is at the `maxFeedsPerUser` cap (no chip
- * feeds get written; flag still marked so we don't retry on every read).
+ * Lazily seeds the caller's tag-chip feeds the first time they opt in via
+ * `includeTagChipFeeds`. Gated by `User.flags.tagChipFeedsSeededAt`: set
+ * atomically before any seed work happens, so a second call is a guaranteed
+ * no-op even if the first failed mid-flight. Skipped if the user is at the
+ * `maxFeedsPerUser` cap (no chip feeds get written; flag still marked so we
+ * don't retry on every read).
+ *
+ * Strategy `V1` (default) seeds one single-tag feed per tag from
+ * `feedClient.getUserTags`, falling back to the user's onboarding tags.
+ * Strategy `V2` clusters those onboarding tags into topics via
+ * `feedClient.getTopics` and seeds one multi-tag feed per topic, falling back to
+ * `V1` when clustering is unavailable or yields nothing.
  */
 export const seedTagChipFeedsIfNeeded = async ({
   con,
   userId,
   limit = TAG_CHIP_FEED_LIMIT,
+  strategy = TagChipSeedStrategy.V1,
 }: {
   con: DataSource;
   userId: string;
   limit?: number;
+  strategy?: TagChipSeedStrategy;
 }): Promise<boolean> => {
-  const reserved = await reserveSeedSlot({ con, userId });
+  const reserved = await reserveSeedSlot({ con, userId, strategy });
   if (!reserved) {
     return false;
   }
@@ -156,37 +198,60 @@ export const seedTagChipFeedsIfNeeded = async ({
     return false;
   }
 
-  const values = await getSeedTagValues({
-    con,
-    userId,
-    limit: effectiveLimit,
-  });
-  if (!values.length) {
+  let topics: FeedTopic[] = [];
+
+  if (strategy === TagChipSeedStrategy.V2) {
+    try {
+      topics = await getSeedTopics({ con, userId, limit: effectiveLimit });
+    } catch (err) {
+      logger.error(
+        { err, userId },
+        'feedClient.getTopics failed; tag-chip seeding will fall back to single-tag feeds',
+      );
+    }
+  }
+
+  if (!topics.length) {
+    const values = await getSeedTagValues({
+      con,
+      userId,
+      limit: effectiveLimit,
+    });
+
+    topics = values.map((value) => ({ label: value, tags: [value] }));
+  }
+
+  if (!topics.length) {
     return false;
   }
 
-  const labelByValue = await resolveLabel({ con, values });
+  const labelByValue = await resolveLabel({
+    con,
+    values: topics.map(({ label }) => label),
+  });
 
   await con.transaction(async (manager) => {
-    for (const value of values) {
+    for (const topic of topics) {
       const feedId = await generateShortId();
       await manager.getRepository(Feed).save({
         id: feedId,
         userId,
         flags: {
-          name: labelByValue.get(value) || value,
+          name: labelByValue.get(topic.label) || topic.label,
           origin: FeedOrigin.TagChip,
         },
       });
-      await manager.getRepository(ContentPreferenceKeyword).save({
-        userId,
-        feedId,
-        referenceId: value,
-        keywordId: value,
-        status: ContentPreferenceStatus.Follow,
-        type: ContentPreferenceType.Keyword,
-      });
-      await manager.getRepository(FeedTag).save({ feedId, tag: value });
+      for (const tag of topic.tags) {
+        await manager.getRepository(ContentPreferenceKeyword).save({
+          userId,
+          feedId,
+          referenceId: tag,
+          keywordId: tag,
+          status: ContentPreferenceStatus.Follow,
+          type: ContentPreferenceType.Keyword,
+        });
+        await manager.getRepository(FeedTag).save({ feedId, tag });
+      }
     }
   });
 

--- a/src/entity/user/User.ts
+++ b/src/entity/user/User.ts
@@ -10,7 +10,7 @@ import {
   PrimaryColumn,
 } from 'typeorm';
 import { DayOfWeek, DEFAULT_TIMEZONE, DEFAULT_WEEK_START } from '../../common';
-import { ContentLanguage, CoresRole } from '../../types';
+import { ContentLanguage, CoresRole, TagChipSeedStrategy } from '../../types';
 import type { Post } from '../posts/Post';
 import type { DevCard } from '../DevCard';
 import type { UserStreak } from './UserStreak';
@@ -56,6 +56,7 @@ export type UserFlags = Partial<{
     updatedAt: string;
   };
   tagChipFeedsSeededAt: string | null;
+  tagChipFeedsSeedStrategy: TagChipSeedStrategy | null;
   // Current cloud provider from campaign onboarding (e.g. aws/gcp/azure/other/
   // none). Stored here rather than a column since it's optional campaign data.
   cloudProvider: string | null;

--- a/src/integrations/feed/clients.ts
+++ b/src/integrations/feed/clients.ts
@@ -1,4 +1,10 @@
-import { FeedConfig, FeedResponse, IFeedClient, BriefingModel } from './types';
+import {
+  FeedConfig,
+  FeedResponse,
+  FeedTopic,
+  IFeedClient,
+  BriefingModel,
+} from './types';
 import fetch, { RequestInit } from 'node-fetch';
 import { fetchOptions as globalFetchOptions } from '../../http';
 import { fetchParse } from '../retry';
@@ -9,6 +15,7 @@ import type { JsonValue } from '@bufbuild/protobuf';
 import { ServiceError } from '../../errors';
 import { isMockEnabled } from '../../mocks/common';
 import { mockUserTagsResponse } from '../../mocks/feed/userTags';
+import { mockTopicsResponse } from '../../mocks/feed/topics';
 
 type RawFeedDataItem = {
   post_id: string;
@@ -188,6 +195,33 @@ export class FeedClient implements IFeedClient, IGarmrClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ user_id: userId, limit }),
+      }),
+    );
+
+    return result?.data ?? [];
+  }
+
+  async getTopics(
+    allowedTags: string[],
+    clusterThreshold?: number,
+  ): Promise<FeedTopic[]> {
+    if (isMockEnabled()) {
+      return mockTopicsResponse(allowedTags);
+    }
+
+    const result = await this.garmr.execute(() =>
+      fetchParse<{ data: FeedTopic[] }>(`${this.url}/api/topics`, {
+        ...this.fetchOptions,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          allowed_tags: allowedTags,
+          ...(typeof clusterThreshold === 'number' && {
+            cluster_threshold: clusterThreshold,
+          }),
+        }),
       }),
     );
 

--- a/src/integrations/feed/types.ts
+++ b/src/integrations/feed/types.ts
@@ -22,6 +22,11 @@ export type FeedResponse = {
   staleCursor?: boolean; // True when feed cache was regenerated and cursor became stale
 };
 
+export type FeedTopic = {
+  label: string;
+  tags: string[];
+};
+
 export const isFeedResponseHighlightItem = (
   item: FeedResponseItem,
 ): item is FeedResponseHighlightItem => item.type === 'highlight';

--- a/src/mocks/feed/topics.ts
+++ b/src/mocks/feed/topics.ts
@@ -1,0 +1,15 @@
+import type { FeedTopic } from '../../integrations/feed/types';
+
+const MOCK_CLUSTER_SIZE = 2;
+
+export const mockTopicsResponse = (allowedTags: string[]): FeedTopic[] => {
+  const topics: FeedTopic[] = [];
+
+  for (let i = 0; i < allowedTags.length; i += MOCK_CLUSTER_SIZE) {
+    const tags = allowedTags.slice(i, i + MOCK_CLUSTER_SIZE);
+
+    topics.push({ label: tags[0], tags });
+  }
+
+  return topics;
+};

--- a/src/remoteConfig.ts
+++ b/src/remoteConfig.ts
@@ -69,6 +69,7 @@ export type RemoteConfigValue = {
   headlineChannelMinPosts: number;
   excludedMarketingCta: string[];
   personalContextEnabled: boolean;
+  tagChipTopicsClusterThreshold: number;
 };
 
 class RemoteConfig {

--- a/src/schema/feeds.ts
+++ b/src/schema/feeds.ts
@@ -86,7 +86,12 @@ import {
   ForbiddenError,
   ValidationError,
 } from 'apollo-server-errors';
-import { DAILY_DROP_HOUR, maxFeedsPerUser, UserVote } from '../types';
+import {
+  DAILY_DROP_HOUR,
+  maxFeedsPerUser,
+  TagChipSeedStrategy,
+  UserVote,
+} from '../types';
 import { createDatePageGenerator } from '../common/datePageGenerator';
 import { generateShortId } from '../ids';
 import { SubmissionFailErrorMessage } from '../errors';
@@ -207,6 +212,8 @@ export const typeDefs = /* GraphQL */ `
   ${toGQLEnum(FeedOrderBy, 'FeedOrderBy')}
 
   ${toGQLEnum(FeedType, 'FeedType')}
+
+  ${toGQLEnum(TagChipSeedStrategy, 'TagChipSeedStrategy')}
 
   input FeedAdvancedSettingsInput {
     """
@@ -1058,6 +1065,14 @@ export const typeDefs = /* GraphQL */ `
       (e.g. behind a GrowthBook rollout flag).
       """
       includeTagChipFeeds: Boolean = false
+      """
+      Which source seeds the caller's tag-chip feeds on their first opted-in
+      read. V1 seeds one single-tag feed per tag from the feed service. V2
+      clusters the caller's onboarding tags into topics and seeds one multi-tag
+      feed per topic. Client-controlled so the two can be A/B tested; only read
+      on the first seed and inert afterwards.
+      """
+      tagChipSeedStrategy: TagChipSeedStrategy = V1
     ): FeedConnection! @auth
 
     """
@@ -2526,7 +2541,10 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       ctx.getRepository(Persona).find({ order: { sortOrder: 'ASC' } }),
     feedList: async (
       source,
-      args: ConnectionArguments & { includeTagChipFeeds?: boolean },
+      args: ConnectionArguments & {
+        includeTagChipFeeds?: boolean;
+        tagChipSeedStrategy?: TagChipSeedStrategy;
+      },
       ctx: AuthContext,
       info,
     ): Promise<Connection<GQLFeed>> => {
@@ -2539,6 +2557,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
           didSeed = await seedTagChipFeedsIfNeeded({
             con: ctx.con,
             userId: ctx.userId,
+            strategy: args.tagChipSeedStrategy,
           });
         } catch (err) {
           ctx.log.error(

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,11 @@ export enum UserVoteEntity {
 
 export const maxFeedsPerUser = 35;
 
+export enum TagChipSeedStrategy {
+  V1 = 'V1',
+  V2 = 'V2',
+}
+
 export const maxBookmarksPerMutation = 10;
 
 export const RECOMMENDED_TAGS_LIMIT = 5;


### PR DESCRIPTION
Adds a second tag-chip seeding strategy behind a client-controlled feedList(tagChipSeedStrategy:) arg so the two can be A/B tested. V1 is today's behavior (one feed per tag from /api/user_tags) and stays the default; V2 clusters the user's onboarding tags through the feed service's new /api/topics endpoint and seeds one multi-tag feed per topic.

- FeedClient.getTopics + mock so MOCK_EXTERNAL_SERVICES still works locally
- cluster_threshold read from remoteConfig, omitted when unset so the service default applies
- getUserOnboardingTags moved out of channelDigest into common/feed and shared by both strategies
- strategy recorded on User.flags.tagChipFeedsSeedStrategy so the arms are segmentable after the fact
- V2 degrades to V1 when the user has no onboarding tags or clustering fails; seeding still never throws into the resolver

Seeding stays one-shot per user, so the experiment buckets users at their first opted-in read and already-seeded users are untouched.