### PR TITLE
feat(world): reward setting up a world and touring others

### DIFF
--- a/__tests__/quests.ts
+++ b/__tests__/quests.ts
@@ -1075,6 +1075,11 @@ describe('quest progress hooks', () => {
       name: 'Off the clock',
       description: 'Visit the Watercooler feed',
     },
+    {
+      eventType: QuestEventType.VisitUserWorld,
+      name: 'Grand tour',
+      description: "Visit 3 other users' worlds",
+    },
   ])(
     'should complete %s client-side page visit quests',
     async ({ eventType, name, description }) => {

--- a/__tests__/userWorld.ts
+++ b/__tests__/userWorld.ts
@@ -4,6 +4,7 @@ import {
   GraphQLTestClient,
   GraphQLTestingState,
   MockContext,
+  createMockLogger,
   disposeGraphQLTesting,
   initializeGraphQLTesting,
   saveFixtures,
@@ -11,7 +12,14 @@ import {
   testQueryErrorCode,
 } from './helpers';
 import { UserWorldSettings } from '../src/entity/user/UserWorldSettings';
-import { User } from '../src/entity';
+import {
+  Achievement,
+  AchievementEventType,
+  AchievementType,
+  User,
+} from '../src/entity';
+import { UserAchievement } from '../src/entity/user/UserAchievement';
+import { syncUserRetroactiveAchievements } from '../src/common/achievement/retroactive';
 import { Niche, NicheBucketGroup } from '../src/entity/Niche';
 import { UserNicheAnalytics } from '../src/entity/user/UserNicheAnalytics';
 import { UserNicheGrowth } from '../src/entity/user/UserNicheGrowth';
@@ -493,6 +501,84 @@ describe('mutation updateUserWorldSettings', () => {
       'GRAPHQL_VALIDATION_FAILED',
       'this world has not raised anything to put on a crest',
     );
+  });
+
+  describe('world setup achievement', () => {
+    const achievementId = '44444444-4444-4444-8444-444444444444';
+
+    beforeEach(async () => {
+      await con.createQueryBuilder().delete().from(UserAchievement).execute();
+      await con.getRepository(Achievement).save({
+        id: achievementId,
+        name: 'Terraformer test',
+        description: 'Make your world your own',
+        image: '',
+        type: AchievementType.Instant,
+        eventType: AchievementEventType.WorldSetup,
+        criteria: { targetCount: 1 },
+        points: 5,
+      });
+    });
+
+    it('should unlock on the first piece of dressing', async () => {
+      loggedUser = '1';
+      const res = await client.mutate(MUTATION, {
+        variables: { name: 'the quiet archive' },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(
+        await con
+          .getRepository(UserAchievement)
+          .findOneBy({ achievementId, userId: '1' }),
+      ).toMatchObject({ progress: 1, unlockedAt: expect.any(Date) });
+    });
+
+    it('should not unlock when only the privacy toggle changed', async () => {
+      loggedUser = '1';
+      const res = await client.mutate(MUTATION, {
+        variables: { private: true },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(
+        await con
+          .getRepository(UserAchievement)
+          .findOneBy({ achievementId, userId: '1' }),
+      ).toBeNull();
+    });
+
+    it('should not unlock when the dressing is cleared', async () => {
+      loggedUser = '1';
+      const res = await client.mutate(MUTATION, {
+        variables: { name: null },
+      });
+
+      expect(res.errors).toBeFalsy();
+      expect(
+        await con
+          .getRepository(UserAchievement)
+          .findOneBy({ achievementId, userId: '1' }),
+      ).toBeNull();
+    });
+
+    it('should unlock retroactively for a world dressed before the achievement existed', async () => {
+      await con
+        .getRepository(UserWorldSettings)
+        .save({ userId: '2', name: 'the long shelf' });
+
+      await syncUserRetroactiveAchievements({
+        con,
+        logger: createMockLogger(),
+        userId: '2',
+      });
+
+      expect(
+        await con
+          .getRepository(UserAchievement)
+          .findOneBy({ achievementId, userId: '2' }),
+      ).toMatchObject({ progress: 1, unlockedAt: expect.any(Date) });
+    });
   });
 });
 

--- a/src/common/achievement/retroactive.ts
+++ b/src/common/achievement/retroactive.ts
@@ -535,6 +535,18 @@ const handleQuestClaim: RetroactiveHandler = async (con, userIds) => {
   return toProgressMap(rows);
 };
 
+const handleWorldSetup: RetroactiveHandler = async (con, userIds) => {
+  const rows = await con.query(
+    `SELECT "userId"
+     FROM user_world_settings
+     WHERE "userId" = ANY($1)
+       AND (name IS NOT NULL OR sky IS NOT NULL OR crest IS NOT NULL OR "look" IS NOT NULL)`,
+    [userIds],
+  );
+
+  return toInstantMap(rows);
+};
+
 const handlers: Partial<Record<AchievementEventType, RetroactiveHandler>> = {
   [AchievementEventType.ProfileImageUpdate]: handleProfileImageUpdate,
   [AchievementEventType.ProfileCoverUpdate]: handleProfileCoverUpdate,
@@ -584,6 +596,7 @@ const handlers: Partial<Record<AchievementEventType, RetroactiveHandler>> = {
   [AchievementEventType.ShareClickMilestone]: handleShareClickMilestone,
   [AchievementEventType.SharePostsClicked]: handleSharePostsClicked,
   [AchievementEventType.QuestClaim]: handleQuestClaim,
+  [AchievementEventType.WorldSetup]: handleWorldSetup,
 };
 
 export const syncUsersRetroactiveAchievements = async ({

--- a/src/entity/Achievement.ts
+++ b/src/entity/Achievement.ts
@@ -59,6 +59,7 @@ export enum AchievementEventType {
   ShareClickMilestone = 'share_click_milestone',
   SharePostsClicked = 'share_posts_clicked',
   QuestClaim = 'quest_claim',
+  WorldSetup = 'world_setup',
 }
 
 export interface AchievementCriteria {

--- a/src/entity/Quest.ts
+++ b/src/entity/Quest.ts
@@ -31,6 +31,7 @@ export enum QuestEventType {
   VisitDiscussionsPage = 'visit_discussions_page',
   VisitReadItLaterPage = 'visit_read_it_later_page',
   VisitWatercoolerFeed = 'visit_watercooler_feed',
+  VisitUserWorld = 'visit_user_world',
   FeedbackSubmit = 'feedback_submit',
   SquadJoin = 'squad_join',
   FollowerGain = 'follower_gain',

--- a/src/migration/1786000000000-AddVisitUserWorldQuest.ts
+++ b/src/migration/1786000000000-AddVisitUserWorldQuest.ts
@@ -1,0 +1,50 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+const questId = 'c7f0a1d4-2e6b-4b93-9f1a-8d3c5b7e0a42';
+
+export class AddVisitUserWorldQuest1786000000000 implements MigrationInterface {
+  name = 'AddVisitUserWorldQuest1786000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "quest" (
+        "id",
+        "name",
+        "description",
+        "type",
+        "eventType",
+        "criteria",
+        "active"
+      )
+      VALUES
+        (
+          '${questId}',
+          'Grand tour',
+          'Visit 3 other users'' worlds',
+          'daily',
+          'visit_user_world',
+          '{"targetCount": 3}',
+          true
+        )
+    `);
+
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "quest_reward" ("questId", "type", "amount")
+      VALUES
+        ('${questId}', 'xp', 15),
+        ('${questId}', 'cores', 5)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "quest_reward"
+      WHERE "questId" = '${questId}'
+    `);
+
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "quest"
+      WHERE "id" = '${questId}'
+    `);
+  }
+}

--- a/src/migration/1786000100000-AddWorldSetupAchievement.ts
+++ b/src/migration/1786000100000-AddWorldSetupAchievement.ts
@@ -1,0 +1,38 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWorldSetupAchievement1786000100000
+  implements MigrationInterface
+{
+  name = 'AddWorldSetupAchievement1786000100000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      INSERT INTO "achievement" (
+        "name",
+        "description",
+        "image",
+        "type",
+        "eventType",
+        "criteria",
+        "points"
+      )
+      VALUES
+        (
+          'Terraformer',
+          'Make your world your own',
+          'https://media.daily.dev/image/upload/s--CV7PPCE0--/q_auto/v1786013533/achievements/terraformer',
+          'instant',
+          'world_setup',
+          '{"targetCount": 1}',
+          5
+        )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(/* sql */ `
+      DELETE FROM "achievement"
+      WHERE "name" = 'Terraformer'
+    `);
+  }
+}

--- a/src/migration/1786000100000-AddWorldSetupAchievement.ts
+++ b/src/migration/1786000100000-AddWorldSetupAchievement.ts
@@ -20,7 +20,7 @@ export class AddWorldSetupAchievement1786000100000
         (
           'Terraformer',
           'Make your world your own',
-          'https://media.daily.dev/image/upload/s--CV7PPCE0--/q_auto/v1786013533/achievements/terraformer',
+          'https://media.daily.dev/image/upload/s--CV7PPCE0--/q_auto/v1786013739/achievements/terraformer',
           'instant',
           'world_setup',
           '{"targetCount": 1}',

--- a/src/schema/quests.ts
+++ b/src/schema/quests.ts
@@ -99,6 +99,7 @@ const CLIENT_TRACKABLE_QUEST_EVENT_TYPES = new Set<QuestEventType>([
   QuestEventType.VisitDiscussionsPage,
   QuestEventType.VisitReadItLaterPage,
   QuestEventType.VisitWatercoolerFeed,
+  QuestEventType.VisitUserWorld,
   QuestEventType.ViewUserProfile,
 ]);
 
@@ -718,6 +719,7 @@ export const typeDefs = /* GraphQL */ `
     visit_discussions_page
     visit_read_it_later_page
     visit_watercooler_feed
+    visit_user_world
     view_user_profile
   }
 

--- a/src/schema/users.ts
+++ b/src/schema/users.ts
@@ -17,6 +17,11 @@ import {
   worldSkySchema,
 } from '../common/schema/userWorld';
 import { UserWorldSettings } from '../entity/user/UserWorldSettings';
+import {
+  AchievementEventType,
+  checkAchievementProgress,
+} from '../common/achievement';
+
 import { Code, ConnectError } from '@connectrpc/connect';
 import { getBragiClient } from '../integrations/bragi';
 import { Keyword, KeywordStatus } from '../entity/Keyword';
@@ -3854,6 +3859,21 @@ export const resolvers: IResolvers<unknown, BaseContext> = {
             .upsert({ userId, ...changes }, ['userId']);
         }
       });
+
+      // Only the dressing counts as having set the place up — flipping it
+      // private is a visibility choice, not an act of making it yours.
+      if (
+        (['name', 'sky', 'crest', 'look'] as const).some(
+          (key) => !isNullOrUndefined(patch[key]),
+        )
+      ) {
+        await checkAchievementProgress(
+          ctx.con,
+          ctx.log,
+          userId,
+          AchievementEventType.WorldSetup,
+        );
+      }
 
       // Read back through graphorm so the mutation answers in exactly the shape
       // the query does rather than assembling a second one. Null is reachable:


### PR DESCRIPTION
Adds an achievement for setting up your world for the first time, and a daily quest for visiting other users' worlds.

## Achievement — "Terraformer"

Instant, 5 points, new `world_setup` event type.

Fires from `updateUserWorldSettings` only when `name`, `sky`, `crest` or `look` lands a non-null value. Flipping the world private is a visibility choice rather than an act of making the place yours, and clearing the dressing back to null is not setting it up either.

`handleWorldSetup` in `retroactive.ts` backfills users who dressed their world before this shipped — without it `syncAchievements` logs a warning and never unlocks.

Image uploaded to Cloudinary at `achievements/terraformer`.

## Quest — "Grand tour"

Daily, visit 3 other users' worlds, 15 XP / 5 cores — matching "Friendly neighbor", the view-3-profiles quest.

Client-tracked via `trackQuestEvent`, added to both the runtime allow-list and the `ClientQuestEventType` enum.

## Two things worth a reviewer's attention

**The quest does not verify the world belongs to someone else.** Client-tracked means the web app decides when to fire `visit_user_world`, so the "other users'" part is enforced client-side. Same tradeoff the existing `view_user_profile` quest already makes. Hooking the `userWorld` resolver instead would double-fire on refresh and that resolver also serves logged-out viewers.

**It will not appear daily.** `rotation.ts` picks 2 regular + 1 Plus daily quest from a pool that is now 22, so this joins the pool rather than showing up every day.

## Testing

`pnpm run lint` passes. `pnpm run build` reports the same 21 errors as clean `main` (all pre-existing in `src/common/interest/*`, missing optional deps) — zero new ones.

Tests are written but **not run locally** — port 5432 was occupied by an unrelated container, so the test DB could not start. CI is the first execution.

- `__tests__/quests.ts` — new row in the visit-quest `it.each` table
- `__tests__/userWorld.ts` — unlock on dressing, no unlock on privacy toggle, no unlock on clearing, retroactive backfill

## Client follow-up

The web app needs to call `trackQuestEvent(eventType: visit_user_world)` when a user opens another user's world.

https://claude.ai/code/session_01QcV8km3PMqz5qHMiEVdaRJ