### PR TITLE
feat(world): store a share-card plate for a user's world

### DIFF
--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -17,6 +17,7 @@ export enum UploadPreset {
   Organization = 'organization',
   ToolIcon = 'tool_icon',
   WorkspacePhoto = 'workspace_photo',
+  WorldPlate = 'world_plate',
 }
 
 interface OptionalProps {

--- a/src/common/cloudinary.ts
+++ b/src/common/cloudinary.ts
@@ -17,7 +17,6 @@ export enum UploadPreset {
   Organization = 'organization',
   ToolIcon = 'tool_icon',
   WorkspacePhoto = 'workspace_photo',
-  WorldPlate = 'world_plate',
 }
 
 interface OptionalProps {
@@ -119,14 +118,15 @@ export const uploadLogoFromUrl = async (
 
 export const uploadFile = (
   name: string,
-  preset: UploadPreset,
+  /** Null uploads without one: a signed upload needs no preset to succeed. */
+  preset: UploadPreset | null,
   stream: Readable,
 ): Promise<UploadResult> =>
   new Promise((resolve, reject) => {
     const outStream = cloudinary.v2.uploader.upload_stream(
       {
         public_id: name,
-        upload_preset: preset,
+        ...(preset && { upload_preset: preset }),
       },
       (err, callResult) => {
         if (err) {
@@ -172,6 +172,14 @@ export const uploadProfileCover: UploadFn = (userId, stream) =>
     UploadPreset.ProfileCover,
     stream,
   );
+
+/**
+ * No preset: a plate needs no transformation of its own, and a signed upload
+ * does not require one. The public id is per user, so a new capture replaces
+ * the previous plate instead of accumulating one asset per save.
+ */
+export const uploadWorldPlate: UploadFn = (userId, stream) =>
+  uploadFile(`world_plate_${userId}`, null, stream);
 
 export const uploadToolIcon: UploadFn = (toolId, stream) =>
   uploadFile(

--- a/src/entity/user/UserWorldSettings.ts
+++ b/src/entity/user/UserWorldSettings.ts
@@ -70,6 +70,27 @@ export class UserWorldSettings {
   @Column({ type: 'boolean', default: false })
   private: boolean;
 
+  /**
+   * A bare render of the world — no name, no stats, no chrome — captured in the
+   * owner's own browser and uploaded. The share card is composed around it
+   * later, so this stays free of anything that would date it when the card is
+   * redesigned.
+   *
+   * It is captured client-side because the world is WebGL: rendering it server
+   * side costs a browser with software GL, several seconds and the better part
+   * of a gigabyte, while the owner's machine has already drawn it.
+   */
+  @Column({ type: 'text', nullable: true })
+  plateUrl: string | null;
+
+  /**
+   * What the plate was a picture OF: settings and district count folded into one
+   * string. A TTL would re-render millions of unchanged worlds, so staleness is
+   * decided by comparing this against the world as it stands now.
+   */
+  @Column({ type: 'text', nullable: true })
+  plateVersion: string | null;
+
   @OneToOne('User', { lazy: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: Promise<User>;

--- a/src/migration/1785900000000-UserWorldPlate.ts
+++ b/src/migration/1785900000000-UserWorldPlate.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserWorldPlate1785900000000 implements MigrationInterface {
+  name = 'UserWorldPlate1785900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // The bare render the share card is composed around, plus what it was a
+    // picture of. Both nullable: a world that has never been visited by its
+    // owner since this shipped has no plate, and the share card falls back to
+    // the profile image rather than inventing one.
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "user_world_settings"
+        ADD COLUMN IF NOT EXISTS "plateUrl" text,
+        ADD COLUMN IF NOT EXISTS "plateVersion" text
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      ALTER TABLE "user_world_settings"
+        DROP COLUMN IF EXISTS "plateUrl",
+        DROP COLUMN IF EXISTS "plateVersion"
+    `);
+  }
+}

--- a/src/routes/shareImages.ts
+++ b/src/routes/shareImages.ts
@@ -15,7 +15,29 @@ const ALLOWED_TYPES = new Set([
   'tags',
   'invite',
   'plus',
+  // The world card composes around a plate the owner's browser already
+  // rendered, so this stays an ordinary DOM capture: no WebGL in the scraper.
+  'world',
 ]);
+
+/**
+ * Per-type capture options. Everything absent here keeps the scraper's defaults
+ * (1280x768 at 2x, PNG), which is what the other types are authored against.
+ */
+const SCRAPER_OPTIONS: Record<string, Record<string, unknown> | undefined> = {
+  // Authored at its true output size rather than half of it, so 1x. JPEG
+  // because most of the card is a photographic render of a 3D world, where PNG
+  // costs several hundred kilobytes and shows nothing extra. Its own webfont is
+  // the point of a branded card, so the Roboto override is off.
+  world: {
+    width: 1200,
+    height: 630,
+    deviceScaleFactor: 1,
+    imageType: 'jpeg',
+    quality: 88,
+    keepFonts: true,
+  },
+};
 
 export default async function (fastify: FastifyInstance): Promise<void> {
   fastify.get<{
@@ -25,7 +47,10 @@ export default async function (fastify: FastifyInstance): Promise<void> {
     const { type } = req.params;
     const [id, format] = req.params.name.split('.');
 
-    if (!ALLOWED_TYPES.has(type) || format !== 'png' || !id) {
+    // The extension is part of the public URL rather than a request for a
+    // format: what comes back is whatever SCRAPER_OPTIONS captures, and the
+    // content-type header is what consumers actually read.
+    if (!ALLOWED_TYPES.has(type) || !['png', 'jpg'].includes(format) || !id) {
       return res.status(404).send();
     }
 
@@ -40,7 +65,11 @@ export default async function (fastify: FastifyInstance): Promise<void> {
 
     const response = await retryFetch(`${process.env.SCRAPER_URL}/screenshot`, {
       method: 'POST',
-      body: JSON.stringify({ url, selector: '#screenshot_wrapper' }),
+      body: JSON.stringify({
+        url,
+        selector: '#screenshot_wrapper',
+        ...SCRAPER_OPTIONS[type],
+      }),
       headers: { 'content-type': 'application/json' },
     });
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -119,6 +119,7 @@ import {
   updateSubscriptionFlags,
   isProd,
   uploadAvatar,
+  uploadFile,
   UploadPreset,
   uploadProfileCover,
   VALID_WEEK_STARTS,
@@ -400,6 +401,8 @@ export type GQLUserWorldSettings = {
   crest: z.infer<typeof worldCrestSchema> | null;
   look: z.infer<typeof worldLookSchema> | null;
   private: boolean;
+  plateUrl: string | null;
+  plateVersion: string | null;
 };
 
 export interface GQLUserProfileAnalytics {
@@ -1587,6 +1590,16 @@ export const typeDefs = /* GraphQL */ `
     Whether the world is hidden from everyone but its owner
     """
     private: Boolean!
+    """
+    A bare render of the world, captured in the owner's browser. The share card
+    is composed around it, so it carries no name, stats or chrome of its own.
+    Null when the owner has not opened their world since plates existed
+    """
+    plateUrl: String
+    """
+    What the plate was a picture of, used to decide staleness without a TTL
+    """
+    plateVersion: String
   }
 
   input UserWorldSkyInput {
@@ -1922,6 +1935,23 @@ export const typeDefs = /* GraphQL */ `
       look: UserWorldLookInput
       private: Boolean
     ): UserWorldSettings @auth
+
+    """
+    Store a bare render of the caller's own world, captured in their browser.
+    Takes no id: like every world customisation, it writes the caller's row and
+    nobody else's, which is what stops a visitor from putting an arbitrary image
+    on someone else's share card.
+    """
+    uploadUserWorldPlate(
+      """
+      The render, as captured from the world canvas
+      """
+      image: Upload!
+      """
+      What the render is a picture of, echoed back on read to decide staleness
+      """
+      version: String!
+    ): UserWorldSettings @auth @rateLimit(limit: 10, duration: 3600)
 
     """
     Update user profile information
@@ -3828,6 +3858,49 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       // Read back through graphorm so the mutation answers in exactly the shape
       // the query does rather than assembling a second one. Null is reachable:
       // a call that changed nothing writes no row.
+      return graphorm.queryOne<GQLUserWorldSettings>(ctx, info, (builder) => {
+        builder.queryBuilder = builder.queryBuilder.where(
+          `"${builder.alias}"."userId" = :id`,
+          { id: userId },
+        );
+
+        return builder;
+      });
+    },
+    uploadUserWorldPlate: async (
+      _,
+      { image, version }: { image: Promise<FileUpload>; version: string },
+      ctx: AuthContext,
+      info: GraphQLResolveInfo,
+    ): Promise<GQLUserWorldSettings | null> => {
+      if (!image) {
+        throw new ValidationError('File is missing!');
+      }
+
+      if (!process.env.CLOUDINARY_URL) {
+        throw new Error('Unable to upload asset to cloudinary!');
+      }
+
+      const trimmed = version?.trim();
+      if (!trimmed || trimmed.length > 128) {
+        throw new ValidationError('Invalid plate version');
+      }
+
+      const { userId } = ctx;
+      const upload = await image;
+      // Overwrites the previous plate rather than accumulating one asset per
+      // capture: only the newest is ever served, and the version column is what
+      // says whether it is current.
+      const { url } = await uploadFile(
+        userId,
+        UploadPreset.WorldPlate,
+        upload.createReadStream(),
+      );
+
+      await ctx.con
+        .getRepository(UserWorldSettings)
+        .upsert({ userId, plateUrl: url, plateVersion: trimmed }, ['userId']);
+
       return graphorm.queryOne<GQLUserWorldSettings>(ctx, info, (builder) => {
         builder.queryBuilder = builder.queryBuilder.where(
           `"${builder.alias}"."userId" = :id`,

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -119,9 +119,9 @@ import {
   updateSubscriptionFlags,
   isProd,
   uploadAvatar,
-  uploadFile,
   UploadPreset,
   uploadProfileCover,
+  uploadWorldPlate,
   VALID_WEEK_STARTS,
   validateWorkEmailDomain,
   voteComment,
@@ -3891,11 +3891,7 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       // Overwrites the previous plate rather than accumulating one asset per
       // capture: only the newest is ever served, and the version column is what
       // says whether it is current.
-      const { url } = await uploadFile(
-        userId,
-        UploadPreset.WorldPlate,
-        upload.createReadStream(),
-      );
+      const { url } = await uploadWorldPlate(userId, upload.createReadStream());
 
       await ctx.con
         .getRepository(UserWorldSettings)


### PR DESCRIPTION
A world is WebGL, so composing its OG image server-side would mean a headless browser with software GL. Measured against the real page (`daily.dev/world/idoshamun`, 22.5K articles / 40 districts, so near worst case) on the pod's exact Puppeteer and Chrome versions:

| Config | Ready | Shot | Total | Peak RSS |
|---|---|---|---|---|
| Current scraper args | no WebGL context at all | | | |
| + swiftshader, 2x | 7.3s | 2.3s | 9.6s | 1732MB |
| + swiftshader, 1x | 6.8s | 1.8s | 8.6s | 1445MB |

That is ~650MB of incremental RSS over an ~800MB browser floor, on a pod capped at 2Gi that runs up to 15 browsers. Two concurrent renders would blow it, and the render would be competing with all of daily.dev's link scraping.

The owner's machine has already drawn the world on real hardware, so the bare render (the "plate") is captured there and uploaded, and the card is composed around it afterwards.

## What changed

- `plateUrl` / `plateVersion` on `UserWorldSettings`, plus migration. Both nullable: a world whose owner has not visited since this ships has no plate, and the share card falls back to the profile image rather than inventing one.
- `uploadUserWorldPlate(image, version)`. Like every world customisation it takes **no id** and writes the caller's own row, which is what stops a visitor putting an arbitrary image on someone else's card.
- `UploadPreset.WorldPlate`, overwriting per user rather than accumulating an asset per capture.
- `'world'` added to the share-image allowlist, so `/og/world/:id` composes the card. Because the plate arrives pre-rendered, **that capture is an ordinary DOM screenshot: no WebGL, no new flags, no separate pool.**
- Per-type scraper options (1200x630 at 1x, JPEG q88, real fonts). `staleness` is a version key rather than a TTL, so unchanged worlds are never re-rendered.

## Merge order

Independent of dailydotdev/daily-scraper#636. An older scraper ignores the unknown option fields and returns the previous size and format, which still produces a valid card.

## Cloudinary

No preset. The plate needs no transformation of its own and a signed upload succeeds without one, so `uploadFile` takes `null` and omits the field. Nothing to configure in the dashboard. The public id is per user, so a new capture replaces the previous plate rather than accumulating one asset per save.

## Verified

`tsc --noEmit` shows no errors in any changed file (the 21 remaining are pre-existing, all in `src/common/interest/`).

**Tests not run.** Port 5432 is held by an unrelated project's container locally and the datasource hardcodes that port, so running them would have pointed a schema-dropping suite at another database. Worth a run in CI or once the port is free.

https://claude.ai/code/session_01MKc7wrVLm26zMX8MsPpikT
