### PR TITLE
feat: add stack type to contextual share images

### DIFF
--- a/src/routes/shareImages.ts
+++ b/src/routes/shareImages.ts
@@ -15,6 +15,7 @@ const ALLOWED_TYPES = new Set([
   'tags',
   'invite',
   'plus',
+  'stack',
 ]);
 
 export default async function (fastify: FastifyInstance): Promise<void> {


### PR DESCRIPTION
Adds `stack` to the /og share-image type allowlist so `/og/stack/:userId.png` screenshots the webapp's new stack share card page (`/image-generator/share/stack/[userId]`).

Pairs with dailydotdev/apps#6431 — this must deploy before the webapp share button goes live, but is harmless standalone (unknown page 404s → scraper error, no user-facing surface until the apps PR ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)