### PR TITLE
feat(post): expose answeredQuestions over GraphQL

### DIFF
--- a/__tests__/posts.ts
+++ b/__tests__/posts.ts
@@ -324,6 +324,59 @@ describe('slug field', () => {
   });
 });
 
+describe('answeredQuestions field', () => {
+  const QUERY = /* GraphQL */ `
+    {
+      post(id: "p1") {
+        answeredQuestions {
+          question
+          answer
+          cta
+        }
+      }
+    }
+  `;
+
+  it('should return null when the post was never enriched with questions', async () => {
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeUndefined();
+    expect(res.data.post.answeredQuestions).toBeNull();
+  });
+
+  it('should return an empty list when enrichment found nothing worth asking', async () => {
+    await con
+      .getRepository(ArticlePost)
+      .update({ id: 'p1' }, { answeredQuestions: [] });
+
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeUndefined();
+    expect(res.data.post.answeredQuestions).toEqual([]);
+  });
+
+  it('should return the questions when present', async () => {
+    const answeredQuestions = [
+      {
+        question: 'What session security defaults change in PHP 8.6?',
+        answer: 'PHP 8.6 flips three session ini defaults to safer values.',
+        cta: 'Teams shipping PHP upgrades track breaking changes like these on daily.dev.',
+      },
+      {
+        question: 'How does partial function application work in PHP 8.6?',
+        answer: 'A ? placeholder prefills arguments and returns a callable.',
+        cta: 'Developers adopting new PHP syntax compare real usage on daily.dev.',
+      },
+    ];
+
+    await con
+      .getRepository(ArticlePost)
+      .update({ id: 'p1' }, { answeredQuestions });
+
+    const res = await client.query(QUERY);
+    expect(res.errors).toBeUndefined();
+    expect(res.data.post.answeredQuestions).toEqual(answeredQuestions);
+  });
+});
+
 describe('communitySentiment field', () => {
   const QUERY = /* GraphQL */ `
     {

--- a/src/graphorm/index.ts
+++ b/src/graphorm/index.ts
@@ -950,6 +950,9 @@ const obj = new GraphORM({
       communitySentiment: {
         jsonType: true,
       },
+      answeredQuestions: {
+        jsonType: true,
+      },
       sharedPost: {
         relation: {
           isMany: false,

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -70,6 +70,7 @@ import {
   Post,
   PostFlagsPublic,
   PostMention,
+  type PostAnsweredQuestion,
   type PostCommunitySentiment,
   PostQuestion,
   PostRelation,
@@ -238,6 +239,7 @@ export interface GQLPost {
   pollOptions?: GQLPollOption[];
   numPollVotes?: number;
   communitySentiment?: PostCommunitySentiment | null;
+  answeredQuestions?: PostAnsweredQuestion[] | null;
 }
 
 type ScheduledPostsContext = AuthContext & {
@@ -919,6 +921,12 @@ export const typeDefs = /* GraphQL */ `
     communitySentiment: PostCommunitySentiment
 
     """
+    Questions this post answers, each with a standalone answer. Null when the
+    post predates enrichment of this field, empty when nothing qualified.
+    """
+    answeredQuestions: [PostAnsweredQuestion!]
+
+    """
     Featured award for the post, currently the most expensive one
     """
     featuredAward: UserPost
@@ -1091,6 +1099,16 @@ export const typeDefs = /* GraphQL */ `
     highlights: [PostCommunitySentimentHighlight!]!
     discussions: [PostCommunitySentimentDiscussion!]!
     updatedAt: DateTime
+  }
+
+  """
+  A question this post answers, with a standalone answer. Distinct from
+  PostQuestion, which is a search question recommendation stored per post.
+  """
+  type PostAnsweredQuestion {
+    question: String!
+    answer: String!
+    cta: String!
   }
 
   type PollOption {


### PR DESCRIPTION
## What

Adds a `PostAnsweredQuestion` GraphQL type and the `answeredQuestions` field on `Post`, so the webapp can read the questions a post answers.

Prerequisite for the webapp work. The column landed in dailydotdev/daily-api#4056; this exposes it.

## How

Follows `communitySentiment` exactly, since it is the same shape — a jsonb column surfaced as a GraphQL object type:

- object type + field in `src/schema/posts.ts`
- `answeredQuestions: { jsonType: true }` in `src/graphorm/index.ts`, so the column is selected and decoded rather than treated as a relation
- `GQLPost` typing updated

## Naming

The GraphQL type is `PostAnsweredQuestion`, not `PostQuestion` — that name is already taken by the type backing `searchQuestionRecommendations`, which is a different concept stored in its own table.

## Tests

Three, pinning each state the field can be in:

- `null` — post predates this enrichment
- `[]` — enrichment ran and nothing qualified
- populated

Note the null/`[]` distinction is currently only reachable by writing the column directly. In the live pipeline an empty result reaches the database as `null`, because yggdrasil omits the field when the list is empty. That is known and accepted; the tests pin the API's behaviour for both, so the distinction still works if the pipeline is ever changed to preserve it.

## Verification

- `tsc --noEmit` clean (only pre-existing errors under `src/common/interest/`)
- `prettier` clean
- Jest not run locally — port 5432 is held by an unrelated project's Postgres on this machine and `pretest` runs `db:schema:drop`, so CI is the check