### PR TITLE
feat: datasetTool query with tool page aggregates

### DIFF
--- a/__tests__/datasetTool.ts
+++ b/__tests__/datasetTool.ts
@@ -1,0 +1,234 @@
+import { DataSource } from 'typeorm';
+import createOrGetConnection from '../src/db';
+import {
+  disposeGraphQLTesting,
+  GraphQLTestClient,
+  GraphQLTestingState,
+  initializeGraphQLTesting,
+  MockContext,
+  saveFixtures,
+  testQueryErrorCode,
+} from './helpers';
+import { User } from '../src/entity/user/User';
+import { usersFixture } from './fixture/user';
+import { UserStack } from '../src/entity/user/UserStack';
+import { DatasetTool } from '../src/entity/dataset/DatasetTool';
+import { Keyword } from '../src/entity/Keyword';
+
+let con: DataSource;
+let state: GraphQLTestingState;
+let client: GraphQLTestClient;
+let loggedUser: string | null = null;
+
+beforeAll(async () => {
+  con = await createOrGetConnection();
+  state = await initializeGraphQLTesting(
+    () => new MockContext(con, loggedUser),
+  );
+  client = state.client;
+});
+
+afterAll(() => disposeGraphQLTesting(state));
+
+const toolsFixture = [
+  {
+    title: 'Next.js',
+    titleNormalized: 'nextdotjs',
+    url: 'https://nextjs.org',
+    faviconSource: 'none',
+  },
+  {
+    title: 'React',
+    titleNormalized: 'react',
+    faviconSource: 'none',
+  },
+  {
+    title: 'Fastify',
+    titleNormalized: 'fastify',
+    faviconSource: 'none',
+  },
+  {
+    title: 'Redis',
+    titleNormalized: 'redis',
+    faviconSource: 'none',
+  },
+];
+
+let tools: DatasetTool[];
+
+beforeEach(async () => {
+  loggedUser = null;
+  await saveFixtures(con, User, usersFixture);
+  tools = await con.getRepository(DatasetTool).save(toolsFixture);
+});
+
+const toolByNormalizedTitle = (titleNormalized: string): DatasetTool => {
+  const tool = tools.find((t) => t.titleNormalized === titleNormalized);
+  if (!tool) {
+    throw new Error(`missing tool fixture ${titleNormalized}`);
+  }
+  return tool;
+};
+
+const stackItem = (
+  userId: string,
+  toolId: string,
+  position = 0,
+): Partial<UserStack> => ({
+  userId,
+  toolId,
+  section: 'Primary',
+  position,
+});
+
+describe('query datasetTool', () => {
+  const QUERY = `
+    query DatasetTool($slug: String!) {
+      datasetTool(slug: $slug) {
+        id
+        title
+        slug
+        url
+        faviconUrl
+        stackCount
+        keyword
+      }
+    }
+  `;
+
+  it('should return the tool by slug with defaults', async () => {
+    const res = await client.query(QUERY, {
+      variables: { slug: 'nextdotjs' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.datasetTool).toMatchObject({
+      title: 'Next.js',
+      slug: 'nextdotjs',
+      url: 'https://nextjs.org',
+      stackCount: 0,
+      keyword: null,
+    });
+  });
+
+  it('should normalize the requested slug', async () => {
+    const res = await client.query(QUERY, {
+      variables: { slug: 'Next.js' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.datasetTool.slug).toEqual('nextdotjs');
+  });
+
+  it('should count stacks including the tool', async () => {
+    const tool = toolByNormalizedTitle('nextdotjs');
+    await con
+      .getRepository(UserStack)
+      .save([stackItem('1', tool.id), stackItem('2', tool.id)]);
+
+    const res = await client.query(QUERY, {
+      variables: { slug: 'nextdotjs' },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.datasetTool.stackCount).toEqual(2);
+  });
+
+  it('should resolve an allowed keyword matching the stripped title', async () => {
+    await con.getRepository(Keyword).save([
+      { value: 'nextjs', status: 'allow', occurrences: 100 },
+      { value: 'react', status: 'allow', occurrences: 50 },
+      { value: 'fastify', status: 'pending', occurrences: 10 },
+    ]);
+
+    const [nextRes, reactRes, fastifyRes] = await Promise.all([
+      client.query(QUERY, { variables: { slug: 'nextdotjs' } }),
+      client.query(QUERY, { variables: { slug: 'react' } }),
+      client.query(QUERY, { variables: { slug: 'fastify' } }),
+    ]);
+
+    expect(nextRes.data.datasetTool.keyword).toEqual('nextjs');
+    expect(reactRes.data.datasetTool.keyword).toEqual('react');
+    expect(fastifyRes.data.datasetTool.keyword).toBeNull();
+  });
+
+  it('should fail when the tool does not exist', () =>
+    testQueryErrorCode(
+      client,
+      { query: QUERY, variables: { slug: 'doesnotexist' } },
+      'NOT_FOUND',
+    ));
+});
+
+describe('query toolsAlsoStacked', () => {
+  const QUERY = `
+    query ToolsAlsoStacked($id: ID!, $first: Int) {
+      toolsAlsoStacked(id: $id, first: $first) {
+        id
+        title
+      }
+    }
+  `;
+
+  it('should return co-occurring tools ordered by shared stacks', async () => {
+    const next = toolByNormalizedTitle('nextdotjs');
+    const react = toolByNormalizedTitle('react');
+    const fastify = toolByNormalizedTitle('fastify');
+    const redis = toolByNormalizedTitle('redis');
+
+    await con.getRepository(UserStack).save([
+      // user 1 stacks next + react + fastify
+      stackItem('1', next.id),
+      stackItem('1', react.id, 1),
+      stackItem('1', fastify.id, 2),
+      // user 2 stacks next + react
+      stackItem('2', next.id),
+      stackItem('2', react.id, 1),
+      // user 3 stacks redis only, no next
+      stackItem('3', redis.id),
+    ]);
+
+    const res = await client.query(QUERY, {
+      variables: { id: next.id },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.toolsAlsoStacked).toEqual([
+      { id: react.id, title: 'React' },
+      { id: fastify.id, title: 'Fastify' },
+    ]);
+  });
+
+  it('should respect the first argument', async () => {
+    const next = toolByNormalizedTitle('nextdotjs');
+    const react = toolByNormalizedTitle('react');
+    const fastify = toolByNormalizedTitle('fastify');
+
+    await con
+      .getRepository(UserStack)
+      .save([
+        stackItem('1', next.id),
+        stackItem('1', react.id, 1),
+        stackItem('1', fastify.id, 2),
+      ]);
+
+    const res = await client.query(QUERY, {
+      variables: { id: next.id, first: 1 },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.toolsAlsoStacked).toHaveLength(1);
+  });
+
+  it('should return empty when nobody shares a stack', async () => {
+    const redis = toolByNormalizedTitle('redis');
+    await con.getRepository(UserStack).save([stackItem('3', redis.id)]);
+
+    const res = await client.query(QUERY, {
+      variables: { id: redis.id },
+    });
+
+    expect(res.errors).toBeFalsy();
+    expect(res.data.toolsAlsoStacked).toEqual([]);
+  });
+});

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -2887,6 +2887,18 @@ const obj = new GraphORM({
       createdAt: {
         transform: transformDate,
       },
+      slug: {
+        select: (_, alias) => `"${alias}"."titleNormalized"`,
+      },
+      stackCount: {
+        select: (_, alias) =>
+          `(SELECT COUNT(*) FROM user_stack us WHERE us."toolId" = "${alias}"."id")`,
+        transform: (value): number => Number(value) || 0,
+      },
+      keyword: {
+        select: (_, alias) =>
+          `(SELECT k.value FROM keyword k WHERE k.status = 'allow' AND k.value IN (regexp_replace(lower("${alias}"."title"), '[^a-z0-9]', '', 'g'), "${alias}"."titleNormalized") ORDER BY k.occurrences DESC LIMIT 1)`,
+      },
     },
   },
   SourceStack: {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -36,6 +36,7 @@ import * as opportunity from './schema/opportunity';
 import * as autocompletes from './schema/autocompletes';
 import * as profile from './schema/profile';
 import * as userStack from './schema/userStack';
+import * as datasetTool from './schema/datasetTool';
 import * as sourceStack from './schema/sourceStack';
 import * as userHotTake from './schema/userHotTake';
 import * as gear from './schema/gear';
@@ -106,6 +107,7 @@ export const schema = urlDirective.transformer(
                 autocompletes.typeDefs,
                 profile.typeDefs,
                 userStack.typeDefs,
+                datasetTool.typeDefs,
                 sourceStack.typeDefs,
                 userHotTake.typeDefs,
                 gear.typeDefs,
@@ -157,6 +159,7 @@ export const schema = urlDirective.transformer(
                   autocompletes.resolvers,
                   profile.resolvers,
                   userStack.resolvers,
+                  datasetTool.resolvers,
                   sourceStack.resolvers,
                   userHotTake.resolvers,
                   gear.resolvers,

--- a/src/schema/datasetTool.ts
+++ b/src/schema/datasetTool.ts
@@ -1,0 +1,109 @@
+import { IResolvers } from '@graphql-tools/utils';
+import { BaseContext, Context } from '../Context';
+import graphorm from '../graphorm';
+import { DatasetTool } from '../entity/dataset/DatasetTool';
+import { UserStack } from '../entity/user/UserStack';
+import { normalizeTitle } from '../common/datasetTool';
+
+const MAX_ALSO_STACKED = 10;
+const DEFAULT_ALSO_STACKED = 6;
+
+export const typeDefs = /* GraphQL */ `
+  extend type DatasetTool {
+    """
+    URL-safe unique identifier (normalized title)
+    """
+    slug: String!
+
+    """
+    Tool website
+    """
+    url: String
+
+    """
+    Number of user stacks that include this tool
+    """
+    stackCount: Int!
+
+    """
+    Allowed content keyword matching this tool, if any
+    """
+    keyword: String
+  }
+
+  extend type Query {
+    """
+    Get a tool from the dataset by its slug
+    """
+    datasetTool(slug: String!): DatasetTool!
+
+    """
+    Tools that most often appear in the same stacks as the given tool
+    """
+    toolsAlsoStacked(id: ID!, first: Int): [DatasetTool!]!
+  }
+`;
+
+export const resolvers: IResolvers<unknown, BaseContext> = {
+  Query: {
+    datasetTool: async (
+      _,
+      args: { slug: string },
+      ctx: Context,
+      info,
+    ): Promise<DatasetTool> =>
+      graphorm.queryOneOrFail<DatasetTool>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder.where(
+            `"${builder.alias}"."titleNormalized" = :slug`,
+            { slug: normalizeTitle(args.slug) },
+          );
+          return builder;
+        },
+        DatasetTool,
+        true,
+      ),
+
+    toolsAlsoStacked: async (
+      _,
+      args: { id: string; first?: number },
+      ctx: Context,
+      info,
+    ): Promise<DatasetTool[]> => {
+      const first = Math.min(
+        args.first ?? DEFAULT_ALSO_STACKED,
+        MAX_ALSO_STACKED,
+      );
+
+      return graphorm.query<DatasetTool>(
+        ctx,
+        info,
+        (builder) => {
+          builder.queryBuilder
+            .innerJoin(
+              (qb) =>
+                qb
+                  .select('us."toolId"', 'toolId')
+                  .addSelect('COUNT(*)', 'cnt')
+                  .from(UserStack, 'us')
+                  .where(
+                    `us."userId" IN (SELECT "userId" FROM user_stack WHERE "toolId" = :toolId)`,
+                  )
+                  .andWhere('us."toolId" != :toolId')
+                  .groupBy('us."toolId"'),
+              'co',
+              `co."toolId" = "${builder.alias}"."id"`,
+            )
+            .setParameter('toolId', args.id)
+            .orderBy('co."cnt"', 'DESC')
+            .addOrderBy(`"${builder.alias}"."title"`, 'ASC')
+            .limit(first);
+          return builder;
+        },
+        true,
+      );
+    },
+  },
+};


### PR DESCRIPTION
## Changes

Backend for the new public tool landing pages (`/tools/[slug]` in the webapp):

- `datasetTool(slug)` — resolves a `DatasetTool` by normalized slug, extending the type with `slug`, `url`, `stackCount` (subquery over `user_stack`), and `keyword` (best allowed keyword matching the stripped title or normalized title, by occurrences) via GraphORM field selects.
- `toolsAlsoStacked(id, first)` — co-occurrence over `user_stack` (tools appearing in the same users' stacks), ordered by shared-stack count, capped at 10.

All reads go to the read replica. No new tables.

Pairs with dailydotdev/apps#6437 (the page) — deploy this first.

## Testing

8 integration tests in `__tests__/datasetTool.ts` (slug lookup + normalization, stack counting, keyword matching incl. pending-status exclusion, NOT_FOUND, co-occurrence ordering/limit/empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)