### PR TITLE
feat(world): a ninth sky, the Arcane Swarm's lilac day

### DIFF
--- a/src/common/worldStyle.ts
+++ b/src/common/worldStyle.ts
@@ -10,10 +10,20 @@
  * losing it costs the portrait nothing; nothing else is that cheap.
  */
 
-/** Nine minus the one that followed your reading, which no longer exists. */
+/**
+ * Nine. `lilac` is the newest — the Arcane Swarm's blue-over-lilac day, read
+ * off the realm concept art, which the ramp had nothing like: orchid is a
+ * saturated magenta and blossom is pink.
+ *
+ * These paint the WORLD view and the share card. Inside a realm the realm's own
+ * light rig takes over, because its materials were painted under one specific
+ * light — so what a palette here has to do is hold six very different islands in
+ * one frame at once.
+ */
 export const SKY_PALETTES = [
   'brand',
   'clear',
+  'lilac',
   'blossom',
   'ember',
   'seaglass',


### PR DESCRIPTION
Adds `lilac` to `SKY_PALETTES`, for the client's second world art pass (dailydotdev/apps#6434).

The six realm concept images each have their own sky, and one of them — the Arcane Swarm's bright blue zenith over a lilac horizon — had no equivalent in the picker: `orchid` is a saturated magenta and `blossom` is pink.

Worth knowing for review: with the new art, entering a realm switches the frame to that realm's own light rig (its materials were painted under one specific light). So these palettes now govern the world view and the share card rather than every zoom — which is why the set is judged on holding six very different islands in one shot.

No migration: stored settings keep working, and the enum only widens.

https://claude.ai/code/session_01HoppQcHJqVMAZGTGsP2jkT