### PR TITLE
chore(infra): add LINEAR_HUGINN_AGENT_ID to prod config

### DIFF
--- a/.infra/Pulumi.prod.yaml
+++ b/.infra/Pulumi.prod.yaml
@@ -277,6 +277,8 @@ config:
       secure: AAABAPNWKCkjj4VNxfW9pxPksz2srCJuBaOfvxnyIRpnb/e7fBFUBIhTJjiZa8Kf2fAOFEqh1Xpioilpy6UrW//CFVHl5EEDtn+1U2K8Ig398ZbLwCYiJcsqj3m0NVnhs5tH/SUfHyiJBexftNuyAjE9KPW1UmyIeUpB4gTUMJG876JFVYqUY7a2XJFjGJ7a4Q==
     slackContributionsWebhook:
       secure: AAABAOKNibr2AoUeSHJzmAyyNaOTqhvy/oDYDu1spT6YzFIUpPP32FbJqNJx6Y9AgoYrJksqY+H5PXMCT87RqKYyoqYXcktk4JQpGtWur8XEMAAEfLM55s3bQnF0hfmKgWQ17nk/CuF52K4ozY0rqnw=
+    linearHuginnAgentId:
+      secure: AAABANKRo+IcGU45hHot31p7j3Qei8oAGU5QSDZRNN1eJRY1yn37uJfRcTnfL0K5GC4LFeBcg7wbGZafY+7h7mIqICo=
   api:k8s:
     host: subs.daily.dev
     namespace: daily


### PR DESCRIPTION
## Changes

Adds `linearHuginnAgentId` to the prod Pulumi `api:env` block (set via `pulumi config set --path --secret`), mapping to `LINEAR_HUGINN_AGENT_ID`.

## Why

Team-member feedback delegation to huginn autopilot (#4045) never fired in prod: `delegateToHuginn = Boolean(isTeamMember && huginnAgentId)` silently skips when the env var is unset — e.g. ENG-1928 had to be delegated manually.

The value is the production Huginn app-user id in Linear (`users` query, `app: true`), verified against the `delegateId` on ENG-1928 after manual delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)