### PR TITLE
feat(posts): keep original titles on the watercooler feed

### DIFF
--- a/__tests__/posts-actions.ts
+++ b/__tests__/posts-actions.ts
@@ -40,7 +40,11 @@ import {
 } from './fixture/post';
 import { DataSource } from 'typeorm';
 import createOrGetConnection from '../src/db';
-import { triggerTypedEvent, updateFlagsStatement } from '../src/common';
+import {
+  triggerTypedEvent,
+  updateFlagsStatement,
+  WATERCOOLER_ID,
+} from '../src/common';
 import { randomUUID } from 'crypto';
 import { deleteKeysByPattern, deleteRedisKey, ioRedisPool } from '../src/redis';
 import { checkHasMention } from '../src/common/markdown';
@@ -2731,6 +2735,34 @@ describe('query fetchSmartTitle', () => {
 
     expect(res.errors).toBeFalsy();
     expect(res.data.fetchSmartTitle.title).toEqual('Alt Title');
+  });
+
+  it('should return the original title for watercooler posts when clickbait shield is disabled', async () => {
+    loggedUser = '1';
+    isPlus = true;
+
+    await con.getRepository(SquadSource).save({
+      id: WATERCOOLER_ID,
+      handle: 'watercooler',
+      name: 'Watercooler',
+      private: false,
+    });
+    await con
+      .getRepository(Post)
+      .update({ id: 'p1' }, { sourceId: WATERCOOLER_ID });
+    await con
+      .getRepository(Settings)
+      .save({ userId: loggedUser, flags: { clickbaitShieldEnabled: false } });
+
+    const res = await client.query<
+      { fetchSmartTitle: GQLPostSmartTitle },
+      { id: string }
+    >(QUERY, {
+      variables: { id: 'p1' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.fetchSmartTitle.title).toEqual('P1');
   });
 
   it('should return the smart title muliple times when clickbait shield is disabled', async () => {

--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -1712,6 +1712,75 @@ describe('query post', () => {
       expect(res.errors).toBeFalsy();
       expect(res.data.post.clickbaitTitleDetected).toEqual(false);
     });
+
+    it('should return false for watercooler posts above threshold', async () => {
+      await con.getRepository(SquadSource).save({
+        id: WATERCOOLER_ID,
+        handle: 'watercooler',
+        name: 'Watercooler',
+        private: false,
+      });
+      await con.getRepository(ArticlePost).update('p1', {
+        sourceId: WATERCOOLER_ID,
+        contentQuality: { is_clickbait_probability: 1.99 },
+        contentMeta: { alt_title: { translations: { en: 'Clickbait title' } } },
+      });
+
+      const res = await client.query(LOCAL_QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.post.clickbaitTitleDetected).toEqual(false);
+    });
+  });
+
+  describe('smart title', () => {
+    const LOCAL_QUERY = /* GraphQL */ `
+      query Post($id: ID!) {
+        post(id: $id) {
+          title
+        }
+      }
+    `;
+
+    beforeEach(async () => {
+      loggedUser = '1';
+      isPlus = true;
+
+      await con.getRepository(ArticlePost).update('p1', {
+        contentQuality: { is_clickbait_probability: 1.99 },
+        contentMeta: { alt_title: { translations: { en: 'Smart title' } } },
+      });
+    });
+
+    it('should return the smart title when clickbait shield is enabled', async () => {
+      const res = await client.query(LOCAL_QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.post.title).toEqual('Smart title');
+    });
+
+    it('should return the original title for watercooler posts', async () => {
+      await con.getRepository(SquadSource).save({
+        id: WATERCOOLER_ID,
+        handle: 'watercooler',
+        name: 'Watercooler',
+        private: false,
+      });
+      await con
+        .getRepository(ArticlePost)
+        .update('p1', { sourceId: WATERCOOLER_ID });
+
+      const res = await client.query(LOCAL_QUERY, {
+        variables: { id: 'p1' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(res.data.post.title).toEqual('P1');
+    });
   });
 
   describe('scheduled post', () => {

--- a/src/common/post.ts
+++ b/src/common/post.ts
@@ -78,6 +78,7 @@ import {
   getScheduledPostFlags,
   validatePostScheduledAt,
 } from './postScheduling';
+import { WATERCOOLER_ID } from './feedGenerator';
 
 export type SourcePostModerationArgs = ConnectionArguments & {
   sourceId: string;
@@ -1239,6 +1240,12 @@ export const getPostTranslatedTitle = (
 
   return post.translation?.[contentLanguage]?.title || post.title!;
 };
+
+// Watercooler titles are casual and human-written, so rewriting them
+// misrepresents what the author actually said.
+export const isClickbaitShieldDisabledForSource = (
+  sourceId?: string | null,
+): boolean => sourceId === WATERCOOLER_ID;
 
 export const getSmartTitle = (
   contentLanguage: ContentLanguage | null,

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -40,6 +40,7 @@ import {
   domainOnly,
   getSmartTitle,
   getTranslationRecord,
+  isClickbaitShieldDisabledForSource,
   ONE_HOUR_IN_SECONDS,
   transformDate,
 } from '../common';
@@ -302,6 +303,25 @@ const checkIfTitleIsClickbait = (value?: string): boolean => {
   return clickbaitProbability > threshold;
 };
 
+type ClickbaitPostColumns = {
+  sourceId?: string;
+  clickbaitProbability?: string;
+  manualClickbaitProbability?: string;
+};
+
+const hasClickbaitTitle = (post: ClickbaitPostColumns): boolean => {
+  if (isClickbaitShieldDisabledForSource(post.sourceId)) {
+    return false;
+  }
+
+  // If manualClickbaitProbability is set, use it, otherwise use clickbaitProbability
+  return checkIfTitleIsClickbait(
+    post.manualClickbaitProbability !== null
+      ? post.manualClickbaitProbability
+      : post.clickbaitProbability,
+  );
+};
+
 const fallbackFailedScrapeTitle = (
   value: string | null,
   parent: unknown,
@@ -325,10 +345,8 @@ const createSmartTitleField = ({ field }: { field: string }): GraphORMField => {
         return fallbackFailedScrapeTitle(value, parent);
       }
 
-      const typedParent = parent as {
+      const typedParent = parent as ClickbaitPostColumns & {
         smartTitle: I18nRecord;
-        clickbaitProbability?: string;
-        manualClickbaitProbability?: string;
         translation: Partial<Record<ContentLanguage, PostTranslation>>;
         [key: string]: unknown;
       };
@@ -349,18 +367,11 @@ const createSmartTitleField = ({ field }: { field: string }): GraphORMField => {
       const clickbaitShieldEnabled =
         settings?.flags?.clickbaitShieldEnabled ?? true;
 
-      // If manualClickbaitProbability is set, use it, otherwise use clickbaitProbability
-      const clickbaitTitleDetected = checkIfTitleIsClickbait(
-        typedParent.manualClickbaitProbability !== null
-          ? typedParent.manualClickbaitProbability
-          : typedParent.clickbaitProbability,
-      );
-
       if (
         ctx.isPlus &&
         altValue &&
         clickbaitShieldEnabled &&
-        clickbaitTitleDetected
+        hasClickbaitTitle(typedParent)
       ) {
         return altValue;
       }
@@ -798,6 +809,7 @@ const obj = new GraphORM({
       'pinnedAt',
       'authorId',
       'scoutId',
+      'sourceId',
       'private',
       'type',
       'liveRoomId',
@@ -840,9 +852,7 @@ const obj = new GraphORM({
       },
       clickbaitTitleDetected: {
         transform: (_, ctx: Context, parent): boolean => {
-          const typedParent = parent as {
-            clickbaitProbability: string;
-            manualClickbaitProbability?: string;
+          const typedParent = parent as ClickbaitPostColumns & {
             smartTitle: I18nRecord;
             translation: Partial<Record<ContentLanguage, PostTranslation>>;
           };
@@ -852,15 +862,7 @@ const obj = new GraphORM({
             typedParent.translation,
           );
 
-          return (
-            !!altValue &&
-            // If manualClickbaitProbability is set, use it, otherwise use clickbaitProbability
-            checkIfTitleIsClickbait(
-              typedParent.manualClickbaitProbability !== null
-                ? typedParent.manualClickbaitProbability
-                : typedParent.clickbaitProbability,
-            )
-          );
+          return !!altValue && hasClickbaitTitle(typedParent);
         },
       },
       read: {

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -41,6 +41,7 @@ import {
   getPostTranslatedTitle,
   getTranslationRecord,
   type GQLSourcePostModeration,
+  isClickbaitShieldDisabledForSource,
   isValidHttpUrl,
   mapCloudinaryUrl,
   notifyView,
@@ -2471,16 +2472,25 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
       ctx: Context,
     ): Promise<GQLPostSmartTitle> =>
       queryReadReplica(ctx.con, async ({ queryRunner }) => {
-        const post: Pick<Post, 'title' | 'contentMeta' | 'translation'> =
-          await queryRunner.manager.getRepository(Post).findOneOrFail({
-            where: { id },
-            select: ['title', 'contentMeta', 'translation'],
-          });
+        const post: Pick<
+          Post,
+          'title' | 'contentMeta' | 'translation' | 'sourceId'
+        > = await queryRunner.manager.getRepository(Post).findOneOrFail({
+          where: { id },
+          select: ['title', 'contentMeta', 'translation', 'sourceId'],
+        });
 
         const translationRecord = getTranslationRecord({
           translations: post.translation,
           contentLanguage: ctx.contentLanguage,
         });
+
+        if (isClickbaitShieldDisabledForSource(post.sourceId)) {
+          return {
+            title: getPostTranslatedTitle(post, ctx.contentLanguage),
+            translation: translationRecord,
+          };
+        }
 
         if (!ctx.isPlus) {
           return {


### PR DESCRIPTION
Watercooler posts are casual, human-written conversation starters, so rewriting their titles with the clickbait shield misrepresents what the author actually said. This exempts the watercooler source from the shield.

## Changes

- `isClickbaitShieldDisabledForSource()` in `src/common/post.ts`, keyed off the existing `WATERCOOLER_ID` constant.
- GraphORM `Post`: the `title` field never resolves to the smart title for watercooler posts, and `clickbaitTitleDetected` is always `false` for them. `sourceId` was added to `requiredColumns` so the transforms can see it.
- `fetchSmartTitle` returns the original translated title for watercooler posts regardless of the viewer's shield setting.

## Key decisions

**Fixed in the API, not the client.** The shield is entirely backend-driven: every render site in `apps` (`ArticleList/Grid`, `FreeformList/Grid`, `ShareList/Grid`, `SocialTwitterList`, `PostContent`, `FocusCardActionBar`, …) is gated on `clickbaitTitleDetected`, and the swapped-in title comes from the `Post.title` transform. Flipping those two fields removes the shield button (including the non-Plus upsell variant) and restores the original title on the feed, the post page, and anywhere else those posts surface — with no client change, and without duplicating the rule in two places. `useTranslation` also follows automatically, requesting `title` instead of `smartTitle`.

**Scoped by source, not by feed.** Keying on the post's source rather than on the watercooler feed means a watercooler post keeps its original title everywhere it appears, including My Feed and its own post page.

**Read-layer only.** Smart titles are still generated for these posts by the content pipeline; they're just never served. That avoids a backfill and fixes existing data immediately.

**Known boundary:** a *share* post in the watercooler that links an external article still shows the shield for that article's title — the shield there acts on the article's title, not on anything a watercooler author wrote. Suppressing it would leave an AI-rewritten title with no way to toggle back, since the original isn't available client-side. Worth a follow-up if product wants that case covered.

## Testing

`build` and `lint` pass. New coverage: `clickbaitTitleDetected` is false for a watercooler post above threshold, `title` returns the original instead of the smart title, and `fetchSmartTitle` returns the original with the shield disabled. Full runs of `posts.ts`, `posts-actions.ts`, `feeds.ts`, `settings.ts` and `boot.ts` pass (890 tests) — the ones that exercise the changed transforms and the `requiredColumns` addition. A whole-suite run was started as an extra regression check but was cut short by the session ending, so CI is the backstop there.

Closes ENG-1928

---
Created by Huginn 🐦‍⬛